### PR TITLE
Issue #64: fix prompt editor modal Escape key not working

### DIFF
--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -203,6 +203,18 @@ export function ProjectsPage() {
       });
   }, [editingPromptId, api]);
 
+  // Close prompt editor on Escape key (document-level listener)
+  useEffect(() => {
+    if (editingPromptId === null) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setEditingPromptId(null);
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [editingPromptId]);
+
   const handleSavePrompt = useCallback(async () => {
     if (editingPromptId === null) return;
     setPromptSaving(true);


### PR DESCRIPTION
Closes #64

## Summary
- Added a `useEffect` with a document-level `keydown` listener to the prompt editor modal in `ProjectsPage.tsx`
- When the modal is open and the user presses Escape, the modal closes
- Matches the exact pattern used by all other dialogs in the codebase (AddProjectDialog, LaunchDialog, CleanupModal, TeamDetail, PRDetail)

## Changed file
- `src/client/views/ProjectsPage.tsx` — new useEffect block (lines 207-216)