### PR TITLE
Issue #49: add missing insertTransition calls in queueTeam()

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1112,6 +1112,13 @@ export class TeamManager {
         stoppedAt: null,
         lastEventAt: null,
       });
+      db.insertTransition({
+        teamId: existing.id,
+        fromStatus: existing.status,
+        toStatus: 'queued',
+        trigger: 'pm_action',
+        reason: 'Re-queued by PM (queue path)',
+      });
       const team = db.getTeam(existing.id)!;
       const activeCount = db.getActiveTeamCountByProject(projectId);
       console.log(`[TeamManager] Team ${team.id} queued (${activeCount}/${project.maxActiveTeams} active)`);
@@ -1131,6 +1138,13 @@ export class TeamManager {
       phase: 'init',
       customPrompt: prompt ?? null,
       launchedAt: now,
+    });
+    db.insertTransition({
+      teamId: team.id,
+      fromStatus: 'none',
+      toStatus: 'queued',
+      trigger: 'pm_action',
+      reason: 'Team created and queued',
     });
 
     const activeCount = db.getActiveTeamCountByProject(projectId);


### PR DESCRIPTION
Closes #49

## Problem
`queueTeam()` creates/reuses teams with status `queued` but never calls `db.insertTransition()`, violating CLAUDE.md rule 13. Transition history shows gaps for teams that go through the queue path.

## Fix
Added two `db.insertTransition()` calls in `src/server/services/team-manager.ts`:

1. **Reuse path:** When an existing terminal team (done/failed) is reset to `queued`, records `fromStatus: existing.status` -> `toStatus: 'queued'` with trigger `pm_action`.
2. **Fresh insert path:** After `db.insertTeam()`, records `fromStatus: 'none'` -> `toStatus: 'queued'` with trigger `pm_action`.

Both follow the exact same pattern used in `launchTeam()`. Trigger values match `state-machine.ts` definitions.