### PR TITLE
Issue #51: extract shared spawn/lifecycle helpers from team-manager.ts

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -283,7 +283,7 @@ export class TeamManager {
 
     // ── Step 2: Create git worktree in the PROJECT's repo ──
     const worktreeOk = await this.createWorktree(
-      project.repoPath, worktreeRelPath, worktreeAbsPath, branchName, team.id,
+      project.repoPath, worktreeRelPath, worktreeAbsPath, branchName, team.id, 'queued',
     );
     if (!worktreeOk) {
       throw new Error(`Failed to create worktree for team ${team.id}`);
@@ -822,7 +822,7 @@ export class TeamManager {
 
     // ── Step 1: Create git worktree ──
     const worktreeOk = await this.createWorktree(
-      project.repoPath, worktreeRelPath, worktreeAbsPath, branchName, team.id,
+      project.repoPath, worktreeRelPath, worktreeAbsPath, branchName, team.id, 'launching',
     );
     if (!worktreeOk) return;
 
@@ -1318,6 +1318,7 @@ export class TeamManager {
     worktreeAbsPath: string,
     branchName: string,
     teamId: number,
+    fromStatus: 'queued' | 'launching',
   ): Promise<boolean> {
     if (fs.existsSync(worktreeAbsPath)) return true;
 
@@ -1339,7 +1340,7 @@ export class TeamManager {
         const db = getDatabase();
         db.insertTransition({
           teamId,
-          fromStatus: 'launching',
+          fromStatus,
           toStatus: 'failed',
           trigger: 'system',
           reason: `Worktree creation failed: ${msg.slice(0, 200)}`,


### PR DESCRIPTION
Closes #51

## Summary

Extracts ~600 lines of duplicated spawn/lifecycle logic from `launch()`, `resume()`, and `launchQueued()` in `team-manager.ts` into 8 shared private helper methods:

- `buildSpawnEnv()` — env object with FLEET_TEAM_ID, FLEET_PROJECT_ID, CLAUDE_CODE_GIT_BASH_PATH
- `buildClaudeArgs()` — CLI args with resume/headless/model variations
- `spawnAndValidate()` — spawn + PID validation + failure handling
- `attachProcessHandlers()` — exit/error handlers with map cleanup, status transitions, SSE broadcasts, queue drain
- `setupStdinAndOutput()` — stdin pipe storage, optional initial prompt, output capture
- `createWorktree()` — git worktree add with -b fallback and failure handling
- `copyHooksAndSettings()` — hook file copy + settings.json generation
- `deriveWorktreeNames()` — slug/worktree/branch name derivation

Bug fixes now only need to be applied in one place instead of three. The interactive-mode Windows terminal path in `launch()` and `launchQueued()` is preserved intact.