### PR TITLE
Issue #192: add dependency_resolved to SSE client event listeners

### DIFF
--- a/src/client/hooks/useSSE.ts
+++ b/src/client/hooks/useSSE.ts
@@ -46,7 +46,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
       'snapshot', 'team_status_changed', 'team_event', 'team_output',
       'pr_updated', 'team_launched', 'team_stopped',
       'usage_updated', 'project_added', 'project_updated', 'project_removed',
-      'project_cleanup', 'heartbeat',
+      'project_cleanup', 'dependency_resolved', 'heartbeat',
     ];
 
     const handleSSEMessage = (event: MessageEvent) => {


### PR DESCRIPTION
Closes #192

## Summary
- Add `'dependency_resolved'` to the `namedEventTypes` array in `src/client/hooks/useSSE.ts`
- The browser's EventSource API requires explicit `addEventListener` calls for named SSE events — since this type was missing, the client silently dropped `dependency_resolved` events
- All 14 SSE event types now match between server (`sse-broker.ts`) and client (`useSSE.ts`)

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 317 tests pass (3 pre-existing failures on main, unrelated)
- [ ] Verify in browser: dependency resolution triggers real-time badge update in Issue Tree view

🤖 Generated with [Claude Code](https://claude.com/claude-code)