### PR TITLE
Issue #229: separate lifecycle diagram edges by trigger type

### DIFF
--- a/src/client/views/StateMachinePage.tsx
+++ b/src/client/views/StateMachinePage.tsx
@@ -320,6 +320,7 @@ interface LayoutNode {
 interface LayoutEdge {
   from: string;
   to: string;
+  trigger: string;
   points: Array<{ x: number; y: number }>;
   transitions: Transition[];
 }
@@ -335,7 +336,7 @@ const ALL_NODE_WIDTH = 70;
 const ALL_NODE_HEIGHT = 30;
 
 function computeLayout(states: StateNode[], transitions: Transition[]): LayoutResult {
-  const g = new dagre.graphlib.Graph();
+  const g = new dagre.graphlib.Graph({ multigraph: true });
   g.setGraph({
     rankdir: 'LR',
     nodesep: 60,
@@ -365,14 +366,15 @@ function computeLayout(states: StateNode[], transitions: Transition[]): LayoutRe
     // Skip edges referencing unknown states (but allow the "*" pseudo-node)
     if (from !== '*' && !stateIds.has(from)) continue;
     if (!stateIds.has(t.to)) continue;
-    const key = `${from}->${t.to}`;
+    const key = `${from}->${t.to}|${t.trigger}`;
     if (!edgeMap.has(key)) edgeMap.set(key, []);
     edgeMap.get(key)!.push(t);
   }
 
   edgeMap.forEach((_trans, key) => {
-    const [from, to] = key.split('->');
-    g.setEdge(from, to);
+    const [fromTo, trigger] = key.split('|');
+    const [from, to] = fromTo.split('->');
+    g.setEdge(from, to, {}, trigger);
   });
 
   dagre.layout(g);
@@ -384,10 +386,11 @@ function computeLayout(states: StateNode[], transitions: Transition[]): LayoutRe
 
   const edges: LayoutEdge[] = g.edges().map((e) => {
     const edge = g.edge(e);
-    const key = `${e.v}->${e.w}`;
+    const key = `${e.v}->${e.w}|${e.name}`;
     return {
       from: e.v,
       to: e.w,
+      trigger: e.name || '',
       points: edge.points || [],
       transitions: edgeMap.get(key) || [],
     };
@@ -845,7 +848,7 @@ export function StateMachinePage() {
 
                 {/* Transition edges */}
                 {layout.edges.map((edge) => {
-                  const edgeKey = `${edge.from}->${edge.to}`;
+                  const edgeKey = `${edge.from}->${edge.to}|${edge.trigger}`;
                   const isHovered = edgeKey === hoveredEdge;
                   const points = edge.points;
                   if (points.length === 0) return null;


### PR DESCRIPTION
Closes #229

## Summary
- Changed edge map key in `computeLayout()` to include trigger type (`from->to|trigger`), so transitions with different triggers between the same states render as separate visual arrows
- Enabled dagre multigraph mode to support parallel edges between the same node pair
- Updated edge retrieval and rendering to use composite keys consistently (hover state, React keys)

## Test plan
- [x] TypeScript compiles clean
- [x] All tests pass (4 pre-existing failures unrelated to this change)
- [ ] Verify `/lifecycle` page shows two separate arrows for `queued -> launching` (system gear icon + PM action user icon)
- [ ] Verify `running -> running` self-loop still shows as single edge (both transitions share `poller` trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)