### PR TITLE
Issue #191: return 422 when send-message fails to deliver

### DIFF
--- a/src/client/components/CommandInput.tsx
+++ b/src/client/components/CommandInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useApi } from '../hooks/useApi';
+import { useApi, ApiError } from '../hooks/useApi';
 
 // ---------------------------------------------------------------------------
 // Component
@@ -10,7 +10,7 @@ interface CommandInputProps {
   disabled?: boolean;
 }
 
-type FeedbackState = null | { type: 'success'; message: string } | { type: 'error'; message: string };
+type FeedbackState = null | { type: 'success'; message: string } | { type: 'warning'; message: string } | { type: 'error'; message: string };
 
 export function CommandInput({ teamId, disabled = false }: CommandInputProps) {
   const api = useApi();
@@ -55,8 +55,12 @@ export function CommandInput({ teamId, disabled = false }: CommandInputProps) {
       // Refocus the input after successful send
       inputRef.current?.focus();
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : 'Failed to send message';
-      showFeedback({ type: 'error', message: errMsg });
+      if (err instanceof ApiError && err.status === 422) {
+        showFeedback({ type: 'warning', message: 'Team is not running \u2014 message not delivered' });
+      } else {
+        const errMsg = err instanceof Error ? err.message : 'Failed to send message';
+        showFeedback({ type: 'error', message: errMsg });
+      }
     } finally {
       setSending(false);
     }
@@ -89,7 +93,9 @@ export function CommandInput({ teamId, disabled = false }: CommandInputProps) {
           className={`mt-2 text-xs px-2 py-1 rounded ${
             feedback.type === 'success'
               ? 'text-[#3FB950] bg-[#3FB950]/10'
-              : 'text-[#F85149] bg-[#F85149]/10'
+              : feedback.type === 'warning'
+                ? 'text-[#D29922] bg-[#D29922]/10'
+                : 'text-[#F85149] bg-[#F85149]/10'
           }`}
         >
           {feedback.message}

--- a/src/client/hooks/useApi.ts
+++ b/src/client/hooks/useApi.ts
@@ -7,7 +7,7 @@ interface ApiClient {
   del<T>(path: string): Promise<T>;
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     public status: number,
     public statusText: string,

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -862,12 +862,19 @@ const teamsRoutes: FastifyPluginCallback = (
           // PM message delivery and the agent's next hook event (#190)
           db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
           request.log.info(`[Teams] Message delivered to team ${teamId} via stdin`);
+        } else {
+          request.log.warn(`[Teams] Message not delivered to team ${teamId} — no stdin pipe`);
+          return reply.code(422).send({
+            ...command,
+            error: 'Unprocessable Entity',
+            message: 'Team is not running \u2014 message not delivered',
+          });
         }
 
         return reply.code(201).send({
           ...command,
-          // Override status if delivered via stdin
-          ...(delivered ? { status: 'delivered' as const, deliveredAt: new Date().toISOString() } : {}),
+          status: 'delivered' as const,
+          deliveredAt: new Date().toISOString(),
         });
       } catch (err: unknown) {
         request.log.error(err, 'Failed to send message to team');

--- a/tests/server/send-message-route.test.ts
+++ b/tests/server/send-message-route.test.ts
@@ -1,0 +1,194 @@
+// =============================================================================
+// Fleet Commander -- Send-message route: 201 vs 422 behavior
+// =============================================================================
+// Verifies that POST /api/teams/:id/send-message returns 201 when the message
+// is delivered via stdin, and 422 when the team has no active stdin pipe.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../src/server/db.js';
+import { sseBroker } from '../../src/server/services/sse-broker.js';
+
+// We need to mock getTeamManager to control sendMessage() return value
+import { getTeamManager } from '../../src/server/services/team-manager.js';
+vi.mock('../../src/server/services/team-manager.js', () => {
+  const mockSendMessage = vi.fn();
+  return {
+    getTeamManager: vi.fn(() => ({
+      sendMessage: mockSendMessage,
+    })),
+  };
+});
+
+// Mock the issue-fetcher to avoid gh CLI calls
+vi.mock('../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: vi.fn(() => ({
+    fetch: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+// Mock the github-poller to avoid gh CLI calls
+vi.mock('../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    getRecentPRs: vi.fn().mockReturnValue([]),
+  },
+}));
+
+// Import routes after mocks
+import teamsRoutes from '../../src/server/routes/teams.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let server: FastifyInstance;
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-sendmsg-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  server = Fastify({ logger: false });
+  await server.register(teamsRoutes);
+  await server.ready();
+});
+
+afterAll(async () => {
+  sseBroker.stop();
+  await server.close();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedTeam(overrides: { issueNumber?: number; worktreeName?: string; status?: string } = {}) {
+  const db = getDatabase();
+  return db.insertTeam({
+    issueNumber: overrides.issueNumber ?? 100,
+    worktreeName: overrides.worktreeName ?? `sendmsg-test-${Date.now()}`,
+    status: (overrides.status as 'running') ?? 'running',
+    phase: 'implementing' as 'implementing',
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('POST /api/teams/:id/send-message', () => {
+  it('returns 201 when message is delivered via stdin', async () => {
+    const team = seedTeam({ issueNumber: 801, worktreeName: 'sendmsg-801' });
+
+    // Mock sendMessage to return true (delivery succeeded)
+    const manager = getTeamManager();
+    (manager.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: 'Hello team' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.status).toBe('delivered');
+    expect(body.deliveredAt).toBeDefined();
+  });
+
+  it('returns 422 when message is not delivered (no stdin pipe)', async () => {
+    const team = seedTeam({ issueNumber: 802, worktreeName: 'sendmsg-802' });
+
+    // Mock sendMessage to return false (no stdin pipe)
+    const manager = getTeamManager();
+    (manager.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: 'Hello team' },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.error).toBe('Unprocessable Entity');
+    expect(body.message).toContain('not running');
+    expect(body.message).toContain('not delivered');
+    // Command record should still be present in the response
+    expect(body.id).toBeDefined();
+    expect(body.teamId).toBe(team.id);
+  });
+
+  it('still inserts command record in DB even when delivery fails', async () => {
+    const team = seedTeam({ issueNumber: 803, worktreeName: 'sendmsg-803' });
+
+    const manager = getTeamManager();
+    (manager.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: 'Pending message' },
+    });
+
+    expect(res.statusCode).toBe(422);
+
+    // Verify command was persisted in DB (undelivered = still pending)
+    const db = getDatabase();
+    const commands = db.getPendingCommands(team.id);
+    expect(commands.length).toBe(1);
+    expect(commands[0]!.message).toBe('Pending message');
+  });
+
+  it('returns 400 for empty message', async () => {
+    const team = seedTeam({ issueNumber: 804, worktreeName: 'sendmsg-804' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: '' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/9999/send-message',
+      payload: { message: 'Hello' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #191

## Summary
- **Server**: `POST /api/teams/:id/message` now returns HTTP 422 with `{ error: 'Unprocessable Entity', message: 'Team is not running — message not delivered' }` when `manager.sendMessage()` returns `false` (no stdin pipe). Previously always returned 201.
- **Client**: `CommandInput.tsx` now shows an amber warning toast for 422 responses, distinguishing delivery failure from success (green) and errors (red). Added `'warning'` type to `FeedbackState`.
- **Export**: `ApiError` class exported from `useApi.ts` for `instanceof` checks.
- **Tests**: 5 new tests in `send-message-route.test.ts` covering 201 success, 422 failure, DB persistence on 422, 400 empty message, 404 unknown team.

## Test plan
- [x] Server returns 422 when `sendMessage()` returns false
- [x] Server returns 201 when delivery succeeds
- [x] Command record persists in DB even on failed delivery (for .fleet-pm-message fallback)
- [x] Client shows amber warning toast for 422
- [x] Client shows red error toast for other failures
- [x] All 5 new tests pass