### PR TITLE
Issue #157: set stoppedAt when poller marks team done on PR merge

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -391,7 +391,7 @@ class GitHubPoller {
           trigger: 'poller',
           reason: `PR #${prNumber} merged`,
         });
-        db.updateTeam(teamId, { status: 'done', phase: 'done' });
+        db.updateTeam(teamId, { status: 'done', phase: 'done', stoppedAt: new Date().toISOString() });
         sseBroker.broadcast(
           'team_status_changed',
           {


### PR DESCRIPTION
Closes #157

## Problem
`stopped_at` is NULL for all teams completed via PR merge. The GitHub poller sets `status: 'done'` on merge detection but does not set `stoppedAt`. The exit handler fires later, sees `done`, and skips its block that would set `stoppedAt`.

## Fix
Added `stoppedAt: new Date().toISOString()` to the `db.updateTeam()` call in `github-poller.ts` where the poller marks a team as done after PR merge detection.

## Files changed
- `src/server/services/github-poller.ts` — single field addition to existing `updateTeam` call