### PR TITLE
Issue #43: Remove legacy total_cost from v_team_dashboard

### DIFF
--- a/src/client/components/FleetGrid.tsx
+++ b/src/client/components/FleetGrid.tsx
@@ -7,7 +7,7 @@ interface FleetGridProps {
   onSelectTeam: (id: number) => void;
 }
 
-const COLUMNS = ['Status', 'Issue', 'Model', 'Duration', 'Activity', 'Cost', 'PR', 'Actions'] as const;
+const COLUMNS = ['Status', 'Issue', 'Model', 'Duration', 'Activity', 'PR', 'Actions'] as const;
 
 export function FleetGrid({ teams, selectedTeamId, onSelectTeam }: FleetGridProps) {
   return (

--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -23,13 +23,6 @@ function truncate(str: string, maxLen: number): string {
   return str.slice(0, maxLen - 1) + '\u2026';
 }
 
-/** Format cost in USD */
-function formatCost(cost: number): string {
-  if (cost === 0) return '--';
-  if (cost < 0.01) return '<$0.01';
-  return `$${cost.toFixed(2)}`;
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -121,13 +114,6 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
       <td className="px-4 whitespace-nowrap">
         <span className={`text-sm ${activityColor}`} title={team.lastEventAt ?? undefined}>
           {activityLabel}
-        </span>
-      </td>
-
-      {/* Cost */}
-      <td className="px-4 whitespace-nowrap">
-        <span className="text-sm text-dark-muted" title={team.totalCost > 0 ? `$${team.totalCost.toFixed(4)} (${team.sessionCount} session${team.sessionCount !== 1 ? 's' : ''})` : undefined}>
-          {formatCost(team.totalCost)}
         </span>
       </td>
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1425,8 +1425,6 @@ export class FleetDatabase {
       lastEventAt: utcify(row.last_event_at as string | null),
       durationMin: row.duration_min as number,
       idleMin: row.idle_min as number | null,
-      totalCost: row.total_cost as number,
-      sessionCount: row.session_count as number,
       prState: (row.pr_state as PRState | null) ?? null,
       ciStatus: (row.ci_status as CIStatus | null) ?? null,
       mergeStatus: row.merge_status as MergeStatus | null,

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -126,8 +126,6 @@ SELECT
   t.last_event_at,
   ROUND((julianday('now') - julianday(t.launched_at)) * 24 * 60, 0) AS duration_min,
   ROUND((julianday('now') - julianday(t.last_event_at)) * 24 * 60, 1) AS idle_min,
-  COALESCE(u.total_cost, 0) AS total_cost,
-  COALESCE(u.session_count, 0) AS session_count,
   pr.state AS pr_state,
   pr.ci_status,
   pr.merge_state AS merge_status,
@@ -135,16 +133,7 @@ SELECT
   t.updated_at
 FROM teams t
 LEFT JOIN projects p ON p.id = t.project_id
-LEFT JOIN pull_requests pr ON pr.team_id = t.id
-LEFT JOIN (
-  SELECT
-    team_id,
-    ROUND(SUM(COALESCE(json_extract(raw_output, '$.total_cost_usd'), 0)), 4) AS total_cost,
-    COUNT(*) AS session_count
-  FROM usage_snapshots
-  WHERE raw_output IS NOT NULL AND json_extract(raw_output, '$.total_cost_usd') IS NOT NULL
-  GROUP BY team_id
-) u ON u.team_id = t.id;
+LEFT JOIN pull_requests pr ON pr.team_id = t.id;
 
 -- ---------------------------------------------------------------------------
 -- USAGE SNAPSHOTS — usage percentage tracking (replaces cost tracking)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,8 +225,6 @@ export interface TeamDashboardRow {
   lastEventAt: string | null;
   durationMin: number;
   idleMin: number | null;
-  totalCost: number;
-  sessionCount: number;
   prState: PRState | null;
   ciStatus: CIStatus | null;
   mergeStatus: MergeStatus | null;

--- a/tests/client/TopBar.test.tsx
+++ b/tests/client/TopBar.test.tsx
@@ -41,11 +41,6 @@ describe('TopBar', () => {
     expect(screen.getByText('Fleet Commander')).toBeInTheDocument();
   });
 
-  it('shows total cost of $0.00 when there are no teams', () => {
-    render(<TopBar />);
-    expect(screen.getByText('$0.00')).toBeInTheDocument();
-  });
-
   it('shows correct count pills for running teams', () => {
     mockTeams = [
       makeTeam({ id: 1, status: 'running' }),
@@ -83,22 +78,4 @@ describe('TopBar', () => {
     expect(screen.queryByText(/Done/)).not.toBeInTheDocument();
   });
 
-  it('calculates and displays total cost across all teams', () => {
-    mockTeams = [
-      makeTeam({ id: 1, totalCost: 1.25 }),
-      makeTeam({ id: 2, totalCost: 3.75 }),
-      makeTeam({ id: 3, totalCost: 0.50 }),
-    ];
-    render(<TopBar />);
-    expect(screen.getByText('$5.50')).toBeInTheDocument();
-  });
-
-  it('handles teams with no totalCost gracefully', () => {
-    mockTeams = [
-      makeTeam({ id: 1, totalCost: 2.00 }),
-      makeTeam({ id: 2, totalCost: 0 }),
-    ];
-    render(<TopBar />);
-    expect(screen.getByText('$2.00')).toBeInTheDocument();
-  });
 });

--- a/tests/client/test-utils.tsx
+++ b/tests/client/test-utils.tsx
@@ -45,8 +45,6 @@ export function makeTeam(overrides: Partial<TeamDashboardRow> = {}): TeamDashboa
     lastEventAt: '2025-01-01T00:05:00Z',
     durationMin: 5,
     idleMin: 0,
-    totalCost: 0.50,
-    sessionCount: 1,
     prState: null,
     ciStatus: null,
     mergeStatus: null,

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -528,8 +528,6 @@ describe('v_team_dashboard view', () => {
     expect(row.worktreeName).toBe('kea-100');
     expect(row.status).toBe('running');
     expect(row.phase).toBe('implementing');
-    expect(row.totalCost).toBe(0);
-    expect(row.sessionCount).toBe(0);
   });
 
   it('includes PR info when associated', () => {
@@ -565,7 +563,6 @@ describe('v_team_dashboard view', () => {
 
     const rows = db.getTeamDashboard();
     expect(rows).toHaveLength(1);
-    expect(rows[0].totalCost).toBe(0);
     expect(rows[0].prState).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #43

## Summary
Remove all traces of the dead `total_cost` / `session_count` cost computation from the codebase. Under OAuth usage, `usage_snapshots.raw_output` never contains cost data, so the Cost column in the dashboard permanently shows "--".

## Changes (8 files, net -57 lines)
- **schema.sql** — Remove `total_cost`/`session_count` columns and LEFT JOIN subquery from `v_team_dashboard`
- **types.ts** — Remove `totalCost`/`sessionCount` from `TeamDashboardRow` interface
- **db.ts** — Remove `totalCost`/`sessionCount` mapping from `mapDashboardRow()`
- **TeamRow.tsx** — Remove `formatCost()` helper and Cost `<td>` column
- **FleetGrid.tsx** — Remove `'Cost'` from `COLUMNS` array
- **db.test.ts** — Remove `totalCost`/`sessionCount` assertions
- **test-utils.tsx** — Remove `totalCost`/`sessionCount` from `makeTeam()` factory
- **TopBar.test.tsx** — Remove 3 stale cost-related test cases

## Notes
- `team-manager.ts` intentionally untouched — it writes `total_cost_usd` to `usage_snapshots.raw_output` for usage tracking (unrelated to the removed view column)
- View uses `DROP VIEW IF EXISTS` so it recreates cleanly on restart — no migration needed