### PR TITLE
Issue #189: disable CommandInput and quick actions for terminal team states

### DIFF
--- a/src/client/components/CommandInput.tsx
+++ b/src/client/components/CommandInput.tsx
@@ -7,11 +7,12 @@ import { useApi } from '../hooks/useApi';
 
 interface CommandInputProps {
   teamId: number;
+  disabled?: boolean;
 }
 
 type FeedbackState = null | { type: 'success'; message: string } | { type: 'error'; message: string };
 
-export function CommandInput({ teamId }: CommandInputProps) {
+export function CommandInput({ teamId, disabled = false }: CommandInputProps) {
   const api = useApi();
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
@@ -69,13 +70,13 @@ export function CommandInput({ teamId }: CommandInputProps) {
           type="text"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          disabled={sending}
-          placeholder="Send message to team..."
+          disabled={disabled || sending}
+          placeholder={disabled ? 'Team is not running' : 'Send message to team...'}
           className="flex-1 bg-dark-base border border-dark-border rounded px-3 py-2 text-sm text-dark-text placeholder-dark-muted focus:outline-none focus:border-dark-accent transition-colors disabled:opacity-50"
         />
         <button
           type="submit"
-          disabled={sending || !message.trim()}
+          disabled={disabled || sending || !message.trim()}
           className="px-4 py-2 text-sm font-medium rounded bg-dark-accent text-white hover:bg-dark-accent/80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
         >
           {sending ? 'Sending...' : 'Send'}

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -725,7 +725,7 @@ export function TeamDetail() {
 
               {/* BOTTOM: Command + Actions footer */}
               <div className="shrink-0 border-t border-dark-border px-5 py-4 space-y-4">
-                <CommandInput teamId={detail.id} />
+                <CommandInput teamId={detail.id} disabled={!isActive} />
                 {/* Quick Actions */}
                 <div className="flex items-center gap-1.5 flex-wrap">
                   <span className="text-xs text-dark-muted mr-1">Quick:</span>
@@ -738,7 +738,7 @@ export function TeamDetail() {
                     <button
                       key={action.id}
                       onClick={() => handleQuickAction(action.id)}
-                      disabled={quickActionLoading !== null}
+                      disabled={!isActive || quickActionLoading !== null}
                       className="px-2.5 py-1 text-xs rounded-full border transition-colors disabled:opacity-40"
                       style={{
                         color: action.color,


### PR DESCRIPTION
Closes #189

## Summary
- Add `disabled` prop to `CommandInput` component — disables input and send button, changes placeholder to "Team is not running"
- Pass `disabled={!isActive}` in `TeamDetail` so teams in `done`, `failed`, or `queued` states cannot receive messages
- Disable quick action buttons (`Status?`, `Open PR`, `Fix CI`, `Wrap Up`) for the same non-active states

## Test plan
- [ ] Open team detail for a `done` team — verify CommandInput is greyed out with "Team is not running" placeholder
- [ ] Open team detail for a `failed` team — same disabled behavior
- [ ] Open team detail for a `queued` team — same disabled behavior
- [ ] Open team detail for a `running` team — verify CommandInput works normally
- [ ] Verify quick action buttons are disabled/enabled matching the same conditions
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)