### PR TITLE
Issue #236: make PR number a clickable link to GitHub in PRDetail popover

### DIFF
--- a/src/client/components/PRBadge.tsx
+++ b/src/client/components/PRBadge.tsx
@@ -23,9 +23,10 @@ interface PRBadgeProps {
   ciStatus: CIStatus | null;
   teamId?: number;
   prState?: PRState | null;
+  githubRepo?: string | null;
 }
 
-export function PRBadge({ prNumber, ciStatus, teamId, prState }: PRBadgeProps) {
+export function PRBadge({ prNumber, ciStatus, teamId, prState, githubRepo }: PRBadgeProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [hovered, setHovered] = useState(false);
 
@@ -87,7 +88,7 @@ export function PRBadge({ prNumber, ciStatus, teamId, prState }: PRBadgeProps) {
 
       {/* PRDetail popover */}
       {popoverOpen && teamId != null && (
-        <PRDetail prNumber={prNumber} teamId={teamId} onClose={handleClose} />
+        <PRDetail prNumber={prNumber} teamId={teamId} onClose={handleClose} githubRepo={githubRepo} />
       )}
     </span>
   );

--- a/src/client/components/PRDetail.tsx
+++ b/src/client/components/PRDetail.tsx
@@ -33,9 +33,10 @@ interface PRDetailProps {
   prNumber: number;
   teamId: number;
   onClose: () => void;
+  githubRepo?: string | null;
 }
 
-export function PRDetail({ prNumber, teamId, onClose }: PRDetailProps) {
+export function PRDetail({ prNumber, teamId, onClose, githubRepo }: PRDetailProps) {
   const api = useApi();
   const [detail, setDetail] = useState<TeamDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -138,6 +139,8 @@ export function PRDetail({ prNumber, teamId, onClose }: PRDetailProps) {
   }, [actionLoading, api, prNumber, teamId]);
 
   const pr = detail?.pr ?? null;
+  const effectiveGithubRepo = githubRepo ?? detail?.githubRepo ?? null;
+  const prUrl = effectiveGithubRepo && pr ? `https://github.com/${effectiveGithubRepo}/pull/${pr.number}` : null;
   const stateInfo = STATE_COLORS[pr?.state ?? ''] ?? { color: '#8B949E', label: 'UNKNOWN' };
   const mergeStatusColor = MERGE_STATUS_COLORS[(pr?.mergeStatus ?? 'unknown').toLowerCase()] ?? '#8B949E';
   const isOpen = pr?.state === 'open';
@@ -167,9 +170,21 @@ export function PRDetail({ prNumber, teamId, onClose }: PRDetailProps) {
         <div className="p-4 space-y-3">
           {/* Header: PR number as link */}
           <div className="flex items-center justify-between">
-            <span className="text-sm font-semibold text-dark-accent">
-              PR #{pr.number}
-            </span>
+            {prUrl ? (
+              <a
+                href={prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="text-sm font-semibold text-dark-accent hover:underline"
+              >
+                PR #{pr.number}
+              </a>
+            ) : (
+              <span className="text-sm font-semibold text-dark-accent">
+                PR #{pr.number}
+              </span>
+            )}
             <button
               onClick={onClose}
               className="text-dark-muted hover:text-dark-text transition-colors p-0.5 rounded hover:bg-dark-border/30"

--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -162,7 +162,7 @@ export function TeamRow({ team, selected, onClick }: TeamRowProps) {
 
       {/* PR */}
       <td className="px-4 whitespace-nowrap">
-        <PRBadge prNumber={team.prNumber} ciStatus={team.ciStatus} teamId={team.id} prState={team.prState} />
+        <PRBadge prNumber={team.prNumber} ciStatus={team.ciStatus} teamId={team.id} prState={team.prState} githubRepo={team.githubRepo} />
       </td>
 
       {/* Actions */}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1912,6 +1912,7 @@ export class FleetDatabase {
       totalCacheCreationTokens: (row.total_cache_creation_tokens as number | undefined) ?? 0,
       totalCacheReadTokens: (row.total_cache_read_tokens as number | undefined) ?? 0,
       totalCostUsd: (row.total_cost_usd as number | undefined) ?? 0,
+      githubRepo: (row.github_repo as string | null) ?? null,
       prState: (row.pr_state as PRState | null) ?? null,
       ciStatus: (row.ci_status as CIStatus | null) ?? null,
       mergeStatus: row.merge_status as MergeStatus | null,

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -500,12 +500,14 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
-        // Look up project to get model
+        // Look up project to get model and GitHub repo
         let projectModel: string | null = null;
+        let projectGithubRepo: string | null = null;
         if (team.projectId) {
           const project = db.getProject(team.projectId);
           if (project) {
             projectModel = project.model ?? null;
+            projectGithubRepo = project.githubRepo ?? null;
           }
         }
 
@@ -562,6 +564,7 @@ const teamsRoutes: FastifyPluginCallback = (
           issueNumber: team.issueNumber,
           issueTitle: team.issueTitle,
           model: projectModel,
+          githubRepo: projectGithubRepo,
           status: team.status,
           phase: team.phase,
           pid: team.pid,

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -136,6 +136,7 @@ SELECT
   t.project_id,
   p.name AS project_name,
   p.model AS model,
+  p.github_repo AS github_repo,
   t.status,
   t.phase,
   t.worktree_name,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -371,6 +371,7 @@ export interface TeamDashboardRow {
   totalCacheCreationTokens: number;
   totalCacheReadTokens: number;
   totalCostUsd: number;
+  githubRepo: string | null;
   prState: PRState | null;
   ciStatus: CIStatus | null;
   mergeStatus: MergeStatus | null;
@@ -410,6 +411,7 @@ export interface TeamDetail {
   totalCacheCreationTokens: number;
   totalCacheReadTokens: number;
   totalCostUsd: number;
+  githubRepo?: string | null;
   pr: {
     number: number;
     state: PRState | null;


### PR DESCRIPTION
Closes #236

## Summary
- Add `p.github_repo` to `v_team_dashboard` SQL view so the GitHub repo slug is available in dashboard queries
- Thread `githubRepo` through `TeamDashboardRow` / `TeamDetail` types, `db.ts` mapping, API route, and React components (`TeamRow` → `PRBadge` → `PRDetail`)
- Render PR number in `PRDetail` popover as a clickable `<a>` link to `https://github.com/{repo}/pull/{number}` with `target="_blank"` and `rel="noopener noreferrer"`
- Graceful degradation: falls back to plain `<span>` when `githubRepo` is null
- `e.stopPropagation()` on the link prevents popover toggle interference
- `githubRepo` prop is optional in `PRBadgeProps` to maintain `TreeNode.tsx` compatibility

## Files changed
- `src/server/schema.sql` — add column to view
- `src/shared/types.ts` — add `githubRepo` to interfaces
- `src/server/db.ts` — add mapping in `mapDashboardRow`
- `src/server/routes/teams.ts` — include in API response
- `src/client/components/TeamRow.tsx` — pass prop
- `src/client/components/PRBadge.tsx` — accept and forward prop
- `src/client/components/PRDetail.tsx` — render clickable link

## Test plan
- [ ] Verify PR number in PRDetail popover is a clickable link
- [ ] Verify link opens correct GitHub PR URL in new tab
- [ ] Verify clicking link does not toggle/close the popover
- [ ] Verify PRBadge in TreeNode (issue tree) still works without githubRepo
- [ ] Verify plain text fallback when project has no GitHub repo
- [ ] TypeScript compilation passes