### PR TITLE
Issue #45: fix deleteTeamsByProject missing events/commands cascade

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1165,22 +1165,15 @@ export class FleetDatabase {
     }));
   }
 
-  // -------------------------------------------------------------------------
-  // Individual record deletion helpers (used by project delete)
-  // -------------------------------------------------------------------------
-
-  deleteTeamEvents(teamId: number): void {
-    this.db.prepare('DELETE FROM events WHERE team_id = ?').run(teamId);
-  }
-
-  deleteTeamCommands(teamId: number): void {
-    this.db.prepare('DELETE FROM commands WHERE team_id = ?').run(teamId);
-  }
-
   deleteTeamsByProject(projectId: number): void {
-    this.db.prepare('DELETE FROM team_transitions WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(projectId);
-    this.db.prepare('DELETE FROM pull_requests WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(projectId);
-    this.db.prepare('DELETE FROM teams WHERE project_id = ?').run(projectId);
+    this.db.transaction((pid: number) => {
+      this.db.prepare('DELETE FROM team_transitions WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.db.prepare('DELETE FROM events WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.db.prepare('DELETE FROM commands WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.db.prepare('DELETE FROM usage_snapshots WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.db.prepare('DELETE FROM pull_requests WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.db.prepare('DELETE FROM teams WHERE project_id = ?').run(pid);
+    })(projectId);
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -688,12 +688,8 @@ const projectsRoutes: FastifyPluginCallback = (
         const issueFetcher = getIssueFetcher();
         issueFetcher.clearProject(projectId);
 
-        // Delete all related records before deleting project (foreign key constraints)
-        const allTeams = db.getTeams({ projectId });
-        for (const t of allTeams) {
-          db.deleteTeamEvents(t.id);
-          db.deleteTeamCommands(t.id);
-        }
+        // Delete all teams and related records (events, commands, usage_snapshots,
+        // transitions, PRs) in a single transaction
         db.deleteTeamsByProject(projectId);
 
         // Delete the project from DB


### PR DESCRIPTION
Closes #45

## Summary

- **Fixed** `deleteTeamsByProject` in `db.ts` to cascade-delete from `events`, `commands`, and `usage_snapshots` tables before deleting `teams`, preventing FK constraint errors when `foreign_keys = ON`
- **Wrapped** all delete statements in a single transaction for atomicity (matching the pattern in `deleteTeamAndRelated`)
- **Removed** the redundant per-team pre-deletion loop in `projects.ts` (lines 688-692) since `deleteTeamsByProject` now handles the full cascade
- **Removed** now-unused `deleteTeamEvents` and `deleteTeamCommands` helper methods from `FleetDatabase`

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 155 existing tests pass (`npm test`)
- [x] Verified no other callers of removed `deleteTeamEvents`/`deleteTeamCommands` methods