### PR TITLE
Issue #233: fix prioritization returning success:true with undefined data

### DIFF
--- a/src/client/hooks/usePrioritization.ts
+++ b/src/client/hooks/usePrioritization.ts
@@ -103,10 +103,12 @@ export function usePrioritization(): UsePrioritizationReturn {
       );
 
       if (!result.success || !result.data) {
+        const errorMsg = result.error ?? 'Prioritization returned no data';
+        const detail = result.text ? `\n\nCC output: ${result.text}` : '';
         setState((prev) => ({
           ...prev,
           loading: false,
-          error: result.error ?? 'Prioritization returned no data',
+          error: errorMsg + detail,
         }));
         return;
       }
@@ -149,10 +151,12 @@ export function usePrioritization(): UsePrioritizationReturn {
       );
 
       if (!result.success || !result.data) {
+        const errorMsg = result.error ?? 'Prioritization returned no data';
+        const detail = result.text ? `\n\nCC output: ${result.text}` : '';
         setState((prev) => ({
           ...prev,
           loading: false,
-          error: result.error ?? 'Prioritization returned no data',
+          error: errorMsg + detail,
         }));
         return;
       }

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -65,6 +65,7 @@ const config = Object.freeze({
 
   ccQueryModel: process.env['FLEET_CC_QUERY_MODEL'] || 'sonnet',
   ccQueryTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_TIMEOUT_MS'] || '30000', 'FLEET_CC_QUERY_TIMEOUT_MS'),
+  ccQueryPrioritizeTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'] || '60000', 'FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'),
 
   outputBufferLines: 500,
   sseHeartbeatMs: 30000,

--- a/src/server/routes/query.ts
+++ b/src/server/routes/query.ts
@@ -58,6 +58,9 @@ const queryRoutes: FastifyPluginCallback = (
               });
             }
             const result = await service.prioritizeIssues(issues);
+            if (!result.success) {
+              request.log.warn({ error: result.error, text: result.text }, `CC query "prioritizeIssues" returned no data`);
+            }
             return reply.code(200).send(result);
           }
 

--- a/src/server/services/cc-query.ts
+++ b/src/server/services/cc-query.ts
@@ -26,6 +26,8 @@ import type {
 interface ExecuteOptions<T> {
   prompt: string;
   jsonSchema: Record<string, unknown>;
+  /** Optional timeout override in milliseconds; defaults to config.ccQueryTimeoutMs */
+  timeoutMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +118,7 @@ export class CCQueryService {
       let stdout = '';
       let stderr = '';
       let timedOut = false;
+      const effectiveTimeout = opts.timeoutMs ?? config.ccQueryTimeoutMs;
 
       const timeout = setTimeout(() => {
         timedOut = true;
@@ -132,7 +135,7 @@ export class CCQueryService {
         } catch {
           // Best effort
         }
-      }, config.ccQueryTimeoutMs);
+      }, effectiveTimeout);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         stdout += chunk.toString();
@@ -151,7 +154,7 @@ export class CCQueryService {
             success: false,
             costUsd: 0,
             durationMs,
-            error: `Query timed out after ${config.ccQueryTimeoutMs}ms`,
+            error: `Query timed out after ${effectiveTimeout}ms`,
           });
           return;
         }
@@ -186,21 +189,41 @@ export class CCQueryService {
           }
 
           const resultText = parsed.result ?? '';
+          const textValue = typeof resultText === 'string' ? resultText : JSON.stringify(resultText);
 
-          resolve({
-            success: true,
-            data,
-            text: typeof resultText === 'string' ? resultText : JSON.stringify(resultText),
-            costUsd: typeof costUsd === 'number' ? costUsd : 0,
-            durationMs: parsed.duration_ms ?? durationMs,
-          });
+          if (data === undefined) {
+            console.warn(
+              `[CCQuery] CC exited 0 but returned no structured data. stdout: ${stdout.substring(0, 500)}`,
+              stderr ? `stderr: ${stderr.substring(0, 500)}` : '',
+            );
+            resolve({
+              success: false,
+              text: textValue,
+              costUsd: typeof costUsd === 'number' ? costUsd : 0,
+              durationMs: parsed.duration_ms ?? durationMs,
+              error: 'CC returned no structured data',
+            });
+          } else {
+            resolve({
+              success: true,
+              data,
+              text: textValue,
+              costUsd: typeof costUsd === 'number' ? costUsd : 0,
+              durationMs: parsed.duration_ms ?? durationMs,
+            });
+          }
         } catch {
           // stdout was not valid JSON — return as text
+          console.warn(
+            `[CCQuery] CC exited 0 but stdout was not valid JSON. stdout: ${stdout.substring(0, 500)}`,
+            stderr ? `stderr: ${stderr.substring(0, 500)}` : '',
+          );
           resolve({
-            success: true,
+            success: false,
             text: stdout.trim(),
             costUsd: 0,
             durationMs,
+            error: 'CC returned no structured data',
           });
         }
       });
@@ -264,12 +287,30 @@ export class CCQueryService {
       required: ['items'],
     };
 
-    const result = await this.execute<{ items: PrioritizedIssue[] }>({ prompt, jsonSchema });
+    const result = await this.execute<{ items: PrioritizedIssue[] }>({
+      prompt,
+      jsonSchema,
+      timeoutMs: config.ccQueryPrioritizeTimeoutMs,
+    });
+
+    if (!result.success) {
+      return result as unknown as CCQueryResult<PrioritizedIssue[]>;
+    }
+
+    const items = result.data?.items;
+    if (!Array.isArray(items)) {
+      return {
+        ...result,
+        success: false,
+        data: undefined,
+        error: 'CC returned unexpected structure: expected { items: [...] }',
+      };
+    }
 
     return {
       ...result,
-      data: result.data?.items,
-    } as CCQueryResult<PrioritizedIssue[]>;
+      data: items,
+    };
   }
 
   async estimateComplexity(

--- a/tests/server/cc-query.test.ts
+++ b/tests/server/cc-query.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../src/server/config.js', () => ({
   default: {
     ccQueryModel: 'claude-sonnet-4-20250514',
     ccQueryTimeoutMs: 60000,
+    ccQueryPrioritizeTimeoutMs: 60000,
   },
 }));
 
@@ -143,7 +144,7 @@ describe('CCQueryService', () => {
       expect(result.costUsd).toBe(0.03);
     });
 
-    it('returns undefined data when result is empty and no structured_output', async () => {
+    it('returns success:false when result is empty and no structured_output', async () => {
       const child = createMockChild();
       mockSpawn.mockReturnValue(child);
 
@@ -160,8 +161,9 @@ describe('CCQueryService', () => {
 
       const result = await resultPromise;
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
+      expect(result.error).toBe('CC returned no structured data');
     });
   });
 
@@ -260,7 +262,7 @@ describe('CCQueryService', () => {
       expect(result.error).toContain('CC exited with code 1');
     });
 
-    it('handles non-JSON stdout gracefully', async () => {
+    it('returns success:false when stdout is not valid JSON', async () => {
       const child = createMockChild();
       mockSpawn.mockReturnValue(child);
 
@@ -270,9 +272,121 @@ describe('CCQueryService', () => {
       emitStdoutAndClose(child, 'Not valid JSON at all');
 
       const result = await resultPromise;
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.text).toBe('Not valid JSON at all');
       expect(result.data).toBeUndefined();
+      expect(result.error).toBe('CC returned no structured data');
+    });
+
+    it('returns success:false when CC returns JSON without structured_output', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: 'Some plain text response',
+        total_cost_usd: 0.02,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('CC returned no structured data');
+      expect(result.text).toBe('Some plain text response');
+    });
+  });
+
+  describe('prioritizeIssues items guard', () => {
+    it('returns error when items is not an array', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.prioritizeIssues([
+        { number: 1, title: 'Test issue' },
+      ]);
+
+      // CC returns structured_output but items is not an array
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          items: 'not an array',
+        },
+        total_cost_usd: 0.01,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('CC returned unexpected structure: expected { items: [...] }');
+      expect(result.data).toBeUndefined();
+    });
+
+    it('returns error when structured_output has no items field', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.prioritizeIssues([
+        { number: 1, title: 'Test issue' },
+      ]);
+
+      // CC returns structured_output without items
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          something: 'else',
+        },
+        total_cost_usd: 0.01,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('CC returned unexpected structure: expected { items: [...] }');
+    });
+
+    it('succeeds when items IS a valid array', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.prioritizeIssues([
+        { number: 10, title: 'Add feature' },
+        { number: 20, title: 'Fix bug' },
+      ]);
+
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          items: [
+            { number: 10, title: 'Add feature', priority: 5, category: 'feature', reason: 'Nice to have' },
+            { number: 20, title: 'Fix bug', priority: 1, category: 'bug', reason: 'Urgent' },
+          ],
+        },
+        total_cost_usd: 0.04,
+        duration_ms: 2000,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual([
+        { number: 10, title: 'Add feature', priority: 5, category: 'feature', reason: 'Nice to have' },
+        { number: 20, title: 'Fix bug', priority: 1, category: 'bug', reason: 'Urgent' },
+      ]);
+      expect(result.costUsd).toBe(0.04);
+      expect(result.durationMs).toBe(2000);
     });
   });
 });


### PR DESCRIPTION
Closes #233

## Summary
- **Core fix**: `_executeImpl()` in cc-query.ts now returns `success: false` (not `success: true`) when CC exits with code 0 but produces no usable structured output
- **Items guard**: `prioritizeIssues()` validates that `items` is an array before unwrapping, returning a descriptive error if not
- **Server logging**: Added warn-level logging of CC stdout/stderr when data is undefined, both in the service and route layers
- **Client error display**: `usePrioritization.ts` now includes `result.text` in the error message so users see what CC actually returned
- **Configurable timeout**: New `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` env var (default 60s) for prioritization queries
- **Tests**: Updated 2 existing tests, added 4 new tests covering all failure modes (12 total, all pass)

## Test plan
- [x] All 12 cc-query tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`npm run build`)
- [ ] Manual test: click Prioritize on Issue Tree view with open issues
- [ ] Manual test: verify error banner shows CC output text on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)