### PR TITLE
Issue #186: add active monitoring loop, idle nudge, and early crash detection

### DIFF
--- a/.claude/prompts/fleet-workflow.md
+++ b/.claude/prompts/fleet-workflow.md
@@ -104,6 +104,30 @@ stateDiagram-v2
 
 ---
 
+## Active Monitoring Loop
+
+After spawning all 3 agents, the TL enters a continuous monitoring loop that runs throughout the entire workflow. This prevents the TL from going silent between phases.
+
+### Monitoring Rules
+
+1. **Run `TaskList` every 30-60 seconds** to check the status of all spawned agents. This is your heartbeat — never go more than 60 seconds without checking.
+2. **If any agent exits unexpectedly** (SubagentStop without sending expected output), **respawn immediately** — do not wait for the stuck detector's 5-minute threshold.
+3. **Between phases** (e.g., analyst done, waiting for dev), actively verify the next agent is alive via `TaskList`. If the agent is gone, respawn it.
+4. **After each subagent phase completes, immediately proceed** to the next action:
+   - **Analyst done** -- validate the brief -- check if dev is alive via `TaskList` -- if dev is gone, respawn it
+   - **Dev done** -- check dev output for completeness -- immediately notify reviewer if not already done by dev
+   - **Reviewer done** -- immediately proceed to PR creation (rebase, `gh pr create`, auto-merge)
+5. **Never passively wait** — if you have nothing to do, run `TaskList` to confirm all agents are healthy.
+
+### What To Do When An Agent Is Missing
+
+If `TaskList` shows an agent is no longer running:
+1. Check the last output/events from that agent
+2. If the agent completed its work (sent its deliverable), proceed to the next phase
+3. If the agent exited without delivering, respawn it with the same task plus any additional context from the failed attempt
+
+---
+
 ## Phase 1 — Analysis
 
 1. Analyst (already spawned in Phase 0) reads the issue, explores the codebase, discovers guidebooks, and produces a structured brief
@@ -323,7 +347,7 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 | `ci_red` | CI fails on PR | "CI failed on PR #{PR}. Failing checks: {details}. Fix count: {N}/{max}." |
 | `ci_blocked` | Too many CI failures | "STOP. {N} unique CI failure types on PR #{PR}. Wait for instructions." |
 | `pr_merged` | PR is merged | "PR #{PR} merged. Close the issue, clean up, and finish." |
-| `nudge_idle` | Team idle 3+ min | "You have been idle for a while. What is the status?" |
+| `nudge_idle` | Team idle 3+ min | "FC status check: You've been idle for {N} minutes. If waiting for subagents, run TaskList to verify they are still active. If a phase just completed, proceed to the next step." |
 | `nudge_stuck` | Team stuck 5+ min | "You appear stuck. Report status or ask for help." |
 
 ### TL Response to FC Messages
@@ -336,7 +360,7 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 
 **On `pr_merged`**: Close the issue, shut down agents (`shutdown_request` to all), finish.
 
-**On `nudge_idle`**: Report current status to FC. If waiting for a subagent, check on them.
+**On `nudge_idle`**: Run `TaskList` to verify all subagents are alive. If any agent is missing or crashed, respawn it. Report current status to FC.
 
 **On `nudge_stuck`**: Check which agent is stuck. Send a targeted nudge. If no progress after nudge, escalate to FC by reporting status.
 
@@ -448,6 +472,7 @@ Atomic commits — each commit should be a logical unit.
 | Ignoring FC messages | Always respond to ci_green, ci_red, pr_merged, nudges |
 | Respawning agent after 2 min idle | Idle is normal — only act at 5min stuck threshold |
 | TL monitors CI manually | FC handles CI monitoring and sends updates via stdin |
+| TL goes idle after spawning agents without monitoring | TL runs active monitoring loop between phases |
 
 ## Decision Summary
 

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
 import { processEvent, EventCollectorError } from '../services/event-collector.js';
-import type { EventPayload, EventCollectorDb, SseBroker } from '../services/event-collector.js';
+import type { EventPayload, EventCollectorDb, SseBroker, TeamMessageSender } from '../services/event-collector.js';
 import { getDatabase } from '../db.js';
 import { sseBroker } from '../services/sse-broker.js';
 import { getTeamManager } from '../services/team-manager.js';
@@ -49,7 +49,8 @@ const eventsRoutes: FastifyPluginCallback = (
         };
 
         const db = getDatabase();
-        const result = processEvent(payload, db as unknown as EventCollectorDb, sseBroker as unknown as SseBroker);
+        const manager = getTeamManager();
+        const result = processEvent(payload, db as unknown as EventCollectorDb, sseBroker as unknown as SseBroker, manager as unknown as TeamMessageSender);
 
         // When a stop event is received, a team may be finishing —
         // trigger queue processing so queued teams can launch.

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -209,6 +209,10 @@ INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
    'STOP. {{FAIL_COUNT}} unique CI failure types on PR #{{PR_NUMBER}}. Wait for my instructions.',
    'Tell TL the team is blocked due to repeated CI failures');
 INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
+  ('idle_nudge',
+   'FC status check: You''ve been idle for {{IDLE_MINUTES}} minutes. If waiting for subagents, run TaskList to verify they are still active. If a phase just completed, proceed to the next step.',
+   'Nudge sent to TL when team transitions to idle to prompt a status check');
+INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
   ('stuck_nudge',
    'Hey, you have been idle for a while on issue #{{ISSUE_NUMBER}}. What is the status? Do you need help?',
    'Nudge sent to TL when team transitions to stuck');

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -77,12 +77,35 @@ export interface SseBroker {
   broadcast<T extends SSEEventType>(event: T, data: SSEEventPayloads[T], teamId?: number): void;
 }
 
+/** Optional team message sender for advisory messages (e.g., crash detection) */
+export interface TeamMessageSender {
+  sendMessage(teamId: number, message: string): boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Throttle state — module-level, persists across requests
 // ---------------------------------------------------------------------------
 
 /** Track last tool_use event time per team for throttling */
 const lastToolUseByTeam = new Map<string, number>();
+
+// ---------------------------------------------------------------------------
+// Subagent tracking for early crash detection
+// ---------------------------------------------------------------------------
+
+/** Track subagent start events: key = "teamWorktree:subagentName", value = { timestamp, eventCount } */
+interface SubagentTracker {
+  startTime: number;
+  eventCount: number;
+}
+
+const subagentTrackers = new Map<string, SubagentTracker>();
+
+/** Minimum duration (ms) for a subagent to be considered healthy */
+const SUBAGENT_MIN_DURATION_MS = 120_000; // 2 minutes
+
+/** Minimum event count for a subagent to be considered having done meaningful work */
+const SUBAGENT_MIN_EVENTS = 5;
 
 /** Throttle window: tool_use events from the same team within this period are deduplicated */
 const TOOL_USE_THROTTLE_MS = 5000; // 5 seconds
@@ -132,6 +155,7 @@ export function processEvent(
   payload: EventPayload,
   db: EventCollectorDb,
   sse: SseBroker,
+  messageSender?: TeamMessageSender,
 ): ProcessEventResult {
   // ── Validate required fields ─────────────────────────────────────
   if (!payload.event || !payload.team) {
@@ -259,6 +283,53 @@ export function processEvent(
     timestamp: payload.timestamp || nowIso,
   });
 
+  // ── Subagent crash detection (advisory) ───────────────────────
+  // Track SubagentStart/SubagentStop pairs. If a subagent stops very
+  // quickly (< 2 min) with minimal events (< 5), it likely crashed.
+  // Send an advisory message to the TL so they can decide to respawn.
+  const evtLower = payload.event.toLowerCase();
+
+  if (evtLower === 'subagent_start') {
+    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${agentName}`;
+    subagentTrackers.set(trackerKey, { startTime: now, eventCount: 0 });
+  }
+
+  // Increment event count for any tracked subagent on this team
+  if (payload.agent_type || payload.teammate_name) {
+    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${agentName}`;
+    const tracker = subagentTrackers.get(trackerKey);
+    if (tracker) {
+      tracker.eventCount++;
+    }
+  }
+
+  if (evtLower === 'subagent_stop' && messageSender) {
+    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${agentName}`;
+    const tracker = subagentTrackers.get(trackerKey);
+
+    if (tracker) {
+      const durationMs = now - tracker.startTime;
+      const durationSec = Math.round(durationMs / 1000);
+
+      if (durationMs < SUBAGENT_MIN_DURATION_MS && tracker.eventCount < SUBAGENT_MIN_EVENTS) {
+        const crashMsg =
+          `Subagent '${agentName}' appears to have crashed (${durationSec}s after start, ${tracker.eventCount} events). Consider respawning.`;
+        try {
+          messageSender.sendMessage(teamId, crashMsg);
+          console.log(`[EventCollector] Subagent crash advisory sent for ${agentName} on team ${teamId}`);
+        } catch {
+          // Non-critical — silently ignore send failures
+        }
+      }
+
+      // Clean up tracker regardless of crash detection
+      subagentTrackers.delete(trackerKey);
+    }
+  }
+
   // ── Capture inter-agent message routing ───────────────────────
   // When a SendMessage tool call is received with a msg_to field,
   // record the message in the agent_messages table for routing visibility.
@@ -302,4 +373,9 @@ export class EventCollectorError extends Error {
 /** Reset all throttle state. Intended for use in tests only. */
 export function resetThrottleState(): void {
   lastToolUseByTeam.clear();
+}
+
+/** Reset subagent tracking state. Intended for use in tests only. */
+export function resetSubagentTrackers(): void {
+  subagentTrackers.clear();
 }

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -154,6 +154,19 @@ class StuckDetector {
             team.id,
           );
 
+          // When a team transitions to idle, send an idle nudge to prompt TL
+          // to check subagent status and proceed with next steps
+          if (newStatus === 'idle') {
+            const idleMsg = resolveMessage('idle_nudge', {
+              IDLE_MINUTES: String(Math.round(idleMinutes)),
+            });
+            if (idleMsg) {
+              const manager = getTeamManager();
+              manager.sendMessage(team.id, idleMsg);
+              console.log(`[StuckDetector] Idle nudge sent to team ${team.id}`);
+            }
+          }
+
           // When a team transitions to stuck, send a nudge message to the TL
           if (newStatus === 'stuck') {
             const msg = resolveMessage('stuck_nudge', {

--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -50,6 +50,14 @@ export const DEFAULT_MESSAGE_TEMPLATES: DefaultMessageTemplate[] = [
     placeholders: ['PR_NUMBER', 'FAIL_COUNT'],
   },
   {
+    id: 'idle_nudge',
+    template:
+      'FC status check: You\'ve been idle for {{IDLE_MINUTES}} minutes. If waiting for subagents, run TaskList to verify they are still active. If a phase just completed, proceed to the next step.',
+    description:
+      'Sent to TL when team transitions to idle to prompt a status check',
+    placeholders: ['IDLE_MINUTES'],
+  },
+  {
     id: 'stuck_nudge',
     template:
       'Hey, you have been idle for a while on issue #{{ISSUE_NUMBER}}. What is the status? Do you need help?',

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -73,7 +73,8 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     to: 'idle',
     trigger: 'timer',
     triggerLabel: 'Idle threshold exceeded',
-    description: 'No hook events received within the idle threshold period',
+    description:
+      'No hook events received within the idle threshold period. Sends idle_nudge message to TL prompting a subagent status check.',
     condition: 'lastEventAt + idleThresholdMin < now',
     hookEvent: null,
   },

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -104,6 +104,30 @@ stateDiagram-v2
 
 ---
 
+## Active Monitoring Loop
+
+After spawning all 3 agents, the TL enters a continuous monitoring loop that runs throughout the entire workflow. This prevents the TL from going silent between phases.
+
+### Monitoring Rules
+
+1. **Run `TaskList` every 30-60 seconds** to check the status of all spawned agents. This is your heartbeat — never go more than 60 seconds without checking.
+2. **If any agent exits unexpectedly** (SubagentStop without sending expected output), **respawn immediately** — do not wait for the stuck detector's 5-minute threshold.
+3. **Between phases** (e.g., analyst done, waiting for dev), actively verify the next agent is alive via `TaskList`. If the agent is gone, respawn it.
+4. **After each subagent phase completes, immediately proceed** to the next action:
+   - **Analyst done** -- validate the brief -- check if dev is alive via `TaskList` -- if dev is gone, respawn it
+   - **Dev done** -- check dev output for completeness -- immediately notify reviewer if not already done by dev
+   - **Reviewer done** -- immediately proceed to PR creation (rebase, `gh pr create`, auto-merge)
+5. **Never passively wait** — if you have nothing to do, run `TaskList` to confirm all agents are healthy.
+
+### What To Do When An Agent Is Missing
+
+If `TaskList` shows an agent is no longer running:
+1. Check the last output/events from that agent
+2. If the agent completed its work (sent its deliverable), proceed to the next phase
+3. If the agent exited without delivering, respawn it with the same task plus any additional context from the failed attempt
+
+---
+
 ## Phase 1 — Analysis
 
 1. Analyst (already spawned in Phase 0) reads the issue, explores the codebase, discovers guidebooks, and produces a structured brief
@@ -323,7 +347,7 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 | `ci_red` | CI fails on PR | "CI failed on PR #{PR}. Failing checks: {details}. Fix count: {N}/{max}." |
 | `ci_blocked` | Too many CI failures | "STOP. {N} unique CI failure types on PR #{PR}. Wait for instructions." |
 | `pr_merged` | PR is merged | "PR #{PR} merged. Close the issue, clean up, and finish." |
-| `nudge_idle` | Team idle 3+ min | "You have been idle for a while. What is the status?" |
+| `nudge_idle` | Team idle 3+ min | "FC status check: You've been idle for {N} minutes. If waiting for subagents, run TaskList to verify they are still active. If a phase just completed, proceed to the next step." |
 | `nudge_stuck` | Team stuck 5+ min | "You appear stuck. Report status or ask for help." |
 
 ### TL Response to FC Messages
@@ -336,7 +360,7 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 
 **On `pr_merged`**: Close the issue, shut down agents (`shutdown_request` to all), finish.
 
-**On `nudge_idle`**: Report current status to FC. If waiting for a subagent, check on them.
+**On `nudge_idle`**: Run `TaskList` to verify all subagents are alive. If any agent is missing or crashed, respawn it. Report current status to FC.
 
 **On `nudge_stuck`**: Check which agent is stuck. Send a targeted nudge. If no progress after nudge, escalate to FC by reporting status.
 
@@ -448,6 +472,7 @@ Atomic commits — each commit should be a logical unit.
 | Ignoring FC messages | Always respond to ci_green, ci_red, pr_merged, nudges |
 | Respawning agent after 2 min idle | Idle is normal — only act at 5min stuck threshold |
 | TL monitors CI manually | FC handles CI monitoring and sends updates via stdin |
+| TL goes idle after spawning agents without monitoring | TL runs active monitoring loop between phases |
 
 ## Decision Summary
 

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -6,10 +6,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   processEvent,
   resetThrottleState,
+  resetSubagentTrackers,
   EventCollectorError,
   type EventPayload,
   type EventCollectorDb,
   type SseBroker,
+  type TeamMessageSender,
 } from '../../src/server/services/event-collector.js';
 
 // ---------------------------------------------------------------------------
@@ -51,8 +53,15 @@ function makePayload(overrides?: Partial<EventPayload>): EventPayload {
 // Setup
 // ---------------------------------------------------------------------------
 
+function createMockMessageSender(): TeamMessageSender & { sendMessage: ReturnType<typeof vi.fn> } {
+  return {
+    sendMessage: vi.fn().mockReturnValue(true),
+  };
+}
+
 beforeEach(() => {
   resetThrottleState();
+  resetSubagentTrackers();
 });
 
 // =============================================================================
@@ -802,5 +811,212 @@ describe('Agent message routing', () => {
     // Should not throw — failure is silently caught
     const result = processEvent(payload, db, sse);
     expect(result.processed).toBe(true);
+  });
+});
+
+// =============================================================================
+// Subagent crash detection
+// =============================================================================
+
+describe('Subagent crash detection', () => {
+  it('sends advisory message when subagent stops quickly with few events', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // SubagentStart
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', agent_type: 'coordinator' }),
+      db,
+      sse,
+      sender,
+    );
+
+    // SubagentStop immediately (within 2 min, < 5 events)
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev', agent_type: 'coordinator' }),
+      db,
+      sse,
+      sender,
+    );
+
+    expect(sender.sendMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Subagent 'fleet-dev' appears to have crashed"),
+    );
+  });
+
+  it('does NOT send advisory when subagent runs long enough', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // SubagentStart — we need to simulate passage of time
+    // Since we can't easily mock Date.now() without affecting all code,
+    // we verify the logic by checking that a subagent with many events does not trigger
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', agent_type: 'coordinator' }),
+      db,
+      sse,
+      sender,
+    );
+
+    // Generate enough events to exceed the minimum (5)
+    for (let i = 0; i < 6; i++) {
+      processEvent(
+        makePayload({ event: 'tool_use', teammate_name: 'fleet-dev', agent_type: 'fleet-dev' }),
+        db,
+        sse,
+        sender,
+      );
+      resetThrottleState(); // Reset throttle to allow each event through
+    }
+
+    // SubagentStop — should NOT trigger crash advisory because event count >= 5
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev', agent_type: 'coordinator' }),
+      db,
+      sse,
+      sender,
+    );
+
+    expect(sender.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT send advisory when no messageSender is provided', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    // SubagentStart without message sender
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+    );
+
+    // SubagentStop — should not crash even without messageSender
+    expect(() => {
+      processEvent(
+        makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+        db,
+        sse,
+      );
+    }).not.toThrow();
+  });
+
+  it('tracks multiple subagents independently', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Start two subagents
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+      sender,
+    );
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-reviewer' }),
+      db,
+      sse,
+      sender,
+    );
+
+    // Generate events for fleet-reviewer (enough to be healthy)
+    for (let i = 0; i < 6; i++) {
+      processEvent(
+        makePayload({ event: 'tool_use', teammate_name: 'fleet-reviewer', agent_type: 'fleet-reviewer' }),
+        db,
+        sse,
+        sender,
+      );
+      resetThrottleState();
+    }
+
+    // Stop fleet-dev (crashed — few events)
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+      sender,
+    );
+
+    // Should have sent crash advisory for fleet-dev
+    expect(sender.sendMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("'fleet-dev'"),
+    );
+
+    sender.sendMessage.mockClear();
+
+    // Stop fleet-reviewer (healthy — many events)
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-reviewer' }),
+      db,
+      sse,
+      sender,
+    );
+
+    // Should NOT send crash advisory for fleet-reviewer
+    expect(sender.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('cleans up tracker after subagent stop', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Start and immediately stop
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+      sender,
+    );
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+      sender,
+    );
+
+    expect(sender.sendMessage).toHaveBeenCalledTimes(1);
+    sender.sendMessage.mockClear();
+
+    // Second stop without a start — should not trigger (tracker cleaned up)
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+      sender,
+    );
+
+    expect(sender.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('includes duration and event count in advisory message', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-analyst' }),
+      db,
+      sse,
+      sender,
+    );
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-analyst' }),
+      db,
+      sse,
+      sender,
+    );
+
+    const msg = sender.sendMessage.mock.calls[0][1] as string;
+    expect(msg).toContain("Subagent 'fleet-analyst' appears to have crashed");
+    expect(msg).toContain('s after start');
+    expect(msg).toContain('events');
+    expect(msg).toContain('Consider respawning');
   });
 });

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -272,3 +272,97 @@ describe('Existing idle/stuck detection', () => {
     expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'stuck' });
   });
 });
+
+// =============================================================================
+// Idle nudge message
+// =============================================================================
+
+describe('Idle nudge message', () => {
+  it('sends idle_nudge message when running -> idle and resolveMessage returns a message', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    mockedResolveMessage.mockReturnValue('FC status check: idle for 4 minutes');
+
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(4), // 4 min ago, past the 3 min idle threshold
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockedResolveMessage).toHaveBeenCalledWith('idle_nudge', {
+      IDLE_MINUTES: '4',
+    });
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'FC status check: idle for 4 minutes');
+
+    // Reset mock to default
+    mockedResolveMessage.mockReturnValue(null);
+  });
+
+  it('does NOT send idle_nudge message when resolveMessage returns null (template disabled)', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    mockedResolveMessage.mockReturnValue(null);
+
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(4),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    // Transition should still happen
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'idle' });
+    // But no message sent
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends stuck_nudge message when idle -> stuck and resolveMessage returns a message', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    // idle->stuck only calls resolveMessage once (for stuck_nudge, not idle_nudge)
+    mockedResolveMessage.mockReturnValue('Hey, you have been idle for a while');
+
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(6),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockedResolveMessage).toHaveBeenCalledWith('stuck_nudge', {
+      ISSUE_NUMBER: '100',
+    });
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'Hey, you have been idle for a while');
+
+    // Reset mock to default
+    mockedResolveMessage.mockReturnValue(null);
+  });
+
+  it('skips idle_nudge when team has pending CI on PR', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    mockedResolveMessage.mockReturnValue('FC status check: idle');
+
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(4),
+      prNumber: 42,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({ ciStatus: 'pending' });
+
+    stuckDetector.check();
+
+    // Transition should be skipped entirely (CI pending)
+    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+
+    // Reset mocks
+    mockedResolveMessage.mockReturnValue(null);
+    mockDb.getPullRequest.mockReturnValue(undefined);
+  });
+});


### PR DESCRIPTION
Closes #186

## Summary
- **Active Monitoring Loop**: Added workflow prompt section instructing TL to TaskList every 30-60s between phases, detect subagent crashes immediately, and proceed without pausing
- **Idle Nudge**: stuck-detector now sends `idle_nudge` message at 3-minute idle threshold (previously only updated DB status silently)
- **Early Crash Detection**: event-collector detects subagents that stop within 2 minutes of starting with <5 events and sends advisory message to TL

## Files Changed
- `templates/workflow.md` + `.claude/prompts/fleet-workflow.md` — Active Monitoring Loop section, updated anti-patterns
- `src/server/services/stuck-detector.ts` — idle_nudge message on running→idle transition
- `src/shared/message-templates.ts` — `idle_nudge` template with {{IDLE_MINUTES}} placeholder
- `src/shared/state-machine.ts` — Updated transition description
- `src/server/schema.sql` — idle_nudge seed INSERT
- `src/server/services/event-collector.ts` — SubagentStart/Stop tracking, crash detection with TeamMessageSender interface
- `src/server/routes/events.ts` — Passes TeamManager as messageSender
- `tests/server/stuck-detector.test.ts` — 4 new tests
- `tests/server/event-collector.test.ts` — 6 new tests

## Test plan
- [x] 4 tests for idle nudge (send, skip when disabled, stuck_nudge still works, CI-pending skip)
- [x] 6 tests for crash detection (trigger, no trigger with enough events, no sender, independent tracking, cleanup, message format)
- [x] Build passes (`npm run build`)
- [x] All new tests pass (`npm test`)