### PR TITLE
Issue #46: persist custom prompt for queued teams

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -56,6 +56,7 @@ export interface TeamInsert {
   pid?: number | null;
   sessionId?: string | null;
   prNumber?: number | null;
+  customPrompt?: string | null;
   launchedAt?: string | null;
 }
 
@@ -67,6 +68,7 @@ export interface TeamUpdate {
   pid?: number | null;
   sessionId?: string | null;
   prNumber?: number | null;
+  customPrompt?: string | null;
   launchedAt?: string | null;
   stoppedAt?: string | null;
   lastEventAt?: string | null;
@@ -210,6 +212,9 @@ export class FleetDatabase {
 
     // Add model column to projects if missing (for existing databases)
     this.addModelColumn();
+
+    // Add custom_prompt column to teams if missing (for existing databases)
+    this.addCustomPromptColumn();
 
     // Resolve schema.sql relative to this file.
     // In dev (tsx): __dirname is src/server
@@ -386,6 +391,18 @@ export class FleetDatabase {
     }
   }
 
+  private addCustomPromptColumn(): void {
+    try {
+      const columns = this.db.prepare("PRAGMA table_info(teams)").all() as Array<{ name: string }>;
+      const hasColumn = columns.some((c) => c.name === 'custom_prompt');
+      if (!hasColumn) {
+        this.db.exec('ALTER TABLE teams ADD COLUMN custom_prompt TEXT');
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
   /**
    * Get the current schema version.
    */
@@ -536,8 +553,8 @@ export class FleetDatabase {
   insertTeam(data: TeamInsert): Team {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(`
-      INSERT INTO teams (issue_number, issue_title, project_id, worktree_name, branch_name, status, phase, pid, session_id, pr_number, launched_at, created_at, updated_at)
-      VALUES (@issueNumber, @issueTitle, @projectId, @worktreeName, @branchName, @status, @phase, @pid, @sessionId, @prNumber, @launchedAt, @createdAt, @updatedAt)
+      INSERT INTO teams (issue_number, issue_title, project_id, worktree_name, branch_name, status, phase, pid, session_id, pr_number, custom_prompt, launched_at, created_at, updated_at)
+      VALUES (@issueNumber, @issueTitle, @projectId, @worktreeName, @branchName, @status, @phase, @pid, @sessionId, @prNumber, @customPrompt, @launchedAt, @createdAt, @updatedAt)
     `);
 
     const info = stmt.run({
@@ -551,6 +568,7 @@ export class FleetDatabase {
       pid: data.pid ?? null,
       sessionId: data.sessionId ?? null,
       prNumber: data.prNumber ?? null,
+      customPrompt: data.customPrompt ?? null,
       launchedAt: data.launchedAt ?? null,
       createdAt: now,
       updatedAt: now,
@@ -670,6 +688,10 @@ export class FleetDatabase {
     if (fields.prNumber !== undefined) {
       setClauses.push('pr_number = @prNumber');
       params.prNumber = fields.prNumber;
+    }
+    if (fields.customPrompt !== undefined) {
+      setClauses.push('custom_prompt = @customPrompt');
+      params.customPrompt = fields.customPrompt;
     }
     if (fields.launchedAt !== undefined) {
       setClauses.push('launched_at = @launchedAt');
@@ -1273,6 +1295,7 @@ export class FleetDatabase {
       worktreeName: row.worktree_name as string,
       branchName: row.branch_name as string | null,
       prNumber: row.pr_number as number | null,
+      customPrompt: (row.custom_prompt as string | null) ?? null,
       launchedAt: (row.launched_at as string | null) ?? null,
       stoppedAt: row.stopped_at as string | null,
       lastEventAt: row.last_event_at as string | null,

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS teams (
   pid             INTEGER,
   session_id      TEXT,
   pr_number       INTEGER,
+  custom_prompt   TEXT,                            -- custom prompt override (persisted for queued teams)
   launched_at     TEXT,
   stopped_at      TEXT,
   last_event_at   TEXT,

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -235,7 +235,7 @@ export class TeamManager {
     const activeCount = db.getActiveTeamCountByProject(projectId);
     if (activeCount >= project.maxActiveTeams) {
       // Queue this team instead of launching
-      return this.queueTeam(db, project, projectId, issueNumber, issueTitle, headless);
+      return this.queueTeam(db, project, projectId, issueNumber, issueTitle, headless, prompt);
     }
 
     // If no title provided, fetch from GitHub
@@ -1063,6 +1063,7 @@ export class TeamManager {
     issueNumber: number,
     issueTitle?: string,
     headless?: boolean,
+    prompt?: string,
   ): Promise<Team> {
     // Fetch title from GitHub if needed
     if (!issueTitle && project.githubRepo) {
@@ -1098,6 +1099,7 @@ export class TeamManager {
         pid: null,
         sessionId: null,
         issueTitle: issueTitle ?? null,
+        customPrompt: prompt ?? null,
         launchedAt: now,
         stoppedAt: null,
         lastEventAt: null,
@@ -1119,6 +1121,7 @@ export class TeamManager {
       branchName,
       status: 'queued',
       phase: 'init',
+      customPrompt: prompt ?? null,
       launchedAt: now,
     });
 
@@ -1284,7 +1287,7 @@ export class TeamManager {
     }
 
     // ── Step 3: Spawn Claude Code ──
-    const resolvedPrompt = this.resolvePromptFromFile(project, team.issueNumber);
+    const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, team.issueNumber);
     const args: string[] = [];
     args.push('--worktree', team.worktreeName);
     args.push('--input-format', 'stream-json');   // Bidirectional: receive messages via stdin

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -91,6 +91,7 @@ export interface Team {
   worktreeName: string;
   branchName: string | null;
   prNumber: number | null;
+  customPrompt: string | null;
   launchedAt: string | null;
   stoppedAt: string | null;
   lastEventAt: string | null;


### PR DESCRIPTION
## Summary

Fixes #46 — when `launch()` queues a team (usage red zone or slot limit), the custom `prompt` parameter was silently dropped. `queueTeam()` didn't accept or persist it, so `launchQueued()` always fell back to the file-based default prompt.

**Fix:**
- Added `custom_prompt TEXT` column to the `teams` table (with migration following existing pattern)
- `queueTeam()` now accepts and persists the `prompt` parameter as `customPrompt` in both reuse and fresh-insert paths
- `launchQueued()` reads `team.customPrompt` before falling back to the file-based default

**Files changed (4):**
- `src/server/schema.sql` — new column
- `src/server/db.ts` — migration, interfaces, insert/update/map
- `src/shared/types.ts` — `customPrompt` on `Team` interface
- `src/server/services/team-manager.ts` — threading prompt through queue lifecycle

Closes #46