### PR TITLE
Issue #195: add subtype to FC automated messages for visual differentiation

### DIFF
--- a/src/client/components/TeamOutput.tsx
+++ b/src/client/components/TeamOutput.tsx
@@ -34,6 +34,24 @@ function getStyle(type: string) {
   return TYPE_STYLES[type] ?? { color: '#8B949E', label: type };
 }
 
+/** Human-readable short labels for FC message subtypes */
+const FC_SUBTYPE_LABELS: Record<string, string> = {
+  initial_prompt:     'prompt',
+  origin_sync:        'sync',
+  idle_nudge:         'idle',
+  stuck_nudge:        'nudge',
+  ci_green:           'CI pass',
+  ci_red:             'CI fail',
+  ci_blocked:         'CI blocked',
+  pr_merged_shutdown: 'shutdown',
+  subagent_crash:     'crash',
+};
+
+function getSubtypeLabel(subtype: string | undefined): string | null {
+  if (!subtype) return null;
+  return FC_SUBTYPE_LABELS[subtype] ?? subtype;
+}
+
 function formatLocalTime(iso: string): string {
   try {
     return new Date(iso).toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit' });
@@ -116,8 +134,9 @@ export function TeamOutput({ teamId, teamStatus }: TeamOutputProps) {
       .map((e) => {
         const ts = e.timestamp ? formatLocalTime(e.timestamp) : '--:--';
         const { label } = getStyle(e.type);
+        const subtypeTag = e.type === 'fc' && e.subtype ? ` [${getSubtypeLabel(e.subtype)}]` : '';
         const body = getEventText(e);
-        return `[${ts}] ${label}: ${body}`;
+        return `[${ts}] ${label}${subtypeTag}: ${body}`;
       }).join('\n');
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
@@ -163,6 +182,9 @@ export function TeamOutput({ teamId, teamStatus }: TeamOutputProps) {
               </span>
               {' '}
               <span style={{ color }} className="font-semibold">{label}</span>
+              {e.type === 'fc' && e.subtype && (
+                <span className="text-dark-muted text-[10px] ml-1">[{getSubtypeLabel(e.subtype)}]</span>
+              )}
               {text && (
                 <>
                   {' '}

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -89,7 +89,7 @@ export interface SseBroker {
 
 /** Optional team message sender for advisory messages (e.g., crash detection) */
 export interface TeamMessageSender {
-  sendMessage(teamId: number, message: string): boolean;
+  sendMessage(teamId: number, message: string, source?: 'user' | 'fc', subtype?: string): boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -349,7 +349,7 @@ export function processEvent(
         const crashMsg =
           `Subagent '${subagentName}' appears to have crashed (${durationSec}s after start, ${tracker.eventCount} events). Consider respawning.`;
         try {
-          messageSender.sendMessage(teamId, crashMsg);
+          messageSender.sendMessage(teamId, crashMsg, 'fc', 'subagent_crash');
           console.log(`[EventCollector] Subagent crash advisory sent for ${subagentName} on team ${teamId}`);
         } catch {
           // Non-critical — silently ignore send failures

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -327,11 +327,13 @@ class GitHubPoller {
             const manager = getTeamManager();
 
             let msg: string | null = null;
+            let ciSubtype: string | undefined;
             if (ciStatus === 'passing') {
               msg = resolveMessage('ci_green', {
                 PR_NUMBER: String(prNumber),
                 AUTO_MERGE_STATUS: autoMerge ? 'enabled' : 'not enabled',
               });
+              ciSubtype = 'ci_green';
             } else if (ciStatus === 'failing') {
               const failedCheckNames = checks
                 .filter((c) => isFailureConclusion(c.conclusion))
@@ -343,8 +345,9 @@ class GitHubPoller {
                 FAIL_COUNT: String(ciFailCount),
                 MAX_FAILURES: String(config.maxUniqueCiFailures),
               });
+              ciSubtype = 'ci_red';
             }
-            if (msg) manager.sendMessage(teamId, msg);
+            if (msg) manager.sendMessage(teamId, msg, 'fc', ciSubtype);
           } catch (err) {
             console.error(`[GitHubPoller] Failed to send CI notification to team ${teamId}:`, err);
           }
@@ -462,7 +465,7 @@ class GitHubPoller {
             PR_NUMBER: String(prNumber),
             FAIL_COUNT: String(ciFailCount),
           });
-          if (msg) manager.sendMessage(teamId, msg);
+          if (msg) manager.sendMessage(teamId, msg, 'fc', 'ci_blocked');
         } catch (err) {
           console.error(`[GitHubPoller] Failed to send blocked notification to team ${teamId}:`, err);
         }

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -162,7 +162,7 @@ class StuckDetector {
             });
             if (idleMsg) {
               const manager = getTeamManager();
-              manager.sendMessage(team.id, idleMsg);
+              manager.sendMessage(team.id, idleMsg, 'fc', 'idle_nudge');
               console.log(`[StuckDetector] Idle nudge sent to team ${team.id}`);
             }
           }
@@ -174,7 +174,7 @@ class StuckDetector {
             });
             if (msg) {
               const manager = getTeamManager();
-              manager.sendMessage(team.id, msg);
+              manager.sendMessage(team.id, msg, 'fc', 'stuck_nudge');
               console.log(`[StuckDetector] Nudge sent to team ${team.id}`);
             }
           }

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -148,6 +148,7 @@ export class TeamManager {
       // Inject a log event into the team's session log
       const syncEvent: StreamEvent = {
         type: 'fc',
+        subtype: 'origin_sync',
         timestamp: new Date().toISOString(),
         message: {
           content: [{
@@ -1060,7 +1061,7 @@ export class TeamManager {
   // sendMessage — deliver a PM message to a running team via stdin
   // -------------------------------------------------------------------------
 
-  sendMessage(teamId: number, message: string, source: 'user' | 'fc' = 'fc'): boolean {
+  sendMessage(teamId: number, message: string, source: 'user' | 'fc' = 'fc', subtype?: string): boolean {
     const stdin = this.stdinPipes.get(teamId);
     if (!stdin || stdin.destroyed) return false;
 
@@ -1071,10 +1072,12 @@ export class TeamManager {
       // Inject a synthetic event into parsedEvents so it appears in the
       // Session Log alongside assistant responses (issue #5).
       // 'user' = manual PM message, 'fc' = automated Fleet Commander message.
+      // 'subtype' distinguishes FC message categories for visual differentiation.
       const syntheticEvent: StreamEvent = {
         type: source,
         timestamp: new Date().toISOString(),
         message: { content: [{ type: 'text', text: message }] },
+        ...(subtype ? { subtype } : {}),
       };
       const events = this.parsedEvents.get(teamId);
       if (events) {
@@ -1123,7 +1126,7 @@ export class TeamManager {
       PR_NUMBER: String(prNumber),
     });
     if (msg) {
-      this.sendMessage(teamId, msg);
+      this.sendMessage(teamId, msg, 'fc', 'pr_merged_shutdown');
     }
     console.log(`[TeamManager] Graceful shutdown initiated for team ${teamId} (PR #${prNumber}, grace=${graceMs}ms)`);
 
@@ -1515,6 +1518,7 @@ export class TeamManager {
     if (prompt && child.stdin) {
       const initEvent: StreamEvent = {
         type: 'fc',
+        subtype: 'initial_prompt',
         timestamp: new Date().toISOString(),
         message: { content: [{ type: 'text', text: prompt }] },
       };

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -294,7 +294,7 @@ describe('Idle nudge message', () => {
     expect(mockedResolveMessage).toHaveBeenCalledWith('idle_nudge', {
       IDLE_MINUTES: '4',
     });
-    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'FC status check: idle for 4 minutes');
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'FC status check: idle for 4 minutes', 'fc', 'idle_nudge');
 
     // Reset mock to default
     mockedResolveMessage.mockReturnValue(null);
@@ -336,7 +336,7 @@ describe('Idle nudge message', () => {
     expect(mockedResolveMessage).toHaveBeenCalledWith('stuck_nudge', {
       ISSUE_NUMBER: '100',
     });
-    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'Hey, you have been idle for a while');
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'Hey, you have been idle for a while', 'fc', 'stuck_nudge');
 
     // Reset mock to default
     mockedResolveMessage.mockReturnValue(null);


### PR DESCRIPTION
Closes #195

## Summary
- Added optional `subtype` parameter to `sendMessage()` in team-manager.ts and propagated through all FC message call sites
- Subtypes: `initial_prompt`, `origin_sync`, `idle_nudge`, `stuck_nudge`, `ci_green`, `ci_red`, `ci_blocked`, `pr_merged_shutdown`, `subagent_crash`
- Updated `TeamOutput.tsx` to render subtype as a small muted tag next to the "FC" label with human-readable labels
- Updated `TeamMessageSender` interface in event-collector.ts (backward-compatible optional params)
- Updated stuck-detector tests to match new call signatures (16/16 pass)
- Graceful degradation for existing events without subtype

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] stuck-detector tests pass (16/16)
- [x] Existing events without subtype render correctly (no tag shown)
- [ ] Visual verification: FC messages in Session Log show differentiated tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)