### PR TITLE
Issue #190: fix PM message not resetting lastEventAt — stuck detector race

### DIFF
--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -858,6 +858,9 @@ const teamsRoutes: FastifyPluginCallback = (
         const delivered = manager.sendMessage(teamId, message.trim(), 'user');
         if (delivered) {
           db.markCommandDelivered(command.id);
+          // Reset lastEventAt so the stuck detector doesn't race between
+          // PM message delivery and the agent's next hook event (#190)
+          db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
           request.log.info(`[Teams] Message delivered to team ${teamId} via stdin`);
         }
 


### PR DESCRIPTION
Closes #190

## Summary
- Update `lastEventAt` in the send-message route (`src/server/routes/teams.ts`) after successful stdin delivery
- Prevents the stuck detector from firing between PM message delivery and the agent's next hook event
- Follows the same pattern used in `event-collector.ts`, `github-poller.ts`, and `startup-recovery.ts`

## Test plan
- [x] TypeScript compilation passes
- [x] All 16 stuck-detector tests pass
- [x] Manual verification: send PM message to idle team, verify `lastEventAt` is updated immediately