### PR TITLE
Issue #78: show merge icon for merged PRs in PRBadge

### DIFF
--- a/src/client/components/PRBadge.tsx
+++ b/src/client/components/PRBadge.tsx
@@ -47,7 +47,10 @@ export function PRBadge({ prNumber, ciStatus, teamId, prState }: PRBadgeProps) {
     return <span className="text-dark-muted text-sm">{'\u2014'}</span>;
   }
 
-  const ci = CI_ICONS[ciStatus ?? 'none'] ?? CI_ICONS.none;
+  const ci =
+    prState === 'merged'
+      ? { icon: '\u2713', color: '#A371F7' }
+      : CI_ICONS[ciStatus ?? 'none'] ?? CI_ICONS.none;
   const canExpand = teamId != null;
   const stateColor = STATE_COLORS[prState ?? ''] ?? '#8B949E';
   const stateLabel = prState ? prState.toUpperCase() : null;

--- a/tests/client/PRBadge.test.tsx
+++ b/tests/client/PRBadge.test.tsx
@@ -94,4 +94,42 @@ describe('PRBadge', () => {
       expect(ciIcon).toHaveStyle({ color: '#8B949E' });
     });
   });
+
+  describe('merged PR override', () => {
+    it('shows purple checkmark when PR is merged with ciStatus "none"', () => {
+      const { container } = render(
+        <PRBadge prNumber={99} ciStatus="none" prState="merged" />,
+      );
+      const ciIcon = container.querySelector('.font-bold');
+      expect(ciIcon?.textContent).toBe('\u2713');
+      expect(ciIcon).toHaveStyle({ color: '#A371F7' });
+    });
+
+    it('shows purple checkmark when PR is merged with ciStatus "passing"', () => {
+      const { container } = render(
+        <PRBadge prNumber={99} ciStatus="passing" prState="merged" />,
+      );
+      const ciIcon = container.querySelector('.font-bold');
+      expect(ciIcon?.textContent).toBe('\u2713');
+      expect(ciIcon).toHaveStyle({ color: '#A371F7' });
+    });
+
+    it('shows purple checkmark when PR is merged with ciStatus null', () => {
+      const { container } = render(
+        <PRBadge prNumber={99} ciStatus={null} prState="merged" />,
+      );
+      const ciIcon = container.querySelector('.font-bold');
+      expect(ciIcon?.textContent).toBe('\u2713');
+      expect(ciIcon).toHaveStyle({ color: '#A371F7' });
+    });
+
+    it('does not override icon for open PRs', () => {
+      const { container } = render(
+        <PRBadge prNumber={99} ciStatus="failing" prState="open" />,
+      );
+      const ciIcon = container.querySelector('.font-bold');
+      expect(ciIcon?.textContent).toBe('\u2715');
+      expect(ciIcon).toHaveStyle({ color: '#F85149' });
+    });
+  });
 });


### PR DESCRIPTION
Closes #78

## Summary
- When `prState === 'merged'`, PRBadge now shows a purple checkmark (`✓` in `#A371F7`) instead of the CI status icon
- Merged state takes priority over any CI status (none, passing, failing, pending, null)
- 4 new test cases covering merged-state override behavior

## Changes
- `src/client/components/PRBadge.tsx` — 3-line ternary override before `CI_ICONS` lookup
- `tests/client/PRBadge.test.tsx` — 4 new tests in "merged PR override" describe block

## Test plan
- [x] All 17 PRBadge tests pass (13 existing + 4 new)
- [x] Type-check clean (`tsc --noEmit`)
- [x] Non-merged PR states unaffected (verified by existing + new tests)