### PR TITLE
Issue #124: add CCQuery service with typed structured queries to Claude Code

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -53,6 +53,9 @@ const config = Object.freeze({
   // FC's own hooks/ directory (source for copying into project worktrees)
   fcHooksDir: path.join(fleetCommanderRoot, 'hooks'),
 
+  ccQueryModel: process.env['FLEET_CC_QUERY_MODEL'] || 'sonnet',
+  ccQueryTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_TIMEOUT_MS'] || '30000', 'FLEET_CC_QUERY_TIMEOUT_MS'),
+
   outputBufferLines: 500,
   sseHeartbeatMs: 30000,
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,7 @@ import usageRoutes from './routes/usage.js';
 import prsRoutes from './routes/prs.js';
 import projectsRoutes from './routes/projects.js';
 import stateMachineRoutes from './routes/state-machine.js';
+import queryRoutes from './routes/query.js';
 import { sseBroker } from './services/sse-broker.js';
 import { getIssueFetcher } from './services/issue-fetcher.js';
 import { stuckDetector } from './services/stuck-detector.js';
@@ -52,6 +53,7 @@ async function main() {
   await server.register(prsRoutes);
   await server.register(projectsRoutes);
   await server.register(stateMachineRoutes);
+  await server.register(queryRoutes);
 
   // Static file serving for production builds
   const clientDistPath = path.resolve(__dirname, '..', 'client');

--- a/src/server/routes/query.ts
+++ b/src/server/routes/query.ts
@@ -1,0 +1,103 @@
+// =============================================================================
+// Fleet Commander — Query Routes (CC Query Service)
+// =============================================================================
+// Fastify plugin exposing predefined CC structured queries via REST API.
+// =============================================================================
+
+import type {
+  FastifyInstance,
+  FastifyPluginCallback,
+  FastifyRequest,
+  FastifyReply,
+} from 'fastify';
+import { CCQueryService } from '../services/cc-query.js';
+
+const VALID_QUERY_NAMES = ['prioritizeIssues', 'estimateComplexity', 'suggestAssignmentOrder'] as const;
+type QueryName = (typeof VALID_QUERY_NAMES)[number];
+
+function isValidQueryName(name: string): name is QueryName {
+  return (VALID_QUERY_NAMES as readonly string[]).includes(name);
+}
+
+const queryRoutes: FastifyPluginCallback = (
+  fastify: FastifyInstance,
+  _opts: Record<string, unknown>,
+  done: (err?: Error) => void,
+) => {
+  // POST /api/query/:queryName
+  fastify.post(
+    '/api/query/:queryName',
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { queryName } = request.params as { queryName: string };
+
+      if (!isValidQueryName(queryName)) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: `Unknown query "${queryName}". Valid queries: ${VALID_QUERY_NAMES.join(', ')}`,
+        });
+      }
+
+      const body = request.body as Record<string, unknown> | null;
+      if (!body) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'Request body is required',
+        });
+      }
+
+      const service = CCQueryService.getInstance();
+
+      try {
+        switch (queryName) {
+          case 'prioritizeIssues': {
+            const issues = body.issues as { number: number; title: string }[];
+            if (!Array.isArray(issues)) {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                message: 'Field "issues" must be an array of { number, title }',
+              });
+            }
+            const result = await service.prioritizeIssues(issues);
+            return reply.code(200).send(result);
+          }
+
+          case 'estimateComplexity': {
+            const issueTitle = body.issueTitle as string;
+            const issueBody = body.issueBody as string;
+            if (typeof issueTitle !== 'string' || typeof issueBody !== 'string') {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                message: 'Fields "issueTitle" and "issueBody" are required strings',
+              });
+            }
+            const result = await service.estimateComplexity(issueTitle, issueBody);
+            return reply.code(200).send(result);
+          }
+
+          case 'suggestAssignmentOrder': {
+            const issues = body.issues as { number: number; title: string; labels: string[] }[];
+            const constraints = body.constraints as { maxConcurrent: number; preferredOrder?: 'priority' | 'complexity' | 'fifo' };
+            if (!Array.isArray(issues) || !constraints || typeof constraints.maxConcurrent !== 'number') {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                message: 'Fields "issues" (array) and "constraints" ({ maxConcurrent: number }) are required',
+              });
+            }
+            const result = await service.suggestAssignmentOrder(issues, constraints);
+            return reply.code(200).send(result);
+          }
+        }
+      } catch (err: unknown) {
+        request.log.error(err, `CC query "${queryName}" failed`);
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  done();
+};
+
+export default queryRoutes;

--- a/src/server/services/cc-query.ts
+++ b/src/server/services/cc-query.ts
@@ -1,0 +1,333 @@
+// =============================================================================
+// Fleet Commander — CC Query Service
+// =============================================================================
+// Spawns Claude Code in -p mode for quick, ad-hoc structured queries.
+// All queries are predefined as typed methods — no freeform prompting.
+// Uses a concurrency queue (max 1 at a time) to avoid overloading CC.
+// =============================================================================
+
+import { spawn } from 'child_process';
+import config from '../config.js';
+import { resolveClaudePath } from '../utils/resolve-claude-path.js';
+import type {
+  CCQueryResult,
+  PrioritizedIssue,
+  ComplexityEstimate,
+  IssueSummary,
+  QueueConstraints,
+  AssignmentPlan,
+} from '../../shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface ExecuteOptions<T> {
+  prompt: string;
+  jsonSchema: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// CCQueryService (singleton)
+// ---------------------------------------------------------------------------
+
+export class CCQueryService {
+  private static _instance: CCQueryService | null = null;
+  private _queue: Array<{ run: () => void }> = [];
+  private _running = false;
+
+  private constructor() {}
+
+  static getInstance(): CCQueryService {
+    if (!CCQueryService._instance) {
+      CCQueryService._instance = new CCQueryService();
+    }
+    return CCQueryService._instance;
+  }
+
+  // -------------------------------------------------------------------------
+  // Concurrency queue — max 1 concurrent query
+  // -------------------------------------------------------------------------
+
+  private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        fn().then(resolve, reject).finally(() => {
+          this._running = false;
+          this.dequeue();
+        });
+      };
+
+      if (!this._running) {
+        this._running = true;
+        run();
+      } else {
+        this._queue.push({ run });
+      }
+    });
+  }
+
+  private dequeue(): void {
+    const next = this._queue.shift();
+    if (next) {
+      this._running = true;
+      next.run();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private execute method — spawns CC in -p mode
+  // -------------------------------------------------------------------------
+
+  private execute<T>(opts: ExecuteOptions<T>): Promise<CCQueryResult<T>> {
+    return this.enqueue(() => this._executeImpl<T>(opts));
+  }
+
+  private _executeImpl<T>(opts: ExecuteOptions<T>): Promise<CCQueryResult<T>> {
+    return new Promise<CCQueryResult<T>>((resolve) => {
+      const start = Date.now();
+      const claudePath = resolveClaudePath();
+
+      const args = [
+        '-p', opts.prompt,
+        '--output-format', 'json',
+        '--no-session-persistence',
+        '--max-turns', '2',
+        '--model', config.ccQueryModel,
+        '--tools', '',
+        '--strict-mcp-config',
+        '--disable-slash-commands',
+        '--json-schema', JSON.stringify(opts.jsonSchema),
+      ];
+
+      const child = spawn(claudePath, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        try {
+          if (process.platform === 'win32') {
+            // Use taskkill for reliable Windows process tree kill
+            spawn('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
+              stdio: 'pipe',
+              windowsHide: true,
+            });
+          } else {
+            child.kill('SIGKILL');
+          }
+        } catch {
+          // Best effort
+        }
+      }, config.ccQueryTimeoutMs);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        const durationMs = Date.now() - start;
+
+        if (timedOut) {
+          resolve({
+            success: false,
+            costUsd: 0,
+            durationMs,
+            error: `Query timed out after ${config.ccQueryTimeoutMs}ms`,
+          });
+          return;
+        }
+
+        if (code !== 0) {
+          resolve({
+            success: false,
+            costUsd: 0,
+            durationMs,
+            error: `CC exited with code ${code}: ${stderr.trim().substring(0, 500)}`,
+          });
+          return;
+        }
+
+        // Parse the JSON output from CC
+        try {
+          const parsed = JSON.parse(stdout);
+          // CC --output-format json wraps the result; extract cost and result text
+          const costUsd = parsed.cost_usd ?? parsed.costUsd ?? 0;
+          const resultText = parsed.result ?? stdout;
+
+          // The actual structured data is in the result field as JSON string
+          let data: T | undefined;
+          if (typeof resultText === 'string') {
+            try {
+              data = JSON.parse(resultText) as T;
+            } catch {
+              // result is plain text, not JSON
+            }
+          } else {
+            data = resultText as T;
+          }
+
+          resolve({
+            success: true,
+            data,
+            text: typeof resultText === 'string' ? resultText : JSON.stringify(resultText),
+            costUsd: typeof costUsd === 'number' ? costUsd : 0,
+            durationMs,
+          });
+        } catch {
+          // stdout was not valid JSON — return as text
+          resolve({
+            success: true,
+            text: stdout.trim(),
+            costUsd: 0,
+            durationMs,
+          });
+        }
+      });
+
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        resolve({
+          success: false,
+          costUsd: 0,
+          durationMs: Date.now() - start,
+          error: `Failed to spawn CC: ${err.message}`,
+        });
+      });
+
+      // Close stdin immediately — -p mode reads from args, not stdin
+      child.stdin?.end();
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Public query methods (predefined, typed)
+  // -------------------------------------------------------------------------
+
+  async prioritizeIssues(
+    issues: { number: number; title: string }[],
+  ): Promise<CCQueryResult<PrioritizedIssue[]>> {
+    const issueList = issues.map((i) => `#${i.number}: ${i.title}`).join('\n');
+    const prompt = [
+      'You are a project manager prioritizing GitHub issues for a software team.',
+      'Analyze the following issues and assign each a priority from 1 (highest) to 5 (lowest).',
+      'Consider urgency, impact, and dependencies.',
+      '',
+      'Issues:',
+      issueList,
+      '',
+      'Return a JSON array of objects with: number, title, priority, reason.',
+    ].join('\n');
+
+    const jsonSchema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              number: { type: 'number' },
+              title: { type: 'string' },
+              priority: { type: 'number' },
+              reason: { type: 'string' },
+            },
+            required: ['number', 'title', 'priority', 'reason'],
+          },
+        },
+      },
+      required: ['items'],
+    };
+
+    const result = await this.execute<{ items: PrioritizedIssue[] }>({ prompt, jsonSchema });
+
+    return {
+      ...result,
+      data: result.data?.items,
+    } as CCQueryResult<PrioritizedIssue[]>;
+  }
+
+  async estimateComplexity(
+    issueTitle: string,
+    issueBody: string,
+  ): Promise<CCQueryResult<ComplexityEstimate>> {
+    const prompt = [
+      'You are a senior software engineer estimating the complexity of a GitHub issue.',
+      'Analyze the issue and provide a complexity estimate.',
+      '',
+      `Title: ${issueTitle}`,
+      '',
+      `Description:`,
+      issueBody,
+      '',
+      'Return a JSON object with: complexity ("low", "medium", or "high"), estimatedHours (number), reason (string), risks (array of strings).',
+    ].join('\n');
+
+    const jsonSchema = {
+      type: 'object',
+      properties: {
+        complexity: { type: 'string', enum: ['low', 'medium', 'high'] },
+        estimatedHours: { type: 'number' },
+        reason: { type: 'string' },
+        risks: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['complexity', 'estimatedHours', 'reason', 'risks'],
+    };
+
+    return this.execute<ComplexityEstimate>({ prompt, jsonSchema });
+  }
+
+  async suggestAssignmentOrder(
+    issues: IssueSummary[],
+    constraints: QueueConstraints,
+  ): Promise<CCQueryResult<AssignmentPlan>> {
+    const issueList = issues
+      .map((i) => `#${i.number}: ${i.title} [${i.labels.join(', ')}]`)
+      .join('\n');
+    const prompt = [
+      'You are a project manager planning the assignment order for a team of AI coding agents.',
+      `The team can run at most ${constraints.maxConcurrent} agents concurrently.`,
+      constraints.preferredOrder
+        ? `Preferred ordering strategy: ${constraints.preferredOrder}.`
+        : '',
+      '',
+      'Issues:',
+      issueList,
+      '',
+      'Return a JSON object with:',
+      '- order: array of { number, reason } indicating the sequence issues should be assigned',
+      '- estimatedTotalHours: total estimated hours for all issues',
+    ].join('\n');
+
+    const jsonSchema = {
+      type: 'object',
+      properties: {
+        order: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              number: { type: 'number' },
+              reason: { type: 'string' },
+            },
+            required: ['number', 'reason'],
+          },
+        },
+        estimatedTotalHours: { type: 'number' },
+      },
+      required: ['order', 'estimatedTotalHours'],
+    };
+
+    return this.execute<AssignmentPlan>({ prompt, jsonSchema });
+  }
+}

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -18,6 +18,7 @@ import { getDatabase } from '../db.js';
 import { sseBroker } from './sse-broker.js';
 import type { StreamEvent } from './sse-broker.js';
 import { findGitBash } from '../utils/find-git-bash.js';
+import { resolveClaudePath } from '../utils/resolve-claude-path.js';
 import type { Team, Project } from '../../shared/types.js';
 import { getUsageZone } from './usage-tracker.js';
 
@@ -29,61 +30,6 @@ const execAsync = promisify(execCallback);
 
 const MAX_OUTPUT_LINES = config.outputBufferLines;
 const MAX_PARSED_EVENTS = 200;
-
-// ---------------------------------------------------------------------------
-// Resolve claude executable path (Windows needs full path for shell-free spawn)
-// ---------------------------------------------------------------------------
-
-let _resolvedClaudePath: string | null = null;
-
-/**
- * On Windows, `spawn('claude', ...)` with `shell: false` fails because Node
- * cannot resolve bare command names via PATH without a shell. We use `where`
- * to find the full path to claude.exe once, then cache the result.
- *
- * On non-Windows platforms, the bare command name works fine with shell: false.
- */
-function resolveClaudePath(): string {
-  if (_resolvedClaudePath) return _resolvedClaudePath;
-
-  if (process.platform === 'win32') {
-    try {
-      const result = execSync('where claude.exe', {
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      const firstLine = result.trim().split('\n')[0]?.trim();
-      if (firstLine) {
-        _resolvedClaudePath = firstLine;
-        console.log(`[TeamManager] Resolved claude path: ${_resolvedClaudePath}`);
-        return _resolvedClaudePath;
-      }
-    } catch {
-      // `where` failed — try `where claude` without .exe extension
-      try {
-        const result = execSync('where claude', {
-          encoding: 'utf-8',
-          timeout: 5000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-        const firstLine = result.trim().split('\n')[0]?.trim();
-        if (firstLine) {
-          _resolvedClaudePath = firstLine;
-          console.log(`[TeamManager] Resolved claude path: ${_resolvedClaudePath}`);
-          return _resolvedClaudePath;
-        }
-      } catch {
-        // Fall through to default
-      }
-    }
-  }
-
-  // Non-Windows or resolution failed — use configured command as-is
-  _resolvedClaudePath = config.claudeCmd;
-  console.log(`[TeamManager] Using claude command: ${_resolvedClaudePath}`);
-  return _resolvedClaudePath;
-}
 
 // ---------------------------------------------------------------------------
 // summarizeEvent — short text summary for console logging

--- a/src/server/utils/resolve-claude-path.ts
+++ b/src/server/utils/resolve-claude-path.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// Resolve Claude CLI executable path
+// =============================================================================
+// On Windows, `spawn('claude', ...)` with `shell: false` fails because Node
+// cannot resolve bare command names via PATH without a shell. We use `where`
+// to find the full path to claude.exe once, then cache the result.
+//
+// On non-Windows platforms, the bare command name works fine with shell: false.
+// =============================================================================
+
+import { execSync } from 'child_process';
+import config from '../config.js';
+
+let _resolvedClaudePath: string | null = null;
+
+export function resolveClaudePath(): string {
+  if (_resolvedClaudePath) return _resolvedClaudePath;
+
+  if (process.platform === 'win32') {
+    try {
+      const result = execSync('where claude.exe', {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const firstLine = result.trim().split('\n')[0]?.trim();
+      if (firstLine) {
+        _resolvedClaudePath = firstLine;
+        console.log(`[resolveClaudePath] Resolved claude path: ${_resolvedClaudePath}`);
+        return _resolvedClaudePath;
+      }
+    } catch {
+      // `where` failed — try `where claude` without .exe extension
+      try {
+        const result = execSync('where claude', {
+          encoding: 'utf-8',
+          timeout: 5000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        const firstLine = result.trim().split('\n')[0]?.trim();
+        if (firstLine) {
+          _resolvedClaudePath = firstLine;
+          console.log(`[resolveClaudePath] Resolved claude path: ${_resolvedClaudePath}`);
+          return _resolvedClaudePath;
+        }
+      } catch {
+        // Fall through to default
+      }
+    }
+  }
+
+  // Non-Windows or resolution failed — use configured command as-is
+  _resolvedClaudePath = config.claudeCmd;
+  console.log(`[resolveClaudePath] Using claude command: ${_resolvedClaudePath}`);
+  return _resolvedClaudePath;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -205,6 +205,55 @@ export interface MessageTemplate {
 }
 
 // ---------------------------------------------------------------------------
+// CC Query Service (structured queries to Claude Code)
+// ---------------------------------------------------------------------------
+
+/** Generic result wrapper for all CC query responses */
+export interface CCQueryResult<T> {
+  success: boolean;
+  data?: T;
+  text?: string;
+  costUsd: number;
+  durationMs: number;
+  error?: string;
+}
+
+/** A single issue with computed priority from CC analysis */
+export interface PrioritizedIssue {
+  number: number;
+  title: string;
+  priority: number;
+  reason: string;
+}
+
+/** Complexity estimate for an issue */
+export interface ComplexityEstimate {
+  complexity: 'low' | 'medium' | 'high';
+  estimatedHours: number;
+  reason: string;
+  risks: string[];
+}
+
+/** Lightweight issue summary used as input to query methods */
+export interface IssueSummary {
+  number: number;
+  title: string;
+  labels: string[];
+}
+
+/** Constraints for queue assignment planning */
+export interface QueueConstraints {
+  maxConcurrent: number;
+  preferredOrder?: 'priority' | 'complexity' | 'fifo';
+}
+
+/** Ordered assignment plan returned by CC */
+export interface AssignmentPlan {
+  order: { number: number; reason: string }[];
+  estimatedTotalHours: number;
+}
+
+// ---------------------------------------------------------------------------
 // Dashboard View (v_team_dashboard)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #124

## Summary
- New `CCQueryService` singleton with private `execute()` and 3 typed public query methods (`prioritizeIssues`, `estimateComplexity`, `suggestAssignmentOrder`)
- New `POST /api/query/:queryName` route with input validation
- Extracted `resolveClaudePath` from `team-manager.ts` into shared `utils/resolve-claude-path.ts`
- Added `FLEET_CC_QUERY_MODEL` and `FLEET_CC_QUERY_TIMEOUT_MS` config env vars
- Added shared types: `CCQueryResult<T>`, `PrioritizedIssue`, `ComplexityEstimate`, `IssueSummary`, `QueueConstraints`, `AssignmentPlan`