### PR TITLE
Issue #198: add StopFailure hook for rate limits and API errors

### DIFF
--- a/hooks/DESIGN.md
+++ b/hooks/DESIGN.md
@@ -65,7 +65,21 @@ sees heartbeats stop WITHOUT a SessionEnd, the team crashed.
 activity. Dashboard tracks stop frequency — many stops in quick succession
 indicates thrashing.
 
-### 1.4 SubagentStart / SubagentStop
+### 1.4 StopFailure
+
+**Why:** Fires when the agent stops due to rate limits, API errors, or other
+infrastructure failures. Unlike a normal Stop, StopFailure indicates the
+agent was forcibly halted by external constraints rather than completing its
+turn. Without this hook, rate limits and API errors are invisible to Fleet
+Commander — the dashboard only sees silence until the stuck detector fires.
+
+**Signal value:** Immediate visibility into infrastructure problems:
+- Rate limit hit → team cannot make progress until the limit resets
+- API error → potential outage or configuration issue
+- The dashboard can surface `error_details` and `last_assistant_message` so
+  the PM knows exactly why the agent stopped and what it was doing.
+
+### 1.5 SubagentStart / SubagentStop
 
 **Why:** The KEA team has 8 agent types (coordinator, analityk, csharp-dev,
 fsharp-dev, ts-dev, devops-dev, weryfikator, pr-watcher). Tracking their
@@ -77,7 +91,7 @@ each team.
 - SubagentStart with `teammate_name: "fsharp-dev"` → team needs F# work
 - SubagentStop with `teammate_name: "weryfikator"` → review phase complete
 
-### 1.5 Notification
+### 1.6 Notification
 
 **Why:** Catches idle prompts ("Your teammate is waiting") and permission
 prompts. Both indicate the team is paused waiting for external input.
@@ -85,7 +99,7 @@ prompts. Both indicate the team is paused waiting for external input.
 **Signal value:** If a team accumulates notifications without tool_use
 events, it is stuck waiting. The dashboard can flag "needs human attention."
 
-### 1.6 PreCompact
+### 1.7 PreCompact
 
 **Why:** Context compaction means the agent is running out of context window
 space. This is an early warning that the task is complex/long-running and
@@ -94,7 +108,7 @@ the agent may lose context of earlier work.
 **Signal value:** Leading indicator of complexity. Multiple PreCompact events
 for one team → the task might need to be broken down.
 
-### 1.7 PostToolUse (heartbeat)
+### 1.8 PostToolUse (heartbeat)
 
 **Why:** This is THE primary activity signal. Every time any tool completes
 (Bash, Read, Write, Edit, Grep, etc.), this hook fires. It proves the agent
@@ -106,7 +120,7 @@ It also captures WHICH tool was used, enabling activity profiling:
 - Lots of `Edit` + `Write` → agent is implementing
 - Lots of `Bash` → agent is testing/building
 
-### 1.8 PostToolUseFailure
+### 1.9 PostToolUseFailure
 
 **Why:** Tool errors (build failures, test failures, permission errors) are
 the strongest signal that a team is struggling. A burst of errors means the
@@ -166,6 +180,7 @@ Fields are omitted when empty. Per-event payloads:
 | session_start    | team, session_id, agent_type                           |
 | session_end      | team, session_id                                       |
 | stop             | team, session_id, stop_reason                          |
+| stop_failure     | team, session_id, error_details, last_assistant_message|
 | subagent_start   | team, session_id, teammate_name, agent_type            |
 | subagent_stop    | team, session_id, teammate_name, agent_type            |
 | notification     | team, session_id, message                              |
@@ -461,6 +476,7 @@ dedup by `(team, event, timestamp_rounded_to_second)`.
   on_session_start.sh        ← hook: SessionStart
   on_session_end.sh          ← hook: SessionEnd
   on_stop.sh                 ← hook: Stop
+  on_stop_failure.sh         ← hook: StopFailure
   on_subagent_start.sh       ← hook: SubagentStart
   on_subagent_stop.sh        ← hook: SubagentStop
   on_notification.sh         ← hook: Notification

--- a/hooks/on_stop_failure.sh
+++ b/hooks/on_stop_failure.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Fleet Commander hook: StopFailure
+# Fires when the agent stops due to rate limits or API errors.
+# stdin JSON example: {"session_id":"abc123","error_details":"rate_limit","last_assistant_message":"..."}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "stop_failure"

--- a/hooks/send_event.sh
+++ b/hooks/send_event.sh
@@ -75,6 +75,8 @@ MESSAGE=$(extract_json_string "message")
 ERROR=$(extract_json_string "error")
 TOOL_USE_ID=$(extract_json_string "tool_use_id")
 STOP_REASON=$(extract_json_string "stop_reason")
+ERROR_DETAILS=$(extract_json_string "error_details")
+LAST_ASSISTANT_MESSAGE=$(extract_json_string "last_assistant_message")
 
 # ── Extract SendMessage routing fields from tool_input ────────────
 # When tool_name is "SendMessage", the hook stdin contains a tool_input
@@ -124,6 +126,8 @@ PAYLOAD="${PAYLOAD}$(json_field "message" "$MESSAGE")"
 PAYLOAD="${PAYLOAD}$(json_field "error" "$ERROR")"
 PAYLOAD="${PAYLOAD}$(json_field "tool_use_id" "$TOOL_USE_ID")"
 PAYLOAD="${PAYLOAD}$(json_field "stop_reason" "$STOP_REASON")"
+PAYLOAD="${PAYLOAD}$(json_field "error_details" "$ERROR_DETAILS")"
+PAYLOAD="${PAYLOAD}$(json_field "last_assistant_message" "$LAST_ASSISTANT_MESSAGE")"
 PAYLOAD="${PAYLOAD}$(json_field "worktree_root" "$WORKTREE_ROOT")"
 PAYLOAD="${PAYLOAD}$(json_field "msg_to" "$MSG_TO")"
 PAYLOAD="${PAYLOAD}$(json_field "msg_summary" "$MSG_SUMMARY")"

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -33,6 +33,16 @@
         ]
       }
     ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/on_stop_failure.sh"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [

--- a/src/client/components/EventTimeline.tsx
+++ b/src/client/components/EventTimeline.tsx
@@ -34,6 +34,7 @@ const EVENT_ICONS: Record<string, React.ReactNode> = {
   SessionStart: <PlayIcon size={14} />,
   SessionEnd: <SquareIcon size={14} />,
   Stop: <CircleStopIcon size={14} />,
+  StopFailure: <AlertTriangleIcon size={14} />,
   SubagentStart: <ArrowRightIcon size={14} />,
   SubagentStop: <ArrowLeftIcon size={14} />,
   Notification: <AlertTriangleIcon size={14} />,

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -43,6 +43,8 @@ const eventsRoutes: FastifyPluginCallback = (
           tool_use_id: body.tool_use_id ? String(body.tool_use_id) : undefined,
           tool_input: body.tool_input ? String(body.tool_input) : undefined,
           stop_reason: body.stop_reason ? String(body.stop_reason) : undefined,
+          error_details: body.error_details ? String(body.error_details) : undefined,
+          last_assistant_message: body.last_assistant_message ? String(body.last_assistant_message) : undefined,
           worktree_root: body.worktree_root ? String(body.worktree_root) : undefined,
           msg_to: body.msg_to ? String(body.msg_to) : undefined,
           msg_summary: body.msg_summary ? String(body.msg_summary) : undefined,
@@ -54,11 +56,11 @@ const eventsRoutes: FastifyPluginCallback = (
 
         // When a stop event is received, a team may be finishing —
         // trigger queue processing so queued teams can launch.
-        if (payload.event === 'stop' || payload.event === 'session_end') {
+        if (payload.event === 'stop' || payload.event === 'stop_failure' || payload.event === 'session_end') {
           const team = db.getTeamByWorktree(payload.team);
           if (team?.projectId) {
             getTeamManager().processQueue(team.projectId).catch((err) => {
-              request.log.error(err, 'processQueue error after stop/session_end event');
+              request.log.error(err, 'processQueue error after stop/session_end/stop_failure event');
             });
           }
         }

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -124,6 +124,7 @@ function checkInstallStatus(repoPath: string): InstallStatus {
     'on_session_start.sh',
     'on_session_end.sh',
     'on_stop.sh',
+    'on_stop_failure.sh',
     'on_subagent_start.sh',
     'on_subagent_stop.sh',
     'on_notification.sh',

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -36,6 +36,8 @@ export interface EventPayload {
   tool_use_id?: string;  // tool_use_id from PostToolUseFailure events
   tool_input?: string;   // tool input JSON from PostToolUseFailure events (passed via route, not shell)
   stop_reason?: string;
+  error_details?: string;       // StopFailure: reason for the failure (e.g. "rate_limit")
+  last_assistant_message?: string; // StopFailure: last thing the agent said before failure
   worktree_root?: string;
   msg_to?: string;
   msg_summary?: string;
@@ -125,6 +127,7 @@ function normalizeEventType(raw: string): string {
     'session_start': 'SessionStart',
     'session_end': 'SessionEnd',
     'stop': 'Stop',
+    'stop_failure': 'StopFailure',
     'subagent_start': 'SubagentStart',
     'subagent_stop': 'SubagentStop',
     'notification': 'Notification',
@@ -188,7 +191,7 @@ export function processEvent(
   //
   // This MUST happen before the throttle check so that even
   // deduplicated tool_use events trigger the recovery transition.
-  const DORMANCY_EVENTS = new Set(['stop', 'session_end']);
+  const DORMANCY_EVENTS = new Set(['stop', 'stop_failure', 'session_end']);
   const eventNameLower = payload.event.toLowerCase();
 
   if ((team.status === 'idle' || team.status === 'stuck') && !DORMANCY_EVENTS.has(eventNameLower)) {

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -74,6 +74,7 @@ describe('Valid payload processing', () => {
     'session_start',
     'session_end',
     'stop',
+    'stop_failure',
     'subagent_start',
     'subagent_stop',
     'notification',
@@ -86,6 +87,7 @@ describe('Valid payload processing', () => {
     session_start: 'SessionStart',
     session_end: 'SessionEnd',
     stop: 'Stop',
+    stop_failure: 'StopFailure',
     subagent_start: 'SubagentStart',
     subagent_stop: 'SubagentStop',
     notification: 'Notification',
@@ -502,6 +504,7 @@ describe('Non-tool_use events never throttled', () => {
     'session_start',
     'session_end',
     'stop',
+    'stop_failure',
     'subagent_start',
     'subagent_stop',
     'notification',
@@ -642,6 +645,103 @@ describe('tool_error event with error field', () => {
     const storedPayload = JSON.parse(insertCall.payload);
     expect(storedPayload.error).toBe('file not found');
     expect(storedPayload.message).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// StopFailure event with error_details and last_assistant_message
+// =============================================================================
+
+describe('StopFailure event', () => {
+  it('stores error_details and last_assistant_message in payload JSON', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'stop_failure',
+      error_details: 'rate_limit',
+      last_assistant_message: 'I was about to run the tests when...',
+    });
+
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'StopFailure',
+      }),
+    );
+
+    // Verify the full payload JSON contains the StopFailure-specific fields
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.error_details).toBe('rate_limit');
+    expect(storedPayload.last_assistant_message).toBe('I was about to run the tests when...');
+  });
+
+  it('is treated as a dormancy event (does not transition idle -> running)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop_failure', error_details: 'api_error' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have called updateTeam with status: 'running'
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('is treated as a dormancy event (does not transition stuck -> running)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop_failure', error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('still updates lastEventAt for stop_failure events', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop_failure', error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ lastEventAt: expect.any(String) }),
+    );
+  });
+
+  it('handles stop_failure with only error field (no error_details)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'stop_failure',
+      team: 'kea-100',
+      session_id: 'sess-abc',
+      error: 'API rate limit exceeded',
+    };
+
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.error).toBe('API rate limit exceeded');
   });
 });
 


### PR DESCRIPTION
Closes #198

## Summary
- Add `on_stop_failure.sh` hook to capture CC StopFailure events (rate_limit, billing_error, auth_failed, server_error)
- Extract `error_details` and `last_assistant_message` fields end-to-end from shell hook through server to DB
- Add `stop_failure` to `DORMANCY_EVENTS` so it doesn't falsely reset idle/stuck teams to running
- Add normalizeEventType entry, settings registration, install status check, UI icon, and 5 new tests

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (pre-existing failures on cost_update unrelated)
- [x] New StopFailure tests verify error_details/last_assistant_message storage
- [x] Dormancy behavior tested — stop_failure does not transition idle/stuck→running
- [ ] Manual: re-install hooks on a target repo and verify on_stop_failure.sh is deployed
- [ ] Manual: trigger a StopFailure event and verify it appears in EventTimeline with AlertTriangle icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)