### PR TITLE
Issue #281: add You and FC filter pills to AgentFilterBar

### DIFF
--- a/src/client/components/AgentFilterBar.tsx
+++ b/src/client/components/AgentFilterBar.tsx
@@ -16,16 +16,32 @@ interface AgentFilterBarProps {
   activeFilters: Set<string>;
   /** Callback to update the active filters */
   onFiltersChange: (filters: Set<string>) => void;
+  /** Whether any "user" (You/PM) entries exist in the timeline */
+  hasUserEntries?: boolean;
+  /** Whether any "fc" (Fleet Commander) entries exist in the timeline */
+  hasFcEntries?: boolean;
 }
+
+// Sentinel keys for non-agent pill entries (prefixed with __ to avoid collision)
+const PM_SENTINEL = '__pm__';
+const FC_SENTINEL = '__fc__';
 
 /** Canonical display name for an agent (capitalise first letter) */
 function displayName(name: string): string {
+  if (name === PM_SENTINEL) return 'You';
+  if (name === FC_SENTINEL) return 'FC';
   if (name === 'team-lead' || name === 'tl') return 'TL';
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
-export function AgentFilterBar({ roster, activeFilters, onFiltersChange }: AgentFilterBarProps) {
-  // Build ordered list of agent names: team-lead first, then alphabetical
+/** Fixed colors for sentinel pills */
+const SENTINEL_COLORS: Record<string, string> = {
+  [PM_SENTINEL]: '#3FB950',
+  [FC_SENTINEL]: '#D29922',
+};
+
+export function AgentFilterBar({ roster, activeFilters, onFiltersChange, hasUserEntries, hasFcEntries }: AgentFilterBarProps) {
+  // Build ordered list of agent names: team-lead first, then alphabetical, then sentinel pills
   const agentNames = useMemo(() => {
     const names = new Set<string>();
     names.add('team-lead');
@@ -37,10 +53,13 @@ export function AgentFilterBar({ roster, activeFilters, onFiltersChange }: Agent
       if (b === 'team-lead') return 1;
       return a.localeCompare(b);
     });
+    // Append sentinel entries for You/FC when those entry types exist
+    if (hasUserEntries) sorted.push(PM_SENTINEL);
+    if (hasFcEntries) sorted.push(FC_SENTINEL);
     return sorted;
-  }, [roster]);
+  }, [roster, hasUserEntries, hasFcEntries]);
 
-  // Hide when only TL exists (no subagents)
+  // Hide when only TL exists and no user/FC entries
   if (agentNames.length <= 1) return null;
 
   const allActive = activeFilters.size === 0 || activeFilters.size === agentNames.length;
@@ -97,7 +116,7 @@ export function AgentFilterBar({ roster, activeFilters, onFiltersChange }: Agent
       </button>
 
       {agentNames.map((name) => {
-        const color = agentColor(name, name);
+        const color = SENTINEL_COLORS[name] ?? agentColor(name, name);
         const isActive = allActive || activeFilters.has(name);
         return (
           <button

--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -360,6 +360,9 @@ interface UnifiedTimelineProps {
 /** Resolve the agent name for a timeline entry (for filtering purposes) */
 function getEntryAgentName(entry: TimelineEntry): string | undefined {
   if (entry.source === 'stream') {
+    // Map user/fc stream types to sentinel keys for filtering
+    if (entry.streamType === 'user') return '__pm__';
+    if (entry.streamType === 'fc') return '__fc__';
     return entry.agentName;
   }
   // Hook entries already have agentName
@@ -478,6 +481,16 @@ export function UnifiedTimeline({
     });
   }, [filteredEntries]);
 
+  // Compute whether user (You) and FC entries exist in the timeline
+  const hasUserEntries = useMemo(
+    () => entries.some((e) => e.source === 'stream' && e.streamType === 'user'),
+    [entries],
+  );
+  const hasFcEntries = useMemo(
+    () => entries.some((e) => e.source === 'stream' && e.streamType === 'fc'),
+    [entries],
+  );
+
   if (entries.length === 0) {
     const isTerminal = teamStatus === 'done' || teamStatus === 'failed';
     return (
@@ -491,12 +504,14 @@ export function UnifiedTimeline({
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
-      {/* Agent filter pills — only shown when roster has subagents */}
+      {/* Agent filter pills — only shown when roster has subagents or user/FC entries */}
       {roster && onAgentFiltersChange && (
         <AgentFilterBar
           roster={roster}
           activeFilters={agentFilters ?? new Set()}
           onFiltersChange={onAgentFiltersChange}
+          hasUserEntries={hasUserEntries}
+          hasFcEntries={hasFcEntries}
         />
       )}
 

--- a/tests/client/AgentFilterBar.test.tsx
+++ b/tests/client/AgentFilterBar.test.tsx
@@ -1,0 +1,321 @@
+// =============================================================================
+// Fleet Commander — AgentFilterBar Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AgentFilterBar } from '../../src/client/components/AgentFilterBar';
+import type { TeamMember } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal TeamMember for testing */
+function member(name: string): TeamMember {
+  return {
+    name,
+    role: name,
+    isActive: true,
+    firstSeen: '2026-01-01T00:00:00Z',
+    lastSeen: '2026-01-01T01:00:00Z',
+    toolUseCount: 10,
+    errorCount: 0,
+  };
+}
+
+const NOOP = () => {};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentFilterBar', () => {
+  // -------------------------------------------------------------------------
+  // Visibility
+  // -------------------------------------------------------------------------
+
+  describe('visibility', () => {
+    it('returns null when only TL exists and no user/FC entries', () => {
+      const { container } = render(
+        <AgentFilterBar
+          roster={[]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when subagents exist', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+        />,
+      );
+      expect(screen.getByText('All')).toBeInTheDocument();
+      expect(screen.getByText('TL')).toBeInTheDocument();
+      expect(screen.getByText('Dev')).toBeInTheDocument();
+    });
+
+    it('renders when only TL exists but hasUserEntries is true', () => {
+      render(
+        <AgentFilterBar
+          roster={[]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+        />,
+      );
+      expect(screen.getByText('You')).toBeInTheDocument();
+    });
+
+    it('renders when only TL exists but hasFcEntries is true', () => {
+      render(
+        <AgentFilterBar
+          roster={[]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasFcEntries={true}
+        />,
+      );
+      expect(screen.getByText('FC')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // "You" pill (PM sentinel)
+  // -------------------------------------------------------------------------
+
+  describe('"You" pill', () => {
+    it('renders when hasUserEntries is true', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+        />,
+      );
+      expect(screen.getByText('You')).toBeInTheDocument();
+    });
+
+    it('does not render when hasUserEntries is false', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={false}
+        />,
+      );
+      expect(screen.queryByText('You')).toBeNull();
+    });
+
+    it('does not render when hasUserEntries is undefined', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+        />,
+      );
+      expect(screen.queryByText('You')).toBeNull();
+    });
+
+    it('uses the correct color (#3FB950)', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+        />,
+      );
+      const pill = screen.getByText('You').closest('button')!;
+      // When allActive, the pill color should be #3FB950
+      expect(pill).toHaveStyle({ color: '#3FB950' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // "FC" pill (Fleet Commander sentinel)
+  // -------------------------------------------------------------------------
+
+  describe('"FC" pill', () => {
+    it('renders when hasFcEntries is true', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasFcEntries={true}
+        />,
+      );
+      expect(screen.getByText('FC')).toBeInTheDocument();
+    });
+
+    it('does not render when hasFcEntries is false', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasFcEntries={false}
+        />,
+      );
+      // "FC" should not appear as a pill (note: there is no other element with text "FC")
+      expect(screen.queryByText('FC')).toBeNull();
+    });
+
+    it('uses the correct color (#D29922)', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasFcEntries={true}
+        />,
+      );
+      const pill = screen.getByText('FC').closest('button')!;
+      expect(pill).toHaveStyle({ color: '#D29922' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Both pills together
+  // -------------------------------------------------------------------------
+
+  describe('both pills together', () => {
+    it('renders both "You" and "FC" pills when both flags are true', () => {
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+          hasFcEntries={true}
+        />,
+      );
+      expect(screen.getByText('You')).toBeInTheDocument();
+      expect(screen.getByText('FC')).toBeInTheDocument();
+    });
+
+    it('places sentinel pills after roster pills', () => {
+      const { container } = render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+          hasFcEntries={true}
+        />,
+      );
+      const buttons = container.querySelectorAll('button');
+      // Order: All, TL, Dev, You, FC
+      const labels = Array.from(buttons).map((b) => b.textContent);
+      expect(labels).toEqual(['All', 'TL', 'Dev', 'You', 'FC']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Toggle behavior
+  // -------------------------------------------------------------------------
+
+  describe('toggle behavior', () => {
+    it('clicking "You" pill when all active selects only __pm__', () => {
+      const onChange = vi.fn();
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={onChange}
+          hasUserEntries={true}
+        />,
+      );
+      fireEvent.click(screen.getByText('You'));
+      expect(onChange).toHaveBeenCalledWith(new Set(['__pm__']));
+    });
+
+    it('clicking "FC" pill when all active selects only __fc__', () => {
+      const onChange = vi.fn();
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={onChange}
+          hasFcEntries={true}
+        />,
+      );
+      fireEvent.click(screen.getByText('FC'));
+      expect(onChange).toHaveBeenCalledWith(new Set(['__fc__']));
+    });
+
+    it('toggling sentinel pill off reverts to "All" when it is the last filter', () => {
+      const onChange = vi.fn();
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set(['__pm__'])}
+          onFiltersChange={onChange}
+          hasUserEntries={true}
+        />,
+      );
+      fireEvent.click(screen.getByText('You'));
+      // Removing the only filter should revert to empty set (all)
+      expect(onChange).toHaveBeenCalledWith(new Set());
+    });
+
+    it('clicking "All" clears all filters', () => {
+      const onChange = vi.fn();
+      render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set(['__pm__'])}
+          onFiltersChange={onChange}
+          hasUserEntries={true}
+        />,
+      );
+      fireEvent.click(screen.getByText('All'));
+      expect(onChange).toHaveBeenCalledWith(new Set());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dot color correctness
+  // -------------------------------------------------------------------------
+
+  describe('dot colors', () => {
+    it('"You" pill dot has correct background color when active', () => {
+      const { container } = render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasUserEntries={true}
+        />,
+      );
+      // Find the "You" button and its inner dot
+      const youButton = screen.getByText('You').closest('button')!;
+      const dot = youButton.querySelector('.rounded-full');
+      expect(dot).toHaveStyle({ backgroundColor: '#3FB950' });
+    });
+
+    it('"FC" pill dot has correct background color when active', () => {
+      const { container } = render(
+        <AgentFilterBar
+          roster={[member('dev')]}
+          activeFilters={new Set()}
+          onFiltersChange={NOOP}
+          hasFcEntries={true}
+        />,
+      );
+      const fcButton = screen.getByText('FC').closest('button')!;
+      const dot = fcButton.querySelector('.rounded-full');
+      expect(dot).toHaveStyle({ backgroundColor: '#D29922' });
+    });
+  });
+});


### PR DESCRIPTION
Closes #281

## Summary
- Add "You" and "FC" sentinel filter pills to AgentFilterBar for PM messages (`streamType === 'user'`) and Fleet Commander messages (`streamType === 'fc'`)
- Map stream types to sentinel filter keys (`__pm__`, `__fc__`) in UnifiedTimeline's `getEntryAgentName()`
- Conditionally render pills only when entries of that type exist in the timeline
- 19 new tests covering pill rendering, conditional visibility, toggle behavior, and color correctness

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 19 new tests pass, no regressions
- [ ] Manual: open session log for a team with PM/FC messages, verify "You" (green) and "FC" (yellow) pills appear
- [ ] Manual: click pills to toggle filtering, verify entries are correctly filtered
- [ ] Manual: verify pills are hidden for teams without PM/FC messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)