### PR TITLE
Issue #193: filter dormancy events from idle/stuck recovery

### DIFF
--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -154,11 +154,20 @@ export function processEvent(
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
 
-  // ── State transition: idle/stuck -> running on any event ──────────
-  // Any event from an idle or stuck team proves it is alive.
+  // ── State transition: idle/stuck -> running on activity events ─────
+  // Most events from an idle or stuck team prove it is alive and doing
+  // work. However, dormancy-indicating events (stop, session_end) mean
+  // the agent finished its turn or the session terminated — they must
+  // NOT reset the idle/stuck status because the agent is not actively
+  // working. Those events still update lastEventAt (line 206) so the
+  // stuck detector has accurate timing data.
+  //
   // This MUST happen before the throttle check so that even
   // deduplicated tool_use events trigger the recovery transition.
-  if (team.status === 'idle' || team.status === 'stuck') {
+  const DORMANCY_EVENTS = new Set(['stop', 'session_end']);
+  const eventNameLower = payload.event.toLowerCase();
+
+  if ((team.status === 'idle' || team.status === 'stuck') && !DORMANCY_EVENTS.has(eventNameLower)) {
     db.insertTransition({
       teamId,
       fromStatus: team.status,

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -83,9 +83,10 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     to: 'running',
     trigger: 'hook',
     triggerLabel: 'Activity resumes',
-    description: 'A new hook event is received from the idle team',
-    condition: 'New hook event arrives',
-    hookEvent: 'tool_use',
+    description:
+      'A non-dormancy hook event is received from the idle team. Dormancy events (stop, session_end) do NOT trigger this transition because they indicate the agent finished its turn, not that it resumed work.',
+    condition: 'New hook event arrives AND event is not a dormancy event (stop, session_end)',
+    hookEvent: 'tool_use | session_start | subagent_start | notification | subagent_stop',
   },
   {
     id: 'running-done',
@@ -124,9 +125,9 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     trigger: 'hook',
     triggerLabel: 'Activity resumes',
     description:
-      'A new hook event is received from the stuck team, indicating it recovered',
-    condition: 'New hook event arrives',
-    hookEvent: 'tool_use',
+      'A non-dormancy hook event is received from the stuck team, indicating it recovered. Dormancy events (stop, session_end) do NOT trigger this transition.',
+    condition: 'New hook event arrives AND event is not a dormancy event (stop, session_end)',
+    hookEvent: 'tool_use | session_start | subagent_start | notification | subagent_stop',
   },
   {
     id: 'running-failed',

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -173,7 +173,7 @@ describe('Invalid payload rejection', () => {
 // =============================================================================
 
 describe('State transitions', () => {
-  it('transitions idle -> running on any event', () => {
+  it('transitions idle -> running on non-dormancy event', () => {
     const db = createMockDb({
       getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
     });
@@ -189,7 +189,7 @@ describe('State transitions', () => {
     );
   });
 
-  it('transitions stuck -> running on any event', () => {
+  it('transitions stuck -> running on non-dormancy event', () => {
     const db = createMockDb({
       getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
     });
@@ -203,6 +203,160 @@ describe('State transitions', () => {
       expect.objectContaining({ status: 'running' }),
     );
   });
+
+  // --- Dormancy event filtering (Issue #193) ---
+
+  it('does NOT transition idle -> running on stop event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have called updateTeam with status: 'running'
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('does NOT transition idle -> running on session_end event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_end' });
+
+    processEvent(payload, db, sse);
+
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('does NOT transition stuck -> running on stop event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop' });
+
+    processEvent(payload, db, sse);
+
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('does NOT transition stuck -> running on session_end event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_end' });
+
+    processEvent(payload, db, sse);
+
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('still updates lastEventAt for dormancy events on idle teams', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop' });
+
+    processEvent(payload, db, sse);
+
+    // lastEventAt should still be updated even though status did not change
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ lastEventAt: expect.any(String) }),
+    );
+  });
+
+  it('still updates lastEventAt for dormancy events on stuck teams', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_end' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ lastEventAt: expect.any(String) }),
+    );
+  });
+
+  it('still inserts DB event and broadcasts SSE for dormancy events on idle teams', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop' });
+
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'Stop' }),
+    );
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_event',
+      expect.objectContaining({ event_type: 'Stop' }),
+    );
+  });
+
+  // --- Non-dormancy events that DO trigger recovery ---
+
+  const nonDormancyRecoveryEvents = [
+    'tool_use',
+    'session_start',
+    'subagent_start',
+    'subagent_stop',
+    'notification',
+  ];
+
+  for (const eventType of nonDormancyRecoveryEvents) {
+    it(`transitions idle -> running on ${eventType} event`, () => {
+      const db = createMockDb({
+        getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+      });
+      const sse = createMockSse();
+      const payload = makePayload({ event: eventType });
+
+      processEvent(payload, db, sse);
+
+      expect(db.insertTransition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamId: 1,
+          fromStatus: 'idle',
+          toStatus: 'running',
+          trigger: 'hook',
+        }),
+      );
+      expect(db.updateTeam).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ status: 'running' }),
+      );
+    });
+  }
+
+  // --- Existing non-dormancy tests ---
 
   it('does NOT transition running -> running (no redundant update)', () => {
     const db = createMockDb({


### PR DESCRIPTION
Closes #193

## Summary
- Stop and session_end events no longer trigger idle/stuck → running transitions in event-collector
- `DORMANCY_EVENTS` denylist filters these events while still updating `lastEventAt` for accurate stuck detection
- State machine definitions updated to reflect the exclusion
- 11 new tests covering dormancy filtering, lastEventAt preservation, and non-dormancy recovery

## Test plan
- [x] `npm test` passes (2 pre-existing failures on main unrelated to this change)
- [x] Dormancy events (stop, session_end) do NOT reset idle/stuck status
- [x] Non-dormancy events still trigger idle/stuck → running recovery
- [x] `lastEventAt` updated for all events including dormancy
- [x] State machine view (`/lifecycle`) reflects updated transition conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)