### PR TITLE
Issue #60: fix unhandled promise rejection in POST /api/prs/refresh

### DIFF
--- a/src/server/routes/prs.ts
+++ b/src/server/routes/prs.ts
@@ -172,7 +172,7 @@ const prsRoutes: FastifyPluginCallback = (
     '/api/prs/refresh',
     async (request: FastifyRequest, reply: FastifyReply) => {
       try {
-        githubPoller.poll();
+        githubPoller.poll().catch(err => request.log.error(err, 'Poll failed'));
         return reply.code(200).send({
           ok: true,
           message: 'GitHub poller poll triggered',


### PR DESCRIPTION
Closes #60

Adds `.catch(err => request.log.error(err, 'Poll failed'))` to the `githubPoller.poll()` call in `POST /api/prs/refresh` route handler. Without this, a rejected promise from `poll()` becomes an unhandled promise rejection that can crash Node.js 20+. The fix preserves fire-and-forget semantics (no `await` added).