### PR TITLE
Issue #288: remove synthetic spawn edges from CommGraph, record real TL spawn messages

### DIFF
--- a/src/client/components/CommGraph.tsx
+++ b/src/client/components/CommGraph.tsx
@@ -37,7 +37,6 @@ interface GraphLink {
   source: string;
   target: string;
   count: number;
-  isSpawn: boolean;
   lastSummary: string | null;
 }
 
@@ -126,22 +125,8 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
       nameMap.set(normalizeName(agent.name), agent.name);
     }
 
-    // Spawn edges: TL -> every non-TL agent (dashed, no count)
-    if (tlName) {
-      for (const agent of agents) {
-        if (agent.name !== tlName) {
-          links.push({
-            source: tlName,
-            target: agent.name,
-            count: 0,
-            isSpawn: true,
-            lastSummary: null,
-          });
-        }
-      }
-    }
-
-    // Message edges from the edges prop
+    // Message edges from the edges prop (spawn edges are now real data
+    // recorded by the server when a subagent_start event is received)
     for (const edge of edges) {
       // Resolve sender/recipient to roster names
       const senderResolved = nameMap.get(normalizeName(edge.sender)) ?? edge.sender;
@@ -152,36 +137,10 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
       const recipientInRoster = agents.some((a) => a.name === recipientResolved);
       if (!senderInRoster || !recipientInRoster) continue;
 
-      // Skip if this would duplicate a spawn edge in the same direction
-      const isSpawnDuplicate =
-        (senderResolved === tlName || recipientResolved === tlName) &&
-        links.some(
-          (l) =>
-            l.isSpawn &&
-            l.source === senderResolved &&
-            l.target === recipientResolved,
-        );
-      if (isSpawnDuplicate) {
-        // Update the spawn edge with message count instead
-        const spawnEdge = links.find(
-          (l) =>
-            l.isSpawn &&
-            l.source === senderResolved &&
-            l.target === recipientResolved,
-        );
-        if (spawnEdge) {
-          spawnEdge.count = edge.count;
-          spawnEdge.isSpawn = false;
-          spawnEdge.lastSummary = edge.lastSummary;
-        }
-        continue;
-      }
-
       links.push({
         source: senderResolved,
         target: recipientResolved,
         count: edge.count,
-        isSpawn: false,
         lastSummary: edge.lastSummary,
       });
     }
@@ -325,26 +284,23 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
 
   // Link width based on message count
   const linkWidth = useCallback((link: GraphLink) => {
-    if (link.isSpawn) return 1;
     if (link.count >= 9) return 3.5;
     if (link.count >= 4) return 2;
     return 1;
   }, []);
 
   // Link color
-  const linkColor = useCallback((link: GraphLink) => {
-    if (link.isSpawn) return '#30363D';
+  const linkColor = useCallback((_link: GraphLink) => {
     return '#8B949E';
   }, []);
 
-  // Link dashed pattern: spawn edges are dashed, message edges are solid
-  const linkLineDash = useCallback((link: GraphLink) => {
-    return link.isSpawn ? [4, 4] : null;
+  // Link dashed pattern: all edges are solid (no more synthetic spawn edges)
+  const linkLineDash = useCallback((_link: GraphLink) => {
+    return null;
   }, []);
 
   // Link label on hover
   const linkLabel = useCallback((link: GraphLink) => {
-    if (link.isSpawn && link.count === 0) return '';
     const summary = link.lastSummary ? `<br/><i>${link.lastSummary}</i>` : '';
     return `<div style="padding:4px 8px;background:#161B22;border:1px solid #30363D;border-radius:4px;font-size:11px;color:#E6EDF3;">
       <b>${typeof link.source === 'object' ? (link.source as GraphNode).id : link.source}</b>
@@ -356,15 +312,14 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
 
   // Directional particles for message edges
   const linkDirectionalParticles = useCallback((link: GraphLink) => {
-    if (link.isSpawn) return 0;
     if (link.count >= 6) return 3;
     if (link.count >= 3) return 2;
     return link.count > 0 ? 1 : 0;
   }, []);
 
   // Directional arrows for message edges
-  const linkDirectionalArrowLength = useCallback((link: GraphLink) => {
-    return link.isSpawn ? 0 : 6;
+  const linkDirectionalArrowLength = useCallback((_link: GraphLink) => {
+    return 6;
   }, []);
 
   // Empty state — show only when no agents at all

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -325,6 +325,24 @@ export function processEvent(
     const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
     const trackerKey = `${payload.team}:${subagentName}`;
     subagentTrackers.set(trackerKey, { startTime: now, eventCount: 0 });
+
+    // Record spawn as a real agent message (TL -> subagent) so the CommGraph
+    // shows data-driven edges instead of synthetic spawn lines.
+    try {
+      const senderName = normalizeAgentName(null); // TL spawns subagents
+      const recipientName = normalizeAgentName(subagentName);
+      db.insertAgentMessage({
+        teamId,
+        eventId,
+        sender: senderName,
+        recipient: recipientName,
+        summary: 'spawned agent',
+        content: null,
+        sessionId: payload.session_id || null,
+      });
+    } catch {
+      // Non-critical — silently ignore insert failures
+    }
   }
 
   // Increment event count for any tracked subagent on this team

--- a/tests/client/CommGraph.test.tsx
+++ b/tests/client/CommGraph.test.tsx
@@ -102,8 +102,8 @@ describe('CommGraph', () => {
     const graphData = call.graphData;
     // Should have 3 nodes (one per agent)
     expect(graphData.nodes).toHaveLength(3);
-    // Should have 2 spawn edges (TL -> analyst, TL -> dev)
-    expect(graphData.links).toHaveLength(2);
+    // No synthetic spawn edges — links come only from real message data
+    expect(graphData.links).toHaveLength(0);
   });
 
   it('should create message edges from the edges prop', () => {
@@ -118,13 +118,12 @@ describe('CommGraph', () => {
     render(<CommGraph edges={edges} agents={agents} />);
     expect(mockForceGraph).toHaveBeenCalled();
 
-    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string }>; links: Array<{ source: string; count: number; isSpawn: boolean }> } };
+    const call = mockForceGraph.mock.calls[0][0] as { graphData: { nodes: Array<{ id: string }>; links: Array<{ source: string; count: number }> } };
     const graphData = call.graphData;
     expect(graphData.nodes).toHaveLength(2);
-    // The spawn edge from TL->dev should be upgraded to a message edge
-    const messageLinks = graphData.links.filter((l) => !l.isSpawn);
-    expect(messageLinks.length).toBeGreaterThanOrEqual(1);
-    expect(messageLinks[0].count).toBe(5);
+    // All edges come from real message data
+    expect(graphData.links).toHaveLength(1);
+    expect(graphData.links[0].count).toBe(5);
   });
 
   it('should render a single agent without crashing', () => {

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -924,6 +924,83 @@ describe('Agent message routing', () => {
 // Subagent crash detection
 // =============================================================================
 
+// =============================================================================
+// Subagent spawn message recording (Issue #288)
+// =============================================================================
+
+describe('Subagent spawn message recording', () => {
+  it('records a TL->subagent agent message on subagent_start', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', agent_type: 'coordinator' }),
+      db,
+      sse,
+    );
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith({
+      teamId: 1,
+      eventId: 1,
+      sender: 'team-lead',     // TL spawns subagents (normalizeAgentName(null))
+      recipient: 'dev',        // fleet- prefix stripped from teammate_name
+      summary: 'spawned agent',
+      content: null,
+      sessionId: 'sess-abc',
+    });
+  });
+
+  it('records spawn message with agent_type fallback when teammate_name is missing', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: undefined, agent_type: 'fleet-reviewer' }),
+      db,
+      sse,
+    );
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: 'team-lead',
+        recipient: 'reviewer', // fleet- prefix stripped from agent_type fallback
+        summary: 'spawned agent',
+      }),
+    );
+  });
+
+  it('silently handles insertAgentMessage failure during subagent_start', () => {
+    const db = createMockDb({
+      insertAgentMessage: vi.fn().mockImplementation(() => {
+        throw new Error('DB constraint violation');
+      }),
+    });
+    const sse = createMockSse();
+
+    // Should not throw
+    const result = processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+    );
+    expect(result.processed).toBe(true);
+  });
+
+  it('does not record spawn message for non-subagent_start events', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+    );
+
+    // insertAgentMessage should NOT have been called (no SendMessage tool_name either)
+    expect(db.insertAgentMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe('Subagent crash detection', () => {
   it('sends advisory message when subagent stops quickly with few events', () => {
     const db = createMockDb();


### PR DESCRIPTION
Closes #288

## Summary
- **CommGraph.tsx**: Removed synthetic dashed spawn edges (`isSpawn` field, spawn-edge generation loop, spawn-duplicate detection) — edges now come exclusively from real `MessageEdge` API data
- **event-collector.ts**: Added `insertAgentMessage()` call on `subagent_start` to record a real TL→subagent "spawned agent" message, creating data-driven edges that replace the old synthetic dashed lines
- **Tests**: Updated CommGraph tests (removed spawn-edge assertions), added 4 new event-collector tests for spawn message recording

## Acceptance criteria
- [x] No dashed lines appear on the CommGraph
- [x] When TL spawns a subagent, a solid edge appears from TL to the new agent with count 1
- [x] Subsequent SendMessage calls between the same pair increment the count normally
- [x] Graph still renders correctly when there are no messages yet (nodes visible, no edges)