### PR TITLE
Issue #187: fix EventTimeline icon casing to match PascalCase event types

### DIFF
--- a/src/client/components/EventTimeline.tsx
+++ b/src/client/components/EventTimeline.tsx
@@ -37,8 +37,8 @@ const EVENT_ICONS: Record<string, React.ReactNode> = {
   SubagentStart: <ArrowRightIcon size={14} />,
   SubagentStop: <ArrowLeftIcon size={14} />,
   Notification: <AlertTriangleIcon size={14} />,
-  tool_error: <XCircleIcon size={14} />,
-  pre_compact: <RefreshCwIcon size={14} />,
+  ToolError: <XCircleIcon size={14} />,
+  PreCompact: <RefreshCwIcon size={14} />,
   ToolUse: <SettingsIcon size={14} />,
 };
 


### PR DESCRIPTION
## Summary

- Fix `EVENT_ICONS` map keys in `EventTimeline.tsx` from snake_case (`tool_error`, `pre_compact`) to PascalCase (`ToolError`, `PreCompact`)
- Keys now match the normalized event types produced by `normalizeEventType()` in `event-collector.ts`
- Icons for ToolError and PreCompact events will now render correctly instead of falling through to the generic dot

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)