### PR TITLE
Issue #171: Show issue dependencies inline on Issue Tree

### DIFF
--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -76,31 +76,41 @@ function IssueStateBadge({ state }: { state: 'open' | 'closed' }) {
 // ---------------------------------------------------------------------------
 
 function BlockedBadge({ dependencies }: { dependencies: IssueDependencyInfo }) {
+  if (!dependencies.blockedBy || dependencies.blockedBy.length === 0) return null;
+
+  // Only show the badge when there are open (unresolved) blockers
   if (dependencies.resolved || dependencies.openCount === 0) return null;
 
-  const blockerLabels = dependencies.blockedBy
-    .filter((d) => d.state === 'open')
-    .map((d) => {
-      // Show owner/repo#N for cross-repo, just #N for same-repo
-      const prefix = d.owner && d.repo ? `${d.owner}/${d.repo}` : '';
-      return prefix ? `${prefix}#${d.number}` : `#${d.number}`;
-    })
-    .join(', ');
-
-  const tooltipText = `Blocked by: ${blockerLabels}`;
-
   return (
-    <span
-      className="inline-flex items-center gap-1 shrink-0 px-1.5 py-0.5 rounded text-xs font-medium cursor-default"
-      style={{ backgroundColor: 'rgba(248, 81, 73, 0.15)', color: '#F85149' }}
-      title={tooltipText}
-    >
-      {/* Shield/block icon */}
-      <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M4.25 7.25a.75.75 0 0 0 0 1.5h7.5a.75.75 0 0 0 0-1.5h-7.5Z" />
-        <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z" />
-      </svg>
-      {dependencies.openCount} blocked
+    <span className="inline-flex items-center gap-1 text-xs text-dark-muted cursor-default flex-wrap">
+      <span>blocked by</span>
+      {dependencies.blockedBy.map((dep, idx) => {
+        const issueUrl = `https://github.com/${dep.owner}/${dep.repo}/issues/${dep.number}`;
+        const isClosed = dep.state === 'closed';
+        const tooltipText = dep.title
+          ? `${dep.title} (${dep.state})`
+          : `#${dep.number} (${dep.state})`;
+
+        return (
+          <span key={`${dep.owner}/${dep.repo}#${dep.number}`}>
+            <a
+              href={issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={tooltipText}
+              className={`hover:text-dark-accent transition-colors ${
+                isClosed ? 'line-through text-dark-muted/60' : 'text-dark-muted'
+              }`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{dep.number}
+            </a>
+            {idx < dependencies.blockedBy.length - 1 && (
+              <span className="text-dark-muted">,</span>
+            )}
+          </span>
+        );
+      })}
     </span>
   );
 }

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -67,6 +67,18 @@ interface ProjectIssueCache {
 }
 
 // ---------------------------------------------------------------------------
+// Per-issue dependency cache entry (60s TTL)
+// ---------------------------------------------------------------------------
+
+interface DependencyCacheEntry {
+  data: IssueDependencyInfo;
+  fetchedAt: number;
+}
+
+/** TTL for per-issue dependency cache entries (milliseconds) */
+const DEPENDENCY_CACHE_TTL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
 // GraphQL query — flat list of all open issues with parent reference
 // ---------------------------------------------------------------------------
 // Fetches ~100 issues per page with ~10 sub-fields each = ~1,000 nodes/page.
@@ -174,6 +186,8 @@ export function parseDependenciesFromBody(body: string, defaultOwner: string, de
 export class IssueFetcher {
   // Per-project cache: projectId -> cache entry
   private cacheByProject: Map<number, ProjectIssueCache> = new Map();
+  // Per-issue dependency cache: "owner/repo#number" -> cached dependency info
+  private dependencyCache: Map<string, DependencyCacheEntry> = new Map();
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private isRunning = false;
 
@@ -384,10 +398,11 @@ export class IssueFetcher {
   }
 
   /**
-   * Clear ALL cached issues (used by factory reset).
+   * Clear ALL cached issues and dependency cache (used by factory reset).
    */
   clearAll(): void {
     this.cacheByProject.clear();
+    this.dependencyCache.clear();
   }
 
   /**
@@ -509,7 +524,8 @@ export class IssueFetcher {
 
   /**
    * Enrich issue nodes with dependency info from GitHub.
-   * Only enriches leaf nodes (no children) since those are the launchable issues.
+   * Enriches ALL issues (not just leaf nodes) so parent issues also show
+   * inline dependency indicators. Uses per-issue caching with 60s TTL.
    * Modifies nodes in place and returns the same array.
    */
   enrichWithDependencies(issues: IssueNode[], projectId: number): IssueNode[] {
@@ -520,16 +536,13 @@ export class IssueFetcher {
     const [owner, repo] = this.parseRepo(project.githubRepo);
 
     const enrichNode = (node: IssueNode): void => {
-      // Only enrich leaf nodes (launchable issues)
-      if (node.children.length === 0) {
-        try {
-          const deps = this.fetchDependencies(owner, repo, node.number);
-          if (deps && deps.blockedBy.length > 0) {
-            node.dependencies = deps;
-          }
-        } catch {
-          // Silently skip — dependency info is optional
+      try {
+        const deps = this.fetchDependenciesCached(owner, repo, node.number);
+        if (deps && deps.blockedBy.length > 0) {
+          node.dependencies = deps;
         }
+      } catch {
+        // Silently skip — dependency info is optional
       }
       for (const child of node.children) {
         enrichNode(child);
@@ -559,6 +572,27 @@ export class IssueFetcher {
     // Go directly to the GraphQL/timeline approach for dependency detection.
     // The REST sub_issues endpoint returns child issues, not blockers.
     return this.fetchDependenciesFromTimeline(owner, repo, issueNumber);
+  }
+
+  /**
+   * Fetch dependencies with per-issue caching (60s TTL).
+   * Avoids re-fetching the same issue's dependencies on every enrichment cycle.
+   * Cache key is "owner/repo#number".
+   */
+  private fetchDependenciesCached(owner: string, repo: string, issueNumber: number): IssueDependencyInfo | null {
+    const cacheKey = `${owner}/${repo}#${issueNumber}`;
+    const now = Date.now();
+    const cached = this.dependencyCache.get(cacheKey);
+
+    if (cached && (now - cached.fetchedAt) < DEPENDENCY_CACHE_TTL_MS) {
+      return cached.data;
+    }
+
+    const result = this.fetchDependencies(owner, repo, issueNumber);
+    if (result) {
+      this.dependencyCache.set(cacheKey, { data: result, fetchedAt: now });
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
Closes #171

## Summary
- **Backend:** Removed leaf-node-only filter in `enrichWithDependencies()` so ALL issues get dependency enrichment, not just leaves. Added per-issue dependency cache with 60s TTL (`fetchDependenciesCached()`) to avoid redundant GitHub API calls.
- **Frontend:** Rewrote `BlockedBadge` component in `TreeNode.tsx` — now shows inline muted "blocked by #N, #M" text with clickable GitHub links, hover tooltips (blocker title + state), and strikethrough styling for closed blockers.
- Purely informational display — no launch-blocking logic changes.

## Test plan
- [ ] Verify issue tree shows "blocked by #N, #M" on issues with dependencies
- [ ] Confirm closed blockers render with strikethrough
- [ ] Hover tooltips show blocker title + open/closed state
- [ ] Issue numbers are clickable links to GitHub
- [ ] No label shown for issues without blockers
- [ ] Dependency cache respects 60s TTL (no redundant API calls)
- [ ] `blocked-deps` status filter still works correctly