### PR TITLE
Issue #68: remove unused export from ParsedUsage interface

### DIFF
--- a/src/server/services/usage-tracker.ts
+++ b/src/server/services/usage-tracker.ts
@@ -47,7 +47,7 @@ export function processUsageSnapshot(data: {
 // Parsed usage result
 // ---------------------------------------------------------------------------
 
-export interface ParsedUsage {
+interface ParsedUsage {
   daily: number;
   weekly: number;
   sonnet: number;


### PR DESCRIPTION
Closes #68

## Summary
- Removed the `export` keyword from the `ParsedUsage` interface in `src/server/services/usage-tracker.ts` (line 50)
- The interface was exported but never imported outside the file — now it is file-private
- Internal usage at lines 150-151 remains intact

## Verification
- `tsc --noEmit` compiles cleanly
- All 155 tests pass (5 test files)