### PR TITLE
Issue #66: fix UsagePoller._lastZone ignoring DB state on restart

### DIFF
--- a/src/server/services/usage-tracker.ts
+++ b/src/server/services/usage-tracker.ts
@@ -121,6 +121,28 @@ class UsagePoller {
   start(intervalMs?: number): void {
     const ms = intervalMs ?? config.usagePollIntervalMs;
 
+    // Seed zone state from the last DB snapshot so that zone transitions
+    // (especially red -> green) are correctly detected on the first poll
+    // after a server restart.  Without this, _lastZone defaults to 'green'
+    // and a red->green recovery would never trigger processQueue.
+    try {
+      const db = getDatabase();
+      const latest = db.getLatestUsage();
+      if (latest) {
+        _latestDaily = latest.dailyPercent;
+        _latestWeekly = latest.weeklyPercent;
+        _lastZone = getUsageZone();
+        console.log(
+          `[UsagePoller] Seeded from DB — daily=${_latestDaily}% weekly=${_latestWeekly}% zone=${_lastZone}`,
+        );
+      }
+    } catch (err: unknown) {
+      console.warn(
+        '[UsagePoller] Could not seed from DB, using defaults:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+
     // Poll immediately on start
     this.poll();
 

--- a/tests/server/usage-tracker.test.ts
+++ b/tests/server/usage-tracker.test.ts
@@ -1,0 +1,164 @@
+// =============================================================================
+// Fleet Commander — UsagePoller.start() DB seeding tests (issue #66)
+// =============================================================================
+// Verifies that _lastZone, _latestDaily, and _latestWeekly are hydrated from
+// the latest usage_snapshots DB row on startup, so that zone transitions
+// (especially red -> green) are correctly detected after a server restart.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockGetLatestUsage = vi.fn();
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => ({
+    getLatestUsage: mockGetLatestUsage,
+    insertUsageSnapshot: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    usagePollIntervalMs: 120_000,
+    usageRedDailyPct: 85,
+    usageRedWeeklyPct: 95,
+  },
+}));
+
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: {
+    broadcast: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { usagePoller, getUsageZone } from '../../src/server/services/usage-tracker.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UsagePoller.start() — DB seeding of zone state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Stop any running interval from a previous test
+    usagePoller.stop();
+  });
+
+  it('seeds _lastZone to red when the latest DB snapshot exceeds the daily threshold', () => {
+    mockGetLatestUsage.mockReturnValue({
+      id: 1,
+      teamId: null,
+      projectId: null,
+      sessionId: null,
+      dailyPercent: 90,
+      weeklyPercent: 50,
+      sonnetPercent: 0,
+      extraPercent: 0,
+      dailyResetsAt: null,
+      weeklyResetsAt: null,
+      rawOutput: null,
+      recordedAt: '2026-03-18T00:00:00Z',
+    });
+
+    // Stub poll() to prevent actual HTTP calls
+    const pollSpy = vi.spyOn(usagePoller, 'poll').mockImplementation(() => {});
+
+    usagePoller.start();
+
+    expect(mockGetLatestUsage).toHaveBeenCalledTimes(1);
+    expect(getUsageZone()).toBe('red');
+
+    usagePoller.stop();
+    pollSpy.mockRestore();
+  });
+
+  it('seeds _lastZone to red when the latest DB snapshot exceeds the weekly threshold', () => {
+    mockGetLatestUsage.mockReturnValue({
+      id: 2,
+      teamId: null,
+      projectId: null,
+      sessionId: null,
+      dailyPercent: 10,
+      weeklyPercent: 96,
+      sonnetPercent: 0,
+      extraPercent: 0,
+      dailyResetsAt: null,
+      weeklyResetsAt: null,
+      rawOutput: null,
+      recordedAt: '2026-03-18T00:00:00Z',
+    });
+
+    const pollSpy = vi.spyOn(usagePoller, 'poll').mockImplementation(() => {});
+
+    usagePoller.start();
+
+    expect(getUsageZone()).toBe('red');
+
+    usagePoller.stop();
+    pollSpy.mockRestore();
+  });
+
+  it('seeds _lastZone to green when the latest DB snapshot is below thresholds', () => {
+    mockGetLatestUsage.mockReturnValue({
+      id: 3,
+      teamId: null,
+      projectId: null,
+      sessionId: null,
+      dailyPercent: 40,
+      weeklyPercent: 60,
+      sonnetPercent: 0,
+      extraPercent: 0,
+      dailyResetsAt: null,
+      weeklyResetsAt: null,
+      rawOutput: null,
+      recordedAt: '2026-03-18T00:00:00Z',
+    });
+
+    const pollSpy = vi.spyOn(usagePoller, 'poll').mockImplementation(() => {});
+
+    usagePoller.start();
+
+    expect(getUsageZone()).toBe('green');
+
+    usagePoller.stop();
+    pollSpy.mockRestore();
+  });
+
+  it('keeps defaults (green) when no usage snapshots exist in DB', () => {
+    mockGetLatestUsage.mockReturnValue(undefined);
+
+    const pollSpy = vi.spyOn(usagePoller, 'poll').mockImplementation(() => {});
+
+    usagePoller.start();
+
+    expect(mockGetLatestUsage).toHaveBeenCalledTimes(1);
+    expect(getUsageZone()).toBe('green');
+
+    usagePoller.stop();
+    pollSpy.mockRestore();
+  });
+
+  it('keeps defaults (green) when getLatestUsage throws', () => {
+    mockGetLatestUsage.mockImplementation(() => {
+      throw new Error('DB locked');
+    });
+
+    const pollSpy = vi.spyOn(usagePoller, 'poll').mockImplementation(() => {});
+
+    // Should not throw — error is caught and logged
+    expect(() => usagePoller.start()).not.toThrow();
+
+    expect(getUsageZone()).toBe('green');
+
+    usagePoller.stop();
+    pollSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #66

## Problem
`_lastZone` is hardcoded to `green` at init. After a server restart where usage was in the red zone but recovered, the `red→green` transition is never detected, `processQueue` is never called, and queued teams stay blocked forever.

## Fix
Seed `_lastZone`, `_latestDaily`, and `_latestWeekly` from the latest DB usage snapshot in `UsagePoller.start()`, before the first `poll()` call. This ensures zone state survives a server restart and the red→green transition is correctly detected to unblock queued teams.

## Changes
- `src/server/services/usage-tracker.ts` — added 22-line seeding block in `start()` that reads the latest usage snapshot from DB via `db.getLatestUsage()`

## Test plan
- 5 new tests covering: daily threshold exceeded, weekly threshold exceeded, below thresholds, no DB data (fresh install), and DB error (graceful degradation)
- All existing tests pass, clean build