### PR TITLE
Issue #183: fix Session Log "you" label misattribution and capitalize to "You"

### DIFF
--- a/src/client/components/TeamOutput.tsx
+++ b/src/client/components/TeamOutput.tsx
@@ -21,7 +21,7 @@ interface StreamEvent {
 
 const TYPE_STYLES: Record<string, { color: string; label: string }> = {
   assistant:    { color: '#58A6FF', label: 'TL' },
-  user:         { color: '#3FB950', label: 'you' },
+  user:         { color: '#3FB950', label: 'You' },
   fc:           { color: '#D29922', label: 'FC' },
   system:       { color: '#8B949E', label: 'system' },
   tool_use:     { color: '#D29922', label: 'tool' },

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1649,6 +1649,13 @@ export class TeamManager {
             const event: StreamEvent = JSON.parse(trimmed);
             console.log(`[CC:${logPrefix}] ${event.type}: ${summarizeEvent(event)}`);
 
+            // Skip CC-echoed "user" events — sendMessage() and
+            // setupStdinAndOutput() already inject properly-labeled
+            // synthetic events (type 'user' or 'fc') into parsedEvents.
+            // The CC echo is redundant and would misattribute automated
+            // FC messages as PM ("You") messages in the Session Log.
+            if (event.type === 'user') continue;
+
             // Store parsed event with timestamp
             const timestampedEvent: StreamEvent = {
               ...event,
@@ -1686,17 +1693,21 @@ export class TeamManager {
           try {
             const event: StreamEvent = JSON.parse(trimmed);
             console.log(`[CC:${logPrefix}] ${event.type}: ${summarizeEvent(event)}`);
-            const timestampedEvent: StreamEvent = {
-              ...event,
-              timestamp: new Date().toISOString(),
-            };
-            events.push(timestampedEvent);
-            if (events.length > MAX_PARSED_EVENTS) {
-              events.shift();
-            }
 
-            // Accumulate token counts from assistant events
-            this.accumulateTokens(teamId, event);
+            // Skip CC-echoed "user" events (same rationale as in 'data' handler)
+            if (event.type !== 'user') {
+              const timestampedEvent: StreamEvent = {
+                ...event,
+                timestamp: new Date().toISOString(),
+              };
+              events.push(timestampedEvent);
+              if (events.length > MAX_PARSED_EVENTS) {
+                events.shift();
+              }
+
+              // Accumulate token counts from assistant events
+              this.accumulateTokens(teamId, event);
+            }
           } catch {
             console.log(`[CC:${logPrefix}:raw] ${trimmed.substring(0, 200)}`);
           }


### PR DESCRIPTION
Closes #183

## Summary
- **Bug 1**: Suppress CC-echoed `type: "user"` events in `captureOutput()` — these are redundant since `sendMessage()` already injects properly-labeled synthetic events (type `user` for PM, type `fc` for FC). The CC echo was causing misattribution of automated FC messages as PM ("You") messages in the Session Log.
- **Bug 2**: Capitalize `'you'` to `'You'` in `TeamOutput.tsx` for visual consistency with other labels (TL, FC, system, tool, result, done).

## Changes
- `src/server/services/team-manager.ts` — Skip `type: "user"` events in both stdout `data` and `end` handlers within `captureOutput()`
- `src/client/components/TeamOutput.tsx` — Change `label: 'you'` to `label: 'You'`

## Test plan
- [ ] Verify Session Log no longer shows duplicate "You" entries for PM messages
- [ ] Verify FC automated messages (stuck nudges, CI notifications) no longer show "You" label
- [ ] Verify PM messages still appear correctly with "You" label (via sendMessage synthetic events)
- [ ] Verify capitalization: "You" instead of "you"