### PR TITLE
Issue #158: extract error field from CC PostToolUseFailure in send_event.sh

### DIFF
--- a/hooks/on_tool_error.sh
+++ b/hooks/on_tool_error.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Fleet Commander hook: PostToolUseFailure (aliased as "tool_error")
 # Tracks tool failures — repeated errors indicate the team is struggling.
-# stdin JSON example: {"session_id":"abc123","tool_name":"Bash","message":"exit code 1"}
+# stdin JSON example: {"session_id":"abc123","tool_name":"Bash","error":"exit code 1","tool_use_id":"toolu_123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 input=$(cat)

--- a/hooks/send_event.sh
+++ b/hooks/send_event.sh
@@ -72,6 +72,8 @@ TOOL_NAME=$(extract_json_string "tool_name")
 AGENT_TYPE=$(extract_json_string "agent_type")
 TEAMMATE_NAME=$(extract_json_string "teammate_name")
 MESSAGE=$(extract_json_string "message")
+ERROR=$(extract_json_string "error")
+TOOL_USE_ID=$(extract_json_string "tool_use_id")
 STOP_REASON=$(extract_json_string "stop_reason")
 
 # ── Build timestamp ───────────────────────────────────────────────
@@ -104,6 +106,8 @@ PAYLOAD="${PAYLOAD}$(json_field "tool_name" "$TOOL_NAME")"
 PAYLOAD="${PAYLOAD}$(json_field "agent_type" "$AGENT_TYPE")"
 PAYLOAD="${PAYLOAD}$(json_field "teammate_name" "$TEAMMATE_NAME")"
 PAYLOAD="${PAYLOAD}$(json_field "message" "$MESSAGE")"
+PAYLOAD="${PAYLOAD}$(json_field "error" "$ERROR")"
+PAYLOAD="${PAYLOAD}$(json_field "tool_use_id" "$TOOL_USE_ID")"
 PAYLOAD="${PAYLOAD}$(json_field "stop_reason" "$STOP_REASON")"
 PAYLOAD="${PAYLOAD}$(json_field "worktree_root" "$WORKTREE_ROOT")"
 # Remove trailing comma, close brace

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -39,6 +39,9 @@ const eventsRoutes: FastifyPluginCallback = (
           agent_type: body.agent_type ? String(body.agent_type) : undefined,
           teammate_name: body.teammate_name ? String(body.teammate_name) : undefined,
           message: body.message ? String(body.message) : undefined,
+          error: body.error ? String(body.error) : undefined,
+          tool_use_id: body.tool_use_id ? String(body.tool_use_id) : undefined,
+          tool_input: body.tool_input ? String(body.tool_input) : undefined,
           stop_reason: body.stop_reason ? String(body.stop_reason) : undefined,
           worktree_root: body.worktree_root ? String(body.worktree_root) : undefined,
         };

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -32,6 +32,9 @@ export interface EventPayload {
   agent_type?: string;   // e.g. "coordinator", "csharp-dev"
   teammate_name?: string;
   message?: string;
+  error?: string;        // PostToolUseFailure error description (CC sends "error", not "message")
+  tool_use_id?: string;  // tool_use_id from PostToolUseFailure events
+  tool_input?: string;   // tool input JSON from PostToolUseFailure events (passed via route, not shell)
   stop_reason?: string;
   worktree_root?: string;
 }

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -413,6 +413,77 @@ describe('SSE broadcast', () => {
 // Edge cases
 // =============================================================================
 
+describe('tool_error event with error field', () => {
+  it('stores error and tool_use_id fields in payload JSON', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_error',
+      tool_name: 'Bash',
+      error: 'exit code 1',
+      tool_use_id: 'toolu_abc123',
+    });
+
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'ToolError',
+        toolName: 'Bash',
+      }),
+    );
+
+    // Verify the full payload JSON contains the error fields
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.error).toBe('exit code 1');
+    expect(storedPayload.tool_use_id).toBe('toolu_abc123');
+  });
+
+  it('stores tool_input when provided via route', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_error',
+      tool_name: 'Bash',
+      error: 'permission denied',
+      tool_use_id: 'toolu_xyz',
+      tool_input: '{"command":"rm -rf /"}',
+    });
+
+    processEvent(payload, db, sse);
+
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.tool_input).toBe('{"command":"rm -rf /"}');
+  });
+
+  it('handles tool_error with only error field (no message)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_error',
+      team: 'kea-100',
+      session_id: 'sess-abc',
+      tool_name: 'Edit',
+      error: 'file not found',
+    };
+
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.error).toBe('file not found');
+    expect(storedPayload.message).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
 describe('Edge cases', () => {
   it('handles unknown event types (passes through unchanged)', () => {
     const db = createMockDb();


### PR DESCRIPTION
Closes #158

## Summary
- `hooks/send_event.sh` now extracts the `error` and `tool_use_id` fields from CC's PostToolUseFailure stdin JSON and includes them in the POST payload to Fleet Commander
- Updated `hooks/on_tool_error.sh` comment to reflect actual CC fields
- Extended `EventPayload` interface and route handler to accept the new fields server-side
- Added 3 test cases covering tool_error events with the new fields

## Problem
CC's PostToolUseFailure hook sends the error description in the `error` field, not `message`. The shell script only extracted `message`, so all ToolError events stored in the DB had empty error descriptions — we knew WHAT tool failed but not WHY.

## Changes
| File | Change |
|------|--------|
| `hooks/send_event.sh` | Extract `error` + `tool_use_id` from stdin, add to payload |
| `hooks/on_tool_error.sh` | Update stdin JSON example comment |
| `src/server/services/event-collector.ts` | Add `error`, `tool_use_id`, `tool_input` to EventPayload |
| `src/server/routes/events.ts` | Map new fields from request.body |
| `tests/server/event-collector.test.ts` | 3 new test cases |

## Notes
- `tool_input` is intentionally NOT extracted in the shell script (it's a JSON object, fragile to parse without jq), but IS in the TS interface for future use
- Existing `message` extraction preserved — other event types still use it