### PR TITLE
Issue #279: fix session log scroll container height constraint

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -637,7 +637,7 @@ export function TeamDetail() {
                 {/* Tab content */}
                 {activeTab === 'session-log' && (
                   <div className="flex-1 min-h-0 flex flex-col px-5 py-3">
-                    <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
+                    <div className="flex-1 min-h-0 flex flex-col">
                       <UnifiedTimeline
                         teamId={detail.id}
                         teamStatus={detail.status}

--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -514,7 +514,7 @@ export function UnifiedTimeline({
   }
 
   return (
-    <div className="relative">
+    <div className="relative flex-1 min-h-0 flex flex-col">
       {/* Agent filter pills — only shown when roster has subagents */}
       {roster && onAgentFiltersChange && (
         <AgentFilterBar
@@ -536,7 +536,7 @@ export function UnifiedTimeline({
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className={`font-mono text-xs overflow-y-auto bg-[#0D1117] p-2 rounded border border-dark-border custom-scrollbar${isThinking ? ' thinking-glow' : ''}`}
+        className={`flex-1 min-h-0 font-mono text-xs overflow-y-auto bg-[#0D1117] p-2 rounded border border-dark-border custom-scrollbar${isThinking ? ' thinking-glow' : ''}`}
       >
         {filteredEntries.map((entry) => {
           if (entry.source === 'stream') {


### PR DESCRIPTION
Closes #279

## Summary
- Remove competing outer `overflow-y-auto` from TeamDetail's Session Log tab wrapper, converting it to a flex passthrough
- Add `flex-1 min-h-0 flex flex-col` to UnifiedTimeline's root div so it participates in the parent flex layout
- Add `flex-1 min-h-0` to UnifiedTimeline's inner scroll container so it gets a real bounded height

The dual nested scroll containers caused `overflow-y-auto` on the inner container to behave like `overflow: visible` since it had no height constraint. The fix establishes a proper flex layout chain from TeamDetail down to the scroll container.

## Test plan
- [ ] Open a team's Session Log tab with many entries (>50)
- [ ] Verify the scrollbar appears and the full history is scrollable
- [ ] Verify the AgentFilterBar stays pinned at the top while scrolling
- [ ] Verify other TeamDetail tabs (Output, Events) still scroll correctly
- [ ] Run `npm run build` — no errors
- [ ] Run `npm run test:client` — no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)