### PR TITLE
Issue #62: extract shared hook install/uninstall utilities

### DIFF
--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -6,7 +6,6 @@
 // =============================================================================
 
 import type {
-  FastifyBaseLogger,
   FastifyInstance,
   FastifyPluginCallback,
   FastifyRequest,
@@ -20,6 +19,7 @@ import { getTeamManager } from '../services/team-manager.js';
 import { getIssueFetcher } from '../services/issue-fetcher.js';
 import { getCleanupPreview, executeCleanup } from '../services/cleanup.js';
 import { sseBroker } from '../services/sse-broker.js';
+import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
 import type { ProjectStatus, InstallStatus, InstallFileStatus, CleanupPreview, CleanupResult } from '../../shared/types.js';
 
@@ -65,37 +65,6 @@ function normalizePath(p: string): string {
 }
 
 /**
- * Find Git Bash executable on Windows.
- * Avoids WSL's bash which can't handle Windows paths.
- */
-let _gitBash: string | null = null;
-function getGitBash(): string {
-  if (_gitBash) return _gitBash;
-  try {
-    // git --exec-path returns e.g. "C:/Git/scm/libexec/git-core"
-    // Git bash is at {git_root}/usr/bin/bash.exe
-    const execPath = execSync('git --exec-path', { encoding: 'utf-8', stdio: 'pipe' }).trim();
-    const gitRoot = path.resolve(execPath, '..', '..');
-    const bashPath = path.join(gitRoot, 'usr', 'bin', 'bash.exe');
-    if (fs.existsSync(bashPath)) {
-      _gitBash = bashPath;
-      return _gitBash;
-    }
-  } catch {
-    // fallback
-  }
-  _gitBash = 'bash'; // hope for the best
-  return _gitBash;
-}
-
-/**
- * Convert a Windows path to a bash-safe format with forward slashes.
- */
-function toBashPath(p: string): string {
-  return p.replace(/\\/g, '/');
-}
-
-/**
  * Check if a directory is a git repository.
  */
 function isGitRepo(dirPath: string): boolean {
@@ -124,63 +93,6 @@ function detectGithubRepo(dirPath: string): string | null {
     return result || null;
   } catch {
     return null;
-  }
-}
-
-/**
- * Install Fleet Commander hooks into a project repo.
- * Returns { ok, stdout, stderr } so callers can log / surface errors.
- */
-function installHooks(repoPath: string, logger: FastifyBaseLogger): { ok: boolean; stdout: string; stderr: string } {
-  const fail = (msg: string) => ({ ok: false, stdout: '', stderr: msg });
-
-  const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'install.sh');
-  if (!fs.existsSync(scriptPath)) {
-    return fail(`install.sh not found at ${scriptPath}`);
-  }
-
-  // On Windows, convert paths to MSYS2 format: C:/foo → /c/foo
-  const cmd = process.platform === 'win32'
-    ? `"${getGitBash()}" "${toBashPath(scriptPath)}" "${toBashPath(repoPath)}"`
-    : `"${scriptPath}" "${repoPath}"`;
-
-  try {
-    const stdout = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
-    return { ok: true, stdout, stderr: '' };
-  } catch (err: unknown) {
-    const e = err as { stdout?: string; stderr?: string; message?: string; status?: number };
-    const stdout = e.stdout ?? '';
-    const stderr = e.stderr ?? '';
-    logger.error(
-      `[installHooks] Failed for ${repoPath} (exit ${e.status ?? '?'}):\n` +
-      `  cmd: ${cmd}\n` +
-      `  stderr: ${stderr.trim()}\n` +
-      `  stdout: ${stdout.trim()}`,
-    );
-    return { ok: false, stdout, stderr: stderr || e.message || 'unknown error' };
-  }
-}
-
-/**
- * Uninstall Fleet Commander hooks from a project repo.
- */
-function uninstallHooks(repoPath: string, logger: FastifyBaseLogger): void {
-  try {
-    const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'uninstall.sh');
-    if (!fs.existsSync(scriptPath)) {
-      return;
-    }
-
-    const cmd = process.platform === 'win32'
-      ? `"${getGitBash()}" "${toBashPath(scriptPath)}" "${toBashPath(repoPath)}"`
-      : `"${scriptPath}" "${repoPath}"`;
-
-    execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
-  } catch (err) {
-    // Non-fatal — log but don't block project deletion
-    logger.error(
-      `[uninstallHooks] Failed to uninstall from ${repoPath}: ${err instanceof Error ? err.message : String(err)}`,
-    );
   }
 }
 

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -11,7 +11,6 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { getDatabase } from '../db.js';
@@ -19,6 +18,7 @@ import { getTeamManager } from '../services/team-manager.js';
 import { sseBroker } from '../services/sse-broker.js';
 import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
 import { getIssueFetcher } from '../services/issue-fetcher.js';
+import { uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
 
 // ---------------------------------------------------------------------------
@@ -337,28 +337,7 @@ const systemRoutes: FastifyPluginCallback = (
         // 2. Uninstall hooks from all projects before deleting them
         const projects = db.getProjects();
         for (const project of projects) {
-          try {
-            const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'uninstall.sh');
-            if (fs.existsSync(scriptPath)) {
-              const toBash = (p: string) => p.replace(/\\/g, '/');
-              // Find Git Bash to avoid WSL bash on Windows
-              let gitBash = 'bash';
-              try {
-                const ep = execSync('git --exec-path', { encoding: 'utf-8', stdio: 'pipe' }).trim();
-                const bp = path.join(path.resolve(ep, '..', '..'), 'usr', 'bin', 'bash.exe');
-                if (fs.existsSync(bp)) gitBash = bp;
-              } catch { /* fallback */ }
-              const cmd = process.platform === 'win32'
-                ? `"${gitBash}" "${toBash(scriptPath)}" "${toBash(project.repoPath)}"`
-                : `"${scriptPath}" "${project.repoPath}"`;
-              execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
-            }
-          } catch (err) {
-            request.log.warn(
-              { project: project.name, error: err instanceof Error ? err.message : String(err) },
-              'Failed to uninstall hooks during factory reset',
-            );
-          }
+          uninstallHooks(project.repoPath, request.log);
         }
 
         // 3. Delete all data and re-seed default templates

--- a/src/server/utils/hook-installer.ts
+++ b/src/server/utils/hook-installer.ts
@@ -1,0 +1,100 @@
+// =============================================================================
+// Fleet Commander — Hook Install/Uninstall Utilities
+// =============================================================================
+// Shared utilities for installing and uninstalling Fleet Commander hooks
+// into target project repositories. Used by both projects.ts and system.ts.
+// =============================================================================
+
+import type { FastifyBaseLogger } from 'fastify';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import config from '../config.js';
+
+/**
+ * Find Git Bash executable on Windows.
+ * Avoids WSL's bash which can't handle Windows paths.
+ */
+let _gitBash: string | null = null;
+export function getGitBash(): string {
+  if (_gitBash) return _gitBash;
+  try {
+    // git --exec-path returns e.g. "C:/Git/scm/libexec/git-core"
+    // Git bash is at {git_root}/usr/bin/bash.exe
+    const execPath = execSync('git --exec-path', { encoding: 'utf-8', stdio: 'pipe' }).trim();
+    const gitRoot = path.resolve(execPath, '..', '..');
+    const bashPath = path.join(gitRoot, 'usr', 'bin', 'bash.exe');
+    if (fs.existsSync(bashPath)) {
+      _gitBash = bashPath;
+      return _gitBash;
+    }
+  } catch {
+    // fallback
+  }
+  _gitBash = 'bash'; // hope for the best
+  return _gitBash;
+}
+
+/**
+ * Convert a Windows path to a bash-safe format with forward slashes.
+ */
+export function toBashPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Install Fleet Commander hooks into a project repo.
+ * Returns { ok, stdout, stderr } so callers can log / surface errors.
+ */
+export function installHooks(repoPath: string, logger: FastifyBaseLogger): { ok: boolean; stdout: string; stderr: string } {
+  const fail = (msg: string) => ({ ok: false, stdout: '', stderr: msg });
+
+  const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'install.sh');
+  if (!fs.existsSync(scriptPath)) {
+    return fail(`install.sh not found at ${scriptPath}`);
+  }
+
+  // On Windows, convert paths to MSYS2 format: C:/foo → /c/foo
+  const cmd = process.platform === 'win32'
+    ? `"${getGitBash()}" "${toBashPath(scriptPath)}" "${toBashPath(repoPath)}"`
+    : `"${scriptPath}" "${repoPath}"`;
+
+  try {
+    const stdout = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+    return { ok: true, stdout, stderr: '' };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message?: string; status?: number };
+    const stdout = e.stdout ?? '';
+    const stderr = e.stderr ?? '';
+    logger.error(
+      `[installHooks] Failed for ${repoPath} (exit ${e.status ?? '?'}):\n` +
+      `  cmd: ${cmd}\n` +
+      `  stderr: ${stderr.trim()}\n` +
+      `  stdout: ${stdout.trim()}`,
+    );
+    return { ok: false, stdout, stderr: stderr || e.message || 'unknown error' };
+  }
+}
+
+/**
+ * Uninstall Fleet Commander hooks from a project repo.
+ */
+export function uninstallHooks(repoPath: string, logger: FastifyBaseLogger): void {
+  try {
+    const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'uninstall.sh');
+    if (!fs.existsSync(scriptPath)) {
+      return;
+    }
+
+    const cmd = process.platform === 'win32'
+      ? `"${getGitBash()}" "${toBashPath(scriptPath)}" "${toBashPath(repoPath)}"`
+      : `"${scriptPath}" "${repoPath}"`;
+
+    execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+  } catch (err) {
+    // Non-fatal — log but don't block project deletion
+    logger.error(
+      `[uninstallHooks] Failed to uninstall from ${repoPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #62

## Summary
- Extracts `getGitBash`, `toBashPath`, `installHooks`, and `uninstallHooks` from `src/server/routes/projects.ts` into a new shared module `src/server/utils/hook-installer.ts`
- Updates `src/server/routes/projects.ts` to import from the new module instead of defining locally
- Replaces ~15 lines of duplicated Git Bash detection + uninstall logic in `src/server/routes/system.ts` factory-reset handler with a single `uninstallHooks()` call
- Removes unused `execSync` import from `system.ts`
- Pure refactor — no behavior changes