### PR TITLE
Issue #289: fix session log scroll losing entries in prolonged sessions

### DIFF
--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -395,7 +395,7 @@ export function UnifiedTimeline({
     async function poll() {
       if (cancelled) return;
       try {
-        const data = await api.get<TimelineEntry[]>(`teams/${teamId}/timeline?limit=200`);
+        const data = await api.get<TimelineEntry[]>(`teams/${teamId}/timeline?limit=500`);
         if (!cancelled) {
           setEntries(data);
         }

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -779,7 +779,7 @@ const teamsRoutes: FastifyPluginCallback = (
         }
 
         const limitParam = (request.query as TimelineQuerystring).limit;
-        const limit = limitParam ? parseInt(limitParam, 10) : 200;
+        const limit = limitParam ? parseInt(limitParam, 10) : 500;
 
         // Fetch stream events from in-memory buffer (same as stream-events endpoint)
         const manager = getTeamManager();

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -30,7 +30,7 @@ const execAsync = promisify(execCallback);
 // ---------------------------------------------------------------------------
 
 const MAX_OUTPUT_LINES = config.outputBufferLines;
-const MAX_PARSED_EVENTS = 200;
+const MAX_PARSED_EVENTS = 1000;
 
 // ---------------------------------------------------------------------------
 // summarizeEvent — short text summary for console logging
@@ -998,6 +998,9 @@ export class TeamManager {
       const events = this.parsedEvents.get(teamId);
       if (events) {
         events.push(syntheticEvent);
+        while (events.length > MAX_PARSED_EVENTS) {
+          events.shift();
+        }
       }
       sseBroker.broadcast('team_output', { team_id: teamId, event: syntheticEvent }, teamId);
 
@@ -1769,7 +1772,7 @@ export class TeamManager {
             // content_block_start/delta/stop events are high-frequency partial
             // message fragments emitted by --include-partial-messages.  They are
             // only needed for thinking detection (above) and must NOT be stored
-            // in the parsedEvents buffer — they would flood the 200-event cap
+            // in the parsedEvents buffer — they would flood the event cap
             // and evict meaningful session log entries.
             if (event.type === 'content_block_start' || event.type === 'content_block_delta' || event.type === 'content_block_stop') {
               continue;

--- a/src/server/utils/build-timeline.ts
+++ b/src/server/utils/build-timeline.ts
@@ -71,7 +71,7 @@ export function buildTimeline(
   streamEvents: RawStreamEvent[],
   hookEvents: Event[],
   teamId: number,
-  limit = 200,
+  limit = 500,
 ): TimelineEntry[] {
   // 1. Map stream events to StreamTimelineEntry
   const streamEntries: StreamTimelineEntry[] = streamEvents.map((e, i) => ({

--- a/tests/server/build-timeline.test.ts
+++ b/tests/server/build-timeline.test.ts
@@ -275,23 +275,23 @@ describe('buildTimeline', () => {
     }
   });
 
-  it('defaults limit to 200', () => {
-    const stream: RawStreamEvent[] = Array.from({ length: 150 }, (_, i) =>
+  it('defaults limit to 500', () => {
+    const stream: RawStreamEvent[] = Array.from({ length: 300 }, (_, i) =>
       makeStreamEvent({
         type: 'assistant',
         timestamp: new Date(Date.UTC(2026, 2, 20, 10, 0, i)).toISOString(),
       }),
     );
-    const hooks: Event[] = Array.from({ length: 100 }, (_, i) =>
+    const hooks: Event[] = Array.from({ length: 300 }, (_, i) =>
       makeHookEvent({
         id: i + 1,
         eventType: 'SessionStart',
-        createdAt: new Date(Date.UTC(2026, 2, 20, 10, 3, i)).toISOString(),
+        createdAt: new Date(Date.UTC(2026, 2, 20, 10, 6, i)).toISOString(),
       }),
     );
 
     const result = buildTimeline(stream, hooks, 1);
-    expect(result).toHaveLength(200);
+    expect(result).toHaveLength(500);
   });
 
   it('handles missing timestamps gracefully', () => {
@@ -404,5 +404,100 @@ describe('buildTimeline', () => {
     expect(entry.toolName).toBe('Bash');
     expect(entry.agentName).toBe('fleet-dev');
     expect(entry.payload).toBe('{"error":"command failed"}');
+  });
+
+  it('preserves stream events (including early TL messages) when many hook events dominate with limit=500', () => {
+    // Simulate a prolonged session: 300 hook events (tool uses during heavy work)
+    // interleaved with 50 stream events (including early TL messages and FC prompts).
+    // With limit=500, all 350 entries should be preserved.
+    const stream: RawStreamEvent[] = Array.from({ length: 50 }, (_, i) =>
+      makeStreamEvent({
+        type: i < 5 ? 'fc' : i < 10 ? 'user' : 'assistant',
+        subtype: i < 5 ? 'initial_prompt' : undefined,
+        agentName: i < 5 ? '__fc__' : i < 10 ? '__pm__' : 'team-lead',
+        timestamp: new Date(Date.UTC(2026, 2, 20, 8, 0, i)).toISOString(),
+        message: { content: [{ type: 'text', text: `Stream message ${i}` }] },
+      }),
+    );
+
+    const hooks: Event[] = Array.from({ length: 300 }, (_, i) =>
+      makeHookEvent({
+        id: i + 1,
+        eventType: 'ToolUse',
+        toolName: `Tool${i % 20}`,
+        agentName: 'developer',
+        createdAt: new Date(Date.UTC(2026, 2, 20, 9, 0, i)).toISOString(),
+      }),
+    );
+
+    const result = buildTimeline(stream, hooks, 1, 500);
+
+    // Total is 350 (50 stream + 300 hook), well within limit=500
+    expect(result).toHaveLength(350);
+
+    // All 50 stream events must be present — none should be evicted
+    const streamCount = result.filter((e) => e.source === 'stream').length;
+    expect(streamCount).toBe(50);
+
+    // Early FC prompt events (the very first entries) must survive
+    const fcPrompts = result.filter(
+      (e) => e.source === 'stream' && (e as any).streamType === 'fc' && (e as any).subtype === 'initial_prompt',
+    );
+    expect(fcPrompts.length).toBe(5);
+
+    // Early PM (user) messages must survive
+    const pmMessages = result.filter(
+      (e) => e.source === 'stream' && (e as any).streamType === 'user',
+    );
+    expect(pmMessages.length).toBe(5);
+
+    // Verify chronological order is maintained
+    for (let i = 1; i < result.length; i++) {
+      const prev = new Date(result[i - 1].timestamp).getTime();
+      const curr = new Date(result[i].timestamp).getTime();
+      expect(curr).toBeGreaterThanOrEqual(prev);
+    }
+  });
+
+  it('evicts early stream events when combined count exceeds a low limit', () => {
+    // Demonstrate that with the old limit=200, early stream events would be lost
+    // when hook events dominate. With limit=500, they survive.
+    const earlyStream: RawStreamEvent[] = Array.from({ length: 20 }, (_, i) =>
+      makeStreamEvent({
+        type: 'fc',
+        subtype: 'initial_prompt',
+        agentName: '__fc__',
+        timestamp: new Date(Date.UTC(2026, 2, 20, 7, 0, i)).toISOString(),
+        message: { content: [{ type: 'text', text: `Early prompt ${i}` }] },
+      }),
+    );
+
+    const hooks: Event[] = Array.from({ length: 250 }, (_, i) =>
+      makeHookEvent({
+        id: i + 1,
+        eventType: 'ToolUse',
+        toolName: `Tool${i}`,
+        agentName: 'developer',
+        createdAt: new Date(Date.UTC(2026, 2, 20, 9, 0, i)).toISOString(),
+      }),
+    );
+
+    // With limit=200: only 200 most recent — early stream events get evicted
+    const resultLow = buildTimeline(earlyStream, hooks, 1, 200);
+    expect(resultLow).toHaveLength(200);
+    const earlyFcLow = resultLow.filter(
+      (e) => e.source === 'stream' && (e as any).subtype === 'initial_prompt',
+    );
+    // All 20 early stream events are older than the 250 hooks,
+    // so slice(-200) drops the 70 oldest entries (20 streams + 50 hooks)
+    expect(earlyFcLow.length).toBe(0);
+
+    // With limit=500: all 270 entries fit — early stream events survive
+    const resultHigh = buildTimeline(earlyStream, hooks, 1, 500);
+    expect(resultHigh).toHaveLength(270);
+    const earlyFcHigh = resultHigh.filter(
+      (e) => e.source === 'stream' && (e as any).subtype === 'initial_prompt',
+    );
+    expect(earlyFcHigh.length).toBe(20);
   });
 });


### PR DESCRIPTION
Closes #289

## Summary
- Increase server-side stream event buffer (`MAX_PARSED_EVENTS`) from 200 to 1000 so early TL messages and prompts survive long-running sessions
- Increase timeline API default limit from 200 to 500 across all layers (route, builder, client)
- Add buffer cap enforcement in `sendMessage()` for consistency with the main stream handler
- Add test cases verifying stream events survive alongside many hook events

## Test plan
- [ ] Verify Session Log remains scrollable from first to last entry during prolonged sessions
- [ ] Verify early TL messages remain visible after 100+ hook events
- [ ] Verify auto-scroll to bottom works, manual scroll-up stays in position
- [ ] `npm test` passes (new build-timeline tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)