### PR TITLE
Issue #61: replace console.error with Fastify structured logging in route helpers

### DIFF
--- a/src/server/routes/issues.ts
+++ b/src/server/routes/issues.ts
@@ -10,7 +10,7 @@
 //   GET  /api/projects/:projectId/issues    — per-project issue tree
 // =============================================================================
 
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { FastifyBaseLogger, FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getIssueFetcher } from '../services/issue-fetcher.js';
 import { getDatabase } from '../db.js';
 
@@ -18,7 +18,7 @@ import { getDatabase } from '../db.js';
 // Helper: get issue numbers for all active teams from the database
 // ---------------------------------------------------------------------------
 
-function getActiveTeamIssueNumbers(projectId?: number): number[] {
+function getActiveTeamIssueNumbers(logger: FastifyBaseLogger, projectId?: number): number[] {
   try {
     const db = getDatabase();
     const activeTeams = projectId !== undefined
@@ -26,7 +26,7 @@ function getActiveTeamIssueNumbers(projectId?: number): number[] {
       : db.getActiveTeams();
     return activeTeams.map((t) => t.issueNumber);
   } catch (err) {
-    console.error('[IssueRoutes] Failed to get active teams:', err instanceof Error ? err.message : err);
+    logger.error('[IssueRoutes] Failed to get active teams: %s', err instanceof Error ? err.message : err);
     return [];
   }
 }
@@ -120,7 +120,7 @@ async function issueRoutes(server: FastifyInstance): Promise<void> {
    */
   server.get('/api/issues/next', async (_request: FastifyRequest, _reply: FastifyReply) => {
     const fetcher = getIssueFetcher();
-    const activeIssues = getActiveTeamIssueNumbers();
+    const activeIssues = getActiveTeamIssueNumbers(server.log);
     const nextIssue = fetcher.getNextIssue(activeIssues);
 
     if (!nextIssue) {
@@ -146,7 +146,7 @@ async function issueRoutes(server: FastifyInstance): Promise<void> {
    */
   server.get('/api/issues/available', async (_request: FastifyRequest, _reply: FastifyReply) => {
     const fetcher = getIssueFetcher();
-    const activeIssues = getActiveTeamIssueNumbers();
+    const activeIssues = getActiveTeamIssueNumbers(server.log);
     const available = fetcher.getAvailableIssues(activeIssues);
 
     // Enrich with team info (should all be null, but for consistency)

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 import type {
+  FastifyBaseLogger,
   FastifyInstance,
   FastifyPluginCallback,
   FastifyRequest,
@@ -130,7 +131,7 @@ function detectGithubRepo(dirPath: string): string | null {
  * Install Fleet Commander hooks into a project repo.
  * Returns { ok, stdout, stderr } so callers can log / surface errors.
  */
-function installHooks(repoPath: string): { ok: boolean; stdout: string; stderr: string } {
+function installHooks(repoPath: string, logger: FastifyBaseLogger): { ok: boolean; stdout: string; stderr: string } {
   const fail = (msg: string) => ({ ok: false, stdout: '', stderr: msg });
 
   const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'install.sh');
@@ -150,7 +151,7 @@ function installHooks(repoPath: string): { ok: boolean; stdout: string; stderr: 
     const e = err as { stdout?: string; stderr?: string; message?: string; status?: number };
     const stdout = e.stdout ?? '';
     const stderr = e.stderr ?? '';
-    console.error(
+    logger.error(
       `[installHooks] Failed for ${repoPath} (exit ${e.status ?? '?'}):\n` +
       `  cmd: ${cmd}\n` +
       `  stderr: ${stderr.trim()}\n` +
@@ -163,7 +164,7 @@ function installHooks(repoPath: string): { ok: boolean; stdout: string; stderr: 
 /**
  * Uninstall Fleet Commander hooks from a project repo.
  */
-function uninstallHooks(repoPath: string): void {
+function uninstallHooks(repoPath: string, logger: FastifyBaseLogger): void {
   try {
     const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'uninstall.sh');
     if (!fs.existsSync(scriptPath)) {
@@ -177,9 +178,8 @@ function uninstallHooks(repoPath: string): void {
     execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
   } catch (err) {
     // Non-fatal — log but don't block project deletion
-    console.error(
-      `[uninstallHooks] Failed to uninstall from ${repoPath}:`,
-      err instanceof Error ? err.message : String(err),
+    logger.error(
+      `[uninstallHooks] Failed to uninstall from ${repoPath}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }
@@ -447,7 +447,7 @@ const projectsRoutes: FastifyPluginCallback = (
         });
 
         // Install hooks (non-fatal)
-        const installResult = installHooks(normalizedPath);
+        const installResult = installHooks(normalizedPath, request.log);
         if (!installResult.ok) {
           request.log.warn(
             `Hook installation failed for ${normalizedPath}: ${installResult.stderr}`,
@@ -682,7 +682,7 @@ const projectsRoutes: FastifyPluginCallback = (
         }
 
         // Uninstall hooks
-        uninstallHooks(project.repoPath);
+        uninstallHooks(project.repoPath, request.log);
 
         // Clear cached issues for this project
         const issueFetcher = getIssueFetcher();
@@ -738,7 +738,7 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const result = installHooks(project.repoPath);
+        const result = installHooks(project.repoPath, request.log);
 
         // Check what actually landed on disk
         const status = checkInstallStatus(project.repoPath);


### PR DESCRIPTION
Closes #61

## Summary
- Replace `console.error` with `logger.error` (Fastify structured logging) in three module-level helper functions that bypassed `LOG_LEVEL` config
- `installHooks()` and `uninstallHooks()` in `src/server/routes/projects.ts` now accept a `FastifyBaseLogger` parameter; call sites pass `request.log`
- `getActiveTeamIssueNumbers()` in `src/server/routes/issues.ts` now accepts a `FastifyBaseLogger` parameter; call sites pass `server.log`
- Zero `console.*` calls remain in `src/server/routes/`