### PR TITLE
Issue #234: remove max-h-[35%] metadata clipping and add CI checks scroll cap

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -411,7 +411,7 @@ export function TeamDetail() {
                 </div>
 
                 {/* Collapsible metadata content */}
-                <div className={`overflow-y-auto custom-scrollbar transition-all duration-200 ${metadataCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-[35%]'}`}>
+                <div className={`overflow-y-auto custom-scrollbar transition-all duration-200 ${metadataCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-[2000px]'}`}>
                 <div className="px-5 pb-4 space-y-4">
                   {/* ---- Header Section ---- */}
                   <section>
@@ -587,7 +587,9 @@ export function TeamDetail() {
                       {/* CI Checks */}
                       <div className="ml-1">
                         <p className="text-xs text-dark-muted mb-1.5 uppercase tracking-wide">CI Checks</p>
-                        <CIChecks checks={detail.pr.checks ?? []} />
+                        <div className="max-h-[120px] overflow-y-auto custom-scrollbar">
+                          <CIChecks checks={detail.pr.checks ?? []} />
+                        </div>
                       </div>
                     </section>
                   )}


### PR DESCRIPTION
Closes #234

## Summary
- Replaced `max-h-[35%]` with `max-h-[2000px]` on the collapsible metadata wrapper in TeamDetail so that State Transitions, PR details, and CI Checks are fully visible when expanded
- Added `max-h-[120px] overflow-y-auto custom-scrollbar` wrapper around CIChecks component to prevent repos with 10+ CI checks from pushing the tab area off-screen (mirrors existing pattern in PRDetail.tsx)

## Changes
- `src/client/components/TeamDetail.tsx`: two targeted CSS changes (line 415 height cap, lines 590-592 CI scroll wrapper)

## Test plan
- [ ] Verify all metadata sections visible when expanded on 1080p
- [ ] Verify CI Checks with 10+ checks scroll within 120px container
- [ ] Verify collapse/expand toggle still animates smoothly
- [ ] Verify auto-collapse for done/failed teams still works
- [ ] Verify tab content area has sufficient space when metadata expanded
- [ ] Verify no horizontal overflow or layout shifts