### PR TITLE
Issue #159: revert FLEET_HOST default to 0.0.0.0 for LAN access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ The SSE broker emits 13 event types:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `4680` | Server port |
-| `FLEET_HOST` | `127.0.0.1` | Network interface to bind to |
+| `FLEET_HOST` | `0.0.0.0` | Network interface to bind to |
 | `FLEET_IDLE_THRESHOLD_MIN` | `3` | Minutes before idle status |
 | `FLEET_STUCK_THRESHOLD_MIN` | `5` | Minutes before stuck status |
 | `FLEET_LAUNCH_TIMEOUT_MIN` | `5` | Minutes before a launching team is marked failed |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -21,7 +21,7 @@ export function safeParseInt(value: string, name: string): number {
 const fleetCommanderRoot = process.env['FLEET_COMMANDER_ROOT'] || findFleetCommanderRoot();
 
 const config = Object.freeze({
-  host: process.env['FLEET_HOST'] || '127.0.0.1',
+  host: process.env['FLEET_HOST'] || '0.0.0.0',
   port: safeParseInt(process.env['PORT'] || '4680', 'PORT'),
 
   /** Absolute path to the fleet-commander installation itself */

--- a/tests/server/config.test.ts
+++ b/tests/server/config.test.ts
@@ -66,9 +66,9 @@ describe('validateConfig', () => {
     expect(mod.default.port).toBe(parseInt(process.env['PORT'] || '4680', 10));
   });
 
-  it('defaults host to 127.0.0.1', async () => {
+  it('defaults host to 0.0.0.0', async () => {
     const mod = await import('../../src/server/config.js');
-    expect(mod.default.host).toBe(process.env['FLEET_HOST'] || '127.0.0.1');
+    expect(mod.default.host).toBe(process.env['FLEET_HOST'] || '0.0.0.0');
   });
 
   it('safeParseInt rejects fully non-numeric PORT before config is built', () => {


### PR DESCRIPTION
Closes #159

## Summary
- Reverts the `FLEET_HOST` default from `127.0.0.1` back to `0.0.0.0` so the server is accessible over LAN
- Updates the environment variables documentation in CLAUDE.md to reflect the new default
- Updates the config test to expect `0.0.0.0` as the default host

The `FLEET_HOST` env var override is preserved, so users who want localhost-only binding can still set `FLEET_HOST=127.0.0.1`.