### PR TITLE
Issue #77: change default usage poll interval from 5min to 2min

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -29,7 +29,7 @@ const config = Object.freeze({
   githubPollIntervalMs: safeParseInt(process.env['FLEET_GITHUB_POLL_MS'] || '30000', 'FLEET_GITHUB_POLL_MS'),
   issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '60000', 'FLEET_ISSUE_POLL_MS'),
   stuckCheckIntervalMs: safeParseInt(process.env['FLEET_STUCK_CHECK_MS'] || '60000', 'FLEET_STUCK_CHECK_MS'),
-  usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '300000', 'FLEET_USAGE_POLL_MS'),
+  usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '120000', 'FLEET_USAGE_POLL_MS'),
 
   idleThresholdMin: safeParseInt(process.env['FLEET_IDLE_THRESHOLD_MIN'] || '5', 'FLEET_IDLE_THRESHOLD_MIN'),
   stuckThresholdMin: safeParseInt(process.env['FLEET_STUCK_THRESHOLD_MIN'] || '15', 'FLEET_STUCK_THRESHOLD_MIN'),


### PR DESCRIPTION
Closes #77

Change the default value of `FLEET_USAGE_POLL_MS` from `300000` (5 minutes) to `120000` (2 minutes) in `src/server/config.ts`. This makes usage data refresh faster, improving responsiveness to Red zone queue gate transitions.

The env var override mechanism is unchanged — only the default is affected.