### PR TITLE
Issue #232: fix false-positive duplicate transition warning

### DIFF
--- a/src/client/views/StateMachinePage.tsx
+++ b/src/client/views/StateMachinePage.tsx
@@ -253,7 +253,7 @@ function validateTransitions(
   for (const t of rawTransitions) {
     // Skip wildcards for dup check — they are by design broad
     if (t.from === '*') continue;
-    const key = `${t.from}|${t.to}|${t.trigger}`;
+    const key = `${t.id}|${t.from}|${t.to}|${t.trigger}`;
     if (!dupCheck.has(key)) dupCheck.set(key, []);
     dupCheck.get(key)!.push(t);
   }


### PR DESCRIPTION
## Summary
- Fixed false-positive "duplicate transition" validation warning on the `/lifecycle` page
- The `validateTransitions()` function in `StateMachinePage.tsx` was using `from|to|trigger` as the dedup key, which incorrectly flagged `ci_green` and `ci_red` as duplicates (both are `running -> running` via `poller`)
- Added the transition `id` to the dedup key so transitions with different IDs are never considered duplicates

Closes #232

## Test plan
- [ ] Open `/lifecycle` page and verify the "Duplicate transition: running -> running (poller) defined 2 times [ci_green, ci_red]" warning no longer appears
- [ ] Verify other validation warnings (if any) still display correctly
- [ ] Verify the transition table and diagram still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)