### PR TITLE
Issue #264: fix vitest config to run .tsx client test files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
-    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+    include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.test.{ts,tsx}'],
     environment: 'node',
+    environmentMatchGlobs: [
+      ['tests/client/**', 'jsdom'],
+    ],
+    globals: true,
   },
 });


### PR DESCRIPTION
Closes #264

## Summary

- Fixed vitest configuration bug where `.tsx` test files were silently never executed
- Expanded include patterns from `*.test.ts` to `*.test.{ts,tsx}`
- Added `@vitejs/plugin-react` plugin for JSX transform in test environment
- Added `environmentMatchGlobs` for jsdom environment in client tests
- Enabled `globals: true` for `@testing-library/jest-dom` compatibility

This ensures all 23 Issue #264 tests (ProjectCard + useInlineEdit) and 5 other previously-skipped client test suites actually run.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All .tsx test files now included in vitest runs
- [x] 23 Issue #264 tests pass (ProjectCard + useInlineEdit)
- [x] Previously skipped client tests (CommGraph, EventTimeline, PRBadge, StatusBadge, TopBar) now execute