### PR TITLE
Issue #69: fix project filter dropdown not filtering Issue Tree view

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -77,7 +77,10 @@ export function IssueTreeView() {
   const fetchTree = useCallback(async () => {
     try {
       setError(null);
-      const data = await api.get<IssueTreeResponse>('issues');
+      const endpoint = selectedProjectId
+        ? `projects/${selectedProjectId}/issues`
+        : 'issues';
+      const data = await api.get<IssueTreeResponse>(endpoint);
       setTree(data.tree);
       setCachedAt(data.cachedAt);
       setIssueCount(data.count);
@@ -87,7 +90,7 @@ export function IssueTreeView() {
     } finally {
       setLoading(false);
     }
-  }, [api]);
+  }, [api, selectedProjectId]);
 
   useEffect(() => {
     fetchTree();
@@ -102,17 +105,16 @@ export function IssueTreeView() {
     setRefreshing(true);
     try {
       setError(null);
-      const data = await api.post<IssueRefreshResponse>('issues/refresh');
-      setTree(data.tree);
-      setCachedAt(data.refreshedAt);
-      setIssueCount(data.issueCount ?? countNodes(data.tree));
+      // Refresh all projects on the server, then re-fetch with the active filter
+      await api.post<IssueRefreshResponse>('issues/refresh');
+      await fetchTree();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
     } finally {
       setRefreshing(false);
     }
-  }, [api, refreshing]);
+  }, [api, refreshing, fetchTree]);
 
   // -------------------------------------------------------------------------
   // Launch team for an issue (play button)


### PR DESCRIPTION
## Summary

- **Bug:** The project filter dropdown in the TopBar had no effect on the Issue Tree view (`/issues`) — it always showed issues from all projects regardless of selection.
- **Fix:** `IssueTreeView.tsx` now calls the per-project endpoint (`GET /api/projects/:id/issues`) when a project is selected, and falls back to `GET /api/issues` for "All Projects". Added `selectedProjectId` to dependency arrays so the tree re-fetches on filter change.
- Single-file client-only change, no server modifications.

Closes #69