### PR TITLE
Issue #295: filter stream_event partials from parsedEvents buffer

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1774,7 +1774,7 @@ export class TeamManager {
             // only needed for thinking detection (above) and must NOT be stored
             // in the parsedEvents buffer — they would flood the event cap
             // and evict meaningful session log entries.
-            if (event.type === 'content_block_start' || event.type === 'content_block_delta' || event.type === 'content_block_stop') {
+            if (event.type === 'content_block_start' || event.type === 'content_block_delta' || event.type === 'content_block_stop' || event.type === 'stream_event') {
               continue;
             }
 
@@ -1882,7 +1882,7 @@ export class TeamManager {
               this.detectThinking(teamId, event);
 
               // Filter out content_block events (same rationale as in 'data' handler)
-              if (event.type !== 'content_block_start' && event.type !== 'content_block_delta' && event.type !== 'content_block_stop') {
+              if (event.type !== 'content_block_start' && event.type !== 'content_block_delta' && event.type !== 'content_block_stop' && event.type !== 'stream_event') {
                 // Resolve agent name (same logic as 'data' handler)
                 const endEv = event as Record<string, unknown>;
                 const endParentId = (endEv.parent_tool_use_id as string | null | undefined) ?? null;
@@ -2021,9 +2021,21 @@ export class TeamManager {
    * index) signals the end.
    */
   private detectThinking(teamId: number, event: StreamEvent): void {
-    const ev = event as Record<string, unknown>;
+    let ev = event as Record<string, unknown>;
+    let effectiveType = event.type;
 
-    if (event.type === 'content_block_start') {
+    // Unwrap stream_event envelopes: thinking signals from
+    // --include-partial-messages arrive wrapped as
+    // { type: "stream_event", event: { type: "content_block_start", ... } }
+    if (event.type === 'stream_event') {
+      const inner = ev.event as Record<string, unknown> | undefined;
+      if (inner && typeof inner.type === 'string') {
+        ev = inner;
+        effectiveType = inner.type as string;
+      }
+    }
+
+    if (effectiveType === 'content_block_start') {
       const block = ev.content_block as Record<string, unknown> | undefined;
       if (block && block.type === 'thinking') {
         this.thinkingTeams.add(teamId);
@@ -2033,7 +2045,7 @@ export class TeamManager {
         sseBroker.broadcast('team_thinking_start', { team_id: teamId }, teamId);
         console.log(`[TeamManager] Team ${teamId} thinking started (block index ${index})`);
       }
-    } else if (event.type === 'content_block_stop') {
+    } else if (effectiveType === 'content_block_stop') {
       const index = typeof ev.index === 'number' ? ev.index : -1;
       const trackedIndex = this.thinkingBlockIndex.get(teamId);
       if (this.thinkingTeams.has(teamId) && (trackedIndex === undefined || trackedIndex === index)) {

--- a/src/server/utils/build-timeline.ts
+++ b/src/server/utils/build-timeline.ts
@@ -30,6 +30,19 @@ export interface RawStreamEvent {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * High-frequency partial-message types emitted by --include-partial-messages.
+ * These should be filtered out by captureOutput() in team-manager.ts, but as a
+ * defense-in-depth measure we also exclude them here so they never appear in
+ * the timeline even if upstream filtering is bypassed.
+ */
+const NOISE_STREAM_TYPES = new Set([
+  'stream_event',
+  'content_block_start',
+  'content_block_delta',
+  'content_block_stop',
+]);
+
 /** 10-second dedup window in milliseconds */
 const DEDUP_WINDOW_MS = 10_000;
 
@@ -73,8 +86,9 @@ export function buildTimeline(
   teamId: number,
   limit = 500,
 ): TimelineEntry[] {
-  // 1. Map stream events to StreamTimelineEntry
-  const streamEntries: StreamTimelineEntry[] = streamEvents.map((e, i) => ({
+  // 1. Filter out noise stream types (defense-in-depth), then map to StreamTimelineEntry
+  const filteredStreamEvents = streamEvents.filter(e => !NOISE_STREAM_TYPES.has(e.type));
+  const streamEntries: StreamTimelineEntry[] = filteredStreamEvents.map((e, i) => ({
     id: `stream-${i}`,
     source: 'stream' as const,
     timestamp: normalizeTimestamp(e.timestamp),

--- a/tests/server/build-timeline.test.ts
+++ b/tests/server/build-timeline.test.ts
@@ -500,4 +500,47 @@ describe('buildTimeline', () => {
     );
     expect(earlyFcHigh.length).toBe(20);
   });
+
+  it('excludes noise stream types (stream_event, content_block_*) from timeline output', () => {
+    const stream: RawStreamEvent[] = [
+      // Legitimate events that should appear
+      makeStreamEvent({ type: 'assistant', timestamp: '2026-03-20T10:00:00.000Z' }),
+      makeStreamEvent({ type: 'tool_use', timestamp: '2026-03-20T10:00:01.000Z', tool: { name: 'Read' } }),
+      // Noise types that should be filtered out
+      makeStreamEvent({ type: 'stream_event', timestamp: '2026-03-20T10:00:02.000Z' }),
+      makeStreamEvent({ type: 'content_block_start', timestamp: '2026-03-20T10:00:03.000Z' }),
+      makeStreamEvent({ type: 'content_block_delta', timestamp: '2026-03-20T10:00:04.000Z' }),
+      makeStreamEvent({ type: 'content_block_stop', timestamp: '2026-03-20T10:00:05.000Z' }),
+      // Another legitimate event
+      makeStreamEvent({ type: 'result', timestamp: '2026-03-20T10:00:06.000Z' }),
+    ];
+
+    const result = buildTimeline(stream, [], 1);
+
+    // Only 3 legitimate events should remain (assistant, tool_use, result)
+    expect(result).toHaveLength(3);
+    const types = result.map((e) => (e as any).streamType);
+    expect(types).toEqual(['assistant', 'tool_use', 'result']);
+
+    // Verify none of the noise types leaked through
+    expect(types).not.toContain('stream_event');
+    expect(types).not.toContain('content_block_start');
+    expect(types).not.toContain('content_block_delta');
+    expect(types).not.toContain('content_block_stop');
+  });
+
+  it('reindexes stream entry IDs after noise filtering', () => {
+    const stream: RawStreamEvent[] = [
+      makeStreamEvent({ type: 'assistant', timestamp: '2026-03-20T10:00:00.000Z' }),
+      makeStreamEvent({ type: 'stream_event', timestamp: '2026-03-20T10:00:01.000Z' }),
+      makeStreamEvent({ type: 'tool_use', timestamp: '2026-03-20T10:00:02.000Z', tool: { name: 'Read' } }),
+    ];
+
+    const result = buildTimeline(stream, [], 1);
+
+    // After filtering, IDs should be contiguous (stream-0, stream-1)
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('stream-0');
+    expect(result[1].id).toBe('stream-1');
+  });
 });


### PR DESCRIPTION
Closes #295

## Summary
- Filter `stream_event` type from `parsedEvents` storage in `captureOutput()` — these high-frequency partial message fragments from `--include-partial-messages` were flooding the event buffer, pushing out real data (assistant messages, task_progress, tool_use)
- Update `detectThinking()` to unwrap `stream_event` envelopes so thinking indicator still works when `content_block_start/stop` arrive wrapped inside stream events
- Add defense-in-depth `NOISE_STREAM_TYPES` filter in `build-timeline.ts` to exclude noise types from timeline output
- Add tests verifying noise type exclusion and ID contiguity

## Test plan
- [x] All 22 existing tests pass
- [x] TypeScript compiles with zero errors
- [x] New tests verify stream_event and content_block_* types excluded from timeline
- [x] Acceptance criteria: stream_event not stored, thinking detection works, buffer used efficiently