### PR TITLE
Issue #70: show model name on Fleet Grid and Team Detail + verify --model flag

### DIFF
--- a/src/client/components/AddProjectDialog.tsx
+++ b/src/client/components/AddProjectDialog.tsx
@@ -33,6 +33,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
   const [repoPath, setRepoPath] = useState('');
   const [githubRepo, setGithubRepo] = useState('');
   const [maxActiveTeams, setMaxActiveTeams] = useState(5);
+  const [model, setModel] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,6 +71,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
       setRepoPath('');
       setGithubRepo('');
       setMaxActiveTeams(5);
+      setModel('');
       setError(null);
       setLoading(false);
       setSuggestions([]);
@@ -234,6 +236,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
         repoPath: repoPath.trim(),
         githubRepo: githubRepo.trim() || undefined,
         maxActiveTeams,
+        model: model.trim() || undefined,
       });
       onAdded();
     } catch (err: unknown) {
@@ -242,7 +245,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
     } finally {
       setLoading(false);
     }
-  }, [name, repoPath, githubRepo, maxActiveTeams, api, onAdded]);
+  }, [name, repoPath, githubRepo, maxActiveTeams, model, api, onAdded]);
 
   // Keyboard navigation for suggestions + Enter to submit
   const handlePathKeyDown = useCallback(
@@ -476,6 +479,25 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
             />
             <p className="mt-1 text-xs text-dark-muted/60">
               Max concurrent active teams before new launches are queued (1-50, default: 5).
+            </p>
+          </div>
+
+          {/* Model */}
+          <div>
+            <label className="block text-sm text-dark-muted mb-1">
+              Model <span className="text-dark-muted/50">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g. opus, sonnet, claude-opus-4-6"
+              className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+              disabled={loading}
+            />
+            <p className="mt-1 text-xs text-dark-muted/60">
+              Claude model to use for teams in this project. Empty uses the default model.
             </p>
           </div>
 

--- a/src/client/components/FleetGrid.tsx
+++ b/src/client/components/FleetGrid.tsx
@@ -7,7 +7,7 @@ interface FleetGridProps {
   onSelectTeam: (id: number) => void;
 }
 
-const COLUMNS = ['Status', 'Issue', 'Duration', 'Activity', 'Cost', 'PR', 'Actions'] as const;
+const COLUMNS = ['Status', 'Issue', 'Model', 'Duration', 'Activity', 'Cost', 'PR', 'Actions'] as const;
 
 export function FleetGrid({ teams, selectedTeamId, onSelectTeam }: FleetGridProps) {
   return (

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -326,6 +326,7 @@ export function TeamDetail() {
                       {detail.branchName && (
                         <span className="ml-3">Branch: {detail.branchName}</span>
                       )}
+                      <span className="ml-3">Model: {detail.model ?? '\u2014'}</span>
                     </div>
                   </section>
 

--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -103,6 +103,13 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
         </span>
       </td>
 
+      {/* Model */}
+      <td className="px-4 whitespace-nowrap">
+        <span className="text-sm text-dark-muted">
+          {team.model ?? '\u2014'}
+        </span>
+      </td>
+
       {/* Duration */}
       <td className="px-4 whitespace-nowrap">
         <span className="text-sm text-dark-muted">

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -33,6 +33,12 @@ export function ProjectsPage() {
   const limitInputRef = useRef<HTMLInputElement>(null);
   const committedRef = useRef(false);
 
+  // Inline edit state for model
+  const [editingModelId, setEditingModelId] = useState<number | null>(null);
+  const [editModelValue, setEditModelValue] = useState('');
+  const modelInputRef = useRef<HTMLInputElement>(null);
+  const modelCommittedRef = useRef(false);
+
   // Prompt editor state
   const [editingPromptId, setEditingPromptId] = useState<number | null>(null);
   const [promptContent, setPromptContent] = useState('');
@@ -154,6 +160,30 @@ export function ProjectsPage() {
 
   const handleCancelEditLimit = useCallback(() => {
     setEditingLimitId(null);
+  }, []);
+
+  const handleEditModel = useCallback((project: ProjectSummary) => {
+    setEditingModelId(project.id);
+    setEditModelValue(project.model ?? '');
+    setTimeout(() => modelInputRef.current?.focus(), 50);
+  }, []);
+
+  const handleSaveModel = useCallback(
+    async (projectId: number) => {
+      try {
+        await api.put(`projects/${projectId}`, { model: editModelValue.trim() || null });
+        await fetchProjects();
+      } catch {
+        // ignore
+      }
+      modelCommittedRef.current = false;
+      setEditingModelId(null);
+    },
+    [api, editModelValue, fetchProjects],
+  );
+
+  const handleCancelEditModel = useCallback(() => {
+    setEditingModelId(null);
   }, []);
 
   // Load prompt content when editing
@@ -458,6 +488,39 @@ export function ProjectsPage() {
                           }}
                         >
                           {project.queuedTeamCount} queued
+                        </span>
+                      )}
+                      {editingModelId === project.id ? (
+                        <span className="shrink-0 inline-flex items-center gap-1">
+                          <span>Model:</span>
+                          <input
+                            ref={modelInputRef}
+                            type="text"
+                            value={editModelValue}
+                            onChange={(e) => setEditModelValue(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                modelCommittedRef.current = true;
+                                handleSaveModel(project.id);
+                              }
+                              if (e.key === 'Escape') handleCancelEditModel();
+                            }}
+                            onBlur={() => {
+                              if (!modelCommittedRef.current) {
+                                handleSaveModel(project.id);
+                              }
+                            }}
+                            placeholder="default"
+                            className="w-32 px-1 py-0 text-xs rounded border border-dark-accent bg-dark-base text-dark-text focus:outline-none"
+                          />
+                        </span>
+                      ) : (
+                        <span
+                          className="shrink-0 cursor-pointer hover:text-dark-text transition-colors"
+                          onClick={() => handleEditModel(project)}
+                          title="Click to edit model"
+                        >
+                          Model: {project.model || 'default'}
                         </span>
                       )}
                     </div>

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -143,6 +143,7 @@ export interface ProjectInsert {
   githubRepo?: string | null;
   maxActiveTeams?: number;
   promptFile?: string | null;
+  model?: string | null;
 }
 
 export interface ProjectUpdate {
@@ -152,6 +153,7 @@ export interface ProjectUpdate {
   hooksInstalled?: boolean;
   maxActiveTeams?: number;
   promptFile?: string | null;
+  model?: string | null;
 }
 
 export interface ProjectFilter {
@@ -205,6 +207,9 @@ export class FleetDatabase {
 
     // Add team_transitions table if missing (for existing databases)
     this.addTeamTransitionsTable();
+
+    // Add model column to projects if missing (for existing databases)
+    this.addModelColumn();
 
     // Resolve schema.sql relative to this file.
     // In dev (tsx): __dirname is src/server
@@ -366,6 +371,22 @@ export class FleetDatabase {
   }
 
   /**
+   * Add model column to projects table if it doesn't exist.
+   * Handles upgrade of existing databases that lack this column.
+   */
+  private addModelColumn(): void {
+    try {
+      const columns = this.db.prepare("PRAGMA table_info(projects)").all() as Array<{ name: string }>;
+      const hasColumn = columns.some((c) => c.name === 'model');
+      if (!hasColumn) {
+        this.db.exec('ALTER TABLE projects ADD COLUMN model TEXT');
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
    * Get the current schema version.
    */
   getSchemaVersion(): number {
@@ -386,8 +407,8 @@ export class FleetDatabase {
   insertProject(data: ProjectInsert): Project {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(`
-      INSERT INTO projects (name, repo_path, github_repo, max_active_teams, prompt_file, created_at, updated_at)
-      VALUES (@name, @repoPath, @githubRepo, @maxActiveTeams, @promptFile, @createdAt, @updatedAt)
+      INSERT INTO projects (name, repo_path, github_repo, max_active_teams, prompt_file, model, created_at, updated_at)
+      VALUES (@name, @repoPath, @githubRepo, @maxActiveTeams, @promptFile, @model, @createdAt, @updatedAt)
     `);
 
     const info = stmt.run({
@@ -396,6 +417,7 @@ export class FleetDatabase {
       githubRepo: data.githubRepo ?? null,
       maxActiveTeams: data.maxActiveTeams ?? 5,
       promptFile: data.promptFile ?? null,
+      model: data.model ?? null,
       createdAt: now,
       updatedAt: now,
     });
@@ -480,6 +502,10 @@ export class FleetDatabase {
     if (fields.promptFile !== undefined) {
       setClauses.push('prompt_file = @promptFile');
       params.promptFile = fields.promptFile;
+    }
+    if (fields.model !== undefined) {
+      setClauses.push('model = @model');
+      params.model = fields.model;
     }
 
     if (setClauses.length === 0) return this.getProject(id);
@@ -1235,6 +1261,7 @@ export class FleetDatabase {
       hooksInstalled: (row.hooks_installed as number) === 1,
       maxActiveTeams: (row.max_active_teams as number | undefined) ?? 5,
       promptFile: (row.prompt_file as string | null) ?? null,
+      model: (row.model as string | null) ?? null,
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
     };
@@ -1324,6 +1351,7 @@ export class FleetDatabase {
       issueTitle: row.issue_title as string | null,
       projectId: (row.project_id as number | null) ?? null,
       projectName: (row.project_name as string | null) ?? null,
+      model: (row.model as string | null) ?? null,
       status: row.status as TeamStatus,
       phase: row.phase as TeamPhase,
       worktreeName: row.worktree_name as string,

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -31,6 +31,7 @@ interface CreateProjectBody {
   repoPath: string;
   githubRepo?: string;
   maxActiveTeams?: number;
+  model?: string;
 }
 
 interface UpdateProjectBody {
@@ -40,6 +41,7 @@ interface UpdateProjectBody {
   hooksInstalled?: boolean;
   maxActiveTeams?: number;
   promptFile?: string | null;
+  model?: string | null;
 }
 
 interface ProjectIdParams {
@@ -346,7 +348,7 @@ const projectsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const { name, repoPath, githubRepo, maxActiveTeams } = request.body;
+        const { name, repoPath, githubRepo, maxActiveTeams, model } = request.body;
 
         // Validate name
         if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -441,6 +443,7 @@ const projectsRoutes: FastifyPluginCallback = (
           githubRepo: resolvedGithubRepo,
           maxActiveTeams: maxActiveTeams ?? 5,
           promptFile: promptRelPath,
+          model: model?.trim() || null,
         });
 
         // Install hooks (non-fatal)
@@ -572,7 +575,7 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const { name, status, githubRepo, hooksInstalled, maxActiveTeams, promptFile } = request.body || {};
+        const { name, status, githubRepo, hooksInstalled, maxActiveTeams, promptFile, model } = request.body || {};
 
         // Validate status if provided
         if (status !== undefined) {
@@ -610,6 +613,7 @@ const projectsRoutes: FastifyPluginCallback = (
           hooksInstalled,
           maxActiveTeams,
           promptFile,
+          model: model !== undefined ? (model?.trim() || null) : undefined,
         });
 
         // Broadcast SSE event

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -363,6 +363,15 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
+        // Look up project to get model
+        let projectModel: string | null = null;
+        if (team.projectId) {
+          const project = db.getProject(team.projectId);
+          if (project) {
+            projectModel = project.model ?? null;
+          }
+        }
+
         // Compute duration & idle in minutes
         const launchedAt = team.launchedAt ? new Date(team.launchedAt) : null;
         const now = new Date();
@@ -415,6 +424,7 @@ const teamsRoutes: FastifyPluginCallback = (
           id: team.id,
           issueNumber: team.issueNumber,
           issueTitle: team.issueTitle,
+          model: projectModel,
           status: team.status,
           phase: team.phase,
           pid: team.pid,

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS projects (
   hooks_installed INTEGER NOT NULL DEFAULT 0,         -- 0 | 1
   max_active_teams INTEGER NOT NULL DEFAULT 5,        -- max concurrent active teams before queueing
   prompt_file     TEXT,                               -- relative path to launch prompt .md file
+  model           TEXT,                               -- Claude model override e.g. "opus", "sonnet", "claude-opus-4-6"
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -114,6 +115,7 @@ SELECT
   t.issue_title,
   t.project_id,
   p.name AS project_name,
+  p.model AS model,
   t.status,
   t.phase,
   t.worktree_name,

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -432,6 +432,10 @@ export class TeamManager {
       args.push('--dangerously-skip-permissions');
     }
 
+    if (project.model) {
+      args.push('--model', project.model);
+    }
+
     // In headless mode, the initial prompt is sent via stdin (not as positional arg)
     // so that the process stays alive for follow-up messages.
     if (!isHeadless) {
@@ -845,6 +849,10 @@ export class TeamManager {
 
     if (config.skipPermissions) {
       args.push('--dangerously-skip-permissions');
+    }
+
+    if (project.model) {
+      args.push('--model', project.model);
     }
 
     // Update status to launching
@@ -1274,6 +1282,10 @@ export class TeamManager {
 
     if (config.skipPermissions) {
       args.push('--dangerously-skip-permissions');
+    }
+
+    if (project.model) {
+      args.push('--model', project.model);
     }
 
     // Initial prompt is sent via stdin, not as positional arg

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,6 +38,7 @@ export interface Project {
   hooksInstalled: boolean;
   maxActiveTeams: number;
   promptFile: string | null;
+  model?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -208,6 +209,7 @@ export interface TeamDashboardRow {
   issueTitle: string | null;
   projectId: number | null;
   projectName: string | null;
+  model: string | null;
   status: TeamStatus;
   phase: TeamPhase;
   worktreeName: string;
@@ -240,6 +242,7 @@ export interface TeamDetail {
   id: number;
   issueNumber: number;
   issueTitle: string | null;
+  model?: string | null;
   status: TeamStatus;
   phase: TeamPhase;
   pid: number | null;


### PR DESCRIPTION
Closes #70

## Summary

- Added `model` column to `projects` table with safe ALTER TABLE migration for existing databases
- Updated `v_team_dashboard` view to surface project model through to the dashboard
- Added `--model` flag to all 3 spawn paths in team-manager.ts (`launch`, `resume`, `launchQueued`) — only when project.model is non-null
- Added 'Model' column to Fleet Grid table, showing model name or em-dash when not configured
- Added model display in Team Detail slide-over metadata section
- Added model input field to project create dialog and inline editor on project cards

## Changes

11 files changed, +158/-6:
- `src/server/schema.sql` — model column + view update
- `src/server/db.ts` — migration, mappers, insert/update
- `src/shared/types.ts` — Project, TeamDashboardRow, TeamDetail types
- `src/server/routes/projects.ts` — accept model in create/update
- `src/server/routes/teams.ts` — include model in team detail
- `src/server/services/team-manager.ts` — --model flag in all 3 spawn paths
- `src/client/components/FleetGrid.tsx` — Model column
- `src/client/components/TeamRow.tsx` — model cell
- `src/client/components/TeamDetail.tsx` — model in metadata
- `src/client/views/ProjectsPage.tsx` — inline model editor
- `src/client/components/AddProjectDialog.tsx` — model input

## Test plan

- [x] TypeScript compiles cleanly (tsc --noEmit)
- [x] All 155 tests pass
- [x] Build succeeds (npm run build)
- [x] All 3 spawn paths verified to include --model when project.model is set
- [x] Schema migration safe for existing databases (PRAGMA check + ALTER TABLE)