### PR TITLE
fix: normalize SQLite timestamps to ISO 8601 UTC in all row mappers

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -29,6 +29,28 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // ---------------------------------------------------------------------------
+// UTC timestamp helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a SQLite datetime string to ISO 8601 UTC format.
+ *
+ * SQLite's `datetime('now')` produces `YYYY-MM-DD HH:MM:SS` which JS Date
+ * parses as *local* time. This helper appends 'T' and 'Z' so it is correctly
+ * interpreted as UTC. Already-valid ISO strings (containing 'T') pass through
+ * unchanged. Returns null unchanged for nullable columns.
+ */
+export function utcify(value: string): string;
+export function utcify(value: string | null): string | null;
+export function utcify(value: string | null): string | null {
+  if (value == null) return null;
+  // Already ISO 8601 (has 'T') — pass through unchanged
+  if (value.includes('T')) return value;
+  // SQLite format: "YYYY-MM-DD HH:MM:SS" -> "YYYY-MM-DDTHH:MM:SS.000Z"
+  return value.replace(' ', 'T') + '.000Z';
+}
+
+// ---------------------------------------------------------------------------
 // Filter / input types
 // ---------------------------------------------------------------------------
 
@@ -1034,7 +1056,7 @@ export class FleetDatabase {
       id: r.id,
       template: r.template,
       enabled: r.enabled === 1,
-      updatedAt: r.updated_at,
+      updatedAt: utcify(r.updated_at),
     }));
   }
 
@@ -1161,7 +1183,7 @@ export class FleetDatabase {
       worktreeName: r.worktree_name as string,
       status: r.status as TeamStatus,
       phase: r.phase as TeamPhase,
-      lastEventAt: r.last_event_at as string | null,
+      lastEventAt: utcify(r.last_event_at as string | null),
       minutesSinceLastEvent: r.minutes_since_last_event as number,
     }));
   }
@@ -1207,7 +1229,7 @@ export class FleetDatabase {
       toStatus: r.to_status,
       trigger: r.trigger,
       reason: r.reason,
-      createdAt: r.created_at,
+      createdAt: utcify(r.created_at),
     }));
   }
 
@@ -1301,8 +1323,8 @@ export class FleetDatabase {
       maxActiveTeams: (row.max_active_teams as number | undefined) ?? 5,
       promptFile: (row.prompt_file as string | null) ?? null,
       model: (row.model as string | null) ?? null,
-      createdAt: row.created_at as string,
-      updatedAt: row.updated_at as string,
+      createdAt: utcify(row.created_at as string),
+      updatedAt: utcify(row.updated_at as string),
     };
   }
 
@@ -1320,11 +1342,11 @@ export class FleetDatabase {
       branchName: row.branch_name as string | null,
       prNumber: row.pr_number as number | null,
       customPrompt: (row.custom_prompt as string | null) ?? null,
-      launchedAt: (row.launched_at as string | null) ?? null,
-      stoppedAt: row.stopped_at as string | null,
-      lastEventAt: row.last_event_at as string | null,
-      createdAt: row.created_at as string,
-      updatedAt: row.updated_at as string,
+      launchedAt: utcify(row.launched_at as string | null),
+      stoppedAt: utcify(row.stopped_at as string | null),
+      lastEventAt: utcify(row.last_event_at as string | null),
+      createdAt: utcify(row.created_at as string),
+      updatedAt: utcify(row.updated_at as string),
     };
   }
 
@@ -1337,7 +1359,7 @@ export class FleetDatabase {
       toolName: row.tool_name as string | null,
       agentName: row.agent_name as string | null,
       payload: row.payload as string | null,
-      createdAt: row.created_at as string,
+      createdAt: utcify(row.created_at as string),
     };
   }
 
@@ -1352,8 +1374,8 @@ export class FleetDatabase {
       ciFailCount: row.ci_fail_count as number,
       checksJson: row.checks_json as string | null,
       autoMerge: (row.auto_merge as number) === 1,
-      mergedAt: row.merged_at as string | null,
-      updatedAt: row.updated_at as string,
+      mergedAt: utcify(row.merged_at as string | null),
+      updatedAt: utcify(row.updated_at as string),
     };
   }
 
@@ -1364,8 +1386,8 @@ export class FleetDatabase {
       targetAgent: (row.target_agent as string | null) ?? null,
       message: row.message as string,
       status: (row.status as 'pending' | 'delivered' | 'failed') ?? 'pending',
-      createdAt: row.created_at as string,
-      deliveredAt: (row.delivered_at as string | null) ?? null,
+      createdAt: utcify(row.created_at as string),
+      deliveredAt: utcify((row.delivered_at as string | null) ?? null),
     };
   }
 
@@ -1379,10 +1401,10 @@ export class FleetDatabase {
       weeklyPercent: row.weekly_percent as number,
       sonnetPercent: row.sonnet_percent as number,
       extraPercent: row.extra_percent as number,
-      dailyResetsAt: (row.daily_resets_at as string | null) ?? null,
-      weeklyResetsAt: (row.weekly_resets_at as string | null) ?? null,
+      dailyResetsAt: utcify((row.daily_resets_at as string | null) ?? null),
+      weeklyResetsAt: utcify((row.weekly_resets_at as string | null) ?? null),
       rawOutput: row.raw_output as string | null,
-      recordedAt: row.recorded_at as string,
+      recordedAt: utcify(row.recorded_at as string),
     };
   }
 
@@ -1399,8 +1421,8 @@ export class FleetDatabase {
       worktreeName: row.worktree_name as string,
       branchName: (row.branch_name as string | null) ?? null,
       prNumber: row.pr_number as number | null,
-      launchedAt: (row.launched_at as string | null) ?? null,
-      lastEventAt: row.last_event_at as string | null,
+      launchedAt: utcify((row.launched_at as string | null) ?? null),
+      lastEventAt: utcify(row.last_event_at as string | null),
       durationMin: row.duration_min as number,
       idleMin: row.idle_min as number | null,
       totalCost: row.total_cost as number,

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { FleetDatabase } from '../../src/server/db.js';
+import { FleetDatabase, utcify } from '../../src/server/db.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -665,6 +665,120 @@ describe('getStuckCandidates', () => {
     expect(candidates[0].worktreeName).toBe('kea-200');
     expect(candidates[1].worktreeName).toBe('kea-300');
     expect(candidates[2].worktreeName).toBe('kea-100');
+  });
+});
+
+// =============================================================================
+// utcify helper
+// =============================================================================
+
+describe('utcify', () => {
+  it('converts SQLite datetime to ISO 8601 UTC', () => {
+    expect(utcify('2025-01-15 14:30:00')).toBe('2025-01-15T14:30:00.000Z');
+  });
+
+  it('passes through ISO 8601 strings unchanged', () => {
+    expect(utcify('2025-01-15T14:30:00.000Z')).toBe('2025-01-15T14:30:00.000Z');
+  });
+
+  it('passes through ISO 8601 without milliseconds unchanged', () => {
+    expect(utcify('2025-01-15T14:30:00Z')).toBe('2025-01-15T14:30:00Z');
+  });
+
+  it('returns null for null input', () => {
+    expect(utcify(null)).toBeNull();
+  });
+});
+
+// =============================================================================
+// Timestamp UTC normalization in row mappers
+// =============================================================================
+
+describe('Timestamp UTC normalization', () => {
+  it('team timestamps end with Z', () => {
+    const team = db.insertTeam({
+      issueNumber: 100,
+      worktreeName: 'utc-test-100',
+    });
+
+    expect(team.createdAt).toMatch(/T.*Z$/);
+    expect(team.updatedAt).toMatch(/T.*Z$/);
+  });
+
+  it('team nullable timestamps are normalized when present', () => {
+    db.insertTeam({ issueNumber: 101, worktreeName: 'utc-test-101' });
+    const updated = db.updateTeam(1, {
+      launchedAt: '2025-06-01 12:00:00',
+      lastEventAt: '2025-06-01 12:05:00',
+    });
+
+    expect(updated!.launchedAt).toBe('2025-06-01T12:00:00.000Z');
+    expect(updated!.lastEventAt).toBe('2025-06-01T12:05:00.000Z');
+  });
+
+  it('event timestamps end with Z', () => {
+    db.insertTeam({ issueNumber: 102, worktreeName: 'utc-test-102' });
+    const event = db.insertEvent({ teamId: 1, eventType: 'SessionStart' });
+
+    expect(event.createdAt).toMatch(/T.*Z$/);
+  });
+
+  it('command timestamps end with Z', () => {
+    db.insertTeam({ issueNumber: 103, worktreeName: 'utc-test-103' });
+    const cmd = db.insertCommand({ teamId: 1, message: 'test' });
+
+    expect(cmd.createdAt).toMatch(/T.*Z$/);
+  });
+
+  it('delivered command has normalized deliveredAt', () => {
+    db.insertTeam({ issueNumber: 104, worktreeName: 'utc-test-104' });
+    db.insertCommand({ teamId: 1, message: 'test' });
+    const delivered = db.markCommandDelivered(1);
+
+    expect(delivered!.deliveredAt).toMatch(/T.*Z$/);
+  });
+
+  it('pull request timestamps end with Z', () => {
+    db.insertTeam({ issueNumber: 105, worktreeName: 'utc-test-105' });
+    const pr = db.insertPullRequest({ prNumber: 999, teamId: 1, state: 'open' });
+
+    expect(pr.updatedAt).toMatch(/T.*Z$/);
+  });
+
+  it('usage snapshot timestamps end with Z', () => {
+    db.insertTeam({ issueNumber: 106, worktreeName: 'utc-test-106' });
+    const usage = db.insertUsageSnapshot({
+      teamId: 1,
+      dailyPercent: 50,
+    });
+
+    expect(usage.recordedAt).toMatch(/T.*Z$/);
+  });
+
+  it('project timestamps end with Z', () => {
+    const project = db.insertProject({
+      name: 'utc-test-proj',
+      repoPath: '/tmp/utc-test',
+    });
+
+    expect(project.createdAt).toMatch(/T.*Z$/);
+    expect(project.updatedAt).toMatch(/T.*Z$/);
+  });
+
+  it('dashboard row timestamps end with Z', () => {
+    db.insertTeam({
+      issueNumber: 107,
+      worktreeName: 'utc-test-107',
+      status: 'running',
+      phase: 'implementing',
+      launchedAt: '2025-06-01 12:00:00',
+    });
+    db.updateTeam(1, { lastEventAt: '2025-06-01 12:05:00' });
+
+    const rows = db.getTeamDashboard();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].launchedAt).toBe('2025-06-01T12:00:00.000Z');
+    expect(rows[0].lastEventAt).toBe('2025-06-01T12:05:00.000Z');
   });
 });
 


### PR DESCRIPTION
Closes #84

## Problem

SQLite `datetime('now')` stores timestamps as `YYYY-MM-DD HH:MM:SS` (UTC, no `Z` suffix). JavaScript `new Date()` interprets this format as local time, causing all displayed timestamps to be off by the timezone offset.

## Fix

Added an exported `utcify()` helper in `src/server/db.ts` that converts SQLite timestamps to ISO 8601 UTC format (`YYYY-MM-DDTHH:MM:SS.000Z`). The helper is idempotent (already-ISO strings pass through unchanged) and null-safe.

Applied `utcify()` to all 20 timestamp fields across 10 row mapper functions:
- `mapProjectRow`, `mapTeamRow`, `mapEventRow`, `mapPRRow`, `mapCommandRow`, `mapUsageRow`, `mapDashboardRow`
- `getTransitions()`, `getMessageTemplates()`, `getStuckCandidates()` inline mappers

## Tests

Added 13 new tests in `tests/server/db.test.ts`:
- 4 unit tests for `utcify()` (SQLite format, ISO passthrough, ISO without ms, null)
- 9 integration tests verifying timestamps end with `Z` across all entity types