### PR TITLE
Issue #127: show usage reset times in TopBar tooltip and Usage View

### DIFF
--- a/src/client/components/TopBar.tsx
+++ b/src/client/components/TopBar.tsx
@@ -5,6 +5,7 @@ import { LaunchDialog } from './LaunchDialog';
 import { useApi } from '../hooks/useApi';
 import { RocketIcon } from './Icons';
 import { STATUS_COLORS, getUsageColor } from '../utils/constants';
+import { formatResetsAt } from '../utils/format-resets-at';
 import type { UsageZone } from '../../shared/types';
 
 interface RedThresholds {
@@ -23,6 +24,8 @@ interface UsageResponse {
   extraPercent: number;
   zone?: UsageZone;
   redThresholds?: RedThresholds;
+  dailyResetsAt?: string | null;
+  weeklyResetsAt?: string | null;
 }
 
 export function TopBar() {
@@ -57,10 +60,10 @@ export function TopBar() {
   // Build usage indicators with full names
   const usageIndicators = usage
     ? [
-        { key: 'daily', label: 'Daily', percent: usage.dailyPercent, redThreshold: thresholds.daily },
-        { key: 'weekly', label: 'Weekly', percent: usage.weeklyPercent, redThreshold: thresholds.weekly },
-        { key: 'sonnet', label: 'Sonnet', percent: usage.sonnetPercent, redThreshold: thresholds.sonnet },
-        { key: 'extra', label: 'Extra', percent: usage.extraPercent, redThreshold: thresholds.extra },
+        { key: 'daily', label: 'Daily', percent: usage.dailyPercent, redThreshold: thresholds.daily, resetLabel: formatResetsAt(usage.dailyResetsAt) },
+        { key: 'weekly', label: 'Weekly', percent: usage.weeklyPercent, redThreshold: thresholds.weekly, resetLabel: formatResetsAt(usage.weeklyResetsAt) },
+        { key: 'sonnet', label: 'Sonnet', percent: usage.sonnetPercent, redThreshold: thresholds.sonnet, resetLabel: null },
+        { key: 'extra', label: 'Extra', percent: usage.extraPercent, redThreshold: thresholds.extra, resetLabel: null },
       ]
     : [];
 
@@ -101,7 +104,7 @@ export function TopBar() {
             <span className="text-dark-muted mx-1">|</span>
           )}
           {usageIndicators.map(ind => (
-            <span key={ind.key} className="text-xs font-medium">
+            <span key={ind.key} className="text-xs font-medium" title={ind.resetLabel ?? undefined}>
               <span className="text-dark-muted">{ind.label}</span>{' '}
               <span style={{ color: getUsageColor(ind.percent, ind.redThreshold) }}>{ind.percent.toFixed(0)}%</span>
             </span>

--- a/src/client/utils/format-resets-at.ts
+++ b/src/client/utils/format-resets-at.ts
@@ -1,0 +1,9 @@
+export function formatResetsAt(isoStr: string | null | undefined): string | null {
+  if (!isoStr) return null;
+  const diff = new Date(isoStr).getTime() - Date.now();
+  if (diff <= 0) return null;
+  const hours = Math.floor(diff / 3600000);
+  const mins = Math.floor((diff % 3600000) / 60000);
+  if (hours > 0) return `Resets in ${hours}h ${mins}m`;
+  return `Resets in ${mins}m`;
+}

--- a/src/client/views/UsageViewPage.tsx
+++ b/src/client/views/UsageViewPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApi } from '../hooks/useApi';
 import { getUsageColor } from '../utils/constants';
+import { formatResetsAt } from '../utils/format-resets-at';
 import type { UsageSnapshot } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -22,13 +23,14 @@ interface UsageBar {
   label: string;
   key: 'dailyPercent' | 'weeklyPercent' | 'sonnetPercent' | 'extraPercent';
   thresholdKey: keyof RedThresholds;
+  resetKey: 'dailyResetsAt' | 'weeklyResetsAt' | null;
 }
 
 const USAGE_BARS: UsageBar[] = [
-  { label: 'Daily Usage', key: 'dailyPercent', thresholdKey: 'daily' },
-  { label: 'Weekly Usage', key: 'weeklyPercent', thresholdKey: 'weekly' },
-  { label: 'Sonnet Usage', key: 'sonnetPercent', thresholdKey: 'sonnet' },
-  { label: 'Extra Usage', key: 'extraPercent', thresholdKey: 'extra' },
+  { label: 'Daily Usage', key: 'dailyPercent', thresholdKey: 'daily', resetKey: 'dailyResetsAt' },
+  { label: 'Weekly Usage', key: 'weeklyPercent', thresholdKey: 'weekly', resetKey: 'weeklyResetsAt' },
+  { label: 'Sonnet Usage', key: 'sonnetPercent', thresholdKey: 'sonnet', resetKey: null },
+  { label: 'Extra Usage', key: 'extraPercent', thresholdKey: 'extra', resetKey: null },
 ];
 
 // ---------------------------------------------------------------------------
@@ -146,6 +148,12 @@ export function UsageViewPage() {
                       }}
                     />
                   </div>
+                  {bar.resetKey && (() => {
+                    const resetLabel = formatResetsAt(usage[bar.resetKey]);
+                    return resetLabel ? (
+                      <p className="text-xs text-gray-500 mt-0.5">{resetLabel}</p>
+                    ) : null;
+                  })()}
                 </div>
               );
             })}

--- a/tests/client/TopBar.test.tsx
+++ b/tests/client/TopBar.test.tsx
@@ -2,8 +2,8 @@
 // Fleet Commander — TopBar Component Tests
 // =============================================================================
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { TeamDashboardRow } from '../../src/shared/types';
 import { makeTeam } from './test-utils';
@@ -34,6 +34,10 @@ import { TopBar } from '../../src/client/components/TopBar';
 describe('TopBar', () => {
   beforeEach(() => {
     mockTeams = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('renders the "Fleet Commander" title', () => {
@@ -91,6 +95,75 @@ describe('TopBar', () => {
     const dots = container.querySelectorAll('span');
     const dotTexts = Array.from(dots).filter(el => el.textContent === '\u00B7');
     expect(dotTexts.length).toBe(1);
+  });
+
+  it('shows reset tooltip on daily and weekly usage indicators', async () => {
+    // Fix Date.now to a known time, but let async code (fetch) resolve naturally
+    const now = new Date('2026-03-18T10:00:00Z').getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    // dailyResetsAt = 2h 30m from now, weeklyResetsAt = 5h 15m from now
+    const usageResponse = {
+      dailyPercent: 42,
+      weeklyPercent: 60,
+      sonnetPercent: 10,
+      extraPercent: 5,
+      zone: 'green',
+      dailyResetsAt: '2026-03-18T12:30:00Z',
+      weeklyResetsAt: '2026-03-18T15:15:00Z',
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => usageResponse,
+    } as Response);
+
+    render(<TopBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Daily')).toBeInTheDocument();
+    });
+
+    // Daily indicator should have tooltip "Resets in 2h 30m"
+    const dailySpan = screen.getByText('Daily').closest('span[title]');
+    expect(dailySpan).toHaveAttribute('title', 'Resets in 2h 30m');
+
+    // Weekly indicator should have tooltip "Resets in 5h 15m"
+    const weeklySpan = screen.getByText('Weekly').closest('span[title]');
+    expect(weeklySpan).toHaveAttribute('title', 'Resets in 5h 15m');
+
+    // Sonnet and Extra should NOT have a title attribute
+    const sonnetSpan = screen.getByText('Sonnet').closest('span');
+    expect(sonnetSpan).not.toHaveAttribute('title');
+
+    const extraSpan = screen.getByText('Extra').closest('span');
+    expect(extraSpan).not.toHaveAttribute('title');
+  });
+
+  it('does not show reset tooltip when reset timestamps are null', async () => {
+    const usageResponse = {
+      dailyPercent: 42,
+      weeklyPercent: 60,
+      sonnetPercent: 10,
+      extraPercent: 5,
+      zone: 'green',
+      dailyResetsAt: null,
+      weeklyResetsAt: null,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => usageResponse,
+    } as Response);
+
+    render(<TopBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Daily')).toBeInTheDocument();
+    });
+
+    const dailySpan = screen.getByText('Daily').closest('span');
+    expect(dailySpan).not.toHaveAttribute('title');
   });
 
 });


### PR DESCRIPTION
## Summary

Display usage reset times that the API already returns (`dailyResetsAt`, `weeklyResetsAt`) in two places:

- **TopBar:** hover tooltip on Daily/Weekly usage indicators showing "Resets in Xh Ym"
- **Usage View:** muted inline text below Daily/Weekly progress bars with the same format
- Sonnet and Extra indicators show nothing (no reset data from API)

New shared helper `formatResetsAt()` in `src/client/utils/format-resets-at.ts` converts ISO timestamps to relative time strings.

## Files changed
- `src/client/utils/format-resets-at.ts` (new) — reset time formatting helper
- `src/client/components/TopBar.tsx` — extended UsageResponse type, added title tooltips
- `src/client/views/UsageViewPage.tsx` — added muted reset text below progress bars
- `tests/client/TopBar.test.tsx` — 2 new tests for tooltip presence/absence

Closes #127