### PR TITLE
Issue #125: add AI-powered issue prioritization to Issue Tree

### DIFF
--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { StatusBadge } from './StatusBadge';
 import { PRBadge } from './PRBadge';
 import { PlayIcon } from './Icons';
-import type { TeamStatus } from '../../shared/types';
+import type { TeamStatus, PrioritizedIssue } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Types (mirrors IssueNode from the server issue-fetcher)
@@ -74,6 +74,35 @@ function IssueStateBadge({ state }: { state: 'open' | 'closed' }) {
 // TreeNode component (recursive)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Priority badge component
+// ---------------------------------------------------------------------------
+
+function PriorityBadge({ data }: { data: PrioritizedIssue }) {
+  let bgColor: string;
+  let textColor: string;
+  if (data.priority <= 3) {
+    bgColor = 'rgba(248, 81, 73, 0.15)';
+    textColor = '#F85149';
+  } else if (data.priority <= 6) {
+    bgColor = 'rgba(210, 153, 34, 0.15)';
+    textColor = '#D29922';
+  } else {
+    bgColor = 'rgba(139, 148, 158, 0.15)';
+    textColor = '#8B949E';
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 shrink-0 px-1.5 py-0.5 rounded text-xs font-medium cursor-default"
+      style={{ backgroundColor: bgColor, color: textColor }}
+      title={`Priority ${data.priority}/10 (${data.category}): ${data.reason}`}
+    >
+      P{data.priority}
+    </span>
+  );
+}
+
 interface TreeNodeProps {
   node: IssueNode;
   depth: number;
@@ -83,9 +112,15 @@ interface TreeNodeProps {
   forceExpand?: boolean;
   /** When set, the play button uses this project instead of requiring the user to select one. */
   projectId?: number;
+  /** Map of issue number -> priority data from AI prioritization */
+  priorityMap?: Map<number, PrioritizedIssue>;
+  /** Set of checked issue numbers for batch launch */
+  checkedIssues?: Set<number>;
+  /** Callback when checkbox state changes */
+  onCheckChange?: (issueNumber: number, checked: boolean) => void;
 }
 
-export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId }: TreeNodeProps) {
+export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(depth < 2);
   const isExpanded = forceExpand || expanded;
   const hasChildren = node.children.length > 0;
@@ -124,6 +159,20 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
           </svg>
         </button>
 
+        {/* Checkbox for batch launch selection */}
+        {onCheckChange && priorityMap && (
+          <input
+            type="checkbox"
+            checked={checkedIssues?.has(node.number) ?? false}
+            onChange={(e) => {
+              e.stopPropagation();
+              onCheckChange(node.number, e.target.checked);
+            }}
+            className="w-3.5 h-3.5 shrink-0 accent-dark-accent cursor-pointer"
+            aria-label={`Select issue #${node.number}`}
+          />
+        )}
+
         {/* Issue state icon */}
         <IssueStateBadge state={node.state} />
 
@@ -142,6 +191,13 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
         <span className={`text-sm truncate ${node.state === 'closed' ? 'text-dark-muted line-through' : 'text-dark-text'}`}>
           {node.title}
         </span>
+
+        {/* Priority badge from AI prioritization */}
+        {priorityMap?.get(node.number) && (
+          <span className="shrink-0 ml-1">
+            <PriorityBadge data={priorityMap.get(node.number)!} />
+          </span>
+        )}
 
         {/* "Launching..." indicator next to title */}
         {launching && (
@@ -224,6 +280,9 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
               launchErrors={launchErrors}
               forceExpand={forceExpand}
               projectId={projectId}
+              priorityMap={priorityMap}
+              checkedIssues={checkedIssues}
+              onCheckChange={onCheckChange}
             />
           ))}
         </div>

--- a/src/client/hooks/usePrioritization.ts
+++ b/src/client/hooks/usePrioritization.ts
@@ -1,0 +1,168 @@
+import { useState, useCallback } from 'react';
+import { useApi } from './useApi';
+import type { PrioritizedIssue, CCQueryResult } from '../../shared/types';
+import type { IssueNode } from '../components/TreeNode';
+
+interface PrioritizationState {
+  /** Map of issue number -> priority data */
+  priorityMap: Map<number, PrioritizedIssue>;
+  /** Whether a prioritization request is in progress */
+  loading: boolean;
+  /** Error message from the last request */
+  error: string | null;
+  /** Cost in USD from the last successful request */
+  costUsd: number | null;
+  /** Duration in ms from the last successful request */
+  durationMs: number | null;
+  /** Set of checked issue numbers for batch launch */
+  checkedIssues: Set<number>;
+}
+
+interface UsePrioritizationReturn extends PrioritizationState {
+  /** Run AI prioritization on the given issue tree */
+  prioritize: (tree: IssueNode[]) => Promise<void>;
+  /** Reset all prioritization state */
+  reset: () => void;
+  /** Toggle an issue's checked state */
+  toggleCheck: (issueNumber: number, checked: boolean) => void;
+  /** Whether prioritization data is available */
+  hasPriority: boolean;
+  /** Get sorted issue numbers by priority (ascending = highest priority first) */
+  sortedIssueNumbers: number[];
+  /** Get checked issue numbers sorted by priority */
+  checkedSortedIssueNumbers: number[];
+}
+
+/** Collect all open leaf issue numbers + titles from a tree */
+function collectOpenIssues(nodes: IssueNode[]): { number: number; title: string }[] {
+  const result: { number: number; title: string }[] = [];
+  for (const node of nodes) {
+    if (node.state === 'open') {
+      result.push({ number: node.number, title: node.title });
+    }
+    if (node.children.length > 0) {
+      result.push(...collectOpenIssues(node.children));
+    }
+  }
+  return result;
+}
+
+/** Sort issue tree by priority map (ascending priority = highest priority first) */
+export function sortTreeByPriority(
+  nodes: IssueNode[],
+  priorityMap: Map<number, PrioritizedIssue>,
+): IssueNode[] {
+  return [...nodes]
+    .map((node) => ({
+      ...node,
+      children: sortTreeByPriority(node.children, priorityMap),
+    }))
+    .sort((a, b) => {
+      const pa = priorityMap.get(a.number)?.priority ?? 999;
+      const pb = priorityMap.get(b.number)?.priority ?? 999;
+      return pa - pb;
+    });
+}
+
+export function usePrioritization(): UsePrioritizationReturn {
+  const api = useApi();
+  const [state, setState] = useState<PrioritizationState>({
+    priorityMap: new Map(),
+    loading: false,
+    error: null,
+    costUsd: null,
+    durationMs: null,
+    checkedIssues: new Set(),
+  });
+
+  const prioritize = useCallback(async (tree: IssueNode[]) => {
+    const issues = collectOpenIssues(tree);
+    if (issues.length === 0) return;
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const result = await api.post<CCQueryResult<PrioritizedIssue[]>>(
+        'query/prioritizeIssues',
+        { issues },
+      );
+
+      if (!result.success || !result.data) {
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: result.error ?? 'Prioritization returned no data',
+        }));
+        return;
+      }
+
+      const map = new Map<number, PrioritizedIssue>();
+      for (const item of result.data) {
+        map.set(item.number, item);
+      }
+
+      // Auto-check all prioritized open issues
+      const checked = new Set(result.data.map((i) => i.number));
+
+      setState({
+        priorityMap: map,
+        loading: false,
+        error: null,
+        costUsd: result.costUsd,
+        durationMs: result.durationMs,
+        checkedIssues: checked,
+      });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [api]);
+
+  const reset = useCallback(() => {
+    setState({
+      priorityMap: new Map(),
+      loading: false,
+      error: null,
+      costUsd: null,
+      durationMs: null,
+      checkedIssues: new Set(),
+    });
+  }, []);
+
+  const toggleCheck = useCallback((issueNumber: number, checked: boolean) => {
+    setState((prev) => {
+      const next = new Set(prev.checkedIssues);
+      if (checked) {
+        next.add(issueNumber);
+      } else {
+        next.delete(issueNumber);
+      }
+      return { ...prev, checkedIssues: next };
+    });
+  }, []);
+
+  const hasPriority = state.priorityMap.size > 0;
+
+  const sortedIssueNumbers = hasPriority
+    ? [...state.priorityMap.entries()]
+        .sort((a, b) => a[1].priority - b[1].priority)
+        .map(([num]) => num)
+    : [];
+
+  const checkedSortedIssueNumbers = sortedIssueNumbers.filter((n) =>
+    state.checkedIssues.has(n),
+  );
+
+  return {
+    ...state,
+    prioritize,
+    reset,
+    toggleCheck,
+    hasPriority,
+    sortedIssueNumbers,
+    checkedSortedIssueNumbers,
+  };
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import React from 'react';
 import { useApi } from '../hooks/useApi';
+import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritization';
 import { TreeNode, type IssueNode } from '../components/TreeNode';
-import type { ProjectSummary } from '../../shared/types';
+import type { ProjectSummary, PrioritizedIssue } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Status filter pill definitions
@@ -62,6 +63,10 @@ export function IssueTreeView() {
   const [groups, setGroups] = useState<ProjectIssueGroup[]>([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [batchLaunching, setBatchLaunching] = useState(false);
+
+  // AI prioritization state
+  const prioritization = usePrioritization();
 
   // Track pending timeouts so we can clear them on unmount
   const pendingTimeouts = useRef(new Set<ReturnType<typeof setTimeout>>());
@@ -233,6 +238,51 @@ export function IssueTreeView() {
       .filter((g) => g.tree.length > 0);
   }, [groups, search, statusFilter]);
 
+  // Apply priority sorting when prioritization data is available
+  const displayTree = useMemo(() => {
+    if (!prioritization.hasPriority) return filteredTree;
+    return sortTreeByPriority(filteredTree, prioritization.priorityMap);
+  }, [filteredTree, prioritization.hasPriority, prioritization.priorityMap]);
+
+  const displayGroups = useMemo(() => {
+    if (!prioritization.hasPriority) return filteredGroups;
+    return filteredGroups.map((g) => ({
+      ...g,
+      tree: sortTreeByPriority(g.tree, prioritization.priorityMap),
+    }));
+  }, [filteredGroups, prioritization.hasPriority, prioritization.priorityMap]);
+
+  // -------------------------------------------------------------------------
+  // Batch launch handler
+  // -------------------------------------------------------------------------
+
+  const handleBatchLaunch = useCallback(async () => {
+    const issuesToLaunch = prioritization.checkedSortedIssueNumbers;
+    if (issuesToLaunch.length === 0 || !launchProjectId) return;
+
+    setBatchLaunching(true);
+    try {
+      await api.post('teams/launch-batch', {
+        projectId: launchProjectId,
+        issues: issuesToLaunch.map((num) => {
+          const data = prioritization.priorityMap.get(num);
+          return { number: num, title: data?.title };
+        }),
+      });
+      // Refresh tree after batch launch
+      const tid = setTimeout(() => {
+        pendingTimeouts.current.delete(tid);
+        fetchTree();
+      }, 3000);
+      pendingTimeouts.current.add(tid);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+    } finally {
+      setBatchLaunching(false);
+    }
+  }, [api, prioritization.checkedSortedIssueNumbers, prioritization.priorityMap, launchProjectId, fetchTree]);
+
   // -------------------------------------------------------------------------
   // Loading state
   // -------------------------------------------------------------------------
@@ -329,6 +379,40 @@ export function IssueTreeView() {
           ))}
         </div>
 
+        {/* Prioritize button */}
+        <button
+          onClick={() => prioritization.prioritize(tree)}
+          disabled={prioritization.loading || tree.length === 0 || (activeProjects.length > 1 && !launchProjectId)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-[#A371F7]/50 text-[#A371F7] hover:bg-[#A371F7]/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title={activeProjects.length > 1 && !launchProjectId ? 'Select a single project first' : 'AI-prioritize open issues'}
+        >
+          {prioritization.loading ? (
+            <svg className="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+          ) : (
+            <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M7.823.9l4.584 4.584-7.636 7.636L.187 8.536 7.823.9ZM14.2 6.1l-1.3 1.3-4.584-4.584L9.6 1.5a1.5 1.5 0 012.122 0L14.2 3.978a1.5 1.5 0 010 2.122Z" />
+            </svg>
+          )}
+          {prioritization.loading ? 'Prioritizing...' : 'Prioritize'}
+        </button>
+
+        {/* Reset button (only shown when prioritization is active) */}
+        {prioritization.hasPriority && (
+          <button
+            onClick={prioritization.reset}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent/50 transition-colors"
+            title="Clear prioritization"
+          >
+            <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+            Reset
+          </button>
+        )}
+
         <button
           onClick={handleRefresh}
           disabled={refreshing}
@@ -344,6 +428,50 @@ export function IssueTreeView() {
           {refreshing ? 'Refreshing...' : 'Refresh'}
         </button>
       </div>
+
+      {/* Prioritization action bar */}
+      {prioritization.hasPriority && (
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-dark-border bg-[#A371F7]/5 shrink-0">
+          <span className="text-xs text-dark-muted">
+            {prioritization.checkedIssues.size} of {prioritization.priorityMap.size} selected
+          </span>
+
+          {launchProjectId && (
+            <button
+              onClick={handleBatchLaunch}
+              disabled={batchLaunching || prioritization.checkedIssues.size === 0}
+              className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded border border-[#3FB950]/50 text-[#3FB950] hover:bg-[#3FB950]/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {batchLaunching ? (
+                <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                </svg>
+              ) : (
+                <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z" />
+                </svg>
+              )}
+              {prioritization.checkedIssues.size === prioritization.priorityMap.size
+                ? 'Launch all in order'
+                : `Launch ${prioritization.checkedIssues.size} selected in order`}
+            </button>
+          )}
+
+          {prioritization.costUsd != null && (
+            <span className="text-xs text-dark-muted ml-auto">
+              ${prioritization.costUsd.toFixed(4)} &middot; {((prioritization.durationMs ?? 0) / 1000).toFixed(1)}s
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Prioritization error banner */}
+      {prioritization.error && (
+        <div className="mx-4 mt-3 px-3 py-2 rounded border border-[#F85149]/30 bg-[#F85149]/10 text-xs text-[#F85149]">
+          Prioritization failed: {prioritization.error}
+        </div>
+      )}
 
       {/* Error banner */}
       {error && (
@@ -374,7 +502,7 @@ export function IssueTreeView() {
               Click Refresh to fetch issues from GitHub
             </p>
           </div>
-        ) : filteredTree.length === 0 ? (
+        ) : displayTree.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full gap-3">
             <p className="text-dark-muted text-sm">
               {search && statusFilter !== 'all'
@@ -390,10 +518,10 @@ export function IssueTreeView() {
               Clear filters
             </button>
           </div>
-        ) : filteredGroups.length > 0 ? (
+        ) : displayGroups.length > 0 ? (
           /* Grouped view — issues organized by project */
           <div className="space-y-1">
-            {filteredGroups.map((group) => (
+            {displayGroups.map((group) => (
               <ProjectGroup
                 key={group.projectId}
                 group={group}
@@ -401,12 +529,15 @@ export function IssueTreeView() {
                 launchingIssues={launchingIssues}
                 launchErrors={launchErrors}
                 forceExpand={!!search || statusFilter !== 'all'}
+                priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
+                checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
+                onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
               />
             ))}
           </div>
         ) : (
           <div className="space-y-0">
-            {filteredTree.map((node) => (
+            {displayTree.map((node) => (
               <TreeNode
                 key={node.number}
                 node={node}
@@ -415,6 +546,9 @@ export function IssueTreeView() {
                 launchingIssues={launchingIssues}
                 launchErrors={launchErrors}
                 forceExpand={!!search || statusFilter !== 'all'}
+                priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
+                checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
+                onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
               />
             ))}
           </div>
@@ -434,9 +568,12 @@ interface ProjectGroupProps {
   launchingIssues: Set<number>;
   launchErrors: Map<number, string>;
   forceExpand: boolean;
+  priorityMap?: Map<number, PrioritizedIssue>;
+  checkedIssues?: Set<number>;
+  onCheckChange?: (issueNumber: number, checked: boolean) => void;
 }
 
-function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand }: ProjectGroupProps) {
+function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, priorityMap, checkedIssues, onCheckChange }: ProjectGroupProps) {
   const [expanded, setExpanded] = React.useState(true);
 
   return (
@@ -477,6 +614,9 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
               launchErrors={launchErrors}
               forceExpand={forceExpand}
               projectId={group.projectId}
+              priorityMap={priorityMap}
+              checkedIssues={checkedIssues}
+              onCheckChange={onCheckChange}
             />
           ))}
         </div>

--- a/src/server/services/cc-query.ts
+++ b/src/server/services/cc-query.ts
@@ -219,14 +219,15 @@ export class CCQueryService {
   ): Promise<CCQueryResult<PrioritizedIssue[]>> {
     const issueList = issues.map((i) => `#${i.number}: ${i.title}`).join('\n');
     const prompt = [
-      'You are a project manager prioritizing GitHub issues for a software team.',
-      'Analyze the following issues and assign each a priority from 1 (highest) to 5 (lowest).',
-      'Consider urgency, impact, and dependencies.',
+      'You are a senior engineering manager prioritizing a backlog.',
+      'Analyze the following issues and assign each a priority from 1 (highest/most urgent) to 10 (lowest/least urgent).',
+      'Also categorize each issue as one of: critical-bug, bug, perf, feature, refactor, cleanup.',
+      'Consider urgency, user impact, severity, and dependencies.',
       '',
       'Issues:',
       issueList,
       '',
-      'Return a JSON array of objects with: number, title, priority, reason.',
+      'Return a JSON array of objects with: number, title, priority (1-10), category, reason.',
     ].join('\n');
 
     const jsonSchema = {
@@ -240,9 +241,13 @@ export class CCQueryService {
               number: { type: 'number' },
               title: { type: 'string' },
               priority: { type: 'number' },
+              category: {
+                type: 'string',
+                enum: ['critical-bug', 'bug', 'perf', 'feature', 'refactor', 'cleanup'],
+              },
               reason: { type: 'string' },
             },
-            required: ['number', 'title', 'priority', 'reason'],
+            required: ['number', 'title', 'priority', 'category', 'reason'],
           },
         },
       },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -218,11 +218,16 @@ export interface CCQueryResult<T> {
   error?: string;
 }
 
+/** Issue category determined by AI prioritization */
+export type IssueCategory = 'critical-bug' | 'bug' | 'perf' | 'feature' | 'refactor' | 'cleanup';
+
 /** A single issue with computed priority from CC analysis */
 export interface PrioritizedIssue {
   number: number;
   title: string;
+  /** Priority score from 1 (highest) to 10 (lowest) */
   priority: number;
+  category: IssueCategory;
   reason: string;
 }
 


### PR DESCRIPTION
Closes #125

## Summary
- Add "Prioritize" button to Issue Tree view that calls CCQuery service to rank open issues by priority (1-10) with category classification
- Display colored priority badges (red P1-3, yellow P4-6, grey P7-10) with reason tooltips on each issue
- Add checkboxes for selective issue selection and "Launch in order" / "Launch selected in order" buttons for batch launching via `POST /api/teams/launch-batch`
- Add "Reset" button to clear prioritization state and cost/duration display after completion
- Update `PrioritizedIssue` type with `category` field and expanded priority range (1-10)
- Update `cc-query.ts` prompt and JSON schema to match new spec

## Files changed
- `src/shared/types.ts` — `IssueCategory` type, extended `PrioritizedIssue`
- `src/server/services/cc-query.ts` — updated prompt, schema, priority range
- `src/client/components/TreeNode.tsx` — priority badge, checkbox, new props
- `src/client/hooks/usePrioritization.ts` — new hook for prioritization state
- `src/client/views/IssueTreeView.tsx` — UI integration (buttons, sorting, action bar)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (188/191, 3 pre-existing failures)
- [ ] Manual: click "Prioritize" button, verify issues re-sort by priority
- [ ] Manual: verify priority badges show correct colors and tooltips
- [ ] Manual: verify checkboxes and "Launch selected in order" works
- [ ] Manual: verify "Reset" clears prioritization state
- [ ] Manual: verify button disabled when no project selected (multi-project mode)