### PR TITLE
Issue #44: remove unused DefaultMessageTemplate export

### DIFF
--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -6,7 +6,7 @@
 // and messaging concerns remain separate.
 // =============================================================================
 
-export interface DefaultMessageTemplate {
+interface DefaultMessageTemplate {
   id: string;
   template: string;
   description: string;


### PR DESCRIPTION
Closes #44

Removes the `export` keyword from the `DefaultMessageTemplate` interface in `src/shared/message-templates.ts:9`. The interface is used locally as the type for the `DEFAULT_MESSAGE_TEMPLATES` array but is never imported by any other file.

Single-line change, build and tests pass.