### PR TITLE
Issue #240: merge session log and events into unified timeline

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -3,8 +3,7 @@ import { useFleet } from '../context/FleetContext';
 import { useApi } from '../hooks/useApi';
 import { StatusBadge } from './StatusBadge';
 import { CIChecks } from './CIChecks';
-import { EventTimeline } from './EventTimeline';
-import { TeamOutput } from './TeamOutput';
+import { UnifiedTimeline } from './UnifiedTimeline';
 import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
 import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember, MessageEdge } from '../../shared/types';
@@ -40,7 +39,7 @@ export function TeamDetail() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [transitions, setTransitions] = useState<TeamTransition[]>([]);
   const [roster, setRoster] = useState<TeamMember[]>([]);
-  const [activeTab, setActiveTab] = useState<'session-log' | 'events' | 'team'>('session-log');
+  const [activeTab, setActiveTab] = useState<'session-log' | 'team'>('session-log');
   const [messageEdges, setMessageEdges] = useState<MessageEdge[]>([]);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
@@ -621,16 +620,6 @@ export function TeamDetail() {
                     Session Log
                   </button>
                   <button
-                    onClick={() => setActiveTab('events')}
-                    className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
-                      activeTab === 'events'
-                        ? 'border-dark-accent text-dark-text'
-                        : 'border-transparent text-dark-muted hover:text-dark-text'
-                    }`}
-                  >
-                    Events
-                  </button>
-                  <button
                     onClick={() => setActiveTab('team')}
                     className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
                       activeTab === 'team'
@@ -646,15 +635,7 @@ export function TeamDetail() {
                 {activeTab === 'session-log' && (
                   <div className="flex-1 min-h-0 flex flex-col px-5 py-3">
                     <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
-                      <TeamOutput teamId={detail.id} teamStatus={detail.status} />
-                    </div>
-                  </div>
-                )}
-
-                {activeTab === 'events' && (
-                  <div className="flex-1 min-h-0 flex flex-col px-5 py-3">
-                    <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
-                      <EventTimeline teamId={detail.id} refreshKey={refreshKey} />
+                      <UnifiedTimeline teamId={detail.id} teamStatus={detail.status} />
                     </div>
                   </div>
                 )}

--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -1,0 +1,430 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useApi } from '../hooks/useApi';
+import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry } from '../../shared/types';
+import {
+  PlayIcon,
+  SquareIcon,
+  CircleStopIcon,
+  ArrowRightIcon,
+  ArrowLeftIcon,
+  AlertTriangleIcon,
+  SettingsIcon,
+  XCircleIcon,
+  RefreshCwIcon,
+  CircleDotIcon,
+  ClockIcon,
+} from './Icons';
+
+// ---------------------------------------------------------------------------
+// Helpers — stream event rendering
+// ---------------------------------------------------------------------------
+
+const TYPE_STYLES: Record<string, { color: string; label: string }> = {
+  assistant:        { color: '#58A6FF', label: 'TL' },
+  user:             { color: '#3FB950', label: 'You' },
+  fc:               { color: '#D29922', label: 'FC' },
+  system:           { color: '#8B949E', label: 'system' },
+  tool_use:         { color: '#D29922', label: 'tool' },
+  tool_result:      { color: '#A371F7', label: 'result' },
+  result:           { color: '#3FB950', label: 'done' },
+  rate_limit_event: { color: '#D29922', label: 'rate-limit' },
+};
+
+function getStreamStyle(type: string) {
+  return TYPE_STYLES[type] ?? { color: '#8B949E', label: type };
+}
+
+const FC_SUBTYPE_LABELS: Record<string, string> = {
+  initial_prompt:     'prompt',
+  origin_sync:        'sync',
+  idle_nudge:         'idle',
+  stuck_nudge:        'nudge',
+  ci_green:           'CI pass',
+  ci_red:             'CI fail',
+  ci_blocked:         'CI blocked',
+  pr_merged_shutdown: 'shutdown',
+  subagent_crash:     'crash',
+};
+
+function getSubtypeLabel(subtype: string | undefined): string | null {
+  if (!subtype) return null;
+  return FC_SUBTYPE_LABELS[subtype] ?? subtype;
+}
+
+/** Text types that render inline message content */
+const TEXT_TYPES = new Set(['assistant', 'user', 'fc']);
+
+function getStreamText(entry: StreamTimelineEntry): string {
+  if (!TEXT_TYPES.has(entry.streamType)) return '';
+  const content = entry.message?.content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((c) => c.type === 'text' && c.text)
+      .map((c) => c.text!)
+      .join('\n');
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — hook event rendering
+// ---------------------------------------------------------------------------
+
+const EVENT_ICONS: Record<string, React.ReactNode> = {
+  SessionStart:  <PlayIcon size={14} />,
+  SessionEnd:    <SquareIcon size={14} />,
+  Stop:          <CircleStopIcon size={14} />,
+  StopFailure:   <AlertTriangleIcon size={14} />,
+  SubagentStart: <ArrowRightIcon size={14} />,
+  SubagentStop:  <ArrowLeftIcon size={14} />,
+  Notification:  <AlertTriangleIcon size={14} />,
+  ToolError:     <XCircleIcon size={14} />,
+  PreCompact:    <RefreshCwIcon size={14} />,
+  ToolUse:       <SettingsIcon size={14} />,
+  TeammateIdle:  <ClockIcon size={14} />,
+};
+
+function getEventIcon(eventType: string): React.ReactNode {
+  return EVENT_ICONS[eventType] ?? <CircleDotIcon size={14} />;
+}
+
+/** Hook event types that represent lifecycle transitions */
+const LIFECYCLE_TYPES = new Set([
+  'SessionStart', 'SessionEnd', 'Stop', 'SubagentStart', 'SubagentStop',
+]);
+
+/** Hook event types that represent errors */
+const ERROR_TYPES = new Set(['ToolError', 'StopFailure']);
+
+function extractPayloadError(payload: string | undefined): string | null {
+  if (!payload) return null;
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'error' in parsed &&
+      typeof (parsed as { error: unknown }).error === 'string'
+    ) {
+      return (parsed as { error: string }).error;
+    }
+  } catch {
+    // Malformed JSON
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function formatLocalTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '--:--';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components for each entry type
+// ---------------------------------------------------------------------------
+
+function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
+  const { color, label } = getStreamStyle(entry.streamType);
+  const text = getStreamText(entry);
+  const isMultiline = text.includes('\n');
+
+  // Text messages (assistant, user, fc)
+  if (TEXT_TYPES.has(entry.streamType) && text) {
+    return (
+      <div className="py-0.5 leading-relaxed">
+        <span className="text-dark-muted">
+          {formatLocalTime(entry.timestamp)}
+        </span>
+        {' '}
+        <span style={{ color }} className="font-semibold">{label}</span>
+        {entry.streamType === 'fc' && entry.subtype && (
+          <span className="text-dark-muted text-[10px] ml-1">[{getSubtypeLabel(entry.subtype)}]</span>
+        )}
+        {' '}
+        {isMultiline ? (
+          <span className="text-dark-text whitespace-pre-wrap">{text}</span>
+        ) : (
+          <span className="text-dark-text">{text}</span>
+        )}
+      </div>
+    );
+  }
+
+  // Tool use — compact badge
+  if (entry.streamType === 'tool_use' && entry.tool?.name) {
+    return (
+      <div className="py-0.5 leading-relaxed flex items-center gap-1.5">
+        <span className="text-dark-muted">
+          {formatLocalTime(entry.timestamp)}
+        </span>
+        <span style={{ color }} className="font-semibold">{label}</span>
+        <span className="text-xs text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
+          {entry.tool.name}
+        </span>
+      </div>
+    );
+  }
+
+  // Result / tool_result — compact
+  if (entry.streamType === 'result' || entry.streamType === 'tool_result') {
+    return (
+      <div className="py-0.5 leading-relaxed">
+        <span className="text-dark-muted">
+          {formatLocalTime(entry.timestamp)}
+        </span>
+        {' '}
+        <span style={{ color }} className="font-semibold">{label}</span>
+      </div>
+    );
+  }
+
+  // All other stream types — generic line
+  if (text) {
+    return (
+      <div className="py-0.5 leading-relaxed">
+        <span className="text-dark-muted">
+          {formatLocalTime(entry.timestamp)}
+        </span>
+        {' '}
+        <span style={{ color }} className="font-semibold">{label}</span>
+        {' '}
+        <span className="text-dark-text">{text}</span>
+      </div>
+    );
+  }
+
+  // Fallback: skip entries with no displayable content
+  return null;
+}
+
+function HookEntryRow({ entry }: { entry: HookTimelineEntry }) {
+  const isLifecycle = LIFECYCLE_TYPES.has(entry.eventType);
+  const isError = ERROR_TYPES.has(entry.eventType);
+  const errorMsg = isError ? extractPayloadError(entry.payload) : null;
+
+  // Lifecycle events — colored badge
+  if (isLifecycle) {
+    const lifecycleColor = entry.eventType === 'SessionStart' || entry.eventType === 'SubagentStart'
+      ? '#3FB950'
+      : '#8B949E';
+
+    return (
+      <div className="py-1 leading-relaxed flex items-center gap-1.5">
+        <span className="text-dark-muted">
+          {formatLocalTime(entry.timestamp)}
+        </span>
+        <span className="text-dark-muted shrink-0">
+          {getEventIcon(entry.eventType)}
+        </span>
+        <span
+          className="text-xs font-medium px-1.5 py-0.5 rounded"
+          style={{ color: lifecycleColor, backgroundColor: lifecycleColor + '18' }}
+        >
+          {entry.eventType}
+        </span>
+        {entry.agentName && (
+          <span className="text-xs text-dark-muted">{entry.agentName}</span>
+        )}
+      </div>
+    );
+  }
+
+  // Error events — red
+  if (isError) {
+    return (
+      <div className="py-1 leading-relaxed">
+        <div className="flex items-center gap-1.5">
+          <span className="text-dark-muted">
+            {formatLocalTime(entry.timestamp)}
+          </span>
+          <span className="text-[#F85149] shrink-0">
+            {getEventIcon(entry.eventType)}
+          </span>
+          <span className="text-xs font-medium text-[#F85149]">
+            {entry.eventType}
+          </span>
+          {entry.toolName && (
+            <span className="text-xs text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
+              {entry.toolName}
+            </span>
+          )}
+        </div>
+        {errorMsg && (
+          <div className="ml-[52px] text-xs text-[#F85149] mt-0.5 line-clamp-2">
+            {errorMsg}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Generic hook event
+  return (
+    <div className="py-0.5 leading-relaxed flex items-center gap-1.5">
+      <span className="text-dark-muted">
+        {formatLocalTime(entry.timestamp)}
+      </span>
+      <span className="text-dark-muted shrink-0">
+        {getEventIcon(entry.eventType)}
+      </span>
+      <span className="text-xs text-dark-text font-medium">
+        {entry.eventType}
+      </span>
+      {entry.toolName && (
+        <span className="text-xs text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
+          {entry.toolName}
+        </span>
+      )}
+      {entry.agentName && (
+        <span className="text-xs text-dark-muted">
+          {entry.agentName}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface UnifiedTimelineProps {
+  teamId: number;
+  teamStatus?: string;
+}
+
+export function UnifiedTimeline({ teamId, teamStatus }: UnifiedTimelineProps) {
+  const api = useApi();
+  const [entries, setEntries] = useState<TimelineEntry[]>([]);
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+
+  // Detect if user has scrolled up — disable auto-scroll in that case
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    // "Stick to bottom" if scrolled within 40px of the bottom
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    stickToBottomRef.current = atBottom;
+  }, []);
+
+  // Poll for timeline data every 2 seconds
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      if (cancelled) return;
+      try {
+        const data = await api.get<TimelineEntry[]>(`teams/${teamId}/timeline?limit=200`);
+        if (!cancelled) {
+          setEntries(data);
+        }
+      } catch {
+        // Ignore polling errors
+      }
+    }
+
+    // Initial fetch
+    poll();
+
+    // Stop polling when team is in a terminal state
+    if (teamStatus === 'done' || teamStatus === 'failed') {
+      return () => { cancelled = true; };
+    }
+
+    const interval = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [api, teamId, teamStatus]);
+
+  // Auto-scroll to bottom when new entries arrive (only if stuck to bottom)
+  useEffect(() => {
+    if (stickToBottomRef.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [entries.length]);
+
+  // Copy full text log to clipboard
+  const handleCopy = useCallback(() => {
+    const lines: string[] = [];
+    for (const entry of entries) {
+      const ts = formatLocalTime(entry.timestamp);
+      if (entry.source === 'stream') {
+        const text = getStreamText(entry);
+        if (text) {
+          const { label } = getStreamStyle(entry.streamType);
+          const subtypeTag = entry.streamType === 'fc' && entry.subtype
+            ? ` [${getSubtypeLabel(entry.subtype)}]`
+            : '';
+          lines.push(`[${ts}] ${label}${subtypeTag}: ${text}`);
+        } else if (entry.streamType === 'tool_use' && entry.tool?.name) {
+          lines.push(`[${ts}] tool: ${entry.tool.name}`);
+        }
+      } else {
+        const hook = entry;
+        let detail = hook.eventType;
+        if (hook.toolName) detail += ` (${hook.toolName})`;
+        if (hook.agentName) detail += ` [${hook.agentName}]`;
+        lines.push(`[${ts}] hook: ${detail}`);
+      }
+    }
+
+    navigator.clipboard.writeText(lines.join('\n')).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      setCopyFailed(true);
+      setTimeout(() => setCopyFailed(false), 2000);
+    });
+  }, [entries]);
+
+  if (entries.length === 0) {
+    const isTerminal = teamStatus === 'done' || teamStatus === 'failed';
+    return (
+      <div className="text-xs text-dark-muted italic py-2">
+        {isTerminal
+          ? 'No session log captured.'
+          : 'No events yet. Events appear when Claude Code is running.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {/* Copy button */}
+      <button
+        onClick={handleCopy}
+        className="absolute top-1.5 right-1.5 z-10 px-2 py-0.5 text-[10px] rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted bg-[#0D1117] transition-colors"
+        title="Copy full log to clipboard"
+      >
+        {copied ? 'Copied!' : copyFailed ? 'Failed' : 'Copy'}
+      </button>
+
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className="font-mono text-xs overflow-y-auto bg-[#0D1117] p-2 rounded border border-dark-border custom-scrollbar"
+      >
+        {entries.map((entry) => {
+          if (entry.source === 'stream') {
+            return <StreamEntryRow key={entry.id} entry={entry} />;
+          }
+          return <HookEntryRow key={entry.id} entry={entry} />;
+        })}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -21,6 +21,7 @@ import { getDatabase } from '../db.js';
 import { sseBroker } from '../services/sse-broker.js';
 import config from '../config.js';
 import type { TeamPhase, IssueDependencyInfo } from '../../shared/types.js';
+import { buildTimeline } from '../utils/build-timeline.js';
 
 // ---------------------------------------------------------------------------
 // Request body / param interfaces
@@ -57,6 +58,10 @@ interface OutputQuerystring {
 
 interface ExportQuerystring {
   format?: string;
+}
+
+interface TimelineQuerystring {
+  limit?: string;
 }
 
 interface SendMessageBody {
@@ -738,6 +743,55 @@ const teamsRoutes: FastifyPluginCallback = (
         return reply.code(200).send(events);
       } catch (err: unknown) {
         request.log.error(err, 'Failed to get team stream events');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // GET /api/teams/:id/timeline — unified timeline (merged stream + hook events)
+  // -------------------------------------------------------------------------
+  fastify.get(
+    '/api/teams/:id/timeline',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams; Querystring: TimelineQuerystring }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseInt(request.params.id, 10);
+        if (isNaN(teamId) || teamId < 1) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Invalid team ID',
+          });
+        }
+
+        const db = getDatabase();
+        const team = db.getTeam(teamId);
+        if (!team) {
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: `Team ${teamId} not found`,
+          });
+        }
+
+        const limitParam = (request.query as TimelineQuerystring).limit;
+        const limit = limitParam ? parseInt(limitParam, 10) : 200;
+
+        // Fetch stream events from in-memory buffer (same as stream-events endpoint)
+        const manager = getTeamManager();
+        const streamEvents = manager.getParsedEvents(teamId);
+
+        // Fetch hook events from DB (no limit — buildTimeline handles it)
+        const hookEvents = db.getEventsByTeam(teamId);
+
+        const timeline = buildTimeline(streamEvents, hookEvents, teamId, limit);
+        return reply.code(200).send(timeline);
+      } catch (err: unknown) {
+        request.log.error(err, 'Failed to get team timeline');
         return reply.code(500).send({
           error: 'Internal Server Error',
           message: err instanceof Error ? err.message : String(err),

--- a/src/server/utils/build-timeline.ts
+++ b/src/server/utils/build-timeline.ts
@@ -1,0 +1,127 @@
+// =============================================================================
+// Fleet Commander — Build Timeline (merge stream + hook events)
+// =============================================================================
+// Server-side utility that combines parsed CC stream events and hook events
+// from the database into a single chronologically-sorted timeline.
+//
+// Deduplication: when a hook ToolUse event matches a stream tool_use event
+// (same tool name within a 10-second window), the hook event is dropped
+// because the stream event carries richer data (input, output, etc.).
+// =============================================================================
+
+import type {
+  StreamTimelineEntry,
+  HookTimelineEntry,
+  TimelineEntry,
+  Event,
+} from '../../shared/types.js';
+
+/** Shape of a parsed stream event from the team manager's in-memory buffer. */
+export interface RawStreamEvent {
+  type: string;
+  timestamp?: string;
+  subtype?: string;
+  message?: { content?: Array<{ type: string; text?: string }> };
+  tool?: { name?: string; input?: unknown };
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** 10-second dedup window in milliseconds */
+const DEDUP_WINDOW_MS = 10_000;
+
+/**
+ * Safely parse an ISO 8601 timestamp string into epoch ms.
+ * Returns 0 for unparseable / missing timestamps so entries still sort.
+ */
+function toEpoch(ts: string | undefined | null): number {
+  if (!ts) return 0;
+  const ms = new Date(ts).getTime();
+  return isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Normalise any ISO-ish timestamp into a consistent ISO 8601 string.
+ * Falls back to current time if the value is missing or unparseable.
+ */
+function normalizeTimestamp(ts: string | undefined | null): string {
+  if (!ts) return new Date().toISOString();
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return new Date().toISOString();
+  return d.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge stream events and hook events into a unified, chronologically-sorted
+ * timeline array.
+ *
+ * @param streamEvents - Parsed NDJSON events from the CC stdout buffer
+ * @param hookEvents   - Hook events from the `events` DB table
+ * @param teamId       - The team these events belong to
+ * @param limit        - Maximum number of entries to return (default 200)
+ */
+export function buildTimeline(
+  streamEvents: RawStreamEvent[],
+  hookEvents: Event[],
+  teamId: number,
+  limit = 200,
+): TimelineEntry[] {
+  // 1. Map stream events to StreamTimelineEntry
+  const streamEntries: StreamTimelineEntry[] = streamEvents.map((e, i) => ({
+    id: `stream-${i}`,
+    source: 'stream' as const,
+    timestamp: normalizeTimestamp(e.timestamp),
+    teamId,
+    streamType: e.type,
+    subtype: e.subtype,
+    message: e.message,
+    tool: e.tool,
+  }));
+
+  // 2. Map hook events to HookTimelineEntry
+  const hookEntries: HookTimelineEntry[] = hookEvents.map((e) => ({
+    id: `event-${e.id}`,
+    source: 'hook' as const,
+    timestamp: normalizeTimestamp(e.createdAt),
+    teamId,
+    eventType: e.eventType,
+    toolName: e.toolName ?? undefined,
+    agentName: e.agentName ?? undefined,
+    payload: e.payload ?? undefined,
+  }));
+
+  // 3. Deduplicate: remove hook ToolUse events that overlap a stream tool_use
+  //    within the same 10-second window and matching tool name.
+  const streamToolUses = streamEntries.filter(
+    (e) => e.streamType === 'tool_use' && e.tool?.name,
+  );
+
+  const dedupedHookEntries = hookEntries.filter((hook) => {
+    if (hook.eventType !== 'ToolUse' || !hook.toolName) return true;
+
+    const hookEpoch = toEpoch(hook.timestamp);
+    return !streamToolUses.some((stream) => {
+      if (stream.tool?.name !== hook.toolName) return false;
+      const streamEpoch = toEpoch(stream.timestamp);
+      return Math.abs(streamEpoch - hookEpoch) <= DEDUP_WINDOW_MS;
+    });
+  });
+
+  // 4. Merge and sort chronologically
+  const merged: TimelineEntry[] = [
+    ...streamEntries,
+    ...dedupedHookEntries,
+  ];
+
+  merged.sort((a, b) => toEpoch(a.timestamp) - toEpoch(b.timestamp));
+
+  // 5. Apply limit
+  return merged.slice(0, limit);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -424,3 +424,36 @@ export interface TeamDetail {
   recentEvents: Event[];
   outputTail: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// Unified Timeline (merged session log + hook events)
+// ---------------------------------------------------------------------------
+
+/** Base fields shared by all timeline entries */
+interface BaseTimelineEntry {
+  id: string;
+  source: 'stream' | 'hook';
+  timestamp: string;
+  teamId: number;
+}
+
+/** A timeline entry originating from the Claude Code stream (stdout) */
+export interface StreamTimelineEntry extends BaseTimelineEntry {
+  source: 'stream';
+  streamType: string;
+  subtype?: string;
+  message?: { content?: Array<{ type: string; text?: string }> };
+  tool?: { name?: string; input?: unknown };
+}
+
+/** A timeline entry originating from a hook event (DB) */
+export interface HookTimelineEntry extends BaseTimelineEntry {
+  source: 'hook';
+  eventType: string;
+  toolName?: string;
+  agentName?: string;
+  payload?: string;
+}
+
+/** Discriminated union of all timeline entry types */
+export type TimelineEntry = StreamTimelineEntry | HookTimelineEntry;

--- a/tests/server/build-timeline.test.ts
+++ b/tests/server/build-timeline.test.ts
@@ -1,0 +1,292 @@
+// =============================================================================
+// Fleet Commander — Build Timeline Tests
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { buildTimeline, type RawStreamEvent } from '../../src/server/utils/build-timeline.js';
+import type { Event } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStreamEvent(overrides: Partial<RawStreamEvent> = {}): RawStreamEvent {
+  return {
+    type: 'assistant',
+    timestamp: '2026-03-20T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeHookEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 1,
+    teamId: 1,
+    eventType: 'ToolUse',
+    sessionId: 'sess-1',
+    toolName: null,
+    agentName: null,
+    payload: null,
+    createdAt: '2026-03-20T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('buildTimeline', () => {
+  it('returns empty array when both inputs are empty', () => {
+    const result = buildTimeline([], [], 1);
+    expect(result).toEqual([]);
+  });
+
+  it('maps stream events to StreamTimelineEntry with correct fields', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'assistant',
+        timestamp: '2026-03-20T10:00:00.000Z',
+        message: { content: [{ type: 'text', text: 'Hello' }] },
+      }),
+    ];
+    const result = buildTimeline(stream, [], 42);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'stream-0',
+      source: 'stream',
+      teamId: 42,
+      streamType: 'assistant',
+    });
+    expect(result[0].timestamp).toContain('2026-03-20');
+  });
+
+  it('maps hook events to HookTimelineEntry with correct fields', () => {
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 7,
+        eventType: 'SessionStart',
+        createdAt: '2026-03-20T10:00:05.000Z',
+        agentName: 'fleet-dev',
+      }),
+    ];
+    const result = buildTimeline([], hooks, 10);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'event-7',
+      source: 'hook',
+      teamId: 10,
+      eventType: 'SessionStart',
+      agentName: 'fleet-dev',
+    });
+  });
+
+  it('sorts entries chronologically', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({ type: 'assistant', timestamp: '2026-03-20T10:00:10.000Z' }),
+      makeStreamEvent({ type: 'user', timestamp: '2026-03-20T10:00:01.000Z' }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({ id: 1, eventType: 'SessionStart', createdAt: '2026-03-20T10:00:05.000Z' }),
+    ];
+
+    const result = buildTimeline(stream, hooks, 1);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe('stream-1');   // 10:00:01
+    expect(result[1].id).toBe('event-1');     // 10:00:05
+    expect(result[2].id).toBe('stream-0');   // 10:00:10
+  });
+
+  it('deduplicates hook ToolUse when stream tool_use has same name within 10s window', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'tool_use',
+        timestamp: '2026-03-20T10:00:05.000Z',
+        tool: { name: 'Read', input: {} },
+      }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 1,
+        eventType: 'ToolUse',
+        toolName: 'Read',
+        createdAt: '2026-03-20T10:00:08.000Z',
+      }),
+    ];
+
+    const result = buildTimeline(stream, hooks, 1);
+
+    // Hook event should be dropped (deduped)
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('stream');
+  });
+
+  it('keeps hook ToolUse when tool names differ', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'tool_use',
+        timestamp: '2026-03-20T10:00:05.000Z',
+        tool: { name: 'Read', input: {} },
+      }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 1,
+        eventType: 'ToolUse',
+        toolName: 'Write',
+        createdAt: '2026-03-20T10:00:08.000Z',
+      }),
+    ];
+
+    const result = buildTimeline(stream, hooks, 1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps hook ToolUse when outside 10s dedup window', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'tool_use',
+        timestamp: '2026-03-20T10:00:00.000Z',
+        tool: { name: 'Read', input: {} },
+      }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 1,
+        eventType: 'ToolUse',
+        toolName: 'Read',
+        createdAt: '2026-03-20T10:00:15.000Z',  // 15s apart — outside window
+      }),
+    ];
+
+    const result = buildTimeline(stream, hooks, 1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not dedup non-ToolUse hook events', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'tool_use',
+        timestamp: '2026-03-20T10:00:05.000Z',
+        tool: { name: 'Read', input: {} },
+      }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 1,
+        eventType: 'SessionStart',
+        toolName: 'Read',
+        createdAt: '2026-03-20T10:00:05.000Z',
+      }),
+    ];
+
+    const result = buildTimeline(stream, hooks, 1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('applies limit parameter', () => {
+    const stream: RawStreamEvent[] = Array.from({ length: 50 }, (_, i) =>
+      makeStreamEvent({
+        type: 'assistant',
+        timestamp: new Date(Date.UTC(2026, 2, 20, 10, 0, i)).toISOString(),
+      }),
+    );
+    const hooks: Event[] = Array.from({ length: 50 }, (_, i) =>
+      makeHookEvent({
+        id: i + 1,
+        eventType: 'SessionStart',
+        createdAt: new Date(Date.UTC(2026, 2, 20, 10, 1, i)).toISOString(),
+      }),
+    );
+
+    const result = buildTimeline(stream, hooks, 1, 30);
+    expect(result).toHaveLength(30);
+  });
+
+  it('defaults limit to 200', () => {
+    const stream: RawStreamEvent[] = Array.from({ length: 150 }, (_, i) =>
+      makeStreamEvent({
+        type: 'assistant',
+        timestamp: new Date(Date.UTC(2026, 2, 20, 10, 0, i)).toISOString(),
+      }),
+    );
+    const hooks: Event[] = Array.from({ length: 100 }, (_, i) =>
+      makeHookEvent({
+        id: i + 1,
+        eventType: 'SessionStart',
+        createdAt: new Date(Date.UTC(2026, 2, 20, 10, 3, i)).toISOString(),
+      }),
+    );
+
+    const result = buildTimeline(stream, hooks, 1);
+    expect(result).toHaveLength(200);
+  });
+
+  it('handles missing timestamps gracefully', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({ type: 'assistant', timestamp: undefined }),
+    ];
+    const hooks: Event[] = [
+      makeHookEvent({ id: 1, eventType: 'SessionStart', createdAt: '2026-03-20T10:00:00.000Z' }),
+    ];
+
+    // Should not throw
+    const result = buildTimeline(stream, hooks, 1);
+    expect(result).toHaveLength(2);
+    // Stream entry with missing timestamp gets current time (will sort after the hook entry)
+    expect(result.every((e) => e.timestamp)).toBe(true);
+  });
+
+  it('normalises hook createdAt to ISO 8601', () => {
+    const hooks: Event[] = [
+      makeHookEvent({ id: 1, eventType: 'SessionStart', createdAt: '2026-03-20T10:00:00Z' }),
+    ];
+
+    const result = buildTimeline([], hooks, 1);
+    expect(result[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('preserves stream event subtype and message fields', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'fc',
+        subtype: 'idle_nudge',
+        timestamp: '2026-03-20T10:00:00.000Z',
+        message: { content: [{ type: 'text', text: 'Wake up!' }] },
+      }),
+    ];
+
+    const result = buildTimeline(stream, [], 1);
+    expect(result).toHaveLength(1);
+
+    const entry = result[0] as { source: 'stream'; streamType: string; subtype?: string; message?: unknown };
+    expect(entry.streamType).toBe('fc');
+    expect(entry.subtype).toBe('idle_nudge');
+    expect(entry.message).toEqual({ content: [{ type: 'text', text: 'Wake up!' }] });
+  });
+
+  it('preserves hook event payload and agentName', () => {
+    const hooks: Event[] = [
+      makeHookEvent({
+        id: 1,
+        eventType: 'ToolError',
+        toolName: 'Bash',
+        agentName: 'fleet-dev',
+        payload: '{"error":"command failed"}',
+        createdAt: '2026-03-20T10:00:00.000Z',
+      }),
+    ];
+
+    const result = buildTimeline([], hooks, 1);
+    expect(result).toHaveLength(1);
+
+    const entry = result[0] as { source: 'hook'; eventType: string; toolName?: string; agentName?: string; payload?: string };
+    expect(entry.eventType).toBe('ToolError');
+    expect(entry.toolName).toBe('Bash');
+    expect(entry.agentName).toBe('fleet-dev');
+    expect(entry.payload).toBe('{"error":"command failed"}');
+  });
+});


### PR DESCRIPTION
Closes #240

## Summary
- Replaces the separate "Session Log" and "Events" tabs in TeamDetail with a **single unified timeline** that interleaves CC output messages with hook events chronologically
- New `TimelineEntry` discriminated union type (`StreamTimelineEntry` | `HookTimelineEntry`) in shared types
- Server-side `buildTimeline()` utility merges stream + hook events, deduplicates overlapping ToolUse within a 10-second fingerprint window, sorts chronologically
- New `GET /api/teams/:id/timeline?limit=200` endpoint
- New `UnifiedTimeline.tsx` component with stick-to-bottom auto-scroll and copy-log button
- TeamDetail reduced from 3 tabs to 2 (Session Log + Team)

## Test plan
- [ ] 14 unit tests for `buildTimeline()` merge/dedup logic pass
- [ ] Build succeeds (`npm run build`)
- [ ] Verify unified timeline renders stream messages (assistant, user, fc) alongside hook events (SubagentStart, SessionStart, etc.)
- [ ] Verify auto-scroll sticks to bottom for new events but allows manual scroll-up
- [ ] Verify copy button exports full log
- [ ] Verify ToolUse dedup: stream tool_use preferred over hook ToolUse when within 10s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)