### PR TITLE
fix: OAuth usage tracker + red zone queue gate

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -35,6 +35,9 @@ const config = Object.freeze({
   stuckThresholdMin: safeParseInt(process.env['FLEET_STUCK_THRESHOLD_MIN'] || '15', 'FLEET_STUCK_THRESHOLD_MIN'),
   maxUniqueCiFailures: safeParseInt(process.env['FLEET_MAX_CI_FAILURES'] || '3', 'FLEET_MAX_CI_FAILURES'),
 
+  usageRedDailyPct: safeParseInt(process.env['FLEET_USAGE_RED_DAILY_PCT'] || '85', 'FLEET_USAGE_RED_DAILY_PCT'),
+  usageRedWeeklyPct: safeParseInt(process.env['FLEET_USAGE_RED_WEEKLY_PCT'] || '95', 'FLEET_USAGE_RED_WEEKLY_PCT'),
+
   claudeCmd: process.env['FLEET_CLAUDE_CMD'] || 'claude',
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -121,6 +121,8 @@ export interface UsageInsert {
   weeklyPercent?: number;
   sonnetPercent?: number;
   extraPercent?: number;
+  dailyResetsAt?: string;
+  weeklyResetsAt?: string;
   rawOutput?: string;
 }
 
@@ -215,6 +217,9 @@ export class FleetDatabase {
 
     // Add custom_prompt column to teams if missing (for existing databases)
     this.addCustomPromptColumn();
+
+    // Add daily_resets_at and weekly_resets_at columns to usage_snapshots if missing
+    this.addUsageResetsAtColumns();
 
     // Resolve schema.sql relative to this file.
     // In dev (tsx): __dirname is src/server
@@ -397,6 +402,23 @@ export class FleetDatabase {
       const hasColumn = columns.some((c) => c.name === 'custom_prompt');
       if (!hasColumn) {
         this.db.exec('ALTER TABLE teams ADD COLUMN custom_prompt TEXT');
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
+   * Add daily_resets_at and weekly_resets_at columns to usage_snapshots if missing.
+   */
+  private addUsageResetsAtColumns(): void {
+    try {
+      const columns = this.db.prepare("PRAGMA table_info(usage_snapshots)").all() as Array<{ name: string }>;
+      if (!columns.some((c) => c.name === 'daily_resets_at')) {
+        this.db.exec('ALTER TABLE usage_snapshots ADD COLUMN daily_resets_at TEXT');
+      }
+      if (!columns.some((c) => c.name === 'weekly_resets_at')) {
+        this.db.exec('ALTER TABLE usage_snapshots ADD COLUMN weekly_resets_at TEXT');
       }
     } catch {
       // Table may not exist yet (fresh database) — schema.sql will create it
@@ -925,8 +947,8 @@ export class FleetDatabase {
 
   insertUsageSnapshot(data: UsageInsert): UsageSnapshot {
     const stmt = this.db.prepare(`
-      INSERT INTO usage_snapshots (team_id, project_id, session_id, daily_percent, weekly_percent, sonnet_percent, extra_percent, raw_output)
-      VALUES (@teamId, @projectId, @sessionId, @dailyPercent, @weeklyPercent, @sonnetPercent, @extraPercent, @rawOutput)
+      INSERT INTO usage_snapshots (team_id, project_id, session_id, daily_percent, weekly_percent, sonnet_percent, extra_percent, daily_resets_at, weekly_resets_at, raw_output)
+      VALUES (@teamId, @projectId, @sessionId, @dailyPercent, @weeklyPercent, @sonnetPercent, @extraPercent, @dailyResetsAt, @weeklyResetsAt, @rawOutput)
     `);
 
     const info = stmt.run({
@@ -937,6 +959,8 @@ export class FleetDatabase {
       weeklyPercent: data.weeklyPercent ?? 0,
       sonnetPercent: data.sonnetPercent ?? 0,
       extraPercent: data.extraPercent ?? 0,
+      dailyResetsAt: data.dailyResetsAt ?? null,
+      weeklyResetsAt: data.weeklyResetsAt ?? null,
       rawOutput: data.rawOutput ?? null,
     });
 
@@ -1355,6 +1379,8 @@ export class FleetDatabase {
       weeklyPercent: row.weekly_percent as number,
       sonnetPercent: row.sonnet_percent as number,
       extraPercent: row.extra_percent as number,
+      dailyResetsAt: (row.daily_resets_at as string | null) ?? null,
+      weeklyResetsAt: (row.weekly_resets_at as string | null) ?? null,
       rawOutput: row.raw_output as string | null,
       recordedAt: row.recorded_at as string,
     };

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -30,6 +30,7 @@ interface LaunchBody {
   issueTitle?: string;
   prompt?: string;
   headless?: boolean;
+  force?: boolean;
 }
 
 interface LaunchBatchBody {
@@ -96,7 +97,7 @@ const teamsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const { projectId, issueNumber, issueTitle, prompt, headless } = request.body;
+        const { projectId, issueNumber, issueTitle, prompt, headless, force } = request.body;
 
         if (!projectId || typeof projectId !== 'number' || projectId < 1) {
           return reply.code(400).send({
@@ -113,7 +114,7 @@ const teamsRoutes: FastifyPluginCallback = (
         }
 
         const manager = getTeamManager();
-        const team = await manager.launch(projectId, issueNumber, issueTitle, prompt, headless);
+        const team = await manager.launch(projectId, issueNumber, issueTitle, prompt, headless, force);
         return reply.code(201).send(team);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/server/routes/usage.ts
+++ b/src/server/routes/usage.ts
@@ -12,7 +12,8 @@ import type {
   FastifyReply,
 } from 'fastify';
 import { getDatabase } from '../db.js';
-import { processUsageSnapshot } from '../services/usage-tracker.js';
+import { processUsageSnapshot, getUsageZone } from '../services/usage-tracker.js';
+import config from '../config.js';
 
 // ---------------------------------------------------------------------------
 // Plugin
@@ -40,10 +41,16 @@ const usageRoutes: FastifyPluginCallback = (
             sonnetPercent: 0,
             extraPercent: 0,
             recordedAt: null,
+            zone: getUsageZone(),
+            redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct },
           });
         }
 
-        return reply.code(200).send(latest);
+        return reply.code(200).send({
+          ...latest,
+          zone: getUsageZone(),
+          redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct },
+        });
       } catch (err: unknown) {
         _request.log.error(err, 'Failed to get latest usage');
         return reply.code(500).send({

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -158,6 +158,8 @@ CREATE TABLE IF NOT EXISTS usage_snapshots (
   weekly_percent  REAL DEFAULT 0,
   sonnet_percent  REAL DEFAULT 0,
   extra_percent   REAL DEFAULT 0,
+  daily_resets_at TEXT,
+  weekly_resets_at TEXT,
   raw_output      TEXT,
   recorded_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -19,6 +19,7 @@ import { sseBroker } from './sse-broker.js';
 import type { StreamEvent } from './sse-broker.js';
 import { findGitBash } from '../utils/find-git-bash.js';
 import type { Team, Project } from '../../shared/types.js';
+import { getUsageZone } from './usage-tracker.js';
 
 const execAsync = promisify(execCallback);
 
@@ -220,6 +221,7 @@ export class TeamManager {
     issueTitle?: string,
     prompt?: string,
     headless?: boolean,
+    force?: boolean,
   ): Promise<Team> {
     const db = getDatabase();
 
@@ -230,6 +232,12 @@ export class TeamManager {
     }
 
     console.log(`[TeamManager] Launch started: project=${project.name} issue=#${issueNumber}`);
+
+    // Usage gate: if in red zone and not forced, queue instead of launching
+    if (!force && getUsageZone() === 'red') {
+      console.log(`[TeamManager] Usage zone is RED — queueing team for issue #${issueNumber}`);
+      return this.queueTeam(db, project, projectId, issueNumber, issueTitle, headless, prompt);
+    }
 
     // Check active team limit before proceeding
     const activeCount = db.getActiveTeamCountByProject(projectId);
@@ -1144,6 +1152,12 @@ export class TeamManager {
       const db = getDatabase();
       const project = db.getProject(projectId);
       if (!project) return;
+
+      // Usage gate: do not dequeue if in red zone
+      if (getUsageZone() === 'red') {
+        console.log(`[TeamManager] processQueue blocked — usage zone is RED`);
+        return;
+      }
 
       const activeCount = db.getActiveTeamCountByProject(projectId);
       const available = project.maxActiveTeams - activeCount;

--- a/src/server/services/usage-tracker.ts
+++ b/src/server/services/usage-tracker.ts
@@ -1,19 +1,46 @@
 /**
- * Usage Tracking Service — Records and broadcasts usage percentage snapshots
+ * Usage Tracking Service — Reads usage from Anthropic OAuth endpoint
  *
- * Replaces cost tracking with usage-percentage tracking that mirrors what
- * Claude Code's /usage command reports: daily, weekly, Sonnet-only, and
- * extra usage as 0-100% progress bars.
+ * Replaces the old `claude -p "/usage"` poller with a direct HTTP call to
+ * the Anthropic OAuth usage API, reading the token from the local
+ * Claude credentials file.
  *
- * Includes a UsagePoller that periodically runs `claude -p "/usage"` to
- * capture real usage data from Claude Code.
+ * Also implements a usage gate: when usage enters the "red zone",
+ * queue blocking is activated — no new teams will be dequeued until
+ * usage drops back to "green".
  */
 
-import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { getDatabase } from '../db.js';
 import { sseBroker } from './sse-broker.js';
 import config from '../config.js';
-import { findGitBash } from '../utils/find-git-bash.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type UsageZone = 'green' | 'red';
+
+export interface ParsedUsage {
+  daily: number;
+  weekly: number;
+  sonnet: number;
+  extra: number;
+}
+
+interface OAuthUsageBucket {
+  utilization: number;
+  resets_at?: string;
+}
+
+interface OAuthUsageResponse {
+  five_hour?: OAuthUsageBucket;
+  seven_day?: OAuthUsageBucket;
+  seven_day_sonnet?: OAuthUsageBucket;
+  extra_usage?: OAuthUsageBucket;
+}
 
 // ---------------------------------------------------------------------------
 // Manual snapshot helper (kept for POST /api/usage testing endpoint)
@@ -30,6 +57,8 @@ export function processUsageSnapshot(data: {
   weeklyPercent?: number;
   sonnetPercent?: number;
   extraPercent?: number;
+  dailyResetsAt?: string;
+  weeklyResetsAt?: string;
   rawOutput?: string;
 }): void {
   const db = getDatabase();
@@ -40,22 +69,46 @@ export function processUsageSnapshot(data: {
     weekly_percent: data.weeklyPercent ?? 0,
     sonnet_percent: data.sonnetPercent ?? 0,
     extra_percent: data.extraPercent ?? 0,
+    zone: getUsageZone(),
   });
 }
 
 // ---------------------------------------------------------------------------
-// Parsed usage result
+// Usage Zone — red/green gate
 // ---------------------------------------------------------------------------
 
-interface ParsedUsage {
-  daily: number;
-  weekly: number;
-  sonnet: number;
-  extra: number;
+let _lastZone: UsageZone = 'green';
+let _latestDaily = 0;
+let _latestWeekly = 0;
+
+/**
+ * Returns 'red' if usage exceeds the configured thresholds, 'green' otherwise.
+ */
+export function getUsageZone(): UsageZone {
+  if (_latestDaily >= config.usageRedDailyPct || _latestWeekly >= config.usageRedWeeklyPct) {
+    return 'red';
+  }
+  return 'green';
 }
 
 // ---------------------------------------------------------------------------
-// Usage Poller — runs `claude -p "/usage"` on a timer
+// OAuth token reader
+// ---------------------------------------------------------------------------
+
+function readOAuthToken(): string | null {
+  try {
+    const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
+    const raw = fs.readFileSync(credPath, 'utf-8');
+    const creds = JSON.parse(raw);
+    const token = creds?.claudeAiOauth?.accessToken;
+    return typeof token === 'string' && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage Poller — fetches from Anthropic OAuth endpoint
 // ---------------------------------------------------------------------------
 
 class UsagePoller {
@@ -88,46 +141,25 @@ class UsagePoller {
   }
 
   /**
-   * Execute a single poll: run `claude -p "/usage"`, parse the output,
-   * store it as a usage snapshot, and broadcast via SSE.
+   * Execute a single poll: fetch usage from Anthropic API,
+   * store as a usage snapshot, and broadcast via SSE.
    */
   poll(): void {
     try {
-      const claudeCmd = config.claudeCmd;
-      // Run claude in print mode with the /usage slash command.
-      // This should output usage information and exit immediately.
-      const env: Record<string, string | undefined> = { ...process.env };
-      const gitBash = findGitBash();
-      if (gitBash) env['CLAUDE_CODE_GIT_BASH_PATH'] = gitBash;
-
-      const output = execSync(`${claudeCmd} -p "/usage"`, {
-        encoding: 'utf-8',
-        timeout: 30000,
-        env,
-      });
-
-      const parsed = this.parseUsageOutput(output);
-      if (parsed) {
-        const db = getDatabase();
-        db.insertUsageSnapshot({
-          dailyPercent: parsed.daily,
-          weeklyPercent: parsed.weekly,
-          sonnetPercent: parsed.sonnet,
-          extraPercent: parsed.extra,
-          rawOutput: output,
-        });
-
-        sseBroker.broadcast('usage_updated', {
-          daily_percent: parsed.daily,
-          weekly_percent: parsed.weekly,
-          sonnet_percent: parsed.sonnet,
-          extra_percent: parsed.extra,
-        });
-
-        console.log(
-          `[UsagePoller] Snapshot recorded — daily=${parsed.daily}% weekly=${parsed.weekly}% sonnet=${parsed.sonnet}% extra=${parsed.extra}%`,
-        );
+      const token = readOAuthToken();
+      if (!token) {
+        console.warn('[UsagePoller] No OAuth token found in ~/.claude/.credentials.json');
+        return;
       }
+
+      // Use synchronous fetch via a self-invoking async to keep poll() sync-compatible
+      // with the setInterval pattern. Fire-and-forget.
+      this.fetchUsage(token).catch((err: unknown) => {
+        console.error(
+          '[UsagePoller] Failed to fetch usage:',
+          err instanceof Error ? err.message : err,
+        );
+      });
     } catch (err: unknown) {
       console.error(
         '[UsagePoller] Failed to poll usage:',
@@ -137,60 +169,89 @@ class UsagePoller {
   }
 
   /**
-   * Parse the raw text output of `claude -p "/usage"` into percentage values.
-   *
-   * The exact format of the /usage output is not guaranteed, so we try
-   * multiple parsing strategies:
-   *
-   * 1. Keyword matching — look for lines containing "daily", "weekly",
-   *    "sonnet", or "extra" with a percentage nearby.
-   * 2. Positional fallback — take the first 2-4 percentage values found
-   *    and assign them in order (daily, weekly, sonnet, extra).
+   * Fetch usage data from the Anthropic OAuth endpoint and process it.
    */
-  parseUsageOutput(output: string): ParsedUsage | null {
-    const result: ParsedUsage = { daily: 0, weekly: 0, sonnet: 0, extra: 0 };
+  private async fetchUsage(token: string): Promise<void> {
+    const resp = await fetch('https://api.anthropic.com/api/oauth/usage', {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+    });
 
-    // Strategy 1: Keyword-based matching on each line
-    const lines = output.split('\n');
-    for (const line of lines) {
-      const lower = line.toLowerCase();
-      const pctMatch = line.match(/(\d+(?:\.\d+)?)\s*%/);
-      if (!pctMatch) continue;
-      const pct = parseFloat(pctMatch[1]);
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.error(`[UsagePoller] API returned ${resp.status}: ${body.substring(0, 200)}`);
+      return;
+    }
 
-      if (lower.includes('daily') || lower.includes('dzien')) {
-        result.daily = pct;
-      } else if (lower.includes('weekly') || lower.includes('tydz') || lower.includes('tygodn')) {
-        result.weekly = pct;
-      } else if (lower.includes('sonnet')) {
-        result.sonnet = pct;
-      } else if (lower.includes('extra') || lower.includes('dodatkow')) {
-        result.extra = pct;
+    const data = (await resp.json()) as OAuthUsageResponse;
+    const rawOutput = JSON.stringify(data);
+
+    // Map response fields to percentages (0-100)
+    const dailyPercent = Math.round((data.five_hour?.utilization ?? 0) * 100);
+    const weeklyPercent = Math.round((data.seven_day?.utilization ?? 0) * 100);
+    const sonnetPercent = Math.round((data.seven_day_sonnet?.utilization ?? 0) * 100);
+    const extraPercent = Math.round((data.extra_usage?.utilization ?? 0) * 100);
+
+    const dailyResetsAt = data.five_hour?.resets_at ?? null;
+    const weeklyResetsAt = data.seven_day?.resets_at ?? null;
+
+    // Update module-level tracking variables
+    _latestDaily = dailyPercent;
+    _latestWeekly = weeklyPercent;
+
+    const previousZone = _lastZone;
+    const currentZone = getUsageZone();
+
+    // Store snapshot
+    const db = getDatabase();
+    db.insertUsageSnapshot({
+      dailyPercent,
+      weeklyPercent,
+      sonnetPercent,
+      extraPercent,
+      dailyResetsAt: dailyResetsAt ?? undefined,
+      weeklyResetsAt: weeklyResetsAt ?? undefined,
+      rawOutput,
+    });
+
+    // Broadcast via SSE
+    sseBroker.broadcast('usage_updated', {
+      daily_percent: dailyPercent,
+      weekly_percent: weeklyPercent,
+      sonnet_percent: sonnetPercent,
+      extra_percent: extraPercent,
+      zone: currentZone,
+    });
+
+    console.log(
+      `[UsagePoller] Snapshot recorded — daily=${dailyPercent}% weekly=${weeklyPercent}% sonnet=${sonnetPercent}% extra=${extraPercent}% zone=${currentZone}`,
+    );
+
+    // Zone transition: red -> green => trigger queue processing for all projects
+    if (previousZone === 'red' && currentZone === 'green') {
+      console.log('[UsagePoller] Zone transition: red -> green — draining queues');
+      try {
+        // Dynamically import to avoid circular dependency
+        const { getTeamManager } = await import('./team-manager.js');
+        const manager = getTeamManager();
+        const projects = db.getProjects({ status: 'active' });
+        for (const project of projects) {
+          const queued = db.getQueuedTeamsByProject(project.id);
+          if (queued.length > 0) {
+            manager.processQueue(project.id).catch((err: unknown) => {
+              console.error(`[UsagePoller] processQueue error for project ${project.id}:`, err);
+            });
+          }
+        }
+      } catch (err: unknown) {
+        console.error('[UsagePoller] Failed to drain queues on zone transition:', err);
       }
     }
 
-    // If at least one value was found via keywords, use them
-    if (result.daily > 0 || result.weekly > 0 || result.sonnet > 0 || result.extra > 0) {
-      return result;
-    }
-
-    // Strategy 2: Positional — grab all percentages in document order
-    const allPcts = output.match(/(\d+(?:\.\d+)?)\s*%/g);
-    if (allPcts && allPcts.length >= 2) {
-      const nums = allPcts.map((s) => parseFloat(s));
-      result.daily = nums[0] ?? 0;
-      result.weekly = nums[1] ?? 0;
-      result.sonnet = nums[2] ?? 0;
-      result.extra = nums[3] ?? 0;
-      return result;
-    }
-
-    // Could not parse — log for debugging
-    console.log(
-      '[UsagePoller] Could not parse usage output:',
-      output.substring(0, 500),
-    );
-    return null;
+    _lastZone = currentZone;
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,6 +24,9 @@ export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'dirty' |
 /** Project status */
 export type ProjectStatus = 'active' | 'paused' | 'archived';
 
+/** Usage zone for queue gating */
+export type UsageZone = 'green' | 'red';
+
 // ---------------------------------------------------------------------------
 // Core Entities (matching PRD section 4 schema)
 // ---------------------------------------------------------------------------
@@ -158,6 +161,8 @@ export interface UsageSnapshot {
   weeklyPercent: number;
   sonnetPercent: number;
   extraPercent: number;
+  dailyResetsAt: string | null;
+  weeklyResetsAt: string | null;
   rawOutput: string | null;
   recordedAt: string;
 }


### PR DESCRIPTION
## Summary
- Rewrites usage-tracker.ts from `claude -p "/usage"` to OAuth endpoint (`api.anthropic.com/api/oauth/usage`)
- Adds usage gate: red zone (daily≥85% OR weekly≥95%) blocks new team launches
- Adds `resets_at` timestamps to usage snapshots
- Adds `zone` and `redThresholds` to GET /api/usage response
- Adds `force` parameter to launch for PM override

## Test plan
- [ ] Usage poller logs real percentages on startup
- [ ] GET /api/usage returns zone and redThresholds
- [ ] Teams queue instead of launching when usage is high

🤖 Generated with [Claude Code](https://claude.com/claude-code)