### PR TITLE
fix: add missing zone field to SSEEventPayloads.usage_updated (#56)

### DIFF
--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -1,5 +1,6 @@
 import { FastifyReply } from 'fastify';
 import { randomUUID } from 'crypto';
+import type { UsageZone } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Stream Event — JSON objects from Claude Code's --output-format stream-json
@@ -39,7 +40,7 @@ export interface SSEEventPayloads {
   pr_updated: { pr_number: number; team_id: number; state?: string; ci_status?: string; merge_status?: string; auto_merge?: boolean; ci_fail_count?: number; action?: string };
   team_launched: { team_id: number; issue_number: number; project_id?: number | null };
   team_stopped: { team_id: number };
-  usage_updated: { daily_percent: number; weekly_percent: number; sonnet_percent: number; extra_percent: number };
+  usage_updated: { daily_percent: number; weekly_percent: number; sonnet_percent: number; extra_percent: number; zone: UsageZone };
   project_added: { project_id: number; name: string; repo_path: string };
   project_updated: { project_id: number; name: string; status: string };
   project_removed: { project_id: number };

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1722,6 +1722,7 @@ export class TeamManager {
                 weekly_percent: 0,
                 sonnet_percent: 0,
                 extra_percent: 0,
+                zone: getUsageZone(),
               }, teamId);
             }
 
@@ -1782,6 +1783,7 @@ export class TeamManager {
                 weekly_percent: 0,
                 sonnet_percent: 0,
                 extra_percent: 0,
+                zone: getUsageZone(),
               }, teamId);
             }
           } catch {


### PR DESCRIPTION
Closes #56

## Summary

- Added `zone: UsageZone` to the `usage_updated` entry in `SSEEventPayloads` interface (`sse-broker.ts`)
- Added missing `zone: getUsageZone()` to 2 `usage_updated` broadcast calls in `team-manager.ts`
- All 4 broadcast sites now consistently include the `zone` field

## Details

The `SSEEventPayloads` type defined `usage_updated` without a `zone` field, but 2 of 4 broadcast sites (in `usage-tracker.ts`) already included `zone: getUsageZone()`. The client reads this field. This fix adds the field to the type contract and ensures the remaining 2 broadcast sites (in `team-manager.ts`) also include it.

Purely additive change — no breaking changes.