### PR TITLE
Issue #250: set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var for CC spawns

### DIFF
--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true
   },

--- a/src/client/views/SettingsPage.tsx
+++ b/src/client/views/SettingsPage.tsx
@@ -21,6 +21,7 @@ interface SettingsResponse {
   sseHeartbeatMs: number;
   outputBufferLines: number;
   claudeCmd: string;
+  enableAgentTeams: boolean;
   fleetCommanderRoot: string;
   dbPath: string;
 }
@@ -70,6 +71,13 @@ const SETTING_GROUPS: SettingGroup[] = [
         label: 'Claude Command',
         envVar: 'FLEET_CLAUDE_CMD',
         description: 'CLI command used to invoke Claude',
+      },
+      {
+        key: 'enableAgentTeams',
+        label: 'Agent Teams',
+        envVar: 'FLEET_ENABLE_AGENT_TEAMS',
+        description: 'Enable CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var for spawned CC processes',
+        format: (v) => (v ? 'Enabled' : 'Disabled'),
       },
       {
         key: 'outputBufferLines',

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -50,6 +50,7 @@ const config = Object.freeze({
 
   claudeCmd: process.env['FLEET_CLAUDE_CMD'] || 'claude',
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',
+  enableAgentTeams: process.env['FLEET_ENABLE_AGENT_TEAMS'] !== 'false',
 
   dbPath: process.env['FLEET_DB_PATH'] || path.join(fleetCommanderRoot, 'fleet.db'),
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors';
 import fastifyStatic from '@fastify/static';
 import path from 'path';
 import fs from 'fs';
+import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import eventsRoutes from './routes/events.js';
 import streamRoutes from './routes/stream.js';
@@ -83,6 +84,37 @@ async function main() {
 
   // Recover state from before restart (reconcile PIDs, detect orphan worktrees)
   await recoverOnStartup();
+
+  // ---------------------------------------------------------------------------
+  // Startup diagnostics: agent teams config + Claude CLI version
+  // ---------------------------------------------------------------------------
+  try {
+    server.log.info(`Agent Teams: ${config.enableAgentTeams ? 'enabled' : 'disabled'} (FLEET_ENABLE_AGENT_TEAMS)`);
+
+    const versionOutput = execSync(`${config.claudeCmd} --version`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    }).trim();
+    // Parse version number from output (e.g. "claude 2.1.32" or just "2.1.32")
+    const versionMatch = versionOutput.match(/(\d+\.\d+\.\d+)/);
+    if (versionMatch) {
+      const version = versionMatch[1];
+      server.log.info(`Claude CLI version: ${version}`);
+      // Check minimum version for agent teams support (2.1.32)
+      const [major, minor, patch] = version.split('.').map(Number);
+      const meetsMinimum =
+        major > 2 ||
+        (major === 2 && minor > 1) ||
+        (major === 2 && minor === 1 && patch >= 32);
+      if (!meetsMinimum && config.enableAgentTeams) {
+        server.log.warn(`Claude CLI ${version} may not support agent teams (minimum 2.1.32)`);
+      }
+    } else {
+      server.log.warn(`Could not parse Claude CLI version from: ${versionOutput}`);
+    }
+  } catch (err: unknown) {
+    server.log.warn(`Claude CLI version check failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   // Start all services
   sseBroker.start(config.sseHeartbeatMs);

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -295,6 +295,7 @@ const systemRoutes: FastifyPluginCallback = (
           sseHeartbeatMs: config.sseHeartbeatMs,
           outputBufferLines: config.outputBufferLines,
           claudeCmd: config.claudeCmd,
+          enableAgentTeams: config.enableAgentTeams,
           fleetCommanderRoot: config.fleetCommanderRoot,
           dbPath: config.dbPath,
         });

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1211,14 +1211,20 @@ export class TeamManager {
       FLEET_TEAM_ID: worktreeName,
       FLEET_PROJECT_ID: String(projectId),
       FLEET_GITHUB_REPO: project.githubRepo ?? '',
-      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
     };
+    // Only set agent teams env var when enabled; explicitly clear it otherwise
+    // so it's not inherited from process.env
+    if (config.enableAgentTeams) {
+      env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = '1';
+    } else {
+      env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = undefined;
+    }
     const gitBash = findGitBash();
     if (gitBash) {
       env['CLAUDE_CODE_GIT_BASH_PATH'] = gitBash;
       console.log(`[TeamManager] CLAUDE_CODE_GIT_BASH_PATH=${gitBash}`);
     }
-    console.log(`[TeamManager] Spawn env: FLEET_TEAM_ID=${worktreeName}, FLEET_PROJECT_ID=${projectId}, CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`);
+    console.log(`[TeamManager] Spawn env: FLEET_TEAM_ID=${worktreeName}, FLEET_PROJECT_ID=${projectId}, CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${config.enableAgentTeams ? '1' : 'disabled'}`);
     return env;
   }
 

--- a/tests/server/team-manager-build-spawn-env.test.ts
+++ b/tests/server/team-manager-build-spawn-env.test.ts
@@ -1,0 +1,137 @@
+// =============================================================================
+// Fleet Commander — TeamManager.buildSpawnEnv unit tests
+// =============================================================================
+// Verifies that buildSpawnEnv() correctly sets (or omits) the
+// CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var based on config.enableAgentTeams,
+// and that other expected env vars are always present.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock modules before importing TeamManager
+// ---------------------------------------------------------------------------
+
+// vi.hoisted ensures the object is available when vi.mock factories run
+const mockConfig = vi.hoisted(() => ({
+  worktreeDir: '.claude/worktrees',
+  outputBufferLines: 500,
+  claudeCmd: 'claude',
+  skipPermissions: true,
+  terminalCmd: 'auto' as const,
+  enableAgentTeams: true,
+}));
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => ({
+    getProject: vi.fn(),
+    getActiveTeamCountByProject: vi.fn(),
+    getQueuedTeamsByProject: vi.fn(),
+    getTeam: vi.fn(),
+    updateTeam: vi.fn(),
+    insertTransition: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: mockConfig,
+}));
+
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: {
+    broadcast: vi.fn(),
+    getSnapshot: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('../../src/server/utils/find-git-bash.js', () => ({
+  findGitBash: vi.fn().mockReturnValue(null),
+}));
+
+import { TeamManager } from '../../src/server/services/team-manager.js';
+import type { Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides?: Partial<Project>): Project {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 2,
+    promptFile: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TeamManager.buildSpawnEnv', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.enableAgentTeams = true;
+    tm = new TeamManager();
+  });
+
+  it('includes CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS when enableAgentTeams is true', () => {
+    mockConfig.enableAgentTeams = true;
+    const project = makeProject();
+    // Access private method via bracket notation for testing
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'test-project-42', 1);
+    expect(env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS']).toBe('1');
+  });
+
+  it('sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to undefined when enableAgentTeams is false', () => {
+    mockConfig.enableAgentTeams = false;
+    const project = makeProject();
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'test-project-42', 1);
+    expect(env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS']).toBeUndefined();
+  });
+
+  it('always includes FLEET_TEAM_ID and FLEET_PROJECT_ID', () => {
+    const project = makeProject();
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'my-worktree', 7);
+    expect(env['FLEET_TEAM_ID']).toBe('my-worktree');
+    expect(env['FLEET_PROJECT_ID']).toBe('7');
+  });
+
+  it('always includes FLEET_GITHUB_REPO from the project', () => {
+    const project = makeProject({ githubRepo: 'acme/widgets' });
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'acme-widgets-1', 1);
+    expect(env['FLEET_GITHUB_REPO']).toBe('acme/widgets');
+  });
+
+  it('defaults FLEET_GITHUB_REPO to empty string when project has no githubRepo', () => {
+    const project = makeProject({ githubRepo: null as unknown as string });
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'test-1', 1);
+    expect(env['FLEET_GITHUB_REPO']).toBe('');
+  });
+
+  it('inherits process.env entries', () => {
+    // process.env.PATH should be inherited
+    const project = makeProject();
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'test-1', 1);
+    expect(env['PATH']).toBeDefined();
+  });
+
+  it('includes CLAUDE_CODE_GIT_BASH_PATH when findGitBash returns a path', async () => {
+    // Re-import with different mock
+    const { findGitBash } = await import('../../src/server/utils/find-git-bash.js');
+    (findGitBash as ReturnType<typeof vi.fn>).mockReturnValue('C:/Program Files/Git/bin/bash.exe');
+
+    const project = makeProject();
+    const env = (tm as unknown as Record<string, Function>)['buildSpawnEnv'](project, 'test-1', 1);
+    expect(env['CLAUDE_CODE_GIT_BASH_PATH']).toBe('C:/Program Files/Git/bin/bash.exe');
+  });
+});


### PR DESCRIPTION
Closes #250

## Summary
- Add `FLEET_ENABLE_AGENT_TEAMS` config flag (default `true`) to control whether `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set when spawning CC processes
- Make the existing env var in `buildSpawnEnv()` conditional on this config flag
- Add `env` block to `hooks/settings.json.example` for belt-and-suspenders coverage
- Add startup diagnostics: log Claude Code CLI version and agent teams enablement status
- Expose `enableAgentTeams` via `/api/settings` endpoint and Settings UI page
- Add 7 unit tests for `buildSpawnEnv()` covering enabled/disabled/env-var scenarios

## Test plan
- [x] Unit tests for `buildSpawnEnv()` verify env var presence when enabled and absence when disabled
- [x] Build passes (`npm run build`)
- [x] Existing tests pass (`npm test`)
- [ ] Manual: verify Settings page shows "Agent Teams" row
- [ ] Manual: verify startup logs show CC version and agent teams status

🤖 Generated with [Claude Code](https://claude.com/claude-code)