### PR TITLE
Issue #67: add launch timeout detection to stuck detector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ The SSE broker emits 13 event types:
 | `FLEET_HOST` | `127.0.0.1` | Network interface to bind to |
 | `FLEET_IDLE_THRESHOLD_MIN` | `3` | Minutes before idle status |
 | `FLEET_STUCK_THRESHOLD_MIN` | `5` | Minutes before stuck status |
+| `FLEET_LAUNCH_TIMEOUT_MIN` | `5` | Minutes before a launching team is marked failed |
 | `FLEET_MAX_CI_FAILURES` | `3` | Unique CI failures before blocking |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub poll interval |
 | `FLEET_DB_PATH` | `./fleet.db` | Database file location |

--- a/src/client/views/SettingsPage.tsx
+++ b/src/client/views/SettingsPage.tsx
@@ -10,6 +10,7 @@ interface SettingsResponse {
   port: number;
   idleThresholdMin: number;
   stuckThresholdMin: number;
+  launchTimeoutMin: number;
   maxUniqueCiFailures: number;
   githubPollIntervalMs: number;
   issuePollIntervalMs: number;
@@ -91,6 +92,13 @@ const SETTING_GROUPS: SettingGroup[] = [
         label: 'Stuck Threshold',
         envVar: 'FLEET_STUCK_THRESHOLD_MIN',
         description: 'Minutes before a team is considered stuck',
+        format: (v) => `${v} min`,
+      },
+      {
+        key: 'launchTimeoutMin',
+        label: 'Launch Timeout',
+        envVar: 'FLEET_LAUNCH_TIMEOUT_MIN',
+        description: 'Minutes before a launching team is marked failed',
         format: (v) => `${v} min`,
       },
       {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -34,6 +34,7 @@ const config = Object.freeze({
 
   idleThresholdMin: safeParseInt(process.env['FLEET_IDLE_THRESHOLD_MIN'] || '3', 'FLEET_IDLE_THRESHOLD_MIN'),
   stuckThresholdMin: safeParseInt(process.env['FLEET_STUCK_THRESHOLD_MIN'] || '5', 'FLEET_STUCK_THRESHOLD_MIN'),
+  launchTimeoutMin: safeParseInt(process.env['FLEET_LAUNCH_TIMEOUT_MIN'] || '5', 'FLEET_LAUNCH_TIMEOUT_MIN'),
   maxUniqueCiFailures: safeParseInt(process.env['FLEET_MAX_CI_FAILURES'] || '3', 'FLEET_MAX_CI_FAILURES'),
 
   usageRedDailyPct: safeParseInt(process.env['FLEET_USAGE_RED_DAILY_PCT'] || '85', 'FLEET_USAGE_RED_DAILY_PCT'),
@@ -80,6 +81,7 @@ export function validateConfig(): void {
     ['issuePollIntervalMs', config.issuePollIntervalMs],
     ['stuckCheckIntervalMs', config.stuckCheckIntervalMs],
     ['usagePollIntervalMs', config.usagePollIntervalMs],
+    ['launchTimeoutMin', config.launchTimeoutMin],
     ['maxUniqueCiFailures', config.maxUniqueCiFailures],
   ];
   for (const [name, value] of positiveIntegers) {

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -284,6 +284,7 @@ const systemRoutes: FastifyPluginCallback = (
           port: config.port,
           idleThresholdMin: config.idleThresholdMin,
           stuckThresholdMin: config.stuckThresholdMin,
+          launchTimeoutMin: config.launchTimeoutMin,
           maxUniqueCiFailures: config.maxUniqueCiFailures,
           githubPollIntervalMs: config.githubPollIntervalMs,
           issuePollIntervalMs: config.issuePollIntervalMs,

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -8,8 +8,9 @@
 // (single source of truth for CI status).
 //
 // State machine transitions (from docs/state-machines.md):
-//   running -> idle   after IDLE_THRESHOLD_MIN  (3 min default)
-//   idle    -> stuck  after STUCK_THRESHOLD_MIN (5 min default)
+//   running   -> idle    after IDLE_THRESHOLD_MIN    (3 min default)
+//   idle      -> stuck   after STUCK_THRESHOLD_MIN   (5 min default)
+//   launching -> failed  after LAUNCH_TIMEOUT_MIN    (5 min default)
 // =============================================================================
 
 import type { TeamStatus } from '../../shared/types.js';
@@ -59,6 +60,50 @@ class StuckDetector {
     const now = Date.now();
 
     for (const team of activeTeams) {
+      // --- Launch timeout detection ----------------------------------------
+      // Teams stuck in 'launching' (CC process hangs without crashing or
+      // sending any events) are transitioned to 'failed' after the timeout.
+
+      if (team.status === 'launching' && team.launchedAt) {
+        const launchedTime = new Date(team.launchedAt).getTime();
+        const launchMinutes = (now - launchedTime) / 60_000;
+
+        if (launchMinutes > config.launchTimeoutMin) {
+          db.insertTransition({
+            teamId: team.id,
+            fromStatus: 'launching',
+            toStatus: 'failed',
+            trigger: 'timer',
+            reason: `Launch timeout after ${Math.round(launchMinutes)} minutes`,
+          });
+          db.updateTeam(team.id, { status: 'failed' });
+
+          sseBroker.broadcast(
+            'team_status_changed',
+            {
+              team_id: team.id,
+              status: 'failed',
+              previous_status: 'launching',
+              idle_minutes: Math.round(launchMinutes),
+            },
+            team.id,
+          );
+
+          // Kill the hung process (best-effort — it may already be dead)
+          try {
+            const manager = getTeamManager();
+            manager.stop(team.id).catch(() => {});
+          } catch {
+            // ignore — process may not exist
+          }
+
+          console.log(
+            `[StuckDetector] Team ${team.id} failed — launch timeout after ${Math.round(launchMinutes)} min`
+          );
+          continue;
+        }
+      }
+
       // --- Idle / stuck detection based on time since last event -----------
 
       if (team.lastEventAt) {

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -1,0 +1,274 @@
+// =============================================================================
+// Fleet Commander — Stuck Detector Tests (launch timeout)
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Team } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getActiveTeams: vi.fn<() => Partial<Team>[]>().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  insertTransition: vi.fn(),
+  getPullRequest: vi.fn(),
+};
+
+const mockSseBroker = {
+  broadcast: vi.fn(),
+};
+
+const mockManager = {
+  stop: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: () => mockManager,
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    stuckCheckIntervalMs: 60000,
+    idleThresholdMin: 3,
+    stuckThresholdMin: 5,
+    launchTimeoutMin: 5,
+  },
+}));
+
+// Import after mocks are set up
+const { stuckDetector } = await import('../../src/server/services/stuck-detector.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides: Partial<Team>): Partial<Team> {
+  return {
+    id: 1,
+    issueNumber: 100,
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-abc',
+    worktreeName: 'test-100',
+    branchName: 'feat/100-test',
+    prNumber: null,
+    customPrompt: null,
+    launchedAt: new Date(Date.now() - 60_000).toISOString(), // 1 min ago
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function minutesAgo(min: number): string {
+  return new Date(Date.now() - min * 60_000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.getActiveTeams.mockReturnValue([]);
+});
+
+// =============================================================================
+// Launch timeout detection
+// =============================================================================
+
+describe('Launch timeout detection', () => {
+  it('transitions launching -> failed when launchedAt exceeds timeout', () => {
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: minutesAgo(10), // 10 min ago, well past the 5 min timeout
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'launching',
+        toStatus: 'failed',
+        trigger: 'timer',
+        reason: expect.stringContaining('Launch timeout'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'failed' });
+  });
+
+  it('does NOT transition launching team with recent launchedAt', () => {
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: minutesAgo(2), // 2 min ago, within the 5 min timeout
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts SSE on launching -> failed', () => {
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: minutesAgo(10),
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({
+        team_id: 1,
+        status: 'failed',
+        previous_status: 'launching',
+      }),
+      1,
+    );
+  });
+
+  it('calls manager.stop to kill hung process', () => {
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: minutesAgo(10),
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockManager.stop).toHaveBeenCalledWith(1);
+  });
+
+  it('does not crash if manager.stop throws', () => {
+    mockManager.stop.mockRejectedValueOnce(new Error('process not found'));
+
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: minutesAgo(10),
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    // Should not throw
+    expect(() => stuckDetector.check()).not.toThrow();
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'failed' });
+  });
+
+  it('guards against launchedAt === null', () => {
+    const team = makeTeam({
+      status: 'launching',
+      launchedAt: null,
+      lastEventAt: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    // Should skip this team entirely
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Teams in other statuses are unaffected by launch timeout
+// =============================================================================
+
+describe('Teams in other statuses unaffected by launch timeout', () => {
+  const otherStatuses = ['running', 'idle', 'stuck', 'queued'] as const;
+
+  for (const status of otherStatuses) {
+    it(`does not apply launch timeout to ${status} team`, () => {
+      const team = makeTeam({
+        status,
+        launchedAt: minutesAgo(10), // Old enough to trigger, but wrong status
+        lastEventAt: status === 'running' ? new Date().toISOString() : minutesAgo(1),
+      });
+      mockDb.getActiveTeams.mockReturnValue([team]);
+
+      stuckDetector.check();
+
+      // Should NOT transition to 'failed' via launch timeout
+      const failedCalls = mockDb.insertTransition.mock.calls.filter(
+        (call: unknown[]) => {
+          const arg = call[0] as Record<string, unknown>;
+          return arg.reason && String(arg.reason).includes('Launch timeout');
+        },
+      );
+      expect(failedCalls).toHaveLength(0);
+    });
+  }
+});
+
+// =============================================================================
+// Existing idle/stuck detection still works
+// =============================================================================
+
+describe('Existing idle/stuck detection', () => {
+  it('transitions running -> idle when lastEventAt exceeds idle threshold', () => {
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(4), // 4 min ago, past the 3 min idle threshold
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'running',
+        toStatus: 'idle',
+        trigger: 'timer',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'idle' });
+  });
+
+  it('transitions idle -> stuck when lastEventAt exceeds stuck threshold', () => {
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(6), // 6 min ago, past the 5 min stuck threshold
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'idle',
+        toStatus: 'stuck',
+        trigger: 'timer',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'stuck' });
+  });
+});


### PR DESCRIPTION
Closes #67

## Summary
- Add launch timeout detection to `StuckDetector.check()` for teams stuck in `launching` status
- New `FLEET_LAUNCH_TIMEOUT_MIN` env var (default 5 minutes) controls the timeout threshold
- Teams exceeding the timeout transition `launching → failed`, with the hung process killed via `manager.stop()`
- Expose `launchTimeoutMin` in `/api/settings` and the Settings UI page

## Changes
- `src/server/config.ts` — new `launchTimeoutMin` config field with validation
- `src/server/services/stuck-detector.ts` — launch timeout check (separate from idle/stuck logic)
- `src/server/services/stuck-detector.test.ts` — tests for timeout, no-timeout, SSE broadcast, and no side-effects on other statuses
- `src/server/routes/system.ts` — expose in settings API
- `src/client/views/SettingsPage.tsx` — display in settings UI
- `CLAUDE.md` — document new env var