### PR TITLE
Issue #182: unify team roster and comm graph into single live visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "better-sqlite3": "^11.9.1",
         "dagre": "^0.8.5",
         "fastify": "^5.3.3",
+        "react-force-graph-2d": "^1.29.1",
         "react-router-dom": "^7.13.1",
         "recharts": "^3.8.0"
       },
@@ -1811,6 +1812,12 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2146,6 +2153,15 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2372,6 +2388,16 @@
         "prebuild-install": "^7.1.1"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2538,6 +2564,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -2818,6 +2856,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -2827,11 +2871,49 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2857,10 +2939,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2878,6 +2975,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -2923,6 +3042,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3405,6 +3559,46 @@
         "node": ">=20"
       }
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.2",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.2.tgz",
+      "integrity": "sha512-zZNdMqx8qIQGurgnbgYIUsdXxSfvhfRSIdncsKGv/twUOZpwCsk9hPHmdjdcme1+epATgb41G0rkIGHJ0Wydng==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3647,6 +3841,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3777,6 +3980,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3791,7 +4003,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -3896,6 +4107,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/light-my-request": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
@@ -3958,6 +4181,24 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -4199,7 +4440,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4556,6 +4796,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -4627,6 +4877,23 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -4712,12 +4979,44 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -5562,6 +5861,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "better-sqlite3": "^11.9.1",
     "dagre": "^0.8.5",
     "fastify": "^5.3.3",
+    "react-force-graph-2d": "^1.29.1",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0"
   },

--- a/src/client/components/CommGraph.tsx
+++ b/src/client/components/CommGraph.tsx
@@ -1,28 +1,13 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useCallback, useState } from 'react';
+import ForceGraph from 'react-force-graph-2d';
+import type { ForceGraphMethods } from 'react-force-graph-2d';
 import type { MessageEdge, TeamMember } from '../../shared/types';
+import { agentColor } from '../utils/constants';
 
 // ---------------------------------------------------------------------------
-// Color helper — same hash-to-palette approach as TeamDetail roster
+// Name normalization — client-side defense for historical data
 // ---------------------------------------------------------------------------
 
-const AGENT_PALETTE = [
-  '#58A6FF', '#3FB950', '#D29922', '#A371F7', '#F778BA',
-  '#79C0FF', '#7EE787', '#E3B341', '#D2A8FF', '#FF7B72',
-];
-
-function agentColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
-  }
-  return AGENT_PALETTE[Math.abs(hash) % AGENT_PALETTE.length];
-}
-
-/**
- * Normalize agent name for consistent matching between roster and message edges.
- * Strips "fleet-" prefix and lowercases. Client-side defense in case server-side
- * normalization hasn't been applied to historical data.
- */
 function normalizeName(name: string): string {
   let n = name.trim().toLowerCase();
   if (n.startsWith('fleet-')) n = n.slice(6);
@@ -30,109 +15,26 @@ function normalizeName(name: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Layout helpers
+// Graph node and link types
 // ---------------------------------------------------------------------------
 
-interface NodePosition {
+interface GraphNode {
+  id: string;
   name: string;
-  x: number;
-  y: number;
-  radius: number;
+  role: string;
   color: string;
   isActive: boolean;
-  messageCount: number;
+  isTL: boolean;
+  fx?: number;
+  fy?: number;
 }
 
-/** Determine edge thickness class from message count */
-function edgeWidth(count: number): number {
-  if (count >= 9) return 3.5;
-  if (count >= 4) return 2;
-  return 1;
-}
-
-function edgeOpacity(count: number): number {
-  if (count >= 9) return 1;
-  if (count >= 4) return 0.7;
-  return 0.4;
-}
-
-/** Place nodes in hub-and-spoke: hub at center, spokes radially */
-function layoutNodes(
-  agents: TeamMember[],
-  edges: MessageEdge[],
-  cx: number,
-  cy: number,
-  orbitRadius: number,
-): NodePosition[] {
-  // Build total message counts per agent for sizing
-  const msgCounts = new Map<string, number>();
-  for (const e of edges) {
-    msgCounts.set(e.sender, (msgCounts.get(e.sender) ?? 0) + e.count);
-    msgCounts.set(e.recipient, (msgCounts.get(e.recipient) ?? 0) + e.count);
-  }
-
-  // Identify the hub: prefer "team-lead" or "coordinator" by normalized name,
-  // else pick the agent with the most messages. When all counts are 0 (no edges),
-  // fall back to the first roster member (typically team-lead).
-  const hubCandidates = agents.filter((a) => {
-    const n = normalizeName(a.name);
-    return n === 'team-lead' || n === 'coordinator' || n === 'tl';
-  });
-  let hub: TeamMember | undefined = hubCandidates[0];
-  if (!hub) {
-    // Pick the agent with highest message volume
-    let maxCount = -1;
-    for (const a of agents) {
-      const c = msgCounts.get(a.name) ?? 0;
-      if (c > maxCount) {
-        maxCount = c;
-        hub = a;
-      }
-    }
-  }
-  if (!hub) hub = agents[0];
-
-  const maxMsg = Math.max(1, ...Array.from(msgCounts.values()));
-
-  const hubName = hub.name;
-  const spokes = agents.filter((a) => a.name !== hubName);
-
-  const positions: NodePosition[] = [];
-
-  // Radius: scale between 14 and 24 based on message volume
-  const nodeRadius = (name: string) => {
-    const count = msgCounts.get(name) ?? 0;
-    return 14 + (count / maxMsg) * 10;
-  };
-
-  // Hub
-  positions.push({
-    name: hubName,
-    x: cx,
-    y: cy,
-    radius: nodeRadius(hubName),
-    color: agentColor(hubName),
-    isActive: hub.isActive,
-    messageCount: msgCounts.get(hubName) ?? 0,
-  });
-
-  // Spokes
-  const angleStep = (2 * Math.PI) / Math.max(spokes.length, 1);
-  const startAngle = -Math.PI / 2; // Start from top
-  spokes.forEach((agent, i) => {
-    const angle = startAngle + i * angleStep;
-    positions.push({
-      name: agent.name,
-      x: cx + orbitRadius * Math.cos(angle),
-      y: cy + orbitRadius * Math.sin(angle),
-      radius: nodeRadius(agent.name),
-      color: agentColor(agent.name),
-      isActive: agent.isActive,
-      messageCount: msgCounts.get(agent.name) ?? 0,
-    });
-  });
-
-  return positions;
+interface GraphLink {
+  source: string;
+  target: string;
+  count: number;
+  isSpawn: boolean;
+  lastSummary: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,270 +47,341 @@ interface CommGraphProps {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NODE_RADIUS = 16;
+const ACTIVE_DOT_RADIUS = 4;
+const FONT_SIZE_INITIAL = 14;
+const FONT_SIZE_LABEL = 10;
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 export function CommGraph({ edges, agents }: CommGraphProps) {
-  const [selectedNode, setSelectedNode] = useState<string | null>(null);
-  const [hoveredEdge, setHoveredEdge] = useState<{ sender: string; recipient: string } | null>(null);
-  const [mousePos, setMousePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink>>();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 500, height: 380 });
+  const prevEdgesRef = useRef<MessageEdge[]>([]);
 
-  // SVG viewBox dimensions
-  const vw = 500;
-  const vh = 380;
-  const cx = vw / 2;
-  const cy = vh / 2;
-  const orbitRadius = Math.min(cx, cy) * 0.6;
+  // Track container size with ResizeObserver
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
 
-  const nodes = useMemo(
-    () => layoutNodes(agents, edges, cx, cy, orbitRadius),
-    [agents, edges, cx, cy, orbitRadius],
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          setDimensions({ width: Math.floor(width), height: Math.floor(height) });
+        }
+      }
+    });
+
+    observer.observe(container);
+    // Set initial dimensions
+    const rect = container.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      setDimensions({ width: Math.floor(rect.width), height: Math.floor(rect.height) });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  // Find TL node
+  const tlName = useMemo(() => {
+    const tl = agents.find((a) => {
+      const n = normalizeName(a.name);
+      return n === 'team-lead' || n === 'coordinator' || n === 'tl';
+    });
+    return tl?.name ?? (agents.length > 0 ? agents[0].name : null);
+  }, [agents]);
+
+  // Build graph data
+  const graphData = useMemo(() => {
+    const nodes: GraphNode[] = agents.map((agent) => {
+      const isTL = agent.name === tlName;
+      return {
+        id: agent.name,
+        name: agent.name,
+        role: agent.role,
+        color: agentColor(agent.name, agent.role),
+        isActive: agent.isActive,
+        isTL,
+        // Pin TL node near center-top
+        ...(isTL ? { fx: 0, fy: -40 } : {}),
+      };
+    });
+
+    const links: GraphLink[] = [];
+
+    // Build a normalized name -> original name lookup for edge matching
+    const nameMap = new Map<string, string>();
+    for (const agent of agents) {
+      nameMap.set(normalizeName(agent.name), agent.name);
+    }
+
+    // Spawn edges: TL -> every non-TL agent (dashed, no count)
+    if (tlName) {
+      for (const agent of agents) {
+        if (agent.name !== tlName) {
+          links.push({
+            source: tlName,
+            target: agent.name,
+            count: 0,
+            isSpawn: true,
+            lastSummary: null,
+          });
+        }
+      }
+    }
+
+    // Message edges from the edges prop
+    for (const edge of edges) {
+      // Resolve sender/recipient to roster names
+      const senderResolved = nameMap.get(normalizeName(edge.sender)) ?? edge.sender;
+      const recipientResolved = nameMap.get(normalizeName(edge.recipient)) ?? edge.recipient;
+
+      // Skip if either end is not in the roster
+      const senderInRoster = agents.some((a) => a.name === senderResolved);
+      const recipientInRoster = agents.some((a) => a.name === recipientResolved);
+      if (!senderInRoster || !recipientInRoster) continue;
+
+      // Skip if this would duplicate a spawn edge in the same direction
+      const isSpawnDuplicate =
+        (senderResolved === tlName || recipientResolved === tlName) &&
+        links.some(
+          (l) =>
+            l.isSpawn &&
+            l.source === senderResolved &&
+            l.target === recipientResolved,
+        );
+      if (isSpawnDuplicate) {
+        // Update the spawn edge with message count instead
+        const spawnEdge = links.find(
+          (l) =>
+            l.isSpawn &&
+            l.source === senderResolved &&
+            l.target === recipientResolved,
+        );
+        if (spawnEdge) {
+          spawnEdge.count = edge.count;
+          spawnEdge.isSpawn = false;
+          spawnEdge.lastSummary = edge.lastSummary;
+        }
+        continue;
+      }
+
+      links.push({
+        source: senderResolved,
+        target: recipientResolved,
+        count: edge.count,
+        isSpawn: false,
+        lastSummary: edge.lastSummary,
+      });
+    }
+
+    return { nodes, links };
+  }, [agents, edges, tlName]);
+
+  // Emit particles for new or increased message edges (synapse animation)
+  useEffect(() => {
+    const fg = graphRef.current;
+    if (!fg || !edges.length) return;
+
+    const prevEdges = prevEdgesRef.current;
+    const prevMap = new Map<string, number>();
+    for (const e of prevEdges) {
+      prevMap.set(`${e.sender}->${e.recipient}`, e.count);
+    }
+
+    for (const edge of edges) {
+      const key = `${edge.sender}->${edge.recipient}`;
+      const prevCount = prevMap.get(key) ?? 0;
+      if (edge.count > prevCount) {
+        // Find the matching link in graphData
+        const link = graphData.links.find(
+          (l) => {
+            const src = typeof l.source === 'object' ? (l.source as GraphNode).id : l.source;
+            const tgt = typeof l.target === 'object' ? (l.target as GraphNode).id : l.target;
+            return src === edge.sender && tgt === edge.recipient;
+          },
+        );
+        if (link) {
+          try {
+            fg.emitParticle(link);
+          } catch {
+            // Silently ignore — particle emission is cosmetic
+          }
+        }
+      }
+    }
+
+    prevEdgesRef.current = edges;
+  }, [edges, graphData.links]);
+
+  // Zoom to fit after data loads
+  useEffect(() => {
+    const fg = graphRef.current;
+    if (!fg || agents.length === 0) return;
+    const timer = setTimeout(() => {
+      fg.zoomToFit(400, 60);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [agents.length]);
+
+  // Custom node rendering
+  const nodeCanvasObject = useCallback(
+    (node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+      const x = node.x ?? 0;
+      const y = node.y ?? 0;
+      const r = NODE_RADIUS;
+      const fontSize = FONT_SIZE_INITIAL / globalScale;
+      const labelFontSize = FONT_SIZE_LABEL / globalScale;
+
+      // Node circle fill
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, 2 * Math.PI);
+      ctx.fillStyle = node.color + '20';
+      ctx.fill();
+
+      // Node circle border
+      ctx.strokeStyle = node.isActive ? node.color : '#484F58';
+      ctx.lineWidth = 2 / globalScale;
+      ctx.stroke();
+
+      // Active/stopped indicator dot
+      const dotX = x + r * 0.65;
+      const dotY = y - r * 0.65;
+      const dotR = ACTIVE_DOT_RADIUS / globalScale;
+      ctx.beginPath();
+      ctx.arc(dotX, dotY, dotR, 0, 2 * Math.PI);
+      ctx.fillStyle = node.isActive ? '#3FB950' : '#484F58';
+      ctx.fill();
+      ctx.strokeStyle = '#0D1117';
+      ctx.lineWidth = 1.5 / globalScale;
+      ctx.stroke();
+
+      // Agent initial
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = node.isActive ? node.color : '#484F58';
+      ctx.fillText(node.name.charAt(0).toUpperCase(), x, y);
+
+      // Full agent name below node
+      ctx.font = `${labelFontSize}px sans-serif`;
+      ctx.fillStyle = '#8B949E';
+      ctx.fillText(node.name, x, y + r + 10 / globalScale);
+
+      // Role label below name (smaller)
+      if (node.role) {
+        ctx.font = `${labelFontSize * 0.85}px sans-serif`;
+        ctx.fillStyle = '#484F58';
+        ctx.fillText(node.role, x, y + r + 20 / globalScale);
+      }
+    },
+    [],
   );
 
-  const nodeMap = useMemo(() => {
-    const map = new Map<string, NodePosition>();
-    for (const n of nodes) {
-      map.set(n.name, n);
-      // Also index by normalized name for edge matching with un-normalized data
-      map.set(normalizeName(n.name), n);
-    }
-    return map;
-  }, [nodes]);
+  // Node pointer area for hover/click detection
+  const nodePointerAreaPaint = useCallback(
+    (node: GraphNode, color: string, ctx: CanvasRenderingContext2D) => {
+      const x = node.x ?? 0;
+      const y = node.y ?? 0;
+      ctx.beginPath();
+      ctx.arc(x, y, NODE_RADIUS + 4, 0, 2 * Math.PI);
+      ctx.fillStyle = color;
+      ctx.fill();
+    },
+    [],
+  );
 
-  // Filter edges when a node is selected (compare with normalized names)
-  const visibleEdges = useMemo(() => {
-    if (!selectedNode) return edges;
-    const selectedNorm = normalizeName(selectedNode);
-    return edges.filter(
-      (e) =>
-        e.sender === selectedNode ||
-        e.recipient === selectedNode ||
-        normalizeName(e.sender) === selectedNorm ||
-        normalizeName(e.recipient) === selectedNorm,
-    );
-  }, [edges, selectedNode]);
-
-  const handleNodeClick = useCallback((name: string) => {
-    setSelectedNode((prev) => (prev === name ? null : name));
+  // Link width based on message count
+  const linkWidth = useCallback((link: GraphLink) => {
+    if (link.isSpawn) return 1;
+    if (link.count >= 9) return 3.5;
+    if (link.count >= 4) return 2;
+    return 1;
   }, []);
 
-  const handleBackgroundClick = useCallback(() => {
-    setSelectedNode(null);
+  // Link color
+  const linkColor = useCallback((link: GraphLink) => {
+    if (link.isSpawn) return '#30363D';
+    return '#8B949E';
   }, []);
 
-  // Empty state
-  if (agents.length < 2 || edges.length === 0) {
+  // Link dashed pattern: spawn edges are dashed, message edges are solid
+  const linkLineDash = useCallback((link: GraphLink) => {
+    return link.isSpawn ? [4, 4] : null;
+  }, []);
+
+  // Link label on hover
+  const linkLabel = useCallback((link: GraphLink) => {
+    if (link.isSpawn && link.count === 0) return '';
+    const summary = link.lastSummary ? `<br/><i>${link.lastSummary}</i>` : '';
+    return `<div style="padding:4px 8px;background:#161B22;border:1px solid #30363D;border-radius:4px;font-size:11px;color:#E6EDF3;">
+      <b>${typeof link.source === 'object' ? (link.source as GraphNode).id : link.source}</b>
+      &rarr;
+      <b>${typeof link.target === 'object' ? (link.target as GraphNode).id : link.target}</b>
+      <br/>${link.count} message${link.count !== 1 ? 's' : ''}${summary}
+    </div>`;
+  }, []);
+
+  // Directional particles for message edges
+  const linkDirectionalParticles = useCallback((link: GraphLink) => {
+    if (link.isSpawn) return 0;
+    if (link.count >= 6) return 3;
+    if (link.count >= 3) return 2;
+    return link.count > 0 ? 1 : 0;
+  }, []);
+
+  // Directional arrows for message edges
+  const linkDirectionalArrowLength = useCallback((link: GraphLink) => {
+    return link.isSpawn ? 0 : 6;
+  }, []);
+
+  // Empty state — show only when no agents at all
+  if (agents.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-dark-muted text-sm">
-        {agents.length < 2
-          ? 'Waiting for multiple agents to communicate...'
-          : 'No communication data available'}
+        Waiting for agents to join the team...
       </div>
     );
   }
 
-  // Arrowhead marker ID
-  const markerId = 'comm-arrow';
-
   return (
-    <div className="relative w-full h-full min-h-[300px]">
-      <svg
-        viewBox={`0 0 ${vw} ${vh}`}
-        className="w-full h-full"
-        style={{ maxHeight: '100%' }}
-        onClick={handleBackgroundClick}
-      >
-        <defs>
-          <marker
-            id={markerId}
-            viewBox="0 0 10 7"
-            refX="10"
-            refY="3.5"
-            markerWidth="8"
-            markerHeight="6"
-            orient="auto-start-reverse"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#8B949E" />
-          </marker>
-        </defs>
-
-        {/* Edges */}
-        {visibleEdges.map((edge) => {
-          // Look up by exact name first, then by normalized name for backward compat
-          const from = nodeMap.get(edge.sender) ?? nodeMap.get(normalizeName(edge.sender));
-          const to = nodeMap.get(edge.recipient) ?? nodeMap.get(normalizeName(edge.recipient));
-          if (!from || !to) return null;
-
-          // Shorten line to stop at node border (radius + gap)
-          const dx = to.x - from.x;
-          const dy = to.y - from.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
-          if (dist === 0) return null;
-
-          const ux = dx / dist;
-          const uy = dy / dist;
-          const startGap = from.radius + 3;
-          const endGap = to.radius + 6; // extra for arrowhead
-
-          const x1 = from.x + ux * startGap;
-          const y1 = from.y + uy * startGap;
-          const x2 = to.x - ux * endGap;
-          const y2 = to.y - uy * endGap;
-
-          const isHovered =
-            hoveredEdge?.sender === edge.sender &&
-            hoveredEdge?.recipient === edge.recipient;
-
-          const dimmed =
-            selectedNode !== null &&
-            edge.sender !== selectedNode &&
-            edge.recipient !== selectedNode;
-
-          const key = `${edge.sender}->${edge.recipient}`;
-
-          return (
-            <line
-              key={key}
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
-              stroke={isHovered ? '#E6EDF3' : agentColor(edge.sender)}
-              strokeWidth={edgeWidth(edge.count)}
-              strokeOpacity={dimmed ? 0.12 : edgeOpacity(edge.count)}
-              markerEnd={`url(#${markerId})`}
-              className="cursor-pointer transition-all duration-150"
-              onMouseEnter={(e) => {
-                e.stopPropagation();
-                setHoveredEdge({ sender: edge.sender, recipient: edge.recipient });
-              }}
-              onMouseMove={(e) => {
-                const rect = (e.currentTarget.ownerSVGElement as SVGSVGElement).getBoundingClientRect();
-                setMousePos({
-                  x: e.clientX - rect.left,
-                  y: e.clientY - rect.top,
-                });
-              }}
-              onMouseLeave={() => setHoveredEdge(null)}
-            />
-          );
-        })}
-
-        {/* Nodes */}
-        {nodes.map((node) => {
-          const dimmed =
-            selectedNode !== null && selectedNode !== node.name;
-          const isSelected = selectedNode === node.name;
-
-          return (
-            <g
-              key={node.name}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleNodeClick(node.name);
-              }}
-              className="cursor-pointer"
-              opacity={dimmed ? 0.35 : 1}
-            >
-              {/* Selection ring */}
-              {isSelected && (
-                <circle
-                  cx={node.x}
-                  cy={node.y}
-                  r={node.radius + 4}
-                  fill="none"
-                  stroke={node.color}
-                  strokeWidth={1.5}
-                  strokeDasharray="4 2"
-                  opacity={0.6}
-                />
-              )}
-              {/* Node circle */}
-              <circle
-                cx={node.x}
-                cy={node.y}
-                r={node.radius}
-                fill={node.color + '20'}
-                stroke={node.isActive ? node.color : '#484F58'}
-                strokeWidth={2}
-              />
-              {/* Active/stopped indicator dot */}
-              <circle
-                cx={node.x + node.radius * 0.65}
-                cy={node.y - node.radius * 0.65}
-                r={4}
-                fill={node.isActive ? '#3FB950' : '#484F58'}
-                stroke="#0D1117"
-                strokeWidth={1.5}
-              />
-              {/* Agent initial */}
-              <text
-                x={node.x}
-                y={node.y}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={node.isActive ? node.color : '#484F58'}
-                fontSize={node.radius * 0.85}
-                fontWeight="bold"
-                style={{ pointerEvents: 'none', userSelect: 'none' }}
-              >
-                {node.name.charAt(0).toUpperCase()}
-              </text>
-              {/* Agent name below */}
-              <text
-                x={node.x}
-                y={node.y + node.radius + 13}
-                textAnchor="middle"
-                fill={dimmed ? '#484F58' : '#8B949E'}
-                fontSize={10}
-                style={{ pointerEvents: 'none', userSelect: 'none' }}
-              >
-                {node.name.length > 12 ? node.name.slice(0, 11) + '\u2026' : node.name}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
-
-      {/* Tooltip for hovered edge */}
-      {hoveredEdge && (() => {
-        const edge = edges.find(
-          (e) => e.sender === hoveredEdge.sender && e.recipient === hoveredEdge.recipient,
-        );
-        if (!edge) return null;
-        return (
-          <div
-            className="absolute px-2.5 py-1.5 bg-dark-surface border border-dark-border rounded text-[11px] text-dark-text shadow-lg pointer-events-none z-20"
-            style={{
-              left: mousePos.x + 12,
-              top: mousePos.y - 8,
-              maxWidth: 260,
-            }}
-          >
-            <div className="font-semibold">
-              <span style={{ color: agentColor(edge.sender) }}>{edge.sender}</span>
-              {' \u2192 '}
-              <span style={{ color: agentColor(edge.recipient) }}>{edge.recipient}</span>
-            </div>
-            <div className="text-dark-muted mt-0.5">
-              {edge.count} message{edge.count !== 1 ? 's' : ''}
-            </div>
-            {edge.lastSummary && (
-              <div className="text-dark-muted mt-0.5 italic truncate">
-                {edge.lastSummary}
-              </div>
-            )}
-          </div>
-        );
-      })()}
-
-      {/* Legend */}
-      {selectedNode && (
-        <div className="absolute top-2 right-2 text-[10px] text-dark-muted bg-dark-surface/80 border border-dark-border/50 rounded px-2 py-1">
-          Filtering: <span className="text-dark-text font-medium">{selectedNode}</span>
-          <span className="ml-1 opacity-60">(click to clear)</span>
-        </div>
-      )}
+    <div ref={containerRef} className="relative w-full h-full min-h-[300px]">
+      <ForceGraph
+        ref={graphRef}
+        graphData={graphData}
+        width={dimensions.width}
+        height={dimensions.height}
+        backgroundColor="transparent"
+        nodeCanvasObject={nodeCanvasObject}
+        nodeCanvasObjectMode={() => 'replace'}
+        nodePointerAreaPaint={nodePointerAreaPaint}
+        linkWidth={linkWidth}
+        linkColor={linkColor}
+        linkLineDash={linkLineDash}
+        linkLabel={linkLabel}
+        linkDirectionalParticles={linkDirectionalParticles}
+        linkDirectionalParticleWidth={3}
+        linkDirectionalParticleSpeed={0.005}
+        linkDirectionalArrowLength={linkDirectionalArrowLength}
+        linkDirectionalArrowRelPos={1}
+        linkDirectionalArrowColor={linkColor}
+        linkCurvature={0.15}
+        d3AlphaDecay={0.05}
+        d3VelocityDecay={0.3}
+        cooldownTicks={100}
+        enableZoomInteraction={true}
+        enablePanInteraction={true}
+        enableNodeDrag={true}
+        minZoom={0.5}
+        maxZoom={4}
+      />
     </div>
   );
 }

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -23,35 +23,6 @@ function formatDuration(minutes: number | undefined | null): string {
   return `${m}m`;
 }
 
-/** Deterministic color from agent name — hash name to pick from a palette. */
-const AGENT_PALETTE = [
-  '#58A6FF', '#3FB950', '#D29922', '#A371F7', '#F778BA',
-  '#79C0FF', '#7EE787', '#E3B341', '#D2A8FF', '#FF7B72',
-];
-
-function agentColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
-  }
-  return AGENT_PALETTE[Math.abs(hash) % AGENT_PALETTE.length];
-}
-
-/** Format a relative time string like "2m", "1h", "just now" */
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const min = Math.floor(ms / 60000);
-  if (min < 1) return 'now';
-  if (min < 60) return `${min}m`;
-  const h = Math.floor(min / 60);
-  return `${h}h`;
-}
-
-/** Truncate agent name to fit in a small card */
-function truncateName(name: string, maxLen = 5): string {
-  if (name.length <= maxLen) return name;
-  return name.slice(0, maxLen);
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -496,69 +467,6 @@ export function TeamDetail() {
                       </div>
                     )}
                   </section>
-
-                  {/* ---- Team Roster ---- */}
-                  {roster.length > 0 && (
-                    <section>
-                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
-                        Team Members ({roster.filter(m => m.isActive).length} active)
-                      </h4>
-                      <div className="flex items-start gap-2 overflow-x-auto pb-1 custom-scrollbar">
-                        {roster.map((member) => {
-                          const color = agentColor(member.name);
-                          const lastActivity = member.isActive ? relativeTime(member.lastSeen) : 'done';
-                          return (
-                            <div
-                              key={member.name}
-                              className="flex flex-col items-center w-14 shrink-0 group relative cursor-default"
-                            >
-                              {/* Status dot */}
-                              <div
-                                className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold border-2"
-                                style={{
-                                  borderColor: member.isActive ? color : '#484F58',
-                                  color: member.isActive ? color : '#484F58',
-                                  backgroundColor: (member.isActive ? color : '#484F58') + '18',
-                                }}
-                              >
-                                {member.name.charAt(0).toUpperCase()}
-                              </div>
-                              {/* Name */}
-                              <span
-                                className="text-[10px] mt-1 leading-tight text-center"
-                                style={{ color: member.isActive ? '#E6EDF3' : '#484F58' }}
-                              >
-                                {truncateName(member.name)}
-                              </span>
-                              {/* Last activity */}
-                              <span
-                                className="text-[9px] leading-none"
-                                style={{ color: member.isActive ? '#8B949E' : '#484F58' }}
-                              >
-                                {lastActivity}
-                              </span>
-                              {/* Tooltip */}
-                              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2.5 py-1.5 bg-dark-surface border border-dark-border rounded text-[10px] text-dark-text whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 shadow-lg">
-                                <div className="font-semibold">{member.name}</div>
-                                <div className="text-dark-muted">{member.role}</div>
-                                <div className="text-dark-muted mt-0.5">
-                                  Tools: {member.toolUseCount}
-                                  {member.errorCount > 0 && (
-                                    <span className="text-[#F85149] ml-1">Errors: {member.errorCount}</span>
-                                  )}
-                                </div>
-                                <div className="text-dark-muted">
-                                  First: {new Date(member.firstSeen).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                                  {' / '}
-                                  Last: {new Date(member.lastSeen).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                                </div>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </section>
-                  )}
 
                   {/* ---- Transition History ---- */}
                   {transitions.length > 0 && (

--- a/src/client/utils/constants.ts
+++ b/src/client/utils/constants.ts
@@ -18,3 +18,38 @@ export function getUsageColor(percent: number, redThreshold: number): string {
   if (percent >= yellowStart) return '#D29922';
   return '#3FB950';
 }
+
+// ---------------------------------------------------------------------------
+// Agent colors — role-based with hash fallback for consistent coloring
+// ---------------------------------------------------------------------------
+
+/** Role-specific colors for agent nodes */
+export const AGENT_ROLE_COLORS: Record<string, string> = {
+  'team-lead': '#58A6FF',
+  'coordinator': '#58A6FF',
+  'tl': '#58A6FF',
+  'analyst': '#D29922',
+  'dev': '#3FB950',
+  'developer': '#3FB950',
+  'reviewer': '#A371F7',
+};
+
+/** Fallback palette for agents with unknown roles */
+const AGENT_FALLBACK_PALETTE = [
+  '#58A6FF', '#3FB950', '#D29922', '#A371F7', '#F778BA',
+  '#79C0FF', '#7EE787', '#E3B341', '#D2A8FF', '#FF7B72',
+];
+
+/** Get a deterministic color for an agent. Prefers role-based color, falls back to name hash. */
+export function agentColor(name: string, role?: string): string {
+  if (role) {
+    const roleColor = AGENT_ROLE_COLORS[role.toLowerCase()];
+    if (roleColor) return roleColor;
+  }
+  // Hash-based fallback
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  return AGENT_FALLBACK_PALETTE[Math.abs(hash) % AGENT_FALLBACK_PALETTE.length];
+}

--- a/tests/client/CommGraph.test.tsx
+++ b/tests/client/CommGraph.test.tsx
@@ -1,0 +1,168 @@
+// =============================================================================
+// Fleet Commander -- CommGraph Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Polyfill ResizeObserver for jsdom (not available by default)
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class ResizeObserver {
+      private callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe() { /* noop */ }
+      unobserve() { /* noop */ }
+      disconnect() { /* noop */ }
+    };
+  }
+});
+
+// Mock react-force-graph-2d since it uses canvas (not available in jsdom)
+const mockForceGraph = vi.fn(() => null);
+vi.mock('react-force-graph-2d', () => ({
+  default: vi.fn((props: Record<string, unknown>) => {
+    mockForceGraph(props);
+    return null;
+  }),
+}));
+
+// Import after mock is set up
+import { CommGraph } from '../../src/client/components/CommGraph';
+import type { MessageEdge, TeamMember } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeAgent(overrides: Partial<TeamMember> = {}): TeamMember {
+  return {
+    name: 'dev',
+    role: 'developer',
+    isActive: true,
+    firstSeen: '2025-01-01T00:00:00Z',
+    lastSeen: '2025-01-01T00:05:00Z',
+    toolUseCount: 10,
+    errorCount: 0,
+    ...overrides,
+  };
+}
+
+function makeEdge(overrides: Partial<MessageEdge> = {}): MessageEdge {
+  return {
+    sender: 'team-lead',
+    recipient: 'dev',
+    count: 3,
+    lastSummary: 'Review request',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CommGraph', () => {
+  beforeEach(() => {
+    mockForceGraph.mockClear();
+  });
+
+  it('should render empty state when no agents are present', () => {
+    render(<CommGraph edges={[]} agents={[]} />);
+    expect(screen.getByText('Waiting for agents to join the team...')).toBeInTheDocument();
+  });
+
+  it('should render the force graph when agents are present', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+
+    render(<CommGraph edges={[]} agents={agents} />);
+    // Empty state should NOT be shown
+    expect(screen.queryByText('Waiting for agents to join the team...')).not.toBeInTheDocument();
+    // ForceGraph should have been called with graphData
+    expect(mockForceGraph).toHaveBeenCalled();
+  });
+
+  it('should show nodes even with zero message edges', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'analyst', role: 'analyst' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+
+    render(<CommGraph edges={[]} agents={agents} />);
+    expect(mockForceGraph).toHaveBeenCalled();
+
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string }>; links: Array<{ source: string }> } };
+    const graphData = call.graphData;
+    // Should have 3 nodes (one per agent)
+    expect(graphData.nodes).toHaveLength(3);
+    // Should have 2 spawn edges (TL -> analyst, TL -> dev)
+    expect(graphData.links).toHaveLength(2);
+  });
+
+  it('should create message edges from the edges prop', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+    const edges = [
+      makeEdge({ sender: 'team-lead', recipient: 'dev', count: 5 }),
+    ];
+
+    render(<CommGraph edges={edges} agents={agents} />);
+    expect(mockForceGraph).toHaveBeenCalled();
+
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string }>; links: Array<{ source: string; count: number; isSpawn: boolean }> } };
+    const graphData = call.graphData;
+    expect(graphData.nodes).toHaveLength(2);
+    // The spawn edge from TL->dev should be upgraded to a message edge
+    const messageLinks = graphData.links.filter((l) => !l.isSpawn);
+    expect(messageLinks.length).toBeGreaterThanOrEqual(1);
+    expect(messageLinks[0].count).toBe(5);
+  });
+
+  it('should render a single agent without crashing', () => {
+    const agents = [makeAgent({ name: 'team-lead', role: 'team-lead' })];
+
+    render(<CommGraph edges={[]} agents={agents} />);
+    expect(mockForceGraph).toHaveBeenCalled();
+
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string }>; links: Array<{ source: string }> } };
+    expect(call.graphData.nodes).toHaveLength(1);
+    expect(call.graphData.links).toHaveLength(0);
+  });
+
+  it('should pin the team-lead node at a fixed position', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+
+    render(<CommGraph edges={[]} agents={agents} />);
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string; fx?: number; fy?: number }> } };
+    const tlNode = call.graphData.nodes.find((n) => n.id === 'team-lead');
+    expect(tlNode).toBeDefined();
+    expect(tlNode!.fx).toBeDefined();
+    expect(tlNode!.fy).toBeDefined();
+  });
+
+  it('should set non-TL nodes without fixed positions', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+
+    render(<CommGraph edges={[]} agents={agents} />);
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string; fx?: number; fy?: number }> } };
+    const devNode = call.graphData.nodes.find((n) => n.id === 'dev');
+    expect(devNode).toBeDefined();
+    expect(devNode!.fx).toBeUndefined();
+    expect(devNode!.fy).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #182

## Summary
- Rewrites `CommGraph.tsx` from custom SVG hub-and-spoke to `react-force-graph-2d` canvas renderer — the graph IS the roster
- Removes separate "Team Members" avatar row from `TeamDetail.tsx`, consolidates into unified "Team" tab
- Adds shared `AGENT_ROLE_COLORS` and `agentColor()` to `constants.ts`, removes duplicated helpers
- Fixes "fleet" name truncation bug (removed `truncateName()`) and edge matching issues
- Nodes: colored by role, green dot for active, grey for stopped, TL pinned at center/top
- Edges: spawn (thin, dashed) + message (solid, thickness by count, synapse particle animation)
- Adds 7 new CommGraph tests

## Supersedes
- #137 (Team Roster) — roster becomes nodes on the graph
- #162 (Communication Graph) — graph now includes roster functionality
- #178 (Comm graph bugs) — fixed as part of this unified implementation

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 325/329 pass (4 pre-existing failures unrelated to this PR)
- [x] 7 new CommGraph tests pass
- [ ] Manual: verify graph renders with real team data on dashboard
- [ ] Manual: verify synapse particle animation on new messages