### PR TITLE
Issue #81: add --state all to detectPR gh pr list command

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -473,7 +473,7 @@ class GitHubPoller {
 
   private detectPR(branchName: string, teamId: number, githubRepo: string): void {
     const result = this.execGH(
-      `gh pr list --head ${branchName} --repo ${githubRepo} --json number --limit 1`
+      `gh pr list --head ${branchName} --repo ${githubRepo} --state all --json number --limit 1`
     );
     if (!result) return; // gh CLI failed — skip
 


### PR DESCRIPTION
Closes #81

## Problem
`detectPR()` in `github-poller.ts` runs `gh pr list --head <branch>` which defaults to `--state open`. If a PR is merged before the 30s poll cycle detects it, the query returns empty and the team never gets a `prNumber`, causing it to idle indefinitely.

## Fix
Added `--state all` to the `gh pr list` command in `detectPR()` so it finds PRs in any state (open, closed, merged).

## Testing
- TypeScript compiles cleanly
- All 173 tests pass
- Single-line change, no scope creep