### PR TITLE
fix: refresh lastEventAt in startup recovery to prevent immediate stuck detection

### DIFF
--- a/src/server/services/startup-recovery.ts
+++ b/src/server/services/startup-recovery.ts
@@ -46,7 +46,7 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: 'Server restart recovery: no PID recorded',
       });
-      db.updateTeam(team.id, { status: 'idle' });
+      db.updateTeam(team.id, { status: 'idle', lastEventAt: new Date().toISOString() });
       continue;
     }
 
@@ -73,7 +73,7 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: `Server restart recovery: process (PID ${team.pid}) no longer alive`,
       });
-      db.updateTeam(team.id, { status: newStatus, pid: null });
+      db.updateTeam(team.id, { status: newStatus, pid: null, lastEventAt: new Date().toISOString() });
     }
   }
 


### PR DESCRIPTION
Closes #52

## Problem
`startup-recovery.ts` marks dead-process teams as `idle` but doesn't refresh `lastEventAt`. The stale timestamp causes the stuck detector to immediately flag them as `stuck` on the next pass.

## Fix
Added `lastEventAt: new Date().toISOString()` to both `db.updateTeam()` calls in startup recovery:
- Line 49: no-PID recovery case
- Line 76: dead-process recovery case

This ensures recovered teams get a fresh timestamp so the stuck detector treats them as newly idle rather than immediately escalating to stuck.