### PR TITLE
Issue #278: fix agent filter pills to exclude user/FC/unattributed messages

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -166,6 +166,7 @@ export class TeamManager {
       const syncEvent: StreamEvent = {
         type: 'fc',
         subtype: 'origin_sync',
+        agentName: '__fc__',
         timestamp: new Date().toISOString(),
         message: {
           content: [{
@@ -989,6 +990,7 @@ export class TeamManager {
       // 'subtype' distinguishes FC message categories for visual differentiation.
       const syntheticEvent: StreamEvent = {
         type: source,
+        agentName: source === 'user' ? '__pm__' : '__fc__',
         timestamp: new Date().toISOString(),
         message: { content: [{ type: 'text', text: message }] },
         ...(subtype ? { subtype } : {}),
@@ -1561,6 +1563,7 @@ export class TeamManager {
       const initEvent: StreamEvent = {
         type: 'fc',
         subtype: 'initial_prompt',
+        agentName: '__fc__',
         timestamp: new Date().toISOString(),
         message: { content: [{ type: 'text', text: prompt }] },
       };

--- a/tests/server/build-timeline.test.ts
+++ b/tests/server/build-timeline.test.ts
@@ -337,6 +337,53 @@ describe('buildTimeline', () => {
     expect(entry.message).toEqual({ content: [{ type: 'text', text: 'Wake up!' }] });
   });
 
+  it('preserves agentName sentinel on synthetic FC stream events', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'fc',
+        subtype: 'initial_prompt',
+        agentName: '__fc__',
+        timestamp: '2026-03-20T10:00:00.000Z',
+        message: { content: [{ type: 'text', text: 'Launch prompt' }] },
+      }),
+      makeStreamEvent({
+        type: 'fc',
+        subtype: 'origin_sync',
+        agentName: '__fc__',
+        timestamp: '2026-03-20T10:00:01.000Z',
+        message: { content: [{ type: 'text', text: 'Synced with origin' }] },
+      }),
+    ];
+
+    const result = buildTimeline(stream, [], 1);
+    expect(result).toHaveLength(2);
+
+    for (const entry of result) {
+      expect(entry.source).toBe('stream');
+      const streamEntry = entry as { agentName?: string; streamType: string };
+      expect(streamEntry.streamType).toBe('fc');
+      expect(streamEntry.agentName).toBe('__fc__');
+    }
+  });
+
+  it('preserves agentName sentinel on synthetic user stream events', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({
+        type: 'user',
+        agentName: '__pm__',
+        timestamp: '2026-03-20T10:00:00.000Z',
+        message: { content: [{ type: 'text', text: 'PM message to team' }] },
+      }),
+    ];
+
+    const result = buildTimeline(stream, [], 1);
+    expect(result).toHaveLength(1);
+
+    const entry = result[0] as { agentName?: string; streamType: string };
+    expect(entry.streamType).toBe('user');
+    expect(entry.agentName).toBe('__pm__');
+  });
+
   it('preserves hook event payload and agentName', () => {
     const hooks: Event[] = [
       makeHookEvent({


### PR DESCRIPTION
Closes #278

## Summary
- Add `agentName` sentinel values (`__you__`, `__fc__`) to synthetic stream events in `team-manager.ts` so they are filterable
- Fix permissive filter fallback in `UnifiedTimeline.tsx` — entries without agent names are now excluded when filters are active (was `return true`, now `return false`)
- Add `streamType`-based fallback in `getEntryAgentName()` for backward compatibility with stale in-memory events
- Add "You" and "FC" filter pills to `AgentFilterBar.tsx` alongside roster agent pills
- Add tests for sentinel preservation through `buildTimeline()`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] New tests verify sentinel agentName preservation
- [ ] Manual: open Session Log, select agent filter pill → user/FC messages should be hidden
- [ ] Manual: verify "You" and "FC" pills appear when those event types exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)