### PR TITLE
Issue #257: fix CC query structured data failures

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -67,6 +67,8 @@ const config = Object.freeze({
   ccQueryModel: process.env['FLEET_CC_QUERY_MODEL'] || 'sonnet',
   ccQueryTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_TIMEOUT_MS'] || '30000', 'FLEET_CC_QUERY_TIMEOUT_MS'),
   ccQueryPrioritizeTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'] || '60000', 'FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'),
+  ccQueryMaxRetries: safeParseInt(process.env['FLEET_CC_QUERY_MAX_RETRIES'] || '2', 'FLEET_CC_QUERY_MAX_RETRIES'),
+  ccQueryMaxTurns: safeParseInt(process.env['FLEET_CC_QUERY_MAX_TURNS'] || '4', 'FLEET_CC_QUERY_MAX_TURNS'),
 
   outputBufferLines: 500,
   sseHeartbeatMs: 30000,
@@ -96,6 +98,7 @@ export function validateConfig(): void {
     ['mergeShutdownGraceMs', config.mergeShutdownGraceMs],
     ['earlyCrashThresholdSec', config.earlyCrashThresholdSec],
     ['earlyCrashMinTools', config.earlyCrashMinTools],
+    ['ccQueryMaxTurns', config.ccQueryMaxTurns],
   ];
   for (const [name, value] of positiveIntegers) {
     if (isNaN(value) || value <= 0) {
@@ -106,6 +109,7 @@ export function validateConfig(): void {
   const nonNegativeIntegers: Array<[string, number]> = [
     ['idleThresholdMin', config.idleThresholdMin],
     ['stuckThresholdMin', config.stuckThresholdMin],
+    ['ccQueryMaxRetries', config.ccQueryMaxRetries],
   ];
   for (const [name, value] of nonNegativeIntegers) {
     if (isNaN(value) || value < 0) {

--- a/src/server/services/cc-query.ts
+++ b/src/server/services/cc-query.ts
@@ -7,6 +7,7 @@
 // =============================================================================
 
 import { spawn } from 'child_process';
+import os from 'os';
 import config from '../config.js';
 import { resolveClaudePath } from '../utils/resolve-claude-path.js';
 import { findGitBash } from '../utils/find-git-bash.js';
@@ -83,7 +84,40 @@ export class CCQueryService {
   // -------------------------------------------------------------------------
 
   private execute<T>(opts: ExecuteOptions<T>): Promise<CCQueryResult<T>> {
-    return this.enqueue(() => this._executeImpl<T>(opts));
+    return this.enqueue(() => this._executeWithRetry<T>(opts));
+  }
+
+  private async _executeWithRetry<T>(opts: ExecuteOptions<T>): Promise<CCQueryResult<T>> {
+    const maxRetries = config.ccQueryMaxRetries;
+    let lastResult: CCQueryResult<T> | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const result = await this._executeImpl<T>(opts);
+
+      // Success — return immediately
+      if (result.success) {
+        return result;
+      }
+
+      lastResult = result;
+
+      // Only retry transient "no structured data" failures:
+      // - Must be exit code 0 (no non-zero exit, no spawn error, no timeout)
+      // - Error must start with "CC returned no structured data"
+      const isTransient =
+        !!result.error?.startsWith('CC returned no structured data');
+
+      if (!isTransient || attempt >= maxRetries) {
+        break;
+      }
+
+      console.warn(
+        `[CCQuery] Transient failure (attempt ${attempt + 1}/${maxRetries + 1}), retrying in 1.5s: ${result.error}`,
+      );
+      await new Promise((r) => setTimeout(r, 1500));
+    }
+
+    return lastResult!;
   }
 
   private _executeImpl<T>(opts: ExecuteOptions<T>): Promise<CCQueryResult<T>> {
@@ -95,7 +129,7 @@ export class CCQueryService {
         '-p', opts.prompt,
         '--output-format', 'json',
         '--no-session-persistence',
-        '--max-turns', '2',
+        '--max-turns', String(config.ccQueryMaxTurns),
         '--model', config.ccQueryModel,
         '--tools', '',
         '--strict-mcp-config',
@@ -110,7 +144,8 @@ export class CCQueryService {
       }
 
       const child = spawn(claudePath, args, {
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: os.tmpdir(),
         windowsHide: true,
         env: spawnEnv,
       });
@@ -169,9 +204,14 @@ export class CCQueryService {
           return;
         }
 
+        // Defense-in-depth: strip non-JSON prefix lines before parsing.
+        // CC may emit warnings or debug text before the JSON payload.
+        const jsonStart = stdout.indexOf('{');
+        const cleanStdout = jsonStart >= 0 ? stdout.substring(jsonStart) : stdout;
+
         // Parse the JSON output from CC
         try {
-          const parsed = JSON.parse(stdout);
+          const parsed = JSON.parse(cleanStdout);
           // CC --output-format json returns total_cost_usd (not cost_usd)
           const costUsd = parsed.total_cost_usd ?? 0;
 
@@ -192,8 +232,13 @@ export class CCQueryService {
           const textValue = typeof resultText === 'string' ? resultText : JSON.stringify(resultText);
 
           if (data === undefined) {
+            // Include diagnostic details: subtype, stop_reason, and raw stdout snippet
+            const subtype = parsed.subtype ?? 'unknown';
+            const stopReason = parsed.stop_reason ?? 'unknown';
             console.warn(
-              `[CCQuery] CC exited 0 but returned no structured data. stdout: ${stdout.substring(0, 500)}`,
+              `[CCQuery] CC exited 0 but returned no structured data.`,
+              `subtype=${subtype} stop_reason=${stopReason}`,
+              `stdout (first 200): ${stdout.substring(0, 200)}`,
               stderr ? `stderr: ${stderr.substring(0, 500)}` : '',
             );
             resolve({
@@ -201,7 +246,7 @@ export class CCQueryService {
               text: textValue,
               costUsd: typeof costUsd === 'number' ? costUsd : 0,
               durationMs: parsed.duration_ms ?? durationMs,
-              error: 'CC returned no structured data',
+              error: `CC returned no structured data (subtype=${subtype}, stop_reason=${stopReason}, stdout=${stdout.substring(0, 200)})`,
             });
           } else {
             resolve({
@@ -213,9 +258,10 @@ export class CCQueryService {
             });
           }
         } catch {
-          // stdout was not valid JSON — return as text
+          // stdout was not valid JSON — return as text with diagnostic snippet
           console.warn(
-            `[CCQuery] CC exited 0 but stdout was not valid JSON. stdout: ${stdout.substring(0, 500)}`,
+            `[CCQuery] CC exited 0 but stdout was not valid JSON.`,
+            `stdout (first 200): ${stdout.substring(0, 200)}`,
             stderr ? `stderr: ${stderr.substring(0, 500)}` : '',
           );
           resolve({
@@ -223,7 +269,7 @@ export class CCQueryService {
             text: stdout.trim(),
             costUsd: 0,
             durationMs,
-            error: 'CC returned no structured data',
+            error: `CC returned no structured data (stdout=${stdout.substring(0, 200)})`,
           });
         }
       });
@@ -237,9 +283,6 @@ export class CCQueryService {
           error: `Failed to spawn CC: ${err.message}`,
         });
       });
-
-      // Close stdin immediately — -p mode reads from args, not stdin
-      child.stdin?.end();
     });
   }
 

--- a/tests/server/cc-query.test.ts
+++ b/tests/server/cc-query.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
+import os from 'os';
 import type { ChildProcess } from 'child_process';
 
 // ---------------------------------------------------------------------------
@@ -21,6 +22,8 @@ vi.mock('../../src/server/config.js', () => ({
     ccQueryModel: 'claude-sonnet-4-20250514',
     ccQueryTimeoutMs: 60000,
     ccQueryPrioritizeTimeoutMs: 60000,
+    ccQueryMaxRetries: 2,
+    ccQueryMaxTurns: 4,
   },
 }));
 
@@ -39,7 +42,6 @@ vi.mock('../../src/server/utils/find-git-bash.js', () => ({
 interface MockChild extends EventEmitter {
   stdout: EventEmitter;
   stderr: EventEmitter;
-  stdin: { end: ReturnType<typeof vi.fn> };
   pid: number;
   kill: ReturnType<typeof vi.fn>;
 }
@@ -48,7 +50,6 @@ function createMockChild(): MockChild {
   const child = new EventEmitter() as MockChild;
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
-  child.stdin = { end: vi.fn() };
   child.pid = 12345;
   child.kill = vi.fn();
   return child;
@@ -57,6 +58,34 @@ function createMockChild(): MockChild {
 function emitStdoutAndClose(child: MockChild, stdout: string, code = 0): void {
   child.stdout.emit('data', Buffer.from(stdout));
   child.emit('close', code);
+}
+
+/**
+ * Set up mockSpawn to return a fresh child for each call, and automatically
+ * emit the given stdout + close with the given exit code after a short delay.
+ * Returns the list of created children for inspection.
+ */
+function mockSpawnWithAutoResponse(
+  stdout: string,
+  code = 0,
+  maxCalls = 5,
+): MockChild[] {
+  const children: MockChild[] = [];
+  mockSpawn.mockImplementation(() => {
+    const child = createMockChild();
+    children.push(child);
+    // Emit response asynchronously so the caller can set up listeners first
+    setImmediate(() => {
+      if (code !== 0) {
+        child.stderr.emit('data', Buffer.from(stdout));
+        child.emit('close', code);
+      } else {
+        emitStdoutAndClose(child, stdout, code);
+      }
+    });
+    return child;
+  });
+  return children;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +106,91 @@ describe('CCQueryService', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('spawn options', () => {
+    it('spawns with stdio: [ignore, pipe, pipe] (no stdin pipe)', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          complexity: 'low',
+          estimatedHours: 1,
+          reason: 'Test',
+          risks: [],
+        },
+        total_cost_usd: 0.01,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+      await resultPromise;
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const spawnOpts = spawnCall[2];
+      expect(spawnOpts.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+    });
+
+    it('spawns with cwd set to os.tmpdir()', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          complexity: 'low',
+          estimatedHours: 1,
+          reason: 'Test',
+          risks: [],
+        },
+        total_cost_usd: 0.01,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+      await resultPromise;
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const spawnOpts = spawnCall[2];
+      expect(spawnOpts.cwd).toBe(os.tmpdir());
+    });
+
+    it('uses config ccQueryMaxTurns for --max-turns arg', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          complexity: 'low',
+          estimatedHours: 1,
+          reason: 'Test',
+          risks: [],
+        },
+        total_cost_usd: 0.01,
+      });
+
+      emitStdoutAndClose(child, ccResponse);
+      await resultPromise;
+
+      const spawnCall = mockSpawn.mock.calls[0];
+      const args: string[] = spawnCall[1];
+      const maxTurnsIdx = args.indexOf('--max-turns');
+      expect(maxTurnsIdx).toBeGreaterThan(-1);
+      expect(args[maxTurnsIdx + 1]).toBe('4');
+    });
   });
 
   describe('structured_output parsing', () => {
@@ -145,26 +259,22 @@ describe('CCQueryService', () => {
     });
 
     it('returns success:false when result is empty and no structured_output', async () => {
-      const child = createMockChild();
-      mockSpawn.mockReturnValue(child);
-
-      const service = CCQueryService.getInstance();
-      const resultPromise = service.estimateComplexity('Fix bug', 'Body');
-
-      const ccResponse = JSON.stringify({
+      const failResponse = JSON.stringify({
         type: 'result',
         result: '',
         total_cost_usd: 0.01,
       });
 
-      emitStdoutAndClose(child, ccResponse);
+      // Auto-respond for all retry attempts
+      mockSpawnWithAutoResponse(failResponse);
 
-      const result = await resultPromise;
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Fix bug', 'Body');
 
       expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
-      expect(result.error).toBe('CC returned no structured data');
-    });
+      expect(result.error).toContain('CC returned no structured data');
+    }, 15000);
   });
 
   describe('cost field parsing', () => {
@@ -263,41 +373,228 @@ describe('CCQueryService', () => {
     });
 
     it('returns success:false when stdout is not valid JSON', async () => {
-      const child = createMockChild();
-      mockSpawn.mockReturnValue(child);
+      // Use auto-response since retries will fire for this transient failure
+      mockSpawnWithAutoResponse('Not valid JSON at all');
 
       const service = CCQueryService.getInstance();
-      const resultPromise = service.estimateComplexity('Test', 'Body');
+      const result = await service.estimateComplexity('Test', 'Body');
 
-      emitStdoutAndClose(child, 'Not valid JSON at all');
-
-      const result = await resultPromise;
       expect(result.success).toBe(false);
       expect(result.text).toBe('Not valid JSON at all');
       expect(result.data).toBeUndefined();
-      expect(result.error).toBe('CC returned no structured data');
-    });
+      expect(result.error).toContain('CC returned no structured data');
+    }, 15000);
 
     it('returns success:false when CC returns JSON without structured_output', async () => {
-      const child = createMockChild();
-      mockSpawn.mockReturnValue(child);
-
-      const service = CCQueryService.getInstance();
-      const resultPromise = service.estimateComplexity('Test', 'Body');
-
-      const ccResponse = JSON.stringify({
+      const failResponse = JSON.stringify({
         type: 'result',
         result: 'Some plain text response',
         total_cost_usd: 0.02,
       });
 
-      emitStdoutAndClose(child, ccResponse);
+      mockSpawnWithAutoResponse(failResponse);
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('CC returned no structured data');
+      expect(result.text).toBe('Some plain text response');
+    }, 15000);
+  });
+
+  describe('JSON prefix stripping', () => {
+    it('strips non-JSON prefix lines before parsing', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      const jsonPayload = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          complexity: 'medium',
+          estimatedHours: 3,
+          reason: 'Moderate complexity',
+          risks: ['risk1'],
+        },
+        total_cost_usd: 0.05,
+      });
+
+      // Simulate CC emitting warning text before the JSON
+      const stdoutWithPrefix = 'Warning: some debug output\nAnother line\n' + jsonPayload;
+
+      emitStdoutAndClose(child, stdoutWithPrefix);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        complexity: 'medium',
+        estimatedHours: 3,
+        reason: 'Moderate complexity',
+        risks: ['risk1'],
+      });
+    });
+
+    it('handles stdout that is entirely non-JSON (no brace found)', async () => {
+      mockSpawnWithAutoResponse('Just plain text with no JSON');
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('CC returned no structured data');
+    }, 15000);
+  });
+
+  describe('retry logic', () => {
+    it('retries on transient "no structured data" failure and succeeds', async () => {
+      const failResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        total_cost_usd: 0.01,
+      });
+
+      const successResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        structured_output: {
+          complexity: 'high',
+          estimatedHours: 8,
+          reason: 'Complex',
+          risks: ['many risks'],
+        },
+        total_cost_usd: 0.03,
+      });
+
+      let callCount = 0;
+      mockSpawn.mockImplementation(() => {
+        callCount++;
+        const child = createMockChild();
+        setImmediate(() => {
+          if (callCount === 1) {
+            emitStdoutAndClose(child, failResponse);
+          } else {
+            emitStdoutAndClose(child, successResponse);
+          }
+        });
+        return child;
+      });
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        complexity: 'high',
+        estimatedHours: 8,
+        reason: 'Complex',
+        risks: ['many risks'],
+      });
+      expect(callCount).toBe(2);
+    }, 15000);
+
+    it('does NOT retry on non-zero exit code', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      child.stderr.emit('data', Buffer.from('error'));
+      child.emit('close', 1);
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toBe('CC returned no structured data');
-      expect(result.text).toBe('Some plain text response');
+      expect(result.error).toContain('CC exited with code 1');
+      // Should only have spawned once — no retry on non-zero exit
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
     });
+
+    it('does NOT retry on spawn errors', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const service = CCQueryService.getInstance();
+      const resultPromise = service.estimateComplexity('Test', 'Body');
+
+      // Simulate spawn error
+      child.emit('error', new Error('ENOENT'));
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to spawn CC');
+      // Should only have spawned once — no retry on spawn error
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts retries and returns last failure', async () => {
+      const failResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        total_cost_usd: 0.01,
+      });
+
+      const children = mockSpawnWithAutoResponse(failResponse);
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('CC returned no structured data');
+      // 1 initial + 2 retries = 3 total
+      expect(mockSpawn).toHaveBeenCalledTimes(3);
+    }, 15000);
+  });
+
+  describe('improved error diagnostics', () => {
+    it('includes subtype and stop_reason in error for no structured data', async () => {
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        subtype: 'max_turns',
+        stop_reason: 'max_turns_reached',
+        result: 'Some text but no structured output',
+        total_cost_usd: 0.02,
+      });
+
+      mockSpawnWithAutoResponse(ccResponse);
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('subtype=max_turns');
+      expect(result.error).toContain('stop_reason=max_turns_reached');
+    }, 15000);
+
+    it('includes stdout snippet in error message', async () => {
+      const ccResponse = JSON.stringify({
+        type: 'result',
+        result: '',
+        total_cost_usd: 0.01,
+      });
+
+      mockSpawnWithAutoResponse(ccResponse);
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('stdout=');
+    }, 15000);
+
+    it('includes stdout snippet in error when JSON parsing fails', async () => {
+      mockSpawnWithAutoResponse('Completely invalid output');
+
+      const service = CCQueryService.getInstance();
+      const result = await service.estimateComplexity('Test', 'Body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('stdout=');
+      expect(result.error).toContain('Completely invalid output');
+    }, 15000);
   });
 
   describe('prioritizeIssues items guard', () => {


### PR DESCRIPTION
Closes #257

## Summary
- **stdio fix**: Changed spawn stdio from `['pipe','pipe','pipe']` to `['ignore','pipe','pipe']` to prevent CC stdin warning corrupting JSON output
- **cwd isolation**: Added `cwd: os.tmpdir()` so CC doesn't inherit Fleet Commander's working directory (CLAUDE.md, hooks, plugins)
- **max-turns headroom**: Increased `--max-turns` from hardcoded `2` to configurable `4` (env `FLEET_CC_QUERY_MAX_TURNS`) giving structured output enough room
- **Retry logic**: New `_executeWithRetry` wrapper retries transient "no structured data" failures (configurable via `FLEET_CC_QUERY_MAX_RETRIES`, default 2)
- **JSON prefix stripping**: Defense-in-depth parsing strips non-JSON prefix before `JSON.parse`
- **Better diagnostics**: Error messages now include CC subtype, stop_reason, and first 200 chars of raw stdout

## Test plan
- [x] Expanded test suite from 14 to 24 tests covering all new behavior
- [x] Tests verify spawn options (stdio, cwd, max-turns)
- [x] Tests verify JSON prefix stripping
- [x] Tests verify retry logic (success after retry, no retry on errors, retry exhaustion)
- [x] Tests verify improved error diagnostics
- [ ] Manual test: trigger prioritization on Issue Tree view

🤖 Generated with [Claude Code](https://claude.com/claude-code)