### PR TITLE
Issue #137: add team roster to Team Detail panel (#154)

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -6,7 +6,7 @@ import { CIChecks } from './CIChecks';
 import { EventTimeline } from './EventTimeline';
 import { TeamOutput } from './TeamOutput';
 import { CommandInput } from './CommandInput';
-import type { TeamDetail as TeamDetailType, TeamTransition } from '../../shared/types';
+import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember } from '../../shared/types';
 import { STATUS_COLORS } from '../utils/constants';
 
 // ---------------------------------------------------------------------------
@@ -20,6 +20,36 @@ function formatDuration(minutes: number | undefined | null): string {
   const m = Math.round(minutes % 60);
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
+}
+
+/** Deterministic color from agent name — hash name to pick from a palette. */
+const AGENT_PALETTE = [
+  '#58A6FF', '#3FB950', '#D29922', '#A371F7', '#F778BA',
+  '#79C0FF', '#7EE787', '#E3B341', '#D2A8FF', '#FF7B72',
+];
+
+function agentColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  return AGENT_PALETTE[Math.abs(hash) % AGENT_PALETTE.length];
+}
+
+/** Format a relative time string like "2m", "1h", "just now" */
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const min = Math.floor(ms / 60000);
+  if (min < 1) return 'now';
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  return `${h}h`;
+}
+
+/** Truncate agent name to fit in a small card */
+function truncateName(name: string, maxLen = 5): string {
+  if (name.length <= maxLen) return name;
+  return name.slice(0, maxLen);
 }
 
 // ---------------------------------------------------------------------------
@@ -36,6 +66,7 @@ export function TeamDetail() {
   const [quickActionLoading, setQuickActionLoading] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [transitions, setTransitions] = useState<TeamTransition[]>([]);
+  const [roster, setRoster] = useState<TeamMember[]>([]);
   const panelRef = useRef<HTMLDivElement>(null);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedTeamIdRef = useRef(selectedTeamId);
@@ -68,6 +99,33 @@ export function TeamDetail() {
     }
 
     fetchTransitions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTeamId, refreshKey, api]);
+
+  // Fetch roster when selectedTeamId changes or detail refreshes
+  useEffect(() => {
+    if (selectedTeamId == null) {
+      setRoster([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchRoster() {
+      try {
+        const data = await api.get<TeamMember[]>(`teams/${selectedTeamId}/roster`);
+        if (!cancelled) {
+          setRoster(data);
+        }
+      } catch {
+        // Non-critical — roster is informational
+      }
+    }
+
+    fetchRoster();
 
     return () => {
       cancelled = true;
@@ -356,6 +414,69 @@ export function TeamDetail() {
                       </div>
                     )}
                   </section>
+
+                  {/* ---- Team Roster ---- */}
+                  {roster.length > 0 && (
+                    <section>
+                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
+                        Team Members ({roster.filter(m => m.isActive).length} active)
+                      </h4>
+                      <div className="flex items-start gap-2 overflow-x-auto pb-1 custom-scrollbar">
+                        {roster.map((member) => {
+                          const color = agentColor(member.name);
+                          const lastActivity = member.isActive ? relativeTime(member.lastSeen) : 'done';
+                          return (
+                            <div
+                              key={member.name}
+                              className="flex flex-col items-center w-14 shrink-0 group relative cursor-default"
+                            >
+                              {/* Status dot */}
+                              <div
+                                className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold border-2"
+                                style={{
+                                  borderColor: member.isActive ? color : '#484F58',
+                                  color: member.isActive ? color : '#484F58',
+                                  backgroundColor: (member.isActive ? color : '#484F58') + '18',
+                                }}
+                              >
+                                {member.name.charAt(0).toUpperCase()}
+                              </div>
+                              {/* Name */}
+                              <span
+                                className="text-[10px] mt-1 leading-tight text-center"
+                                style={{ color: member.isActive ? '#E6EDF3' : '#484F58' }}
+                              >
+                                {truncateName(member.name)}
+                              </span>
+                              {/* Last activity */}
+                              <span
+                                className="text-[9px] leading-none"
+                                style={{ color: member.isActive ? '#8B949E' : '#484F58' }}
+                              >
+                                {lastActivity}
+                              </span>
+                              {/* Tooltip */}
+                              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2.5 py-1.5 bg-dark-surface border border-dark-border rounded text-[10px] text-dark-text whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 shadow-lg">
+                                <div className="font-semibold">{member.name}</div>
+                                <div className="text-dark-muted">{member.role}</div>
+                                <div className="text-dark-muted mt-0.5">
+                                  Tools: {member.toolUseCount}
+                                  {member.errorCount > 0 && (
+                                    <span className="text-[#F85149] ml-1">Errors: {member.errorCount}</span>
+                                  )}
+                                </div>
+                                <div className="text-dark-muted">
+                                  First: {new Date(member.firstSeen).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                  {' / '}
+                                  Last: {new Date(member.lastSeen).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  )}
 
                   {/* ---- Transition History ---- */}
                   {transitions.length > 0 && (

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -23,6 +23,7 @@ import type {
   ProjectStatus,
   MessageTemplate,
   TeamTransition,
+  TeamMember,
 } from '../shared/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -48,6 +49,25 @@ export function utcify(value: string | null): string | null {
   if (value.includes('T')) return value;
   // SQLite format: "YYYY-MM-DD HH:MM:SS" -> "YYYY-MM-DDTHH:MM:SS.000Z"
   return value.replace(' ', 'T') + '.000Z';
+}
+
+// ---------------------------------------------------------------------------
+// Agent name -> role mapping
+// ---------------------------------------------------------------------------
+
+const ROLE_MAP: Record<string, string> = {
+  coordinator: 'Coordinator',
+  analyst: 'Analyst',
+  reviewer: 'Reviewer',
+};
+
+/** Derive a human-readable role from the agent name. */
+function deriveRole(name: string): string {
+  const lower = name.toLowerCase();
+  if (ROLE_MAP[lower]) return ROLE_MAP[lower];
+  if (lower.startsWith('dev-')) return `Developer (${name.slice(4)})`;
+  if (lower.includes('dev')) return 'Developer';
+  return name;
 }
 
 // ---------------------------------------------------------------------------
@@ -924,6 +944,42 @@ export class FleetDatabase {
     const stmt = this.db.prepare(sql);
     const rows = (Object.keys(params).length > 0 ? stmt.all(params) : stmt.all()) as Record<string, unknown>[];
     return rows.map((r) => this.mapEventRow(r));
+  }
+
+  // -------------------------------------------------------------------------
+  // Team Roster (subagent members derived from events)
+  // -------------------------------------------------------------------------
+
+  getTeamRoster(teamId: number): TeamMember[] {
+    const sql = `
+      SELECT
+        agent_name AS name,
+        MIN(created_at) AS first_seen,
+        MAX(created_at) AS last_seen,
+        SUM(CASE WHEN event_type = 'ToolUse' THEN 1 ELSE 0 END) AS tool_use_count,
+        SUM(CASE WHEN event_type = 'ToolError' THEN 1 ELSE 0 END) AS error_count,
+        SUM(CASE WHEN event_type = 'SubagentStart' THEN 1 ELSE 0 END) AS starts,
+        SUM(CASE WHEN event_type = 'SubagentStop' THEN 1 ELSE 0 END) AS stops
+      FROM events
+      WHERE team_id = ? AND agent_name IS NOT NULL AND agent_name != ''
+      GROUP BY agent_name
+      ORDER BY MIN(created_at) ASC
+    `;
+    const rows = this.db.prepare(sql).all(teamId) as Record<string, unknown>[];
+    return rows.map((row) => {
+      const name = row.name as string;
+      const starts = (row.starts as number) ?? 0;
+      const stops = (row.stops as number) ?? 0;
+      return {
+        name,
+        role: deriveRole(name),
+        isActive: starts > stops,
+        firstSeen: utcify(row.first_seen as string),
+        lastSeen: utcify(row.last_seen as string),
+        toolUseCount: (row.tool_use_count as number) ?? 0,
+        errorCount: (row.error_count as number) ?? 0,
+      };
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -874,6 +874,45 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // GET /api/teams/:id/roster — team member roster derived from events
+  // -------------------------------------------------------------------------
+  fastify.get(
+    '/api/teams/:id/roster',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseInt(request.params.id, 10);
+        if (isNaN(teamId) || teamId < 1) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Invalid team ID',
+          });
+        }
+
+        const db = getDatabase();
+        const team = db.getTeam(teamId);
+        if (!team) {
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: `Team ${teamId} not found`,
+          });
+        }
+
+        const roster = db.getTeamRoster(teamId);
+        return reply.code(200).send(roster);
+      } catch (err: unknown) {
+        request.log.error(err, 'Failed to get team roster');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // GET /api/teams/:id/transitions — state transition history
   // -------------------------------------------------------------------------
   fastify.get(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -265,6 +265,21 @@ export interface AssignmentPlan {
 }
 
 // ---------------------------------------------------------------------------
+// Team Roster (subagent members derived from events)
+// ---------------------------------------------------------------------------
+
+/** A subagent team member derived from hook events */
+export interface TeamMember {
+  name: string;
+  role: string;
+  isActive: boolean;
+  firstSeen: string;
+  lastSeen: string;
+  toolUseCount: number;
+  errorCount: number;
+}
+
+// ---------------------------------------------------------------------------
 // Dashboard View (v_team_dashboard)
 // ---------------------------------------------------------------------------
 

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -783,6 +783,99 @@ describe('Timestamp UTC normalization', () => {
 // Connection management
 // =============================================================================
 
+// =============================================================================
+// Team Roster
+// =============================================================================
+
+describe('Team Roster', () => {
+  beforeEach(() => {
+    db.insertTeam({ issueNumber: 100, worktreeName: 'kea-100', status: 'running', phase: 'implementing' });
+  });
+
+  it('returns empty roster when no events have agent_name', () => {
+    db.insertEvent({ teamId: 1, eventType: 'ToolUse' });
+    const roster = db.getTeamRoster(1);
+    expect(roster).toHaveLength(0);
+  });
+
+  it('aggregates events by agent_name', () => {
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 1, eventType: 'ToolUse', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 1, eventType: 'ToolUse', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'dev-typescript' });
+    db.insertEvent({ teamId: 1, eventType: 'ToolUse', agentName: 'dev-typescript' });
+    db.insertEvent({ teamId: 1, eventType: 'ToolError', agentName: 'dev-typescript' });
+
+    const roster = db.getTeamRoster(1);
+    expect(roster).toHaveLength(2);
+
+    const coord = roster.find(m => m.name === 'coordinator')!;
+    expect(coord.role).toBe('Coordinator');
+    expect(coord.toolUseCount).toBe(2);
+    expect(coord.errorCount).toBe(0);
+    expect(coord.isActive).toBe(true);
+
+    const dev = roster.find(m => m.name === 'dev-typescript')!;
+    expect(dev.role).toBe('Developer (typescript)');
+    expect(dev.toolUseCount).toBe(1);
+    expect(dev.errorCount).toBe(1);
+    expect(dev.isActive).toBe(true);
+  });
+
+  it('marks agent as inactive when stops >= starts', () => {
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'analyst' });
+    db.insertEvent({ teamId: 1, eventType: 'ToolUse', agentName: 'analyst' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStop', agentName: 'analyst' });
+
+    const roster = db.getTeamRoster(1);
+    expect(roster).toHaveLength(1);
+    expect(roster[0].isActive).toBe(false);
+  });
+
+  it('returns all members ordered by first_seen', () => {
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'analyst' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'reviewer' });
+
+    const roster = db.getTeamRoster(1);
+    expect(roster).toHaveLength(3);
+    const names = roster.map(m => m.name);
+    expect(names).toContain('coordinator');
+    expect(names).toContain('analyst');
+    expect(names).toContain('reviewer');
+  });
+
+  it('excludes events from other teams', () => {
+    db.insertTeam({ issueNumber: 200, worktreeName: 'kea-200', status: 'running', phase: 'implementing' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 2, eventType: 'SubagentStart', agentName: 'dev-python' });
+
+    const roster1 = db.getTeamRoster(1);
+    expect(roster1).toHaveLength(1);
+    expect(roster1[0].name).toBe('coordinator');
+
+    const roster2 = db.getTeamRoster(2);
+    expect(roster2).toHaveLength(1);
+    expect(roster2[0].name).toBe('dev-python');
+  });
+
+  it('derives roles correctly', () => {
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'coordinator' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'analyst' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'reviewer' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'dev-csharp' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'some-agent' });
+
+    const roster = db.getTeamRoster(1);
+    const roles = Object.fromEntries(roster.map(m => [m.name, m.role]));
+    expect(roles['coordinator']).toBe('Coordinator');
+    expect(roles['analyst']).toBe('Analyst');
+    expect(roles['reviewer']).toBe('Reviewer');
+    expect(roles['dev-csharp']).toBe('Developer (csharp)');
+    expect(roles['some-agent']).toBe('some-agent');
+  });
+});
+
 describe('Connection management', () => {
   it('closes the database', () => {
     db.close();


### PR DESCRIPTION
## Summary
- Add Team Roster section to the Team Detail slide-over showing subagent teammates with active/inactive status, deterministic avatar colors, relative activity times, and hover tooltips with full stats
- New `GET /api/teams/:id/roster` endpoint deriving team members from existing `events` table data (no schema changes)
- New `getTeamRoster()` DB method with SQL aggregation on `agent_name`
- 6 unit tests for roster DB logic

Closes #137