### PR TITLE
Issue #228: remove Pause button and paused project status

### DIFF
--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -10,7 +10,6 @@ import type { ProjectSummary, ProjectStatus, ProjectGroup } from '../../shared/t
 
 const STATUS_STYLES: Record<ProjectStatus, { bg: string; text: string; border: string }> = {
   active: { bg: '#3FB95020', text: '#3FB950', border: '#3FB95040' },
-  paused: { bg: '#D2992220', text: '#D29922', border: '#D2992240' },
   archived: { bg: '#8B949E20', text: '#8B949E', border: '#8B949E40' },
 };
 
@@ -51,7 +50,6 @@ function ProjectCard({
   reinstallResult,
   handleReinstall,
   handleCleanup,
-  handleToggleStatus,
   handleDelete,
   setEditingPromptId,
   onGroupChange,
@@ -80,7 +78,6 @@ function ProjectCard({
   reinstallResult: { id: number; ok: boolean; error?: string } | null;
   handleReinstall: (p: ProjectSummary) => void;
   handleCleanup: (p: ProjectSummary) => void;
-  handleToggleStatus: (p: ProjectSummary) => void;
   handleDelete: (p: ProjectSummary) => void;
   setEditingPromptId: (id: number | null) => void;
   onGroupChange: (projectId: number, groupId: number | null) => void;
@@ -406,12 +403,6 @@ function ProjectCard({
           Clean Up
         </button>
         <button
-          onClick={() => handleToggleStatus(project)}
-          className="px-3 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted transition-colors"
-        >
-          {project.status === 'active' ? 'Pause' : 'Resume'}
-        </button>
-        <button
           onClick={() => handleDelete(project)}
           className="px-3 py-1 text-xs rounded border border-[#F85149]/30 text-[#F85149] hover:bg-[#F85149]/10 transition-colors"
         >
@@ -728,19 +719,6 @@ export function ProjectsPage() {
 
   // --- Project Actions ---
 
-  const handleToggleStatus = useCallback(
-    async (project: ProjectSummary) => {
-      const newStatus: ProjectStatus = project.status === 'active' ? 'paused' : 'active';
-      try {
-        await api.put(`projects/${project.id}`, { status: newStatus });
-        await fetchProjects();
-      } catch {
-        // ignore
-      }
-    },
-    [api, fetchProjects],
-  );
-
   const handleDelete = useCallback(
     async (project: ProjectSummary) => {
       const confirmed = window.confirm(
@@ -930,7 +908,6 @@ export function ProjectsPage() {
     reinstallResult,
     handleReinstall,
     handleCleanup,
-    handleToggleStatus,
     handleDelete,
     setEditingPromptId,
     onGroupChange: handleGroupChange,

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -319,6 +319,9 @@ export class FleetDatabase {
     // Add stream_events table if missing (v6 migration — persist session log)
     this.addStreamEventsTable();
 
+    // Migrate any 'paused' projects to 'active' (paused status removed in #228)
+    this.migratePausedProjects();
+
     // Resolve schema.sql relative to this file.
     // In dev (tsx): __dirname is src/server
     // In compiled (node): __dirname is dist/server/server
@@ -635,6 +638,23 @@ export class FleetDatabase {
       `);
     } catch {
       // Table may already exist — safe to ignore
+    }
+  }
+
+  /**
+   * Migrate any projects with status 'paused' to 'active'.
+   * The paused status was removed in issue #228.
+   */
+  private migratePausedProjects(): void {
+    try {
+      const result = this.db.prepare(
+        "UPDATE projects SET status = 'active', updated_at = datetime('now') WHERE status = 'paused'"
+      ).run();
+      if (result.changes > 0) {
+        console.log(`[DB] Migrated ${result.changes} paused project(s) to active`);
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
     }
   }
 

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -227,7 +227,7 @@ const projectsRoutes: FastifyPluginCallback = (
         const statusFilter = (request.query as ProjectListQuery).status;
 
         if (statusFilter) {
-          const validStatuses: ProjectStatus[] = ['active', 'paused', 'archived'];
+          const validStatuses: ProjectStatus[] = ['active', 'archived'];
           if (!validStatuses.includes(statusFilter)) {
             return reply.code(400).send({
               error: 'Bad Request',
@@ -501,7 +501,7 @@ const projectsRoutes: FastifyPluginCallback = (
 
         // Validate status if provided
         if (status !== undefined) {
-          const validStatuses: ProjectStatus[] = ['active', 'paused', 'archived'];
+          const validStatuses: ProjectStatus[] = ['active', 'archived'];
           if (!validStatuses.includes(status)) {
             return reply.code(400).send({
               error: 'Bad Request',

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS projects (
   repo_path       TEXT NOT NULL UNIQUE,               -- absolute path, e.g. "C:/Git/my-project"
   github_repo     TEXT,                               -- e.g. "org/my-project"
   group_id        INTEGER REFERENCES project_groups(id), -- optional group membership
-  status          TEXT NOT NULL DEFAULT 'active',     -- active | paused | archived
+  status          TEXT NOT NULL DEFAULT 'active',     -- active | archived
   hooks_installed INTEGER NOT NULL DEFAULT 0,         -- 0 | 1
   max_active_teams INTEGER NOT NULL DEFAULT 5,        -- max concurrent active teams before queueing
   prompt_file     TEXT,                               -- relative path to launch prompt .md file

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -6,7 +6,7 @@
 // broadcasts changes via SSE.
 //
 // Per-project: each team's github_repo is resolved from its project record.
-// Teams in paused/archived projects are skipped during polling.
+// Teams in archived projects are skipped during polling.
 //
 // Uses `gh` CLI exclusively (never Octokit) as per project conventions.
 // All gh CLI errors are handled gracefully — a single failed poll never
@@ -148,7 +148,7 @@ class GitHubPoller {
     try {
       const db = getDatabase();
 
-      // Get all active projects — skip paused/archived
+      // Get all active projects — skip archived
       const projects = db.getProjects({ status: 'active' });
 
       if (projects.length === 0) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,7 +22,7 @@ export type CIStatus = 'none' | 'pending' | 'passing' | 'failing';
 export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'dirty' | 'unstable' | 'has_hooks' | 'draft';
 
 /** Project status */
-export type ProjectStatus = 'active' | 'paused' | 'archived';
+export type ProjectStatus = 'active' | 'archived';
 
 /** Usage zone for queue gating */
 export type UsageZone = 'green' | 'red';


### PR DESCRIPTION
Closes #228

## Summary
- Remove `paused` from `ProjectStatus` type union — projects now only have `active` and `archived` statuses
- Remove Pause/Resume button, `handleToggleStatus` callback, and `paused` STATUS_STYLES entry from ProjectsPage
- Remove `paused` from `validStatuses` arrays in GET and PUT project routes (server now rejects `paused` with 400)
- Add startup migration in `db.ts` to convert any existing `paused` projects to `active`
- Update schema and service comments to reflect removal

## Test plan
- [ ] Verify Projects page renders without Pause/Resume button
- [ ] Verify PUT `/api/projects/:id` with `status: 'paused'` returns 400
- [ ] Verify GET `/api/projects?status=paused` returns 400
- [ ] Verify existing projects with `paused` status are migrated to `active` on startup
- [ ] Run `npm run build` — no TypeScript errors
- [ ] Run `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>