### PR TITLE
Issue #196: filter TeamDetail SSE refreshes by selected team

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -58,7 +58,7 @@ function truncateName(name: string, maxLen = 5): string {
 // ---------------------------------------------------------------------------
 
 export function TeamDetail() {
-  const { selectedTeamId, setSelectedTeamId, lastEvent } = useFleet();
+  const { selectedTeamId, setSelectedTeamId, lastEvent, lastEventTeamId } = useFleet();
   const api = useApi();
   const [detail, setDetail] = useState<TeamDetailType | null>(null);
   const [loading, setLoading] = useState(false);
@@ -215,9 +215,16 @@ export function TeamDetail() {
   }, [selectedTeamId, api]);
 
   // Refresh detail on SSE updates (when lastEvent changes and panel is open)
-  // Debounced to 2 seconds to avoid hammering the REST API on rapid SSE events
+  // Debounced to 2 seconds to avoid hammering the REST API on rapid SSE events.
+  // Only refresh when the SSE event pertains to the selected team — events from
+  // other teams (or non-team events like usage_updated, project_*) are skipped.
   useEffect(() => {
     if (selectedTeamId == null || !lastEvent) return;
+
+    // Skip refresh when the SSE event is for a different team.
+    // lastEventTeamId === null means a non-team event (e.g. usage_updated,
+    // project_*, snapshot) which does not affect team detail — skip those too.
+    if (lastEventTeamId !== selectedTeamId) return;
 
     // Clear any pending debounce timer
     if (refreshTimerRef.current) {
@@ -245,7 +252,7 @@ export function TeamDetail() {
         refreshTimerRef.current = null;
       }
     };
-  }, [lastEvent, selectedTeamId, api]);
+  }, [lastEvent, lastEventTeamId, selectedTeamId, api]);
 
   // Close panel handler
   const handleClose = useCallback(() => {

--- a/src/client/context/FleetContext.tsx
+++ b/src/client/context/FleetContext.tsx
@@ -8,6 +8,8 @@ interface FleetContextValue {
   setSelectedTeamId: (id: number | null) => void;
   connected: boolean;
   lastEvent: Date | null;
+  /** The team_id from the most recent SSE event, or null for non-team events */
+  lastEventTeamId: number | null;
 }
 
 const FleetContext = createContext<FleetContextValue | null>(null);
@@ -67,7 +69,7 @@ export function FleetProvider({ children }: { children: ReactNode }) {
     }
   }, [debouncedFetchTeams]);
 
-  const { connected, lastEvent } = useSSE({ onEvent: handleSSEEvent });
+  const { connected, lastEvent, lastEventTeamId } = useSSE({ onEvent: handleSSEEvent });
 
   // Fetch teams on mount as a fallback in case the SSE snapshot is missed
   useEffect(() => {
@@ -95,7 +97,8 @@ export function FleetProvider({ children }: { children: ReactNode }) {
     setSelectedTeamId,
     connected,
     lastEvent,
-  }), [teams, selectedTeamId, connected, lastEvent]);
+    lastEventTeamId,
+  }), [teams, selectedTeamId, connected, lastEvent, lastEventTeamId]);
 
   return (
     <FleetContext.Provider value={value}>

--- a/src/client/hooks/useSSE.ts
+++ b/src/client/hooks/useSSE.ts
@@ -8,6 +8,8 @@ interface UseSSEOptions {
 interface UseSSEResult {
   connected: boolean;
   lastEvent: Date | null;
+  /** The team_id from the most recent SSE event, or null for non-team events */
+  lastEventTeamId: number | null;
 }
 
 /**
@@ -17,6 +19,7 @@ interface UseSSEResult {
 export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
   const [connected, setConnected] = useState(false);
   const [lastEvent, setLastEvent] = useState<Date | null>(null);
+  const [lastEventTeamId, setLastEventTeamId] = useState<number | null>(null);
   const onEventRef = useRef(options.onEvent);
   const retryDelayRef = useRef(1000);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -52,9 +55,14 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
     const handleSSEMessage = (event: MessageEvent) => {
       if (!mountedRef.current) return;
       let eventType = 'message';
+      let teamId: number | null = null;
       try {
         const parsed = JSON.parse(event.data);
         eventType = parsed.type ?? event.type ?? 'message';
+        // Extract team_id from team-scoped SSE events
+        if (typeof parsed.team_id === 'number') {
+          teamId = parsed.team_id;
+        }
         onEventRef.current?.(eventType, parsed);
       } catch {
         // Non-JSON message — still invoke callback with raw data
@@ -66,6 +74,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
         if (now - lastEventTimeRef.current > 1000) {
           lastEventTimeRef.current = now;
           setLastEvent(new Date(now));
+          setLastEventTeamId(teamId);
         }
       }
     };
@@ -111,5 +120,5 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
     };
   }, [connect]);
 
-  return { connected, lastEvent };
+  return { connected, lastEvent, lastEventTeamId };
 }

--- a/tests/client/test-utils.tsx
+++ b/tests/client/test-utils.tsx
@@ -16,6 +16,7 @@ interface FleetContextValue {
   setSelectedTeamId: (id: number | null) => void;
   connected: boolean;
   lastEvent: Date | null;
+  lastEventTeamId: number | null;
 }
 
 /**
@@ -62,6 +63,7 @@ interface MockFleetProviderProps {
   selectedTeamId?: number | null;
   connected?: boolean;
   lastEvent?: Date | null;
+  lastEventTeamId?: number | null;
 }
 
 export function MockFleetProvider({
@@ -70,6 +72,7 @@ export function MockFleetProvider({
   selectedTeamId = null,
   connected = true,
   lastEvent = null,
+  lastEventTeamId = null,
 }: MockFleetProviderProps) {
   const value: FleetContextValue = {
     teams,
@@ -77,6 +80,7 @@ export function MockFleetProvider({
     setSelectedTeamId: () => {},
     connected,
     lastEvent,
+    lastEventTeamId,
   };
 
   return (


### PR DESCRIPTION
Closes #196

## Summary
- Extract `team_id` from SSE event payloads in `useSSE.ts` and expose as `lastEventTeamId`
- Thread `lastEventTeamId` through `FleetContext` to consumers
- Add guard in `TeamDetail.tsx` refresh effect to only fire when the SSE event matches the selected team
- Update test utilities to include `lastEventTeamId` in mock context

## Problem
`lastEvent` updated on every SSE event from ANY team. TeamDetail debounced and fetched on every `lastEvent` change. With 10 active teams this meant ~1 REST request every 2s for a team that hadn't changed.

## Fix
Pass `team_id` from SSE payload through to context so TeamDetail only refreshes when the selected team has new activity. Non-team events (usage_updated, project_*, snapshot) are correctly skipped since they don't affect team-specific data.

## Test plan
- [x] Build passes
- [x] Existing tests pass (pre-existing failures unrelated)
- [x] StatusBar "Last update" indicator still works (uses global `lastEvent`)
- [ ] Manual: open TeamDetail for one team, verify no REST refresh when other teams generate events
- [ ] Manual: verify TeamDetail refreshes correctly when the selected team generates events