### PR TITLE
Issue #92: add dynamic usage bar colors based on configurable red thresholds

### DIFF
--- a/src/client/components/TopBar.tsx
+++ b/src/client/components/TopBar.tsx
@@ -5,36 +5,36 @@ import { LaunchDialog } from './LaunchDialog';
 import { ProjectSelector } from './ProjectSelector';
 import { useApi } from '../hooks/useApi';
 import { RocketIcon } from './Icons';
-import { STATUS_COLORS } from '../utils/constants';
+import { STATUS_COLORS, getUsageColor } from '../utils/constants';
+import type { UsageZone } from '../../shared/types';
 
-/** Get usage text color: green under 50%, yellow 50-80%, red over 80% */
-function getUsageColor(percent: number): string {
-  if (percent > 80) return '#F85149';
-  if (percent >= 50) return '#D29922';
-  return '#3FB950';
+interface RedThresholds {
+  daily: number;
+  weekly: number;
+  sonnet: number;
+  extra: number;
 }
 
-/** Check if any usage category is in red zone (>80%) */
-function isUsageRedZone(data: UsageData): boolean {
-  return Math.max(data.dailyPercent, data.weeklyPercent, data.sonnetPercent, data.extraPercent) > 80;
-}
+const DEFAULT_RED_THRESHOLDS: RedThresholds = { daily: 85, weekly: 95, sonnet: 95, extra: 95 };
 
-interface UsageData {
+interface UsageResponse {
   dailyPercent: number;
   weeklyPercent: number;
   sonnetPercent: number;
   extraPercent: number;
+  zone?: UsageZone;
+  redThresholds?: RedThresholds;
 }
 
 export function TopBar() {
   const { teams } = useFleet();
   const api = useApi();
   const [launchOpen, setLaunchOpen] = useState(false);
-  const [usage, setUsage] = useState<UsageData | null>(null);
+  const [usage, setUsage] = useState<UsageResponse | null>(null);
 
   const fetchUsage = useCallback(async () => {
     try {
-      const data = await api.get<UsageData>('usage');
+      const data = await api.get<UsageResponse>('usage');
       setUsage(data);
     } catch {
       // Silently ignore — pill will just not show
@@ -53,13 +53,15 @@ export function TopBar() {
     return acc;
   }, {} as Record<string, number>);
 
+  const thresholds = usage?.redThresholds ?? DEFAULT_RED_THRESHOLDS;
+
   // Build usage indicators with full names
   const usageIndicators = usage
     ? [
-        { key: 'daily', label: 'Daily', percent: usage.dailyPercent },
-        { key: 'weekly', label: 'Weekly', percent: usage.weeklyPercent },
-        { key: 'sonnet', label: 'Sonnet', percent: usage.sonnetPercent },
-        { key: 'extra', label: 'Extra', percent: usage.extraPercent },
+        { key: 'daily', label: 'Daily', percent: usage.dailyPercent, redThreshold: thresholds.daily },
+        { key: 'weekly', label: 'Weekly', percent: usage.weeklyPercent, redThreshold: thresholds.weekly },
+        { key: 'sonnet', label: 'Sonnet', percent: usage.sonnetPercent, redThreshold: thresholds.sonnet },
+        { key: 'extra', label: 'Extra', percent: usage.extraPercent, redThreshold: thresholds.extra },
       ]
     : [];
 
@@ -71,6 +73,9 @@ export function TopBar() {
     { label: 'idle', count: counts.idle || 0, color: STATUS_COLORS.idle },
     { label: 'stuck', count: counts.stuck || 0, color: STATUS_COLORS.stuck },
   ].filter(s => s.count > 0);
+
+  // Use server-provided zone instead of computing locally
+  const isRedZone = usage?.zone === 'red';
 
   return (
     <>
@@ -100,12 +105,12 @@ export function TopBar() {
           {usageIndicators.map(ind => (
             <span key={ind.key} className="text-xs font-medium">
               <span className="text-dark-muted">{ind.label}</span>{' '}
-              <span style={{ color: getUsageColor(ind.percent) }}>{ind.percent.toFixed(0)}%</span>
+              <span style={{ color: getUsageColor(ind.percent, ind.redThreshold) }}>{ind.percent.toFixed(0)}%</span>
             </span>
           ))}
 
           {/* PAUSED badge when usage is in red zone */}
-          {usage && isUsageRedZone(usage) && (
+          {isRedZone && (
             <span className="text-xs font-bold animate-pulse" style={{ color: '#F85149' }}>
               PAUSED
             </span>

--- a/src/client/utils/constants.ts
+++ b/src/client/utils/constants.ts
@@ -9,3 +9,12 @@ export const STATUS_COLORS: Record<TeamStatus, string> = {
   done: '#A371F7',
   failed: '#F85149',
 };
+
+/** Get usage bar color based on a configurable red threshold.
+ *  Yellow starts 10pp below the red threshold. */
+export function getUsageColor(percent: number, redThreshold: number): string {
+  const yellowStart = Math.max(0, redThreshold - 10);
+  if (percent >= redThreshold) return '#F85149';
+  if (percent >= yellowStart) return '#D29922';
+  return '#3FB950';
+}

--- a/src/client/views/UsageViewPage.tsx
+++ b/src/client/views/UsageViewPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApi } from '../hooks/useApi';
+import { getUsageColor } from '../utils/constants';
 import type { UsageSnapshot } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -8,29 +9,31 @@ import type { UsageSnapshot } from '../../shared/types';
 
 const REFRESH_INTERVAL_MS = 30_000; // 30 seconds
 
+interface RedThresholds {
+  daily: number;
+  weekly: number;
+  sonnet: number;
+  extra: number;
+}
+
+const DEFAULT_RED_THRESHOLDS: RedThresholds = { daily: 85, weekly: 95, sonnet: 95, extra: 95 };
+
 interface UsageBar {
   label: string;
   key: 'dailyPercent' | 'weeklyPercent' | 'sonnetPercent' | 'extraPercent';
-  baseColor: string;
+  thresholdKey: keyof RedThresholds;
 }
 
 const USAGE_BARS: UsageBar[] = [
-  { label: 'Daily Usage', key: 'dailyPercent', baseColor: '#58A6FF' },
-  { label: 'Weekly Usage', key: 'weeklyPercent', baseColor: '#3FB950' },
-  { label: 'Sonnet Usage', key: 'sonnetPercent', baseColor: '#A371F7' },
-  { label: 'Extra Usage', key: 'extraPercent', baseColor: '#D29922' },
+  { label: 'Daily Usage', key: 'dailyPercent', thresholdKey: 'daily' },
+  { label: 'Weekly Usage', key: 'weeklyPercent', thresholdKey: 'weekly' },
+  { label: 'Sonnet Usage', key: 'sonnetPercent', thresholdKey: 'sonnet' },
+  { label: 'Extra Usage', key: 'extraPercent', thresholdKey: 'extra' },
 ];
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Get color based on usage threshold */
-function getBarColor(percent: number, baseColor: string): string {
-  if (percent > 80) return '#F85149';
-  if (percent >= 50) return '#D29922';
-  return baseColor;
-}
 
 /** Format a date string for display */
 function formatTimestamp(dateStr: string): string {
@@ -44,8 +47,12 @@ function formatTimestamp(dateStr: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// HistoryResponse type
+// Response types
 // ---------------------------------------------------------------------------
+
+interface UsageResponse extends UsageSnapshot {
+  redThresholds?: RedThresholds;
+}
 
 interface UsageHistoryResponse {
   count: number;
@@ -59,6 +66,7 @@ interface UsageHistoryResponse {
 export function UsageViewPage() {
   const api = useApi();
   const [usage, setUsage] = useState<UsageSnapshot | null>(null);
+  const [redThresholds, setRedThresholds] = useState<RedThresholds>(DEFAULT_RED_THRESHOLDS);
   const [history, setHistory] = useState<UsageSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -66,10 +74,13 @@ export function UsageViewPage() {
   const fetchUsage = useCallback(async () => {
     try {
       const [latest, historyData] = await Promise.all([
-        api.get<UsageSnapshot>('usage'),
+        api.get<UsageResponse>('usage'),
         api.get<UsageHistoryResponse>('usage/history?limit=10'),
       ]);
       setUsage(latest);
+      if (latest.redThresholds) {
+        setRedThresholds(latest.redThresholds);
+      }
       setHistory(historyData.snapshots);
       setError(null);
     } catch (err) {
@@ -108,7 +119,7 @@ export function UsageViewPage() {
           <div className="flex flex-col gap-4">
             {USAGE_BARS.map((bar) => {
               const percent = usage[bar.key] ?? 0;
-              const color = getBarColor(percent, bar.baseColor);
+              const color = getUsageColor(percent, redThresholds[bar.thresholdKey]);
               const clampedPercent = Math.min(Math.max(percent, 0), 100);
 
               return (
@@ -192,19 +203,19 @@ export function UsageViewPage() {
                         {snap.recordedAt ? formatTimestamp(snap.recordedAt) : '--'}
                       </td>
                       <td className="px-4 whitespace-nowrap text-sm text-right tabular-nums"
-                        style={{ color: getBarColor(snap.dailyPercent, '#58A6FF') }}>
+                        style={{ color: getUsageColor(snap.dailyPercent, redThresholds.daily) }}>
                         {snap.dailyPercent.toFixed(1)}%
                       </td>
                       <td className="px-4 whitespace-nowrap text-sm text-right tabular-nums"
-                        style={{ color: getBarColor(snap.weeklyPercent, '#3FB950') }}>
+                        style={{ color: getUsageColor(snap.weeklyPercent, redThresholds.weekly) }}>
                         {snap.weeklyPercent.toFixed(1)}%
                       </td>
                       <td className="px-4 whitespace-nowrap text-sm text-right tabular-nums"
-                        style={{ color: getBarColor(snap.sonnetPercent, '#A371F7') }}>
+                        style={{ color: getUsageColor(snap.sonnetPercent, redThresholds.sonnet) }}>
                         {snap.sonnetPercent.toFixed(1)}%
                       </td>
                       <td className="px-4 whitespace-nowrap text-sm text-right tabular-nums"
-                        style={{ color: getBarColor(snap.extraPercent, '#D29922') }}>
+                        style={{ color: getUsageColor(snap.extraPercent, redThresholds.extra) }}>
                         {snap.extraPercent.toFixed(1)}%
                       </td>
                     </tr>

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -37,6 +37,8 @@ const config = Object.freeze({
 
   usageRedDailyPct: safeParseInt(process.env['FLEET_USAGE_RED_DAILY_PCT'] || '85', 'FLEET_USAGE_RED_DAILY_PCT'),
   usageRedWeeklyPct: safeParseInt(process.env['FLEET_USAGE_RED_WEEKLY_PCT'] || '95', 'FLEET_USAGE_RED_WEEKLY_PCT'),
+  usageRedSonnetPct: safeParseInt(process.env['FLEET_USAGE_RED_SONNET_PCT'] || '95', 'FLEET_USAGE_RED_SONNET_PCT'),
+  usageRedExtraPct: safeParseInt(process.env['FLEET_USAGE_RED_EXTRA_PCT'] || '95', 'FLEET_USAGE_RED_EXTRA_PCT'),
 
   claudeCmd: process.env['FLEET_CLAUDE_CMD'] || 'claude',
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',

--- a/src/server/routes/usage.ts
+++ b/src/server/routes/usage.ts
@@ -42,14 +42,14 @@ const usageRoutes: FastifyPluginCallback = (
             extraPercent: 0,
             recordedAt: null,
             zone: getUsageZone(),
-            redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct },
+            redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct, sonnet: config.usageRedSonnetPct, extra: config.usageRedExtraPct },
           });
         }
 
         return reply.code(200).send({
           ...latest,
           zone: getUsageZone(),
-          redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct },
+          redThresholds: { daily: config.usageRedDailyPct, weekly: config.usageRedWeeklyPct, sonnet: config.usageRedSonnetPct, extra: config.usageRedExtraPct },
         });
       } catch (err: unknown) {
         _request.log.error(err, 'Failed to get latest usage');


### PR DESCRIPTION
Closes #92

## Summary
- Add `FLEET_USAGE_RED_SONNET_PCT` and `FLEET_USAGE_RED_EXTRA_PCT` env vars to server config (defaults: 95)
- Expand `GET /api/usage` response to include all 4 red thresholds (`daily`, `weekly`, `sonnet`, `extra`)
- Add shared `getUsageColor(percent, redThreshold)` helper with 3-tier color logic: green below (threshold-10), yellow in 10% band, red at/above threshold
- Replace hardcoded color functions in both `UsageViewPage.tsx` and `TopBar.tsx` with the shared helper
- TopBar now uses server-provided `zone` field instead of local hardcoded threshold computation