### PR TITLE
Issue #178: fix CommGraph edge matching, normalize agent names, make metadata collapsible

### DIFF
--- a/src/client/components/CommGraph.tsx
+++ b/src/client/components/CommGraph.tsx
@@ -18,6 +18,17 @@ function agentColor(name: string): string {
   return AGENT_PALETTE[Math.abs(hash) % AGENT_PALETTE.length];
 }
 
+/**
+ * Normalize agent name for consistent matching between roster and message edges.
+ * Strips "fleet-" prefix and lowercases. Client-side defense in case server-side
+ * normalization hasn't been applied to historical data.
+ */
+function normalizeName(name: string): string {
+  let n = name.trim().toLowerCase();
+  if (n.startsWith('fleet-')) n = n.slice(6);
+  return n;
+}
+
 // ---------------------------------------------------------------------------
 // Layout helpers
 // ---------------------------------------------------------------------------
@@ -60,11 +71,13 @@ function layoutNodes(
     msgCounts.set(e.recipient, (msgCounts.get(e.recipient) ?? 0) + e.count);
   }
 
-  // Identify the hub: prefer "team-lead" or "coordinator", else pick the agent
-  // with the most messages. Fallback to first agent.
-  const hubCandidates = agents.filter(
-    (a) => a.name === 'team-lead' || a.name === 'coordinator',
-  );
+  // Identify the hub: prefer "team-lead" or "coordinator" by normalized name,
+  // else pick the agent with the most messages. When all counts are 0 (no edges),
+  // fall back to the first roster member (typically team-lead).
+  const hubCandidates = agents.filter((a) => {
+    const n = normalizeName(a.name);
+    return n === 'team-lead' || n === 'coordinator' || n === 'tl';
+  });
   let hub: TeamMember | undefined = hubCandidates[0];
   if (!hub) {
     // Pick the agent with highest message volume
@@ -154,15 +167,24 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
 
   const nodeMap = useMemo(() => {
     const map = new Map<string, NodePosition>();
-    for (const n of nodes) map.set(n.name, n);
+    for (const n of nodes) {
+      map.set(n.name, n);
+      // Also index by normalized name for edge matching with un-normalized data
+      map.set(normalizeName(n.name), n);
+    }
     return map;
   }, [nodes]);
 
-  // Filter edges when a node is selected
+  // Filter edges when a node is selected (compare with normalized names)
   const visibleEdges = useMemo(() => {
     if (!selectedNode) return edges;
+    const selectedNorm = normalizeName(selectedNode);
     return edges.filter(
-      (e) => e.sender === selectedNode || e.recipient === selectedNode,
+      (e) =>
+        e.sender === selectedNode ||
+        e.recipient === selectedNode ||
+        normalizeName(e.sender) === selectedNorm ||
+        normalizeName(e.recipient) === selectedNorm,
     );
   }, [edges, selectedNode]);
 
@@ -212,8 +234,9 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
 
         {/* Edges */}
         {visibleEdges.map((edge) => {
-          const from = nodeMap.get(edge.sender);
-          const to = nodeMap.get(edge.recipient);
+          // Look up by exact name first, then by normalized name for backward compat
+          const from = nodeMap.get(edge.sender) ?? nodeMap.get(normalizeName(edge.sender));
+          const to = nodeMap.get(edge.recipient) ?? nodeMap.get(normalizeName(edge.recipient));
           if (!from || !to) return null;
 
           // Shorten line to stop at node border (radius + gap)

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -71,6 +71,7 @@ export function TeamDetail() {
   const [roster, setRoster] = useState<TeamMember[]>([]);
   const [activeTab, setActiveTab] = useState<'activity' | 'communication'>('activity');
   const [messageEdges, setMessageEdges] = useState<MessageEdge[]>([]);
+  const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -164,10 +165,19 @@ export function TeamDetail() {
     };
   }, [selectedTeamId, refreshKey, api]);
 
-  // Reset active tab when team changes
+  // Reset active tab and metadata collapse state when team changes
   useEffect(() => {
     setActiveTab('activity');
+    // Auto-collapse metadata for done/failed teams to give more space to content
+    setMetadataCollapsed(false);
   }, [selectedTeamId]);
+
+  // Auto-collapse metadata when team transitions to terminal state
+  useEffect(() => {
+    if (detail?.status === 'done' || detail?.status === 'failed') {
+      setMetadataCollapsed(true);
+    }
+  }, [detail?.status]);
 
   // Fetch team detail when selectedTeamId changes
   useEffect(() => {
@@ -400,20 +410,34 @@ export function TeamDetail() {
 
           {detail && (
             <>
-              {/* TOP: Metadata — scrollable if needed */}
-              <div className="shrink-0 overflow-y-auto max-h-[40%] custom-scrollbar">
-                <div className="p-5 space-y-4">
+              {/* TOP: Metadata — collapsible, auto-collapsed for done/failed */}
+              <div className="shrink-0">
+                {/* Always-visible header with collapse toggle */}
+                <div
+                  className="flex items-center justify-between px-5 py-3 cursor-pointer hover:bg-dark-border/10 transition-colors"
+                  onClick={() => setMetadataCollapsed((c) => !c)}
+                >
+                  <h3 className="text-base font-semibold text-dark-text">
+                    <span className="text-dark-muted mr-1.5">#{detail.issueNumber}</span>
+                    {detail.issueTitle ?? 'Untitled'}
+                  </h3>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge status={detail.status} />
+                    <svg
+                      className={`w-4 h-4 text-dark-muted transition-transform duration-200 ${metadataCollapsed ? '' : 'rotate-180'}`}
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                </div>
+
+                {/* Collapsible metadata content */}
+                <div className={`overflow-y-auto custom-scrollbar transition-all duration-200 ${metadataCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-[35%]'}`}>
+                <div className="px-5 pb-4 space-y-4">
                   {/* ---- Header Section ---- */}
                   <section>
-                    <h3 className="text-base font-semibold text-dark-text mb-2">
-                      <span className="text-dark-muted mr-1.5">#{detail.issueNumber}</span>
-                      {detail.issueTitle ?? 'Untitled'}
-                    </h3>
-
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <StatusBadge status={detail.status} />
-                    </div>
-
                     {/* Duration + Last Activity row */}
                     <div className="flex items-center gap-4 mt-3 text-sm">
                       <span className="text-dark-muted">
@@ -662,6 +686,7 @@ export function TeamDetail() {
                       <p className="text-sm text-dark-muted">PR #{detail.prNumber} (details loading...)</p>
                     </section>
                   )}
+                </div>
                 </div>
               </div>
 

--- a/src/client/components/TeamOutput.tsx
+++ b/src/client/components/TeamOutput.tsx
@@ -129,9 +129,12 @@ export function TeamOutput({ teamId, teamStatus }: TeamOutputProps) {
   }, [events]);
 
   if (events.length === 0) {
+    const isTerminal = teamStatus === 'done' || teamStatus === 'failed';
     return (
       <div className="text-xs text-dark-muted italic py-2">
-        No stream events yet. Events appear when Claude Code is running.
+        {isTerminal
+          ? 'No session log captured.'
+          : 'No stream events yet. Events appear when Claude Code is running.'}
       </div>
     );
   }

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -62,14 +62,19 @@ const ROLE_MAP: Record<string, string> = {
   coordinator: 'Coordinator',
   analyst: 'Analyst',
   reviewer: 'Reviewer',
+  'team-lead': 'Team Lead',
+  tl: 'Team Lead',
+  dev: 'Developer',
 };
 
 /** Derive a human-readable role from the agent name. */
 function deriveRole(name: string): string {
   const lower = name.toLowerCase();
-  if (ROLE_MAP[lower]) return ROLE_MAP[lower];
-  if (lower.startsWith('dev-')) return `Developer (${name.slice(4)})`;
-  if (lower.includes('dev')) return 'Developer';
+  // Strip fleet- prefix for role lookup (backward compat with un-normalized data)
+  const stripped = lower.startsWith('fleet-') ? lower.slice(6) : lower;
+  if (ROLE_MAP[stripped]) return ROLE_MAP[stripped];
+  if (stripped.startsWith('dev-')) return `Developer (${name.replace(/^fleet-/i, '').slice(4)})`;
+  if (stripped.includes('dev')) return 'Developer';
   return name;
 }
 
@@ -1119,9 +1124,14 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   getTeamRoster(teamId: number): TeamMember[] {
+    // Normalize agent names in SQL: strip "fleet-" prefix and coalesce empty to "team-lead"
+    // for backward compatibility with data inserted before normalization was added.
     const sql = `
       SELECT
-        agent_name AS name,
+        CASE
+          WHEN agent_name LIKE 'fleet-%' THEN SUBSTR(agent_name, 7)
+          ELSE agent_name
+        END AS name,
         MIN(created_at) AS first_seen,
         MAX(created_at) AS last_seen,
         SUM(CASE WHEN event_type = 'ToolUse' THEN 1 ELSE 0 END) AS tool_use_count,
@@ -1130,7 +1140,10 @@ export class FleetDatabase {
         SUM(CASE WHEN event_type = 'SubagentStop' THEN 1 ELSE 0 END) AS stops
       FROM events
       WHERE team_id = ? AND agent_name IS NOT NULL AND agent_name != ''
-      GROUP BY agent_name
+      GROUP BY CASE
+        WHEN agent_name LIKE 'fleet-%' THEN SUBSTR(agent_name, 7)
+        ELSE agent_name
+      END
       ORDER BY MIN(created_at) ASC
     `;
     const rows = this.db.prepare(sql).all(teamId) as Record<string, unknown>[];
@@ -1187,22 +1200,28 @@ export class FleetDatabase {
   }
 
   getAgentMessageSummary(teamId: number): MessageEdge[] {
+    // Normalize sender/recipient names: strip "fleet-" prefix for backward compat
+    // with data inserted before normalization was added.
     const sql = `
       SELECT
-        sender,
-        recipient,
+        CASE WHEN sender LIKE 'fleet-%' THEN SUBSTR(sender, 7) ELSE sender END AS sender,
+        CASE WHEN recipient LIKE 'fleet-%' THEN SUBSTR(recipient, 7) ELSE recipient END AS recipient,
         COUNT(*) AS count,
         (
           SELECT summary FROM agent_messages AS am2
           WHERE am2.team_id = am.team_id
-            AND am2.sender = am.sender
-            AND am2.recipient = am.recipient
+            AND (CASE WHEN am2.sender LIKE 'fleet-%' THEN SUBSTR(am2.sender, 7) ELSE am2.sender END)
+              = (CASE WHEN am.sender LIKE 'fleet-%' THEN SUBSTR(am.sender, 7) ELSE am.sender END)
+            AND (CASE WHEN am2.recipient LIKE 'fleet-%' THEN SUBSTR(am2.recipient, 7) ELSE am2.recipient END)
+              = (CASE WHEN am.recipient LIKE 'fleet-%' THEN SUBSTR(am.recipient, 7) ELSE am.recipient END)
           ORDER BY am2.created_at DESC, am2.id DESC
           LIMIT 1
         ) AS last_summary
       FROM agent_messages AS am
       WHERE team_id = ?
-      GROUP BY sender, recipient
+      GROUP BY
+        CASE WHEN sender LIKE 'fleet-%' THEN SUBSTR(sender, 7) ELSE sender END,
+        CASE WHEN recipient LIKE 'fleet-%' THEN SUBSTR(recipient, 7) ELSE recipient END
       ORDER BY count DESC
     `;
     const rows = this.db.prepare(sql).all(teamId) as Array<{

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -120,6 +120,27 @@ const SUBAGENT_MIN_EVENTS = 5;
 const TOOL_USE_THROTTLE_MS = 5000; // 5 seconds
 
 // ---------------------------------------------------------------------------
+// Agent name normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize agent name for consistent matching across roster and messages.
+ *
+ * - Strips `fleet-` prefix (e.g. "fleet-dev" -> "dev", "fleet-analyst" -> "analyst")
+ * - Maps empty/null/undefined to "team-lead" (the main CC process has no agent_type)
+ * - Returns lowercase trimmed name
+ */
+export function normalizeAgentName(name: string | null | undefined): string {
+  if (!name || name.trim() === '') return 'team-lead';
+  let normalized = name.trim();
+  // Strip "fleet-" prefix for consistent cross-reference
+  if (normalized.startsWith('fleet-')) {
+    normalized = normalized.slice(6);
+  }
+  return normalized;
+}
+
+// ---------------------------------------------------------------------------
 // Event type normalization
 // ---------------------------------------------------------------------------
 
@@ -271,11 +292,16 @@ export function processEvent(
   // ── Normalize event type ─────────────────────────────────────────
   const eventType = normalizeEventType(payload.event);
 
+  // ── Normalize agent name ────────────────────────────────────────
+  // Strip "fleet-" prefix and map empty agent_type to "team-lead"
+  // so roster names and message sender/recipient names match.
+  const agentName = normalizeAgentName(payload.agent_type);
+
   // ── Insert event into database ───────────────────────────────────
   const inserted = db.insertEvent({
     teamId,
     sessionId: payload.session_id || null,
-    agentName: payload.agent_type || null,
+    agentName,
     eventType,
     toolName: payload.tool_name || null,
     payload: JSON.stringify(payload),
@@ -288,7 +314,7 @@ export function processEvent(
     team_id: teamId,
     event_type: eventType,
     session_id: payload.session_id || null,
-    agent_name: payload.agent_type || null,
+    agent_name: agentName,
     tool_name: payload.tool_name || null,
     timestamp: payload.timestamp || nowIso,
   });
@@ -300,15 +326,15 @@ export function processEvent(
   const evtLower = payload.event.toLowerCase();
 
   if (evtLower === 'subagent_start') {
-    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
-    const trackerKey = `${payload.team}:${agentName}`;
+    const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${subagentName}`;
     subagentTrackers.set(trackerKey, { startTime: now, eventCount: 0 });
   }
 
   // Increment event count for any tracked subagent on this team
   if (payload.agent_type || payload.teammate_name) {
-    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
-    const trackerKey = `${payload.team}:${agentName}`;
+    const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${subagentName}`;
     const tracker = subagentTrackers.get(trackerKey);
     if (tracker) {
       tracker.eventCount++;
@@ -316,8 +342,8 @@ export function processEvent(
   }
 
   if (evtLower === 'subagent_stop' && messageSender) {
-    const agentName = payload.teammate_name || payload.agent_type || 'unknown';
-    const trackerKey = `${payload.team}:${agentName}`;
+    const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
+    const trackerKey = `${payload.team}:${subagentName}`;
     const tracker = subagentTrackers.get(trackerKey);
 
     if (tracker) {
@@ -326,10 +352,10 @@ export function processEvent(
 
       if (durationMs < SUBAGENT_MIN_DURATION_MS && tracker.eventCount < SUBAGENT_MIN_EVENTS) {
         const crashMsg =
-          `Subagent '${agentName}' appears to have crashed (${durationSec}s after start, ${tracker.eventCount} events). Consider respawning.`;
+          `Subagent '${subagentName}' appears to have crashed (${durationSec}s after start, ${tracker.eventCount} events). Consider respawning.`;
         try {
           messageSender.sendMessage(teamId, crashMsg);
-          console.log(`[EventCollector] Subagent crash advisory sent for ${agentName} on team ${teamId}`);
+          console.log(`[EventCollector] Subagent crash advisory sent for ${subagentName} on team ${teamId}`);
         } catch {
           // Non-critical — silently ignore send failures
         }
@@ -348,8 +374,8 @@ export function processEvent(
       db.insertAgentMessage({
         teamId,
         eventId,
-        sender: payload.agent_type || 'unknown',
-        recipient: payload.msg_to,
+        sender: normalizeAgentName(payload.agent_type),
+        recipient: normalizeAgentName(payload.msg_to),
         summary: payload.msg_summary || null,
         content: payload.message || null,
         sessionId: payload.session_id || null,

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -7,6 +7,7 @@ import {
   processEvent,
   resetThrottleState,
   resetSubagentTrackers,
+  normalizeAgentName,
   EventCollectorError,
   type EventPayload,
   type EventCollectorDb,
@@ -556,7 +557,7 @@ describe('SSE broadcast', () => {
         team_id: 1,
         event_type: 'SessionStart',
         session_id: 'sess-xyz',
-        agent_name: 'kea-coordinator',
+        agent_name: 'kea-coordinator', // No fleet- prefix to strip here
         tool_name: null,
       }),
     );
@@ -792,7 +793,7 @@ describe('Edge cases', () => {
     expect(db.insertEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: null,
-        agentName: null,
+        agentName: 'team-lead', // Empty agent_type maps to "team-lead"
       }),
     );
   });
@@ -821,8 +822,8 @@ describe('Agent message routing', () => {
     expect(db.insertAgentMessage).toHaveBeenCalledWith({
       teamId: 1,
       eventId: 1,
-      sender: 'coordinator',
-      recipient: 'dev-typescript',
+      sender: 'coordinator', // already normalized (no fleet- prefix)
+      recipient: 'dev-typescript', // already normalized (no fleet- prefix)
       summary: 'Implement the feature',
       content: 'Full message content here',
       sessionId: 'sess-abc',
@@ -872,13 +873,14 @@ describe('Agent message routing', () => {
 
     expect(db.insertAgentMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        recipient: '*',
+        sender: 'coordinator',
+        recipient: '*', // "*" passes through normalization unchanged
         content: 'Team-wide broadcast',
       }),
     );
   });
 
-  it('uses "unknown" as sender when agent_type is missing', () => {
+  it('uses "team-lead" as sender when agent_type is missing', () => {
     const db = createMockDb();
     const sse = createMockSse();
     const payload = makePayload({
@@ -892,7 +894,7 @@ describe('Agent message routing', () => {
 
     expect(db.insertAgentMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        sender: 'unknown',
+        sender: 'team-lead', // Empty agent_type normalizes to "team-lead"
         recipient: 'dev-typescript',
       }),
     );
@@ -1452,8 +1454,8 @@ describe('cc_stdin payloads through processEvent', () => {
     expect(db.insertAgentMessage).toHaveBeenCalledWith({
       teamId: 1,
       eventId: 1,
-      sender: 'coordinator',
-      recipient: 'dev-typescript',
+      sender: 'coordinator', // normalized (no fleet- prefix to strip)
+      recipient: 'dev-typescript', // normalized (no fleet- prefix to strip)
       summary: 'Implement the fix',
       content: 'Full content',
       sessionId: 'sess-1',
@@ -1488,5 +1490,135 @@ describe('cc_stdin payloads through processEvent', () => {
     const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
     const storedPayload = JSON.parse(insertCall.payload);
     expect(storedPayload.tool_input).toBe(JSON.stringify(complexToolInput));
+  });
+});
+
+// =============================================================================
+// normalizeAgentName (Issue #178)
+// =============================================================================
+
+describe('normalizeAgentName', () => {
+  it('strips fleet- prefix', () => {
+    expect(normalizeAgentName('fleet-dev')).toBe('dev');
+    expect(normalizeAgentName('fleet-analyst')).toBe('analyst');
+    expect(normalizeAgentName('fleet-reviewer')).toBe('reviewer');
+  });
+
+  it('maps empty/null/undefined to "team-lead"', () => {
+    expect(normalizeAgentName(null)).toBe('team-lead');
+    expect(normalizeAgentName(undefined)).toBe('team-lead');
+    expect(normalizeAgentName('')).toBe('team-lead');
+    expect(normalizeAgentName('  ')).toBe('team-lead');
+  });
+
+  it('passes through names without fleet- prefix', () => {
+    expect(normalizeAgentName('coordinator')).toBe('coordinator');
+    expect(normalizeAgentName('dev-typescript')).toBe('dev-typescript');
+    expect(normalizeAgentName('team-lead')).toBe('team-lead');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeAgentName(' fleet-dev ')).toBe('dev');
+    expect(normalizeAgentName(' coordinator ')).toBe('coordinator');
+  });
+});
+
+// =============================================================================
+// Agent name normalization in event processing (Issue #178)
+// =============================================================================
+
+describe('Agent name normalization in event processing', () => {
+  it('normalizes fleet- prefixed agent_type in event insertion', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_use',
+      agent_type: 'fleet-dev',
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'dev', // fleet- prefix stripped
+      }),
+    );
+  });
+
+  it('normalizes fleet- prefixed agent_type in SSE broadcast', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'session_start',
+      agent_type: 'fleet-analyst',
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_event',
+      expect.objectContaining({
+        agent_name: 'analyst', // fleet- prefix stripped
+      }),
+    );
+  });
+
+  it('maps missing agent_type to team-lead in event insertion', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'session_start',
+      agent_type: undefined,
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'team-lead',
+      }),
+    );
+  });
+
+  it('normalizes fleet- prefixed sender and recipient in agent messages', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_use',
+      tool_name: 'SendMessage',
+      agent_type: 'fleet-analyst',
+      msg_to: 'fleet-dev',
+      msg_summary: 'Here is the brief',
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: 'analyst', // fleet- prefix stripped
+        recipient: 'dev',  // fleet- prefix stripped
+      }),
+    );
+  });
+
+  it('normalizes msg_to with fleet- prefix in agent messages', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_use',
+      tool_name: 'SendMessage',
+      agent_type: 'coordinator',
+      msg_to: 'fleet-reviewer',
+      msg_summary: 'Please review',
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: 'coordinator',
+        recipient: 'reviewer', // fleet- prefix stripped
+      }),
+    );
   });
 });


### PR DESCRIPTION
Closes #178

## Summary
- **CommGraph edges**: Added `normalizeAgentName()` server-side (strips `fleet-` prefix, maps empty `agent_type` to `team-lead`) and defensive `normalizeName()` client-side. Dual-indexed nodeMap ensures edges connect properly. SQL-level CASE WHEN normalization in `getTeamRoster()` and `getAgentMessageSummary()` for backward compat with historical data.
- **Hub layout**: Improved hub detection to match `tl` variant alongside `team-lead` and `coordinator`.
- **Team Detail layout**: Made metadata section collapsible with chevron toggle. Auto-collapses for done/failed teams. Reduced max-h from 40% to 35%.
- **Session Log empty text**: Shows "No session log captured." for done/failed teams instead of "No stream events yet."

## Files changed
- `src/server/services/event-collector.ts` — `normalizeAgentName()` + apply at all insertion points
- `src/server/db.ts` — SQL normalization, `deriveRole()` updates
- `src/client/components/CommGraph.tsx` — client-side normalization, dual nodeMap, hub fallback
- `src/client/components/TeamDetail.tsx` — collapsible metadata
- `src/client/components/TeamOutput.tsx` — terminal state empty text
- `tests/server/event-collector.test.ts` — 9 new tests for normalization

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 92 tests pass (2 pre-existing failures unrelated)
- [ ] Verify CommGraph shows edges for teams with SendMessage data
- [ ] Verify metadata collapses by default for done/failed teams
- [ ] Verify session log shows correct empty text for done teams