### PR TITLE
Issue #261: remove Open PR and Wrap Up quick action buttons

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -655,9 +655,7 @@ export function TeamDetail() {
                   <span className="text-xs text-dark-muted mr-1">Quick:</span>
                   {[
                     { id: 'nudge_progress', label: 'Status?', color: '#58A6FF' },
-                    { id: 'ask_for_pr', label: 'Open PR', color: '#3FB950' },
                     { id: 'check_ci', label: 'Fix CI', color: '#F85149', show: !!detail?.prNumber },
-                    { id: 'wrap_up', label: 'Wrap Up', color: '#D29922' },
                   ].filter(a => a.show !== false).map((action) => (
                     <button
                       key={action.id}

--- a/src/client/views/StateMachinePage.tsx
+++ b/src/client/views/StateMachinePage.tsx
@@ -40,9 +40,7 @@ const PM_MESSAGE_CARDS: Array<{
   { id: 'ci_blocked', eventName: 'CI Blocked', description: 'When CI failure count exceeds threshold' },
   { id: 'stuck_nudge', eventName: 'Stuck Nudge', description: 'When a team has been idle too long' },
   { id: 'nudge_progress', eventName: 'Nudge Progress', description: 'Ask TL for a status update' },
-  { id: 'ask_for_pr', eventName: 'Ask for PR', description: 'Request TL to open a pull request' },
   { id: 'check_ci', eventName: 'Check CI', description: 'Tell TL to fix failing CI' },
-  { id: 'wrap_up', eventName: 'Wrap Up', description: 'Tell TL to finish and push' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -322,6 +322,9 @@ export class FleetDatabase {
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
 
+    // Remove obsolete ask_for_pr and wrap_up message templates (#261)
+    this.removeObsoleteMessageTemplates();
+
     // Resolve schema.sql relative to this file.
     // In dev (tsx): __dirname is src/server
     // In compiled (node): __dirname is dist/server/server
@@ -652,6 +655,23 @@ export class FleetDatabase {
       ).run();
       if (result.changes > 0) {
         console.log(`[DB] Migrated ${result.changes} paused project(s) to active`);
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
+   * Remove obsolete ask_for_pr and wrap_up message templates.
+   * These quick-action templates were removed in issue #261.
+   */
+  private removeObsoleteMessageTemplates(): void {
+    try {
+      const result = this.db.prepare(
+        "DELETE FROM message_templates WHERE id IN ('ask_for_pr', 'wrap_up')"
+      ).run();
+      if (result.changes > 0) {
+        console.log(`[DB] Removed ${result.changes} obsolete message template(s) (ask_for_pr, wrap_up)`);
       }
     } catch {
       // Table may not exist yet (fresh database) — schema.sql will create it

--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -72,21 +72,9 @@ export const DEFAULT_MESSAGE_TEMPLATES: DefaultMessageTemplate[] = [
     placeholders: ['ISSUE_NUMBER'],
   },
   {
-    id: 'ask_for_pr',
-    template: 'Please open a PR with your current changes for issue #{{ISSUE_NUMBER}}. Push what you have.',
-    description: 'Ask TL to create a pull request',
-    placeholders: ['ISSUE_NUMBER'],
-  },
-  {
     id: 'check_ci',
     template: 'CI is failing on PR #{{PR_NUMBER}}. Check the failing tests and fix them.',
     description: 'Tell TL to investigate CI failures',
     placeholders: ['PR_NUMBER'],
-  },
-  {
-    id: 'wrap_up',
-    template: 'Wrap up your work on issue #{{ISSUE_NUMBER}}. Commit all changes, push, and open a PR if not already done.',
-    description: 'Tell TL to finish up and create PR',
-    placeholders: ['ISSUE_NUMBER'],
   },
 ];


### PR DESCRIPTION
Closes #261

## Summary
- Removed `ask_for_pr` (Open PR) and `wrap_up` (Wrap Up) quick action buttons from TeamDetail slide-over panel
- Removed corresponding template definitions from `DEFAULT_MESSAGE_TEMPLATES`
- Removed corresponding PM message cards from StateMachinePage
- Added DB migration to clean up orphaned rows from existing databases

## What stays
- `nudge_progress` (Status?) and `check_ci` (Fix CI) buttons remain
- `handleQuickAction()` function and related state remain
- All automated templates (`ci_green`, `ci_red`, `pr_merged`, etc.) untouched

## Files changed
- `src/client/components/TeamDetail.tsx` — removed 2 button entries
- `src/shared/message-templates.ts` — removed 2 template definitions
- `src/client/views/StateMachinePage.tsx` — removed 2 PM message cards
- `src/server/db.ts` — added `removeObsoleteMessageTemplates()` migration