### PR TITLE
Issue #197: make early subagent crash thresholds configurable via env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ The SSE broker emits 14 event types:
 | `FLEET_STUCK_THRESHOLD_MIN` | `5` | Minutes before stuck status |
 | `FLEET_LAUNCH_TIMEOUT_MIN` | `5` | Minutes before a launching team is marked failed |
 | `FLEET_MAX_CI_FAILURES` | `3` | Unique CI failures before blocking |
+| `FLEET_EARLY_CRASH_THRESHOLD_SEC` | `120` | Seconds before a SubagentStop is considered an early crash |
+| `FLEET_EARLY_CRASH_MIN_TOOLS` | `5` | Minimum tool-use events for a subagent to be considered healthy |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub poll interval |
 | `FLEET_DB_PATH` | `./fleet.db` | Database file location |
 | `FLEET_TERMINAL` | `auto` | Windows terminal preference (`auto`/`wt`/`cmd`) |

--- a/src/client/views/SettingsPage.tsx
+++ b/src/client/views/SettingsPage.tsx
@@ -12,6 +12,8 @@ interface SettingsResponse {
   stuckThresholdMin: number;
   launchTimeoutMin: number;
   maxUniqueCiFailures: number;
+  earlyCrashThresholdSec: number;
+  earlyCrashMinTools: number;
   githubPollIntervalMs: number;
   issuePollIntervalMs: number;
   stuckCheckIntervalMs: number;
@@ -106,6 +108,19 @@ const SETTING_GROUPS: SettingGroup[] = [
         label: 'Max CI Failures',
         envVar: 'FLEET_MAX_CI_FAILURES',
         description: 'Unique CI failures before a team is blocked',
+      },
+      {
+        key: 'earlyCrashThresholdSec',
+        label: 'Early Crash Threshold',
+        envVar: 'FLEET_EARLY_CRASH_THRESHOLD_SEC',
+        description: 'Seconds before a SubagentStop is considered an early crash',
+        format: (v) => `${v}s`,
+      },
+      {
+        key: 'earlyCrashMinTools',
+        label: 'Early Crash Min Tools',
+        envVar: 'FLEET_EARLY_CRASH_MIN_TOOLS',
+        description: 'Minimum tool-use events for a subagent to be considered healthy',
       },
     ],
   },

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -37,6 +37,12 @@ const config = Object.freeze({
   launchTimeoutMin: safeParseInt(process.env['FLEET_LAUNCH_TIMEOUT_MIN'] || '5', 'FLEET_LAUNCH_TIMEOUT_MIN'),
   maxUniqueCiFailures: safeParseInt(process.env['FLEET_MAX_CI_FAILURES'] || '3', 'FLEET_MAX_CI_FAILURES'),
 
+  /** Seconds after SubagentStart before a SubagentStop is considered an early crash */
+  earlyCrashThresholdSec: safeParseInt(process.env['FLEET_EARLY_CRASH_THRESHOLD_SEC'] || '120', 'FLEET_EARLY_CRASH_THRESHOLD_SEC'),
+
+  /** Minimum tool-use events for a subagent session to be considered healthy */
+  earlyCrashMinTools: safeParseInt(process.env['FLEET_EARLY_CRASH_MIN_TOOLS'] || '5', 'FLEET_EARLY_CRASH_MIN_TOOLS'),
+
   usageRedDailyPct: safeParseInt(process.env['FLEET_USAGE_RED_DAILY_PCT'] || '85', 'FLEET_USAGE_RED_DAILY_PCT'),
   usageRedWeeklyPct: safeParseInt(process.env['FLEET_USAGE_RED_WEEKLY_PCT'] || '95', 'FLEET_USAGE_RED_WEEKLY_PCT'),
   usageRedSonnetPct: safeParseInt(process.env['FLEET_USAGE_RED_SONNET_PCT'] || '95', 'FLEET_USAGE_RED_SONNET_PCT'),
@@ -86,6 +92,8 @@ export function validateConfig(): void {
     ['launchTimeoutMin', config.launchTimeoutMin],
     ['maxUniqueCiFailures', config.maxUniqueCiFailures],
     ['mergeShutdownGraceMs', config.mergeShutdownGraceMs],
+    ['earlyCrashThresholdSec', config.earlyCrashThresholdSec],
+    ['earlyCrashMinTools', config.earlyCrashMinTools],
   ];
   for (const [name, value] of positiveIntegers) {
     if (isNaN(value) || value <= 0) {

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -286,6 +286,8 @@ const systemRoutes: FastifyPluginCallback = (
           stuckThresholdMin: config.stuckThresholdMin,
           launchTimeoutMin: config.launchTimeoutMin,
           maxUniqueCiFailures: config.maxUniqueCiFailures,
+          earlyCrashThresholdSec: config.earlyCrashThresholdSec,
+          earlyCrashMinTools: config.earlyCrashMinTools,
           githubPollIntervalMs: config.githubPollIntervalMs,
           issuePollIntervalMs: config.issuePollIntervalMs,
           stuckCheckIntervalMs: config.stuckCheckIntervalMs,

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -17,6 +17,7 @@
 
 import type { TeamStatus } from '../../shared/types.js';
 import type { SSEEventType, SSEEventPayloads } from './sse-broker.js';
+import config from '../config.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -109,12 +110,6 @@ interface SubagentTracker {
 }
 
 const subagentTrackers = new Map<string, SubagentTracker>();
-
-/** Minimum duration (ms) for a subagent to be considered healthy */
-const SUBAGENT_MIN_DURATION_MS = 120_000; // 2 minutes
-
-/** Minimum event count for a subagent to be considered having done meaningful work */
-const SUBAGENT_MIN_EVENTS = 5;
 
 /** Throttle window: tool_use events from the same team within this period are deduplicated */
 const TOOL_USE_THROTTLE_MS = 5000; // 5 seconds
@@ -350,7 +345,7 @@ export function processEvent(
       const durationMs = now - tracker.startTime;
       const durationSec = Math.round(durationMs / 1000);
 
-      if (durationMs < SUBAGENT_MIN_DURATION_MS && tracker.eventCount < SUBAGENT_MIN_EVENTS) {
+      if (durationMs < config.earlyCrashThresholdSec * 1000 && tracker.eventCount < config.earlyCrashMinTools) {
         const crashMsg =
           `Subagent '${subagentName}' appears to have crashed (${durationSec}s after start, ${tracker.eventCount} events). Consider respawning.`;
         try {


### PR DESCRIPTION
Closes #197

## Summary
- Add `FLEET_EARLY_CRASH_THRESHOLD_SEC` (default: 120) and `FLEET_EARLY_CRASH_MIN_TOOLS` (default: 5) environment variables to make the early subagent crash detection thresholds configurable
- Replace hardcoded `SUBAGENT_MIN_DURATION_MS` and `SUBAGENT_MIN_EVENTS` constants in `event-collector.ts` with config-driven values
- Expose new settings in `/api/settings` endpoint and Settings UI page
- Document new env vars in CLAUDE.md

## Changes
- `src/server/config.ts` — new config properties with `safeParseInt` + validation
- `src/server/services/event-collector.ts` — import config, remove hardcoded constants
- `src/server/routes/system.ts` — expose in `/api/settings` response
- `src/client/views/SettingsPage.tsx` — display in Thresholds group
- `CLAUDE.md` — document env vars