### PR TITLE
Issue #132: add Prioritize button on every parent tree node

### DIFF
--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -118,9 +118,13 @@ interface TreeNodeProps {
   checkedIssues?: Set<number>;
   /** Callback when checkbox state changes */
   onCheckChange?: (issueNumber: number, checked: boolean) => void;
+  /** Callback to prioritize a subtree (parent nodes only) */
+  onPrioritizeSubtree?: (subtreeChildren: IssueNode[]) => Promise<void>;
+  /** Whether a prioritization request is in progress */
+  prioritizing?: boolean;
 }
 
-export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange }: TreeNodeProps) {
+export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange, onPrioritizeSubtree, prioritizing }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(depth < 2);
   const isExpanded = forceExpand || expanded;
   const hasChildren = node.children.length > 0;
@@ -232,6 +236,33 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
           </span>
         )}
 
+        {/* Prioritize button — only for parent nodes with children */}
+        {hasChildren && onPrioritizeSubtree && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onPrioritizeSubtree(node.children);
+            }}
+            disabled={prioritizing}
+            className={`ml-auto shrink-0 transition-opacity inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded border border-[#A371F7]/50 text-[#A371F7] hover:bg-[#A371F7]/10 disabled:opacity-50 disabled:cursor-not-allowed ${
+              prioritizing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            }`}
+            title={`Prioritize sub-issues under #${node.number}`}
+          >
+            {prioritizing ? (
+              <svg className="animate-spin w-3 h-3" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+              </svg>
+            ) : (
+              <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M7.823.9l4.584 4.584-7.636 7.636L.187 8.536 7.823.9ZM14.2 6.1l-1.3 1.3-4.584-4.584L9.6 1.5a1.5 1.5 0 012.122 0L14.2 3.978a1.5 1.5 0 010 2.122Z" />
+              </svg>
+            )}
+            Prioritize
+          </button>
+        )}
+
         {/* Play button — only for leaf issues with no active team that are open */}
         {!hasActiveTeam && node.state === 'open' && !hasChildren && (
           <button
@@ -283,6 +314,8 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
               priorityMap={priorityMap}
               checkedIssues={checkedIssues}
               onCheckChange={onCheckChange}
+              onPrioritizeSubtree={onPrioritizeSubtree}
+              prioritizing={prioritizing}
             />
           ))}
         </div>

--- a/src/client/hooks/usePrioritization.ts
+++ b/src/client/hooks/usePrioritization.ts
@@ -21,6 +21,8 @@ interface PrioritizationState {
 interface UsePrioritizationReturn extends PrioritizationState {
   /** Run AI prioritization on the given issue tree */
   prioritize: (tree: IssueNode[]) => Promise<void>;
+  /** Run AI prioritization on a subtree and merge results into existing priorityMap */
+  prioritizeSubtree: (subtreeNodes: IssueNode[]) => Promise<void>;
   /** Reset all prioritization state */
   reset: () => void;
   /** Toggle an issue's checked state */
@@ -33,7 +35,7 @@ interface UsePrioritizationReturn extends PrioritizationState {
   checkedSortedIssueNumbers: number[];
 }
 
-/** Collect all open leaf issue numbers + titles from a tree */
+/** Collect all open issue numbers + titles from a tree (including parents) */
 function collectOpenIssues(nodes: IssueNode[]): { number: number; title: string }[] {
   const result: { number: number; title: string }[] = [];
   for (const node of nodes) {
@@ -42,6 +44,19 @@ function collectOpenIssues(nodes: IssueNode[]): { number: number; title: string 
     }
     if (node.children.length > 0) {
       result.push(...collectOpenIssues(node.children));
+    }
+  }
+  return result;
+}
+
+/** Collect only open leaf issues (no children) from a tree */
+export function collectOpenLeafIssues(nodes: IssueNode[]): { number: number; title: string }[] {
+  const result: { number: number; title: string }[] = [];
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      result.push(...collectOpenLeafIssues(node.children));
+    } else if (node.state === 'open') {
+      result.push({ number: node.number, title: node.title });
     }
   }
   return result;
@@ -121,6 +136,53 @@ export function usePrioritization(): UsePrioritizationReturn {
     }
   }, [api]);
 
+  const prioritizeSubtree = useCallback(async (subtreeNodes: IssueNode[]) => {
+    const issues = collectOpenLeafIssues(subtreeNodes);
+    if (issues.length === 0) return;
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const result = await api.post<CCQueryResult<PrioritizedIssue[]>>(
+        'query/prioritizeIssues',
+        { issues },
+      );
+
+      if (!result.success || !result.data) {
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: result.error ?? 'Prioritization returned no data',
+        }));
+        return;
+      }
+
+      // Merge new results into existing priorityMap
+      setState((prev) => {
+        const mergedMap = new Map(prev.priorityMap);
+        const mergedChecked = new Set(prev.checkedIssues);
+        for (const item of result.data!) {
+          mergedMap.set(item.number, item);
+          mergedChecked.add(item.number);
+        }
+        return {
+          priorityMap: mergedMap,
+          loading: false,
+          error: null,
+          costUsd: result.costUsd,
+          durationMs: result.durationMs,
+          checkedIssues: mergedChecked,
+        };
+      });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [api]);
+
   const reset = useCallback(() => {
     setState({
       priorityMap: new Map(),
@@ -159,6 +221,7 @@ export function usePrioritization(): UsePrioritizationReturn {
   return {
     ...state,
     prioritize,
+    prioritizeSubtree,
     reset,
     toggleCheck,
     hasPriority,

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -634,6 +634,8 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
               priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
               checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
               onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
+              onPrioritizeSubtree={prioritization.prioritizeSubtree}
+              prioritizing={prioritization.loading}
             />
           ))}
         </div>
@@ -702,6 +704,8 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
             priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
             checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
             onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
+            onPrioritizeSubtree={prioritization.prioritizeSubtree}
+            prioritizing={prioritization.loading}
           />
         ))}
       </div>


### PR DESCRIPTION
Closes #132

## Summary
- Add Prioritize button on every tree node that has children (project groups, epics, sub-epics)
- Leaf nodes retain Launch button only — parent nodes get Prioritize button
- Clicking Prioritize collects only that subtree's leaf issues and sends them to the existing prioritize API
- Results merge additively into the shared priorityMap, allowing multiple independent subtree prioritizations
- Existing top-level project prioritization continues to work unchanged

## Changed files
- `src/client/hooks/usePrioritization.ts` — new `prioritizeSubtree()` with merge semantics, `collectOpenLeafIssues()` helper
- `src/client/components/TreeNode.tsx` — Prioritize button on parent nodes, recursive prop threading
- `src/client/views/IssueTreeView.tsx` — wired subtree prioritization into ProjectGroup and SingleProjectTree