### PR TITLE
Issue #235: add Project column to Fleet Grid

### DIFF
--- a/src/client/components/FleetGrid.tsx
+++ b/src/client/components/FleetGrid.tsx
@@ -7,7 +7,7 @@ interface FleetGridProps {
   onSelectTeam: (id: number) => void;
 }
 
-const COLUMNS = ['Status', 'Issue', 'Model', 'Duration', 'Activity', 'Tokens', 'PR', 'Actions'] as const;
+const COLUMNS = ['Status', 'Project', 'Issue', 'Model', 'Duration', 'Activity', 'Tokens', 'PR', 'Actions'] as const;
 
 export function FleetGrid({ teams, selectedTeamId, onSelectTeam }: FleetGridProps) {
   return (

--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -110,6 +110,13 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
         <StatusBadge status={team.status} />
       </td>
 
+      {/* Project */}
+      <td className="px-4 whitespace-nowrap">
+        <span className="text-sm text-dark-muted">
+          {team.projectName ?? '\u2014'}
+        </span>
+      </td>
+
       {/* Issue */}
       <td className="px-4 whitespace-nowrap">
         <span className="text-sm">


### PR DESCRIPTION
## Summary
- Added 'Project' column to Fleet Grid table between Status and Issue columns
- Renders `team.projectName` with em-dash fallback for null values
- No backend changes needed — data was already available via `TeamDashboardRow.projectName`

Closes #235

## Files Changed
- `src/client/components/FleetGrid.tsx` — added 'Project' to COLUMNS array
- `src/client/components/TeamRow.tsx` — added `<td>` cell rendering project name

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Verify Project column appears between Status and Issue
- [ ] Verify null projectName shows em dash
- [ ] Verify table scrolls horizontally on narrow viewports