### PR TITLE
Issue #211: add Force Launch button for queued teams in Fleet Grid

### DIFF
--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -43,6 +43,7 @@ interface TeamRowProps {
 export function TeamRow({ team, selected, onClick }: TeamRowProps) {
   const api = useApi();
   const [stopping, setStopping] = useState(false);
+  const [forceLaunching, setForceLaunching] = useState(false);
 
   const handleStop = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -54,6 +55,19 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
       // Ignore — the SSE stream will reflect actual state
     } finally {
       setStopping(false);
+    }
+  };
+
+  const handleForceLaunch = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (forceLaunching) return;
+    setForceLaunching(true);
+    try {
+      await api.post(`teams/${team.id}/force-launch`);
+    } catch {
+      // Ignore — the SSE stream will reflect actual state
+    } finally {
+      setForceLaunching(false);
     }
   };
 
@@ -147,6 +161,16 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
       {/* Actions */}
       <td className="px-4 whitespace-nowrap">
         <span className="inline-flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          {team.status === 'queued' && (
+            <button
+              onClick={handleForceLaunch}
+              disabled={forceLaunching}
+              className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-[#D29922] hover:border-[#D29922]/50 transition-colors disabled:opacity-50"
+              title="Launch immediately despite usage limit"
+            >
+              {forceLaunching ? 'Launching\u2026' : 'Force Launch'}
+            </button>
+          )}
           {isActive && (
             <button
               onClick={handleStop}

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -318,6 +318,46 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // POST /api/teams/:id/force-launch — force-launch a queued team
+  // -------------------------------------------------------------------------
+  fastify.post(
+    '/api/teams/:id/force-launch',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseInt(request.params.id, 10);
+        if (isNaN(teamId) || teamId < 1) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Invalid team ID',
+          });
+        }
+
+        const manager = getTeamManager();
+        const team = await manager.forceLaunch(teamId);
+        return reply.code(200).send(team);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+
+        if (message.includes('not found')) {
+          return reply.code(404).send({ error: 'Not Found', message });
+        }
+        if (message.includes('not queued')) {
+          return reply.code(409).send({ error: 'Conflict', message });
+        }
+
+        request.log.error(err, 'Failed to force-launch team');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message,
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // POST /api/teams/:id/resume — resume a stopped team
   // -------------------------------------------------------------------------
   fastify.post(

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -744,6 +744,57 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // forceLaunch — bypass usage gate and slot limits to launch a queued team
+  // -------------------------------------------------------------------------
+
+  async forceLaunch(teamId: number): Promise<Team> {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw new Error(`Team ${teamId} not found`);
+    }
+
+    if (team.status !== 'queued') {
+      throw new Error(`Team ${teamId} is not queued (current status: ${team.status})`);
+    }
+
+    const projectId = team.projectId;
+    if (!projectId) {
+      throw new Error(`Team ${teamId} has no project ID`);
+    }
+
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw new Error(`Project ${projectId} not found`);
+    }
+
+    // Log a warning if this exceeds maxActiveTeams
+    const activeCount = db.getActiveTeamCountByProject(projectId);
+    if (activeCount >= project.maxActiveTeams) {
+      console.warn(
+        `[TeamManager] Force-launching team ${teamId} exceeds maxActiveTeams (${activeCount}/${project.maxActiveTeams})`,
+      );
+    }
+
+    // Insert transition and update status BEFORE calling launchQueued,
+    // since launchQueued's guard at the top accepts both 'queued' and 'launching'.
+    db.insertTransition({
+      teamId,
+      fromStatus: 'queued',
+      toStatus: 'launching',
+      trigger: 'pm_action',
+      reason: 'PM force-launched team',
+    });
+    db.updateTeam(teamId, { status: 'launching' });
+    this.broadcastSnapshot();
+
+    // Delegate to the existing private launch method
+    await this.launchQueued(team);
+
+    return db.getTeam(teamId)!;
+  }
+
+  // -------------------------------------------------------------------------
   // processQueue — dequeue and launch teams when slots free up
   // -------------------------------------------------------------------------
 

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -58,6 +58,16 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     hookEvent: null,
   },
   {
+    id: 'queued-launching-force',
+    from: 'queued',
+    to: 'launching',
+    trigger: 'pm_action',
+    triggerLabel: 'PM force launch',
+    description: 'PM force-launches a queued team, bypassing usage gate and slot limits',
+    condition: 'Manual PM action via API, bypasses usage gate',
+    hookEvent: null,
+  },
+  {
     id: 'launching-running',
     from: 'launching',
     to: 'running',


### PR DESCRIPTION
Closes #211

## Summary
- Add **Force Launch** button on queued team rows in Fleet Grid, allowing PMs to bypass usage-zone limits and launch a specific team immediately
- New `POST /api/teams/:id/force-launch` endpoint with proper validation (400/404/409/500)
- New `forceLaunch(teamId)` method in TeamManager that bypasses usage zone and slot limit checks
- New `queued-launching-force` state machine transition with `pm_action` trigger (CLAUDE.md rule #13)

## Changes
| File | Change |
|------|--------|
| `src/client/components/TeamRow.tsx` | Force Launch button (warning-styled, queued-only, with tooltip) |
| `src/server/routes/teams.ts` | `POST /api/teams/:id/force-launch` endpoint |
| `src/server/services/team-manager.ts` | `forceLaunch()` method with race condition safety |
| `src/shared/state-machine.ts` | `queued-launching-force` transition entry |

## Test plan
- [ ] Verify Force Launch button appears only on queued team rows
- [ ] Click Force Launch on a queued team — team transitions to launching
- [ ] Verify button has warning styling and tooltip
- [ ] Verify force launch works when usage is in red zone
- [ ] Verify TypeScript compiles cleanly (`npm run build`)
- [ ] Verify existing tests pass (`npm test`)