### PR TITLE
Issue #263: fix FLEET_CLAUDE_CMD inconsistent usage across spawn paths

### DIFF
--- a/src/client/views/SettingsPage.tsx
+++ b/src/client/views/SettingsPage.tsx
@@ -21,6 +21,7 @@ interface SettingsResponse {
   sseHeartbeatMs: number;
   outputBufferLines: number;
   claudeCmd: string;
+  resolvedClaudeCmd: string;
   enableAgentTeams: boolean;
   fleetCommanderRoot: string;
   dbPath: string;
@@ -71,6 +72,12 @@ const SETTING_GROUPS: SettingGroup[] = [
         label: 'Claude Command',
         envVar: 'FLEET_CLAUDE_CMD',
         description: 'CLI command used to invoke Claude',
+      },
+      {
+        key: 'resolvedClaudeCmd',
+        label: 'Resolved Claude Path',
+        envVar: '(auto-detected)',
+        description: 'Actual path used after auto-detection (Windows) or explicit override',
       },
       {
         key: 'enableAgentTeams',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import { getDatabase, closeDatabase } from './db.js';
 import { recoverOnStartup } from './services/startup-recovery.js';
 import { usagePoller } from './services/usage-tracker.js';
 import config from './config.js';
+import { resolveClaudePath } from './utils/resolve-claude-path.js';
 import { DEFAULT_MESSAGE_TEMPLATES } from '../shared/message-templates.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -91,7 +92,8 @@ async function main() {
   try {
     server.log.info(`Agent Teams: ${config.enableAgentTeams ? 'enabled' : 'disabled'} (FLEET_ENABLE_AGENT_TEAMS)`);
 
-    const versionOutput = execSync(`${config.claudeCmd} --version`, {
+    const claudePath = resolveClaudePath();
+    const versionOutput = execSync(`"${claudePath}" --version`, {
       encoding: 'utf-8',
       timeout: 10000,
     }).trim();

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -20,6 +20,7 @@ import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
 import { getIssueFetcher } from '../services/issue-fetcher.js';
 import { uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
+import { resolveClaudePath } from '../utils/resolve-claude-path.js';
 
 // ---------------------------------------------------------------------------
 // Server start time (captured at module load)
@@ -295,6 +296,7 @@ const systemRoutes: FastifyPluginCallback = (
           sseHeartbeatMs: config.sseHeartbeatMs,
           outputBufferLines: config.outputBufferLines,
           claudeCmd: config.claudeCmd,
+          resolvedClaudeCmd: resolveClaudePath(),
           enableAgentTeams: config.enableAgentTeams,
           fleetCommanderRoot: config.fleetCommanderRoot,
           dbPath: config.dbPath,

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1333,7 +1333,8 @@ export class TeamManager {
     });
 
     const spawnEnv = this.buildSpawnEnv(project, team.worktreeName, team.projectId!);
-    const fullCmd = `${config.claudeCmd} ${args.join(' ')}`;
+    const claudePath = resolveClaudePath();
+    const fullCmd = `${claudePath} ${args.join(' ')}`;
     const windowTitle = `Team ${team.worktreeName}`;
 
     // Build env set commands dynamically from buildSpawnEnv()

--- a/src/server/utils/resolve-claude-path.ts
+++ b/src/server/utils/resolve-claude-path.ts
@@ -16,6 +16,14 @@ let _resolvedClaudePath: string | null = null;
 export function resolveClaudePath(): string {
   if (_resolvedClaudePath) return _resolvedClaudePath;
 
+  // If the user explicitly set FLEET_CLAUDE_CMD to something other than the
+  // default 'claude', honour it directly — skip auto-detection entirely.
+  if (config.claudeCmd !== 'claude') {
+    _resolvedClaudePath = config.claudeCmd;
+    console.log(`[resolveClaudePath] Using explicit FLEET_CLAUDE_CMD: ${_resolvedClaudePath}`);
+    return _resolvedClaudePath;
+  }
+
   if (process.platform === 'win32') {
     try {
       const result = execSync('where claude.exe', {
@@ -53,4 +61,9 @@ export function resolveClaudePath(): string {
   _resolvedClaudePath = config.claudeCmd;
   console.log(`[resolveClaudePath] Using claude command: ${_resolvedClaudePath}`);
   return _resolvedClaudePath;
+}
+
+/** Reset the cached path — exposed only for unit tests. */
+export function _resetForTesting(): void {
+  _resolvedClaudePath = null;
 }

--- a/tests/server/resolve-claude-path.test.ts
+++ b/tests/server/resolve-claude-path.test.ts
@@ -1,0 +1,197 @@
+// =============================================================================
+// Fleet Commander — resolveClaudePath unit tests
+// =============================================================================
+// Verifies that resolveClaudePath() correctly handles:
+// - Explicit FLEET_CLAUDE_CMD override (bypasses auto-detection)
+// - Windows auto-detection via `where` when default is in use
+// - Non-Windows fallback to 'claude' as-is
+// - _resetForTesting() clears the cached path
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock modules before importing resolveClaudePath
+// ---------------------------------------------------------------------------
+
+const mockConfig = vi.hoisted(() => ({
+  claudeCmd: 'claude',
+}));
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/server/config.js', () => ({
+  default: mockConfig,
+}));
+
+vi.mock('child_process', () => ({
+  execSync: mockExecSync,
+}));
+
+import { resolveClaudePath, _resetForTesting } from '../../src/server/utils/resolve-claude-path.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('resolveClaudePath', () => {
+  beforeEach(() => {
+    _resetForTesting();
+    mockConfig.claudeCmd = 'claude';
+    mockExecSync.mockReset();
+  });
+
+  // -------------------------------------------------------------------------
+  // Explicit override
+  // -------------------------------------------------------------------------
+
+  it('returns explicit FLEET_CLAUDE_CMD without running auto-detection', () => {
+    mockConfig.claudeCmd = '/opt/custom/claude-special';
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('/opt/custom/claude-special');
+    // Should NOT have called execSync for `where`
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit Windows path without running auto-detection', () => {
+    mockConfig.claudeCmd = 'C:\\Program Files\\Claude\\claude.exe';
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('C:\\Program Files\\Claude\\claude.exe');
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Windows auto-detection
+  // -------------------------------------------------------------------------
+
+  it('runs where auto-detection on Windows when default is in use', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockReturnValueOnce('C:\\Users\\me\\AppData\\Local\\npm\\claude.exe\r\n');
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('C:\\Users\\me\\AppData\\Local\\npm\\claude.exe');
+    expect(mockExecSync).toHaveBeenCalledWith('where claude.exe', expect.objectContaining({
+      encoding: 'utf-8',
+      timeout: 5000,
+    }));
+
+    // Restore platform
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('falls back to where claude (no .exe) if where claude.exe fails on Windows', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    // First call (where claude.exe) fails
+    mockExecSync.mockImplementationOnce(() => { throw new Error('not found'); });
+    // Second call (where claude) succeeds
+    mockExecSync.mockReturnValueOnce('C:\\tools\\claude.cmd\r\n');
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('C:\\tools\\claude.cmd');
+    expect(mockExecSync).toHaveBeenCalledTimes(2);
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('falls back to config.claudeCmd if both where calls fail on Windows', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('claude');
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-Windows fallback
+  // -------------------------------------------------------------------------
+
+  it('returns claude as-is on non-Windows without calling where', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const result = resolveClaudePath();
+
+    expect(result).toBe('claude');
+    expect(mockExecSync).not.toHaveBeenCalled();
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Caching + _resetForTesting
+  // -------------------------------------------------------------------------
+
+  it('caches the resolved path on subsequent calls', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockReturnValueOnce('C:\\cached\\claude.exe\r\n');
+
+    const first = resolveClaudePath();
+    const second = resolveClaudePath();
+
+    expect(first).toBe('C:\\cached\\claude.exe');
+    expect(second).toBe('C:\\cached\\claude.exe');
+    // execSync should only have been called once (cached on second call)
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('_resetForTesting clears the cached path', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockReturnValueOnce('C:\\first\\claude.exe\r\n');
+    resolveClaudePath();
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+
+    _resetForTesting();
+
+    mockExecSync.mockReturnValueOnce('C:\\second\\claude.exe\r\n');
+    const result = resolveClaudePath();
+
+    expect(result).toBe('C:\\second\\claude.exe');
+    expect(mockExecSync).toHaveBeenCalledTimes(2);
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('caches explicit override and returns it on subsequent calls', () => {
+    mockConfig.claudeCmd = '/custom/claude';
+
+    const first = resolveClaudePath();
+    const second = resolveClaudePath();
+
+    expect(first).toBe('/custom/claude');
+    expect(second).toBe('/custom/claude');
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #263

## Summary
- `resolveClaudePath()` now honors explicit `FLEET_CLAUDE_CMD` — if set to a non-default value, it skips Windows `where` auto-detection and uses the configured path directly
- Interactive spawn path (`launchInteractive()`) now uses `resolveClaudePath()` instead of `config.claudeCmd` directly, ensuring consistent behavior across all spawn paths
- Startup `--version` check uses `resolveClaudePath()` for consistency
- `/api/settings` response now includes `resolvedClaudeCmd` so users can see both configured and resolved values
- Settings UI displays the resolved Claude path below the configured command
- 9 new unit tests covering explicit override, Windows auto-detection, non-Windows fallback, and cache reset

## Test plan
- [ ] Verify `resolveClaudePath()` returns explicit path when `FLEET_CLAUDE_CMD` is set to non-default
- [ ] Verify auto-detection still works when `FLEET_CLAUDE_CMD` is default (`claude`)
- [ ] Verify interactive and headless spawns use the same resolved path
- [ ] Verify Settings page shows both configured and resolved Claude paths
- [ ] Run `npm test` — all tests pass including 9 new resolve-claude-path tests