### PR TITLE
Issue #63: fix TeamTimeline Gantt bars freeze — stale useMemo for Date.now()

### DIFF
--- a/src/client/components/TeamTimeline.tsx
+++ b/src/client/components/TeamTimeline.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { TeamDashboardRow, TeamStatus } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -58,7 +58,12 @@ interface BarInfo {
 export function TeamTimeline({ teams }: TeamTimelineProps) {
   const [hoveredId, setHoveredId] = useState<number | null>(null);
 
-  const now = useMemo(() => Date.now(), []);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, []);
 
   // Build bar info for each team that has a launchedAt timestamp
   const bars = useMemo<BarInfo[]>(() => {


### PR DESCRIPTION
Closes #63

## Summary
- Replaced `useMemo(() => Date.now(), [])` with `useState(() => Date.now())` + `useEffect`/`setInterval` (15s) in `TeamTimeline.tsx`
- Running team Gantt bars and axis labels now refresh every 15 seconds instead of freezing on mount
- Interval is properly cleaned up on unmount via `clearInterval`

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [x] Client tests pass (3 pre-existing failures in TopBar.test.tsx are unrelated)
- [x] Code review approved