### PR TITLE
Issue #276: extract inline route logic to service methods

### DIFF
--- a/src/server/routes/project-groups.ts
+++ b/src/server/routes/project-groups.ts
@@ -1,6 +1,8 @@
 // =============================================================================
 // Fleet Commander — Project Group Routes (CRUD)
 // =============================================================================
+// Business logic for list/get-with-projects is delegated to ProjectGroupService.
+// =============================================================================
 
 import type {
   FastifyInstance,
@@ -9,7 +11,8 @@ import type {
   FastifyReply,
 } from 'fastify';
 import { getDatabase } from '../db.js';
-import type { ProjectGroup } from '../../shared/types.js';
+import { getProjectGroupService } from '../services/project-group-service.js';
+import { ServiceError } from '../services/service-error.js';
 
 // ---------------------------------------------------------------------------
 // Request body / param interfaces
@@ -48,21 +51,13 @@ const projectGroupsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const db = getDatabase();
-        const groups = db.getProjectGroups();
-
-        // Enrich with project counts
-        const allProjects = db.getProjects();
-        const enriched = groups.map((g: ProjectGroup) => {
-          const linked = allProjects.filter((p) => p.groupId === g.id);
-          return {
-            ...g,
-            projectCount: linked.length,
-          };
-        });
-
+        const service = getProjectGroupService();
+        const enriched = service.listWithCounts();
         return reply.code(200).send(enriched);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         _request.log.error(err, 'Failed to list project groups');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -135,23 +130,13 @@ const projectGroupsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const group = db.getProjectGroup(groupId);
-        if (!group) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project group ${groupId} not found`,
-          });
-        }
-
-        const allProjects = db.getProjects();
-        const projects = allProjects.filter((p) => p.groupId === groupId);
-
-        return reply.code(200).send({
-          ...group,
-          projects,
-        });
+        const service = getProjectGroupService();
+        const result = service.getWithProjects(groupId);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to get project group');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -3,6 +3,7 @@
 // =============================================================================
 // Fastify plugin that registers all project-related API endpoints:
 // list, create, detail, update, delete, project teams.
+// Business logic is delegated to ProjectService.
 // =============================================================================
 
 import type {
@@ -11,17 +12,12 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
 import { getDatabase } from '../db.js';
-import { getTeamManager } from '../services/team-manager.js';
-import { getIssueFetcher } from '../services/issue-fetcher.js';
-import { getCleanupPreview, executeCleanup } from '../services/cleanup.js';
 import { sseBroker } from '../services/sse-broker.js';
-import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
-import config from '../config.js';
-import type { ProjectStatus, InstallStatus, InstallFileStatus, CleanupPreview, CleanupResult } from '../../shared/types.js';
+import { getProjectService, checkInstallStatus } from '../services/project-service.js';
+import { ServiceError } from '../services/service-error.js';
+import type { ProjectStatus, CleanupPreview, CleanupResult } from '../../shared/types.js';
+import { getCleanupPreview, executeCleanup } from '../services/cleanup.js';
 
 // ---------------------------------------------------------------------------
 // Request body / param / query interfaces
@@ -55,156 +51,6 @@ interface ProjectListQuery {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Normalize a file path to use forward slashes (cross-platform).
- */
-function normalizePath(p: string): string {
-  return path.resolve(p).replace(/\\/g, '/');
-}
-
-/**
- * Check if a directory is a git repository.
- */
-function isGitRepo(dirPath: string): boolean {
-  try {
-    execSync('git rev-parse --is-inside-work-tree', {
-      cwd: dirPath,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Auto-detect the GitHub repo (owner/name) for a local git repo via gh CLI.
- * Returns null if detection fails (non-fatal).
- */
-function detectGithubRepo(dirPath: string): string | null {
-  try {
-    const result = execSync(
-      'gh repo view --json nameWithOwner -q .nameWithOwner',
-      { cwd: dirPath, encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
-    ).trim();
-    return result || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Check whether a file contains CRLF line endings by reading its first 512 bytes.
- */
-function fileHasCrlf(filePath: string): boolean {
-  try {
-    const buf = Buffer.alloc(512);
-    const fd = fs.openSync(filePath, 'r');
-    const bytesRead = fs.readSync(fd, buf, 0, 512, 0);
-    fs.closeSync(fd);
-    return buf.subarray(0, bytesRead).includes(0x0D);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Check the install status of artifacts deployed by install.sh:
- * hooks directory and workflow prompt.
- * Returns detailed file-level breakdown for tooltip display.
- */
-function checkInstallStatus(repoPath: string): InstallStatus {
-  // Hook scripts expected in .claude/hooks/fleet-commander/
-  const hookNames = [
-    'send_event.sh',
-    'on_session_start.sh',
-    'on_session_end.sh',
-    'on_stop.sh',
-    'on_stop_failure.sh',
-    'on_subagent_start.sh',
-    'on_subagent_stop.sh',
-    'on_notification.sh',
-    'on_post_tool_use.sh',
-    'on_tool_error.sh',
-    'on_pre_compact.sh',
-    'on_teammate_idle.sh',
-  ];
-
-  const hooksDir = path.join(repoPath, '.claude', 'hooks', 'fleet-commander');
-  const hookFiles: InstallFileStatus[] = hookNames.map((name) => {
-    const filePath = path.join(hooksDir, name);
-    const exists = fs.existsSync(filePath);
-    return {
-      name,
-      exists,
-      hasCrlf: exists ? fileHasCrlf(filePath) : false,
-    };
-  });
-  const hookFoundCount = hookFiles.filter((f) => f.exists).length;
-  const hookHasCrlf = hookFiles.some((f) => f.hasCrlf);
-
-  // Prompt files expected in .claude/prompts/
-  const promptFiles: InstallFileStatus[] = [
-    {
-      name: 'fleet-workflow.md',
-      exists: fs.existsSync(path.join(repoPath, '.claude', 'prompts', 'fleet-workflow.md')),
-    },
-  ];
-
-  // Agent templates expected in .claude/agents/
-  const agentNames = [
-    'fleet-planner.md',
-    'fleet-dev.md',
-    'fleet-reviewer.md',
-  ];
-  const agentsDir = path.join(repoPath, '.claude', 'agents');
-  const agentFiles: InstallFileStatus[] = agentNames.map((name) => ({
-    name,
-    exists: fs.existsSync(path.join(agentsDir, name)),
-  }));
-
-  // Guidebooks in .claude/guides/
-  const guidesDir = path.join(repoPath, '.claude', 'guides');
-  const guideFiles: InstallFileStatus[] = fs.existsSync(guidesDir)
-    ? fs.readdirSync(guidesDir)
-        .filter((f) => f.endsWith('.md'))
-        .map((name) => ({ name, exists: true }))
-    : [];
-
-  // Additional config files
-  const settingsFile: InstallFileStatus = {
-    name: 'settings.json',
-    exists: fs.existsSync(path.join(repoPath, '.claude', 'settings.json')),
-  };
-
-  return {
-    hooks: {
-      installed: hookFoundCount === hookNames.length && !hookHasCrlf,
-      total: hookNames.length,
-      found: hookFoundCount,
-      files: hookFiles,
-    },
-    prompt: {
-      installed: promptFiles.every((f) => f.exists),
-      files: promptFiles,
-    },
-    agents: {
-      installed: agentFiles.every((f) => f.exists),
-      files: agentFiles,
-    },
-    guides: {
-      installed: guideFiles.length > 0,
-      files: guideFiles,
-    },
-    settings: settingsFile,
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -223,33 +69,14 @@ const projectsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const db = getDatabase();
         const statusFilter = (request.query as ProjectListQuery).status;
-
-        if (statusFilter) {
-          const validStatuses: ProjectStatus[] = ['active', 'archived'];
-          if (!validStatuses.includes(statusFilter)) {
-            return reply.code(400).send({
-              error: 'Bad Request',
-              message: `Invalid status filter. Must be one of: ${validStatuses.join(', ')}`,
-            });
-          }
-        }
-
-        // Get summaries (includes team counts) and filter if needed
-        const summaries = db.getProjectSummaries();
-        const filtered = statusFilter
-          ? summaries.filter((p) => p.status === statusFilter)
-          : summaries;
-
-        // Enrich each project with live install status from the filesystem
-        const enriched = filtered.map((p) => ({
-          ...p,
-          installStatus: checkInstallStatus(p.repoPath),
-        }));
-
+        const service = getProjectService();
+        const enriched = service.listProjects(statusFilter);
         return reply.code(200).send(enriched);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to list projects');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -269,140 +96,15 @@ const projectsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const { name, repoPath, githubRepo, maxActiveTeams, model } = request.body;
-
-        // Validate name
-        if (!name || typeof name !== 'string' || name.trim().length === 0) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'name is required and must be a non-empty string',
-          });
-        }
-
-        // Validate repoPath
-        if (!repoPath || typeof repoPath !== 'string' || repoPath.trim().length === 0) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'repoPath is required and must be a non-empty string',
-          });
-        }
-
-        // Normalize the path
-        const normalizedPath = normalizePath(repoPath);
-
-        // Check that the path exists
-        if (!fs.existsSync(normalizedPath)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Path does not exist: ${normalizedPath}`,
-          });
-        }
-
-        // Check that it's a git repository
-        if (!isGitRepo(normalizedPath)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Path is not a git repository: ${normalizedPath}`,
-          });
-        }
-
-        // Check for duplicate repo_path
-        const db = getDatabase();
-        const existing = db.getProjectByRepoPath(normalizedPath);
-        if (existing) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            message: `A project already exists for this path: ${normalizedPath} (project: ${existing.name})`,
-          });
-        }
-
-        // Auto-detect githubRepo if not provided
-        const resolvedGithubRepo = githubRepo || detectGithubRepo(normalizedPath);
-
-        // Validate maxActiveTeams if provided
-        if (maxActiveTeams !== undefined) {
-          if (typeof maxActiveTeams !== 'number' || maxActiveTeams < 1 || maxActiveTeams > 50) {
-            return reply.code(400).send({
-              error: 'Bad Request',
-              message: 'maxActiveTeams must be a number between 1 and 50',
-            });
-          }
-        }
-
-        // Create project-specific prompt file from default template
-        const slug = name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-        const promptRelPath = `prompts/${slug}-prompt.md`;
-        const promptAbsPath = path.join(config.fleetCommanderRoot, promptRelPath);
-        const defaultPromptPath = path.join(config.fleetCommanderRoot, 'prompts', 'default-prompt.md');
-
-        try {
-          // Ensure prompts directory exists
-          fs.mkdirSync(path.join(config.fleetCommanderRoot, 'prompts'), { recursive: true });
-
-          // Copy default prompt if the project-specific one doesn't exist
-          if (!fs.existsSync(promptAbsPath)) {
-            if (fs.existsSync(defaultPromptPath)) {
-              fs.copyFileSync(defaultPromptPath, promptAbsPath);
-            } else {
-              // Create a basic default prompt inline
-              fs.writeFileSync(promptAbsPath,
-                'Read the ENTIRE file `.claude/prompts/fleet-workflow.md` before taking any actions.\n' +
-                'You are the TL. There is NO coordinator — you orchestrate the Diamond team directly.\n' +
-                'Phase 0: Spawn fleet-planner. Wait for plan. Phase 1: Spawn fleet-dev WITH the planner\'s plan. Wait for ready. Phase 2: Spawn fleet-reviewer. Planner stays alive for p2p questions.\n' +
-                'Issue: #{{ISSUE_NUMBER}}\n',
-                'utf-8',
-              );
-            }
-          }
-        } catch (promptErr: unknown) {
-          request.log.warn(promptErr, 'Failed to create project prompt file (non-fatal)');
-        }
-
-        // Insert the project
-        const project = db.insertProject({
-          name: name.trim(),
-          repoPath: normalizedPath,
-          githubRepo: resolvedGithubRepo,
-          maxActiveTeams: maxActiveTeams ?? 5,
-          promptFile: promptRelPath,
-          model: model?.trim() || null,
-        });
-
-        // Install hooks (non-fatal)
-        const installResult = installHooks(normalizedPath, request.log);
-        if (!installResult.ok) {
-          request.log.warn(
-            `Hook installation failed for ${normalizedPath}: ${installResult.stderr}`,
-          );
-        }
-
-        // Verify artifacts were actually installed
-        const status = checkInstallStatus(normalizedPath);
-        const allInstalled = status.hooks.installed && status.prompt.installed;
-        if (allInstalled) {
-          db.updateProject(project.id, { hooksInstalled: true });
-        }
-
-        // Re-fetch to get updated hooks_installed
-        const finalProject = db.getProject(project.id)!;
-
-        // Ensure the issue fetcher's polling loop is running.
-        // After a factory reset the fetcher is stopped; re-start it now that
-        // there is at least one project to poll issues for.
-        const issueFetcher = getIssueFetcher();
-        issueFetcher.start(); // no-op if already running
-
-        // Broadcast SSE event
-        sseBroker.broadcast('project_added', {
-          project_id: finalProject.id,
-          name: finalProject.name,
-          repo_path: finalProject.repoPath,
-        });
-
-        return reply.code(201).send(finalProject);
+        const service = getProjectService();
+        const project = service.createProject(request.body);
+        return reply.code(201).send(project);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
 
+        const message = err instanceof Error ? err.message : String(err);
         if (message.includes('UNIQUE constraint failed')) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -437,30 +139,13 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const project = db.getProject(projectId);
-        if (!project) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project ${projectId} not found`,
-          });
-        }
-
-        // Get team counts for this project
-        const teams = db.getTeams({ projectId });
-        const activeStatuses = ['launching', 'running', 'idle', 'stuck'];
-        const activeCount = teams.filter((t) => activeStatuses.includes(t.status)).length;
-        const queuedCount = teams.filter((t) => t.status === 'queued').length;
-
-        const summary = {
-          ...project,
-          teamCount: teams.length,
-          activeTeamCount: activeCount,
-          queuedTeamCount: queuedCount,
-        };
-
-        return reply.code(200).send(summary);
+        const service = getProjectService();
+        const detail = service.getProjectDetail(projectId);
+        return reply.code(200).send(detail);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to get project');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -575,56 +260,13 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const project = db.getProject(projectId);
-        if (!project) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project ${projectId} not found`,
-          });
-        }
-
-        // Mark queued teams as failed before deletion
-        const queuedTeams = db.getQueuedTeamsByProject(projectId);
-        for (const t of queuedTeams) {
-          db.updateTeam(t.id, { status: 'failed' });
-        }
-
-        // Stop all active teams for this project
-        const activeTeams = db.getTeams({ projectId }).filter((t) =>
-          ['launching', 'running', 'idle', 'stuck'].includes(t.status),
-        );
-
-        const manager = getTeamManager();
-        for (const team of activeTeams) {
-          try {
-            await manager.stop(team.id);
-          } catch {
-            // Continue stopping other teams even if one fails
-          }
-        }
-
-        // Uninstall hooks
-        uninstallHooks(project.repoPath, request.log);
-
-        // Clear cached issues for this project
-        const issueFetcher = getIssueFetcher();
-        issueFetcher.clearProject(projectId);
-
-        // Delete all teams and related records (events, commands, usage_snapshots,
-        // transitions, PRs) in a single transaction
-        db.deleteTeamsByProject(projectId);
-
-        // Delete the project from DB
-        db.deleteProject(projectId);
-
-        // Broadcast SSE event
-        sseBroker.broadcast('project_removed', {
-          project_id: projectId,
-        });
-
+        const service = getProjectService();
+        await service.deleteProject(projectId);
         return reply.code(200).send({ success: true });
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to delete project');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -652,36 +294,13 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const project = db.getProject(projectId);
-        if (!project) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project ${projectId} not found`,
-          });
-        }
-
-        const result = installHooks(project.repoPath, request.log);
-
-        // Check what actually landed on disk
-        const status = checkInstallStatus(project.repoPath);
-        const allInstalled = status.hooks.installed && status.prompt.installed;
-        db.updateProject(project.id, { hooksInstalled: allInstalled });
-
-        // Broadcast so UI refreshes badges
-        sseBroker.broadcast('project_updated', {
-          project_id: projectId,
-          name: project.name,
-          status: project.status,
-        });
-
-        return reply.code(200).send({
-          ok: result.ok,
-          output: result.stdout.trim(),
-          error: result.stderr.trim() || undefined,
-          installStatus: status,
-        });
+        const service = getProjectService();
+        const result = service.installHooksForProject(projectId);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to install hooks');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -846,39 +465,13 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const project = db.getProject(projectId);
-        if (!project) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project ${projectId} not found`,
-          });
-        }
-
-        if (!project.promptFile) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `No prompt file configured for project ${projectId}`,
-          });
-        }
-
-        const absPath = path.join(config.fleetCommanderRoot, project.promptFile);
-        if (!fs.existsSync(absPath)) {
-          // Try falling back to default
-          const defaultPath = path.join(config.fleetCommanderRoot, 'prompts', 'default-prompt.md');
-          if (fs.existsSync(defaultPath)) {
-            const content = fs.readFileSync(defaultPath, 'utf-8');
-            return reply.code(200).send({ promptFile: project.promptFile, content, isDefault: true });
-          }
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Prompt file not found: ${project.promptFile}`,
-          });
-        }
-
-        const content = fs.readFileSync(absPath, 'utf-8');
-        return reply.code(200).send({ promptFile: project.promptFile, content, isDefault: false });
+        const service = getProjectService();
+        const result = service.getPrompt(projectId);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to read project prompt');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -906,15 +499,6 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const project = db.getProject(projectId);
-        if (!project) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Project ${projectId} not found`,
-          });
-        }
-
         const { content } = request.body || {};
         if (content === undefined || typeof content !== 'string') {
           return reply.code(400).send({
@@ -923,21 +507,13 @@ const projectsRoutes: FastifyPluginCallback = (
           });
         }
 
-        if (!project.promptFile) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `No prompt file configured for project ${projectId}`,
-          });
-        }
-
-        const absPath = path.join(config.fleetCommanderRoot, project.promptFile);
-
-        // Ensure directory exists
-        fs.mkdirSync(path.dirname(absPath), { recursive: true });
-        fs.writeFileSync(absPath, content, 'utf-8');
-
-        return reply.code(200).send({ promptFile: project.promptFile, content });
+        const service = getProjectService();
+        const result = service.savePrompt(projectId, content);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to update project prompt');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/routes/prs.ts
+++ b/src/server/routes/prs.ts
@@ -5,9 +5,8 @@
 // enable/disable auto-merge, and update branch.
 //
 // All GitHub operations use the `gh` CLI (never Octokit) per project conventions.
-// gh CLI errors are caught and returned as structured JSON responses.
-// Successful mutation actions broadcast SSE events so the dashboard updates
-// in real time.
+// Mutation actions delegate to PRService which handles CLI calls, DB updates,
+// and SSE broadcasts.
 // =============================================================================
 
 import type {
@@ -16,10 +15,10 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import { execSync } from 'child_process';
 import { getDatabase } from '../db.js';
 import { githubPoller } from '../services/github-poller.js';
-import { sseBroker } from '../services/sse-broker.js';
+import { getPRService } from '../services/pr-service.js';
+import { ServiceError } from '../services/service-error.js';
 
 // ---------------------------------------------------------------------------
 // Request param interfaces
@@ -36,62 +35,6 @@ interface PRNumberParams {
 function parsePRNumber(raw: string): number | null {
   const n = parseInt(raw, 10);
   return isNaN(n) || n < 1 ? null : n;
-}
-
-// ---------------------------------------------------------------------------
-// Helper: validate a GitHub repo slug (owner/repo) to prevent injection
-// ---------------------------------------------------------------------------
-
-const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
-
-function validateGithubRepo(repo: string): boolean {
-  return GITHUB_REPO_RE.test(repo);
-}
-
-// ---------------------------------------------------------------------------
-// Helper: execute a gh CLI command, returning { ok, stdout?, error? }
-// ---------------------------------------------------------------------------
-
-interface GHResult {
-  ok: boolean;
-  stdout?: string;
-  error?: string;
-}
-
-function execGH(command: string): GHResult {
-  try {
-    const stdout = execSync(command, {
-      encoding: 'utf-8',
-      timeout: 15_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { ok: true, stdout };
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    // Try to extract stderr from the ExecSyncError
-    let stderr = message;
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      const rawStderr = (err as { stderr: string | Buffer }).stderr;
-      stderr = typeof rawStderr === 'string' ? rawStderr : rawStderr.toString('utf-8');
-    }
-    return { ok: false, error: stderr.trim() || message };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helper: resolve github_repo for a PR by looking up the team's project
-// ---------------------------------------------------------------------------
-
-function resolveGithubRepoForPR(prNumber: number): string | null {
-  const db = getDatabase();
-  const pr = db.getPullRequest(prNumber);
-  if (!pr || !pr.teamId) return null;
-
-  const team = db.getTeam(pr.teamId);
-  if (!team || !team.projectId) return null;
-
-  const project = db.getProject(team.projectId);
-  return project?.githubRepo ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,7 +99,6 @@ const prsRoutes: FastifyPluginCallback = (
           try {
             checks = JSON.parse(pr.checksJson);
           } catch {
-            // If checks_json is malformed, return it as-is
             checks = [];
           }
         }
@@ -215,63 +157,17 @@ const prsRoutes: FastifyPluginCallback = (
           });
         }
 
-        // Resolve github_repo from the PR's team's project
-        const githubRepo = resolveGithubRepoForPR(prNumber);
-        if (!githubRepo) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
-          });
-        }
-
-        if (!validateGithubRepo(githubRepo)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Invalid GitHub repo slug: ${githubRepo}`,
-          });
-        }
-
-        const result = execGH(
-          `gh pr merge ${prNumber} --auto --squash --repo ${githubRepo}`,
-        );
-
-        if (!result.ok) {
-          request.log.warn(
-            { prNumber, error: result.error },
-            'gh pr merge --auto failed',
-          );
-          return reply.code(502).send({
-            error: 'GitHub CLI Error',
-            message: `Failed to enable auto-merge for PR #${prNumber}`,
-            details: result.error,
-          });
-        }
-
-        // Update the database record
-        const db = getDatabase();
-        const pr = db.getPullRequest(prNumber);
-        if (pr) {
-          db.updatePullRequest(prNumber, { autoMerge: true });
-        }
-
-        // Broadcast SSE event
-        sseBroker.broadcast(
-          'pr_updated',
-          {
-            pr_number: prNumber,
-            team_id: pr?.teamId ?? 0,
-            action: 'auto_merge_enabled',
-            auto_merge: true,
-          },
-          pr?.teamId ?? undefined,
-        );
-
-        return reply.code(200).send({
-          ok: true,
-          message: `Auto-merge enabled for PR #${prNumber}`,
-          output: result.stdout?.trim() ?? '',
-        });
+        const service = getPRService();
+        const result = service.enableAutoMerge(prNumber);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({
+            error: err.code === 'EXTERNAL_ERROR' ? 'GitHub CLI Error' : err.code,
+            message: err.message,
+            details: err.details,
+          });
+        }
         request.log.error(err, 'Failed to enable auto-merge');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -299,63 +195,17 @@ const prsRoutes: FastifyPluginCallback = (
           });
         }
 
-        // Resolve github_repo from the PR's team's project
-        const githubRepo = resolveGithubRepoForPR(prNumber);
-        if (!githubRepo) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
-          });
-        }
-
-        if (!validateGithubRepo(githubRepo)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Invalid GitHub repo slug: ${githubRepo}`,
-          });
-        }
-
-        const result = execGH(
-          `gh pr merge ${prNumber} --disable-auto --repo ${githubRepo}`,
-        );
-
-        if (!result.ok) {
-          request.log.warn(
-            { prNumber, error: result.error },
-            'gh pr merge --disable-auto failed',
-          );
-          return reply.code(502).send({
-            error: 'GitHub CLI Error',
-            message: `Failed to disable auto-merge for PR #${prNumber}`,
-            details: result.error,
-          });
-        }
-
-        // Update the database record
-        const db = getDatabase();
-        const pr = db.getPullRequest(prNumber);
-        if (pr) {
-          db.updatePullRequest(prNumber, { autoMerge: false });
-        }
-
-        // Broadcast SSE event
-        sseBroker.broadcast(
-          'pr_updated',
-          {
-            pr_number: prNumber,
-            team_id: pr?.teamId ?? 0,
-            action: 'auto_merge_disabled',
-            auto_merge: false,
-          },
-          pr?.teamId ?? undefined,
-        );
-
-        return reply.code(200).send({
-          ok: true,
-          message: `Auto-merge disabled for PR #${prNumber}`,
-          output: result.stdout?.trim() ?? '',
-        });
+        const service = getPRService();
+        const result = service.disableAutoMerge(prNumber);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({
+            error: err.code === 'EXTERNAL_ERROR' ? 'GitHub CLI Error' : err.code,
+            message: err.message,
+            details: err.details,
+          });
+        }
         request.log.error(err, 'Failed to disable auto-merge');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -383,58 +233,17 @@ const prsRoutes: FastifyPluginCallback = (
           });
         }
 
-        // Resolve github_repo from the PR's team's project
-        const githubRepo = resolveGithubRepoForPR(prNumber);
-        if (!githubRepo) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
-          });
-        }
-
-        if (!validateGithubRepo(githubRepo)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Invalid GitHub repo slug: ${githubRepo}`,
-          });
-        }
-
-        const result = execGH(
-          `gh api repos/${githubRepo}/pulls/${prNumber}/update-branch -X PUT`,
-        );
-
-        if (!result.ok) {
-          request.log.warn(
-            { prNumber, error: result.error },
-            'gh api update-branch failed',
-          );
-          return reply.code(502).send({
-            error: 'GitHub CLI Error',
-            message: `Failed to update branch for PR #${prNumber}`,
-            details: result.error,
-          });
-        }
-
-        // Broadcast SSE event
-        const db = getDatabase();
-        const pr = db.getPullRequest(prNumber);
-
-        sseBroker.broadcast(
-          'pr_updated',
-          {
-            pr_number: prNumber,
-            team_id: pr?.teamId ?? 0,
-            action: 'branch_updated',
-          },
-          pr?.teamId ?? undefined,
-        );
-
-        return reply.code(200).send({
-          ok: true,
-          message: `Branch updated for PR #${prNumber}`,
-          output: result.stdout?.trim() ?? '',
-        });
+        const service = getPRService();
+        const result = service.updateBranch(prNumber);
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({
+            error: err.code === 'EXTERNAL_ERROR' ? 'GitHub CLI Error' : err.code,
+            message: err.message,
+            details: err.details,
+          });
+        }
         request.log.error(err, 'Failed to update PR branch');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/routes/state-machine.ts
+++ b/src/server/routes/state-machine.ts
@@ -13,12 +13,12 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import { getDatabase } from '../db.js';
 import {
   STATES,
   STATE_MACHINE_TRANSITIONS,
 } from '../../shared/state-machine.js';
-import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
+import { getMessageTemplateService } from '../services/message-template-service.js';
+import { ServiceError } from '../services/service-error.js';
 
 // ---------------------------------------------------------------------------
 // Plugin
@@ -65,25 +65,13 @@ const stateMachineRoutes: FastifyPluginCallback = (
     '/api/message-templates',
     async (_request: FastifyRequest, reply: FastifyReply) => {
       try {
-        const db = getDatabase();
-        const dbTemplates = db.getMessageTemplates();
-        const dbMap = new Map(dbTemplates.map((t) => [t.id, t]));
-
-        // Merge defaults with DB overrides so every template is always returned
-        const enriched = DEFAULT_MESSAGE_TEMPLATES.map((def) => {
-          const dbRow = dbMap.get(def.id);
-          return {
-            id: def.id,
-            template: dbRow?.template ?? def.template,
-            enabled: dbRow?.enabled ?? true,
-            description: def.description,
-            placeholders: def.placeholders,
-            isDefault: !dbRow,
-          };
-        });
-
+        const service = getMessageTemplateService();
+        const enriched = service.listTemplates();
         return reply.code(200).send(enriched);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         _request.log.error(err, 'Failed to get message templates');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -103,40 +91,13 @@ const stateMachineRoutes: FastifyPluginCallback = (
         const { id } = request.params as { id: string };
         const body = request.body as { template?: string; enabled?: boolean } | null;
 
-        if (!body || (body.template === undefined && body.enabled === undefined)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'Body must include at least one of: template, enabled',
-          });
-        }
-
-        const db = getDatabase();
-        const existing = db.getMessageTemplate(id);
-
-        if (existing) {
-          db.updateMessageTemplate(id, {
-            template: body.template,
-            enabled: body.enabled,
-          });
-        } else {
-          const defaultTmpl = DEFAULT_MESSAGE_TEMPLATES.find((t) => t.id === id);
-          if (!defaultTmpl) {
-            return reply.code(404).send({
-              error: 'Not Found',
-              message: `No message template found for id '${id}'`,
-            });
-          }
-
-          db.insertMessageTemplate({
-            id,
-            template: body.template ?? defaultTmpl.template,
-            enabled: body.enabled ?? true,
-          });
-        }
-
-        const updated = db.getMessageTemplate(id);
+        const service = getMessageTemplateService();
+        const updated = service.upsertTemplate(id, body ?? {});
         return reply.code(200).send(updated);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to update message template');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/routes/system.ts
+++ b/src/server/routes/system.ts
@@ -3,6 +3,7 @@
 // =============================================================================
 // Fastify plugin that registers system-level endpoints:
 // stuck diagnostics, blocked teams, fleet health summary, server status.
+// Diagnostics logic is delegated to DiagnosticsService.
 // =============================================================================
 
 import type {
@@ -14,11 +15,9 @@ import type {
 import fs from 'fs';
 import path from 'path';
 import { getDatabase } from '../db.js';
-import { getTeamManager } from '../services/team-manager.js';
 import { sseBroker } from '../services/sse-broker.js';
-import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
-import { getIssueFetcher } from '../services/issue-fetcher.js';
-import { uninstallHooks } from '../utils/hook-installer.js';
+import { getDiagnosticsService } from '../services/diagnostics-service.js';
+import { ServiceError } from '../services/service-error.js';
 import config from '../config.js';
 import { resolveClaudePath } from '../utils/resolve-claude-path.js';
 
@@ -73,40 +72,13 @@ const systemRoutes: FastifyPluginCallback = (
     '/api/diagnostics/blocked',
     async (_request: FastifyRequest, reply: FastifyReply) => {
       try {
-        const db = getDatabase();
-
-        // Find teams whose PR has ci_status = 'failing' and ci_fail_count >= threshold
-        const teams = db.getActiveTeams();
-        const blockedTeams = [];
-
-        for (const team of teams) {
-          if (!team.prNumber) continue;
-
-          const pr = db.getPullRequest(team.prNumber);
-          if (!pr) continue;
-
-          if (pr.ciStatus === 'failing' && pr.ciFailCount >= config.maxUniqueCiFailures) {
-            blockedTeams.push({
-              teamId: team.id,
-              worktreeName: team.worktreeName,
-              issueNumber: team.issueNumber,
-              issueTitle: team.issueTitle,
-              status: team.status,
-              phase: team.phase,
-              prNumber: pr.prNumber,
-              ciStatus: pr.ciStatus,
-              ciFailCount: pr.ciFailCount,
-              maxAllowed: config.maxUniqueCiFailures,
-            });
-          }
-        }
-
-        return reply.code(200).send({
-          maxUniqueCiFailures: config.maxUniqueCiFailures,
-          count: blockedTeams.length,
-          teams: blockedTeams,
-        });
+        const service = getDiagnosticsService();
+        const result = service.getBlockedTeams();
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         _request.log.error(err, 'Failed to get blocked diagnostics');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -123,35 +95,13 @@ const systemRoutes: FastifyPluginCallback = (
     '/api/diagnostics/health',
     async (_request: FastifyRequest, reply: FastifyReply) => {
       try {
-        const db = getDatabase();
-        const allTeams = db.getTeams();
-
-        // Count teams by status
-        const statusCounts: Record<string, number> = {};
-        for (const team of allTeams) {
-          statusCounts[team.status] = (statusCounts[team.status] ?? 0) + 1;
-        }
-
-        // Count teams by phase
-        const phaseCounts: Record<string, number> = {};
-        for (const team of allTeams) {
-          phaseCounts[team.phase] = (phaseCounts[team.phase] ?? 0) + 1;
-        }
-
-        const activeTeams = db.getActiveTeams();
-        const stuckCandidates = db.getStuckCandidates(
-          config.idleThresholdMin,
-          config.stuckThresholdMin,
-        );
-
-        return reply.code(200).send({
-          totalTeams: allTeams.length,
-          activeTeams: activeTeams.length,
-          stuckOrIdle: stuckCandidates.length,
-          byStatus: statusCounts,
-          byPhase: phaseCounts,
-        });
+        const service = getDiagnosticsService();
+        const summary = service.getHealthSummary();
+        return reply.code(200).send(summary);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         _request.log.error(err, 'Failed to get fleet health');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -318,57 +268,18 @@ const systemRoutes: FastifyPluginCallback = (
     '/api/system/factory-reset',
     async (request: FastifyRequest, reply: FastifyReply) => {
       try {
-        // Require explicit confirmation to prevent accidental resets
         const body = request.body as Record<string, unknown> | null;
-        if (!body || body.confirm !== 'FACTORY_RESET') {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'Factory reset requires { "confirm": "FACTORY_RESET" } in body',
-          });
-        }
+        const confirm = (body?.confirm as string) ?? '';
 
-        const db = getDatabase();
-        const manager = getTeamManager();
-
-        // 1. Stop all running teams
-        const activeTeams = db.getActiveTeams();
-        for (const team of activeTeams) {
-          try {
-            await manager.stop(team.id);
-          } catch {
-            // Best-effort — continue stopping remaining teams
-          }
-        }
-
-        // 2. Uninstall hooks from all projects before deleting them
-        const projects = db.getProjects();
-        for (const project of projects) {
-          uninstallHooks(project.repoPath, request.log);
-        }
-
-        // 3. Delete all data and re-seed default templates
-        const templatesSeeded = db.factoryReset(
-          DEFAULT_MESSAGE_TEMPLATES.map((t) => ({ id: t.id, template: t.template })),
-        );
-
-        // 4. Clear in-memory caches (issue fetcher, team manager)
-        //    Stop the polling timer first so it doesn't re-fetch while we clear,
-        //    then wipe the cache. Do NOT restart — there are no projects left.
-        const issueFetcher = getIssueFetcher();
-        issueFetcher.stop();
-        issueFetcher.clearAll();
-
-        // 5. Broadcast empty state to all SSE clients
-        sseBroker.broadcast('snapshot', { teams: [] });
+        const service = getDiagnosticsService();
+        const result = await service.factoryReset(confirm);
 
         request.log.info('Factory reset completed — all data cleared');
-
-        return reply.code(200).send({
-          status: 'ok',
-          message: 'Factory reset complete. All projects, teams, and data have been cleared.',
-          templatesSeeded,
-        });
+        return reply.code(200).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Factory reset failed');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -4,6 +4,7 @@
 // Fastify plugin that registers all team-related API endpoints:
 // launch, stop, resume, restart, batch-launch, stop-all, list, detail, output,
 // export, send-message, set-phase, acknowledge.
+// Business logic is delegated to TeamService.
 // =============================================================================
 
 import type {
@@ -12,16 +13,11 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import fs from 'fs';
-import path from 'path';
 import { getTeamManager } from '../services/team-manager.js';
-import { getIssueFetcher } from '../services/issue-fetcher.js';
-import { githubPoller } from '../services/github-poller.js';
 import { getDatabase } from '../db.js';
-import { sseBroker } from '../services/sse-broker.js';
-import config from '../config.js';
-import type { TeamPhase, IssueDependencyInfo } from '../../shared/types.js';
-import { buildTimeline } from '../utils/build-timeline.js';
+import { getTeamService } from '../services/team-service.js';
+import { ServiceError } from '../services/service-error.js';
+import type { TeamPhase } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Request body / param interfaces
@@ -74,41 +70,6 @@ interface SetPhaseBody {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Produce a short one-line summary of a stream event for text export. */
-function summarize(e: Record<string, unknown>): string {
-  if (typeof e.message === 'string') return e.message;
-  if (typeof e.tool === 'string') return `tool:${e.tool}`;
-  if (typeof e.content === 'string') return e.content.slice(0, 120);
-  return '';
-}
-
-// ---------------------------------------------------------------------------
-// Dependency check helper
-// ---------------------------------------------------------------------------
-
-/**
- * Check whether an issue has unresolved dependencies.
- * Returns the dependency info, or null if dependencies cannot be determined
- * (which is treated as "no blockers" -- permissive fallback).
- */
-async function checkDependencies(projectId: number, issueNumber: number): Promise<IssueDependencyInfo | null> {
-  try {
-    const fetcher = getIssueFetcher();
-    return await fetcher.fetchDependenciesForIssue(projectId, issueNumber);
-  } catch (err) {
-    console.error(
-      `[Teams] Dependency check failed for issue #${issueNumber}:`,
-      err instanceof Error ? err.message : err
-    );
-    // Permissive fallback: if we can't check, allow launch
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -127,47 +88,22 @@ const teamsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const { projectId, issueNumber, issueTitle, prompt, headless, force } = request.body;
-
-        if (!projectId || typeof projectId !== 'number' || projectId < 1) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'projectId is required and must be a positive integer',
-          });
-        }
-
-        if (!issueNumber || typeof issueNumber !== 'number' || issueNumber < 1) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'issueNumber is required and must be a positive integer',
-          });
-        }
-
-        // Dependency check -- block launch if unresolved dependencies exist
-        if (!force) {
-          const depInfo = await checkDependencies(projectId, issueNumber);
-          if (depInfo && !depInfo.resolved) {
-            // Track for resolution detection in the poller
-            const blockerNumbers = depInfo.blockedBy
-              .filter((b) => b.state === 'open')
-              .map((b) => b.number);
-            githubPoller.trackBlockedIssue(projectId, issueNumber, blockerNumbers);
-
+        const service = getTeamService();
+        const team = await service.launchTeam(request.body);
+        return reply.code(201).send(team);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          if (err.code === 'BLOCKED_BY_DEPENDENCIES') {
             return reply.code(409).send({
               error: 'Blocked by Dependencies',
-              message: `Issue #${issueNumber} is blocked by ${depInfo.openCount} unresolved dependency${depInfo.openCount !== 1 ? 'ies' : ''}`,
-              dependencies: depInfo,
+              message: err.message,
               hint: 'Set force: true to bypass dependency check',
             });
           }
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
         }
 
-        const manager = getTeamManager();
-        const team = await manager.launch(projectId, issueNumber, issueTitle, prompt, headless, force);
-        return reply.code(201).send(team);
-      } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-
         if (message.includes('already active') || message.includes('already completed')) {
           return reply.code(409).send({ error: 'Conflict', message });
         }
@@ -191,70 +127,13 @@ const teamsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const { projectId, issues, prompt, delayMs, headless } = request.body;
-
-        if (!projectId || typeof projectId !== 'number' || projectId < 1) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'projectId is required and must be a positive integer',
-          });
-        }
-
-        if (!issues || !Array.isArray(issues) || issues.length === 0) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'issues array is required and must not be empty',
-          });
-        }
-
-        // Validate each issue entry
-        for (const issue of issues) {
-          if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
-            return reply.code(400).send({
-              error: 'Bad Request',
-              message: `Invalid issue number: ${JSON.stringify(issue)}`,
-            });
-          }
-        }
-
-        // Dependency check for batch launch: check each issue, separate blocked from launchable
-        const blocked: Array<{ issueNumber: number; dependencies: IssueDependencyInfo }> = [];
-        const launchable: Array<{ number: number; title?: string }> = [];
-
-        // Build set of issue numbers in this batch for intra-batch ordering
-        const batchNumbers = new Set(issues.map((i) => i.number));
-
-        for (const issue of issues) {
-          const depInfo = await checkDependencies(projectId, issue.number);
-          if (depInfo && !depInfo.resolved) {
-            // Check if all open blockers are in this same batch (intra-batch dependency)
-            const allBlockersInBatch = depInfo.blockedBy
-              .filter((b) => b.state === 'open')
-              .every((b) => batchNumbers.has(b.number));
-
-            if (allBlockersInBatch) {
-              // Defer: will be launched after its blockers (handled by ordering)
-              launchable.push(issue);
-            } else {
-              blocked.push({ issueNumber: issue.number, dependencies: depInfo });
-            }
-          } else {
-            launchable.push(issue);
-          }
-        }
-
-        const manager = getTeamManager();
-        const teams = launchable.length > 0
-          ? await manager.launchBatch(projectId, launchable, prompt, delayMs, headless)
-          : [];
-
-        // Return launched teams plus any blocked issues
-        const response = {
-          launched: teams,
-          blocked: blocked.length > 0 ? blocked : undefined,
-        };
-        return reply.code(201).send(response);
+        const service = getTeamService();
+        const result = await service.launchBatch(request.body);
+        return reply.code(201).send(result);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         const message = err instanceof Error ? err.message : String(err);
         request.log.error(err, 'Failed to launch batch');
         return reply.code(500).send({
@@ -496,104 +375,13 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
-        // Look up project to get model and GitHub repo
-        let projectModel: string | null = null;
-        let projectGithubRepo: string | null = null;
-        if (team.projectId) {
-          const project = db.getProject(team.projectId);
-          if (project) {
-            projectModel = project.model ?? null;
-            projectGithubRepo = project.githubRepo ?? null;
-          }
-        }
-
-        // Compute duration & idle in minutes
-        const launchedAt = team.launchedAt ? new Date(team.launchedAt) : null;
-        const now = new Date();
-        const durationMin = launchedAt
-          ? Math.round((now.getTime() - launchedAt.getTime()) / 60_000)
-          : 0;
-
-        const lastEventAt = team.lastEventAt ? new Date(team.lastEventAt) : null;
-        const idleMin = lastEventAt
-          ? Math.round((now.getTime() - lastEventAt.getTime()) / 60_000 * 10) / 10
-          : null;
-
-        // Pull request detail (if linked)
-        let prDetail = null;
-        if (team.prNumber) {
-          const pr = db.getPullRequest(team.prNumber);
-          if (pr) {
-            // Parse CI checks from JSON
-            let checks: Array<{ name: string; status: string; conclusion: string | null }> = [];
-            if (pr.checksJson) {
-              try {
-                checks = JSON.parse(pr.checksJson);
-              } catch {
-                // Malformed JSON — leave empty
-              }
-            }
-
-            prDetail = {
-              number: pr.prNumber,
-              state: pr.state,
-              mergeStatus: pr.mergeStatus,
-              ciStatus: pr.ciStatus,
-              ciFailCount: pr.ciFailCount,
-              checks,
-              autoMerge: pr.autoMerge,
-            };
-          }
-        }
-
-        // Recent events
-        const recentEvents = db.getEventsByTeam(teamId, 20);
-
-        // Output tail
-        const manager = getTeamManager();
-        const outputLines = manager.getOutput(teamId, 50);
-        const outputTail = outputLines.length > 0 ? outputLines.join('\n') : null;
-
-        // Assemble full TeamDetail response
-        const detail = {
-          id: team.id,
-          issueNumber: team.issueNumber,
-          issueTitle: team.issueTitle,
-          model: projectModel,
-          githubRepo: projectGithubRepo,
-          status: team.status,
-          phase: team.phase,
-          pid: team.pid,
-          sessionId: team.sessionId,
-          worktreeName: team.worktreeName,
-          branchName: team.branchName,
-          prNumber: team.prNumber,
-          launchedAt: team.launchedAt,
-          stoppedAt: team.stoppedAt,
-          lastEventAt: team.lastEventAt,
-          durationMin,
-          idleMin,
-          totalInputTokens: team.totalInputTokens,
-          totalOutputTokens: team.totalOutputTokens,
-          totalCacheCreationTokens: team.totalCacheCreationTokens,
-          totalCacheReadTokens: team.totalCacheReadTokens,
-          totalCostUsd: team.totalCostUsd,
-          pr: prDetail,
-          recentEvents,
-          outputTail,
-        };
-
+        const service = getTeamService();
+        const detail = service.getTeamDetail(teamId);
         return reply.code(200).send(detail);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to get team');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -613,47 +401,13 @@ const teamsRoutes: FastifyPluginCallback = (
       reply: FastifyReply,
     ) => {
       try {
-        const db = getDatabase();
-        const idParam = request.params.id;
-        const teamId = parseInt(idParam, 10);
-
-        // Support both integer IDs and worktree names (MCP sends worktree name)
-        let team;
-        if (!isNaN(teamId) && teamId > 0) {
-          team = db.getTeam(teamId);
-        }
-        if (!team) {
-          team = db.getTeamByWorktree(idParam);
-        }
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${idParam} not found`,
-          });
-        }
-
-        // Fetch pending PM commands for this team
-        const pendingCommands = db.getPendingCommands(team.id);
-        const latestMessage = pendingCommands.length > 0 ? pendingCommands[0].message : null;
-
-        // Compact MCP-compatible format
-        return reply.code(200).send({
-          id: team.id,
-          issueNumber: team.issueNumber,
-          worktreeName: team.worktreeName,
-          status: team.status,
-          phase: team.phase,
-          pid: team.pid,
-          prNumber: team.prNumber,
-          lastEventAt: team.lastEventAt,
-          pm_message: latestMessage,
-          pending_commands: pendingCommands.map(c => ({
-            id: c.id,
-            message: c.message,
-            createdAt: c.createdAt,
-          })),
-        });
+        const service = getTeamService();
+        const status = service.getTeamStatus(request.params.id);
+        return reply.code(200).send(status);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to get team status');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -769,28 +523,16 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
         const limitParam = (request.query as TimelineQuerystring).limit;
         const limit = limitParam ? parseInt(limitParam, 10) : 500;
 
-        // Fetch stream events from in-memory buffer (same as stream-events endpoint)
-        const manager = getTeamManager();
-        const streamEvents = manager.getParsedEvents(teamId);
-
-        // Fetch hook events from DB — cap at 500 to prevent unbounded queries
-        const hookEvents = db.getEventsByTeam(teamId, 500);
-
-        const timeline = buildTimeline(streamEvents, hookEvents, teamId, limit);
+        const service = getTeamService();
+        const timeline = service.getTeamTimeline(teamId, limit);
         return reply.code(200).send(timeline);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to get team timeline');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -818,44 +560,17 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
         const format = (request.query as ExportQuerystring).format ?? 'json';
-        const events = db.getEventsByTeam(teamId);
-        const manager = getTeamManager();
-        const streamEvents = manager.getParsedEvents(teamId);
-        const outputLines = manager.getOutput(teamId);
+        const service = getTeamService();
+        const result = service.exportTeam(teamId, format);
 
-        if (format === 'txt') {
-          // Plain text format
-          let text = `# Team ${team.worktreeName} - Export\n`;
-          text += `Issue: #${team.issueNumber} ${team.issueTitle ?? ''}\n`;
-          text += `Status: ${team.status}\n`;
-          text += `Launched: ${team.launchedAt ?? 'N/A'}\n\n`;
-          text += `## Stream Events\n`;
-          for (const e of streamEvents) {
-            text += `[${e.timestamp ?? ''}] ${e.type} ${summarize(e as unknown as Record<string, unknown>)}\n`;
-          }
-          text += `\n## Raw Output\n`;
-          text += outputLines.join('\n');
-
-          reply.header('Content-Type', 'text/plain');
-          reply.header('Content-Disposition', `attachment; filename="${team.worktreeName}-export.txt"`);
-          return text;
-        }
-
-        // JSON format (default)
-        reply.header('Content-Type', 'application/json');
-        reply.header('Content-Disposition', `attachment; filename="${team.worktreeName}-export.json"`);
-        return { team, events, streamEvents, output: outputLines };
+        reply.header('Content-Type', result.contentType);
+        reply.header('Content-Disposition', `attachment; filename="${result.filename}"`);
+        return result.data;
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to export team logs');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -926,72 +641,26 @@ const teamsRoutes: FastifyPluginCallback = (
         }
 
         const { message } = request.body || {};
-        if (!message || typeof message !== 'string' || message.trim().length === 0) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: 'message is required and must be a non-empty string',
-          });
-        }
+        const service = getTeamService();
+        const { command, delivered } = service.sendMessage(teamId, message);
 
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
-        // Resolve worktree path from the team's project
-        let worktreePath: string;
-        if (team.projectId) {
-          const project = db.getProject(team.projectId);
-          worktreePath = project
-            ? path.join(project.repoPath, config.worktreeDir, team.worktreeName)
-            : path.join(config.worktreeDir, team.worktreeName);
-        } else {
-          worktreePath = path.join(config.worktreeDir, team.worktreeName);
-        }
-        const messagePath = path.join(worktreePath, '.fleet-pm-message');
-
-        try {
-          fs.writeFileSync(messagePath, message.trim(), 'utf-8');
-        } catch (fsErr: unknown) {
-          const fsMsg = fsErr instanceof Error ? fsErr.message : String(fsErr);
-          request.log.warn({ worktreePath, error: fsMsg }, 'Failed to write .fleet-pm-message file');
-          // Continue anyway — the command record is still useful
-        }
-
-        // Insert command row in the database
-        const command = db.insertCommand({
-          teamId,
-          message: message.trim(),
-        });
-
-        // Try to deliver via stdin pipe (direct delivery to running process)
-        const manager = getTeamManager();
-        const delivered = manager.sendMessage(teamId, message.trim(), 'user');
-        if (delivered) {
-          db.markCommandDelivered(command.id);
-          // Reset lastEventAt so the stuck detector doesn't race between
-          // PM message delivery and the agent's next hook event (#190)
-          db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
-          request.log.info(`[Teams] Message delivered to team ${teamId} via stdin`);
-        } else {
-          request.log.warn(`[Teams] Message not delivered to team ${teamId} — no stdin pipe`);
+        if (!delivered) {
           return reply.code(422).send({
-            ...command,
+            ...command as object,
             error: 'Unprocessable Entity',
             message: 'Team is not running \u2014 message not delivered',
           });
         }
 
         return reply.code(201).send({
-          ...command,
+          ...command as object,
           status: 'delivered' as const,
           deliveredAt: new Date().toISOString(),
         });
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to send message to team');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -1020,53 +689,13 @@ const teamsRoutes: FastifyPluginCallback = (
         }
 
         const { phase, reason } = request.body || {};
-
-        const validPhases: TeamPhase[] = [
-          'init', 'analyzing', 'implementing', 'reviewing', 'pr', 'done', 'blocked',
-        ];
-        if (!phase || !validPhases.includes(phase)) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `phase is required and must be one of: ${validPhases.join(', ')}`,
-          });
-        }
-
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
-        // Guard: cannot change phase on a terminal-status team
-        if (['done', 'failed'].includes(team.status)) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            message: `Cannot set phase on a ${team.status} team. Use restart to reactivate.`,
-          });
-        }
-
-        const previousPhase = team.phase;
-        const updated = db.updateTeam(teamId, { phase });
-
-        // Broadcast SSE event for phase change
-        sseBroker.broadcast(
-          'team_status_changed',
-          {
-            team_id: teamId,
-            status: team.status,
-            previous_status: team.status,
-            phase,
-            previous_phase: previousPhase,
-            reason: reason ?? undefined,
-          },
-          teamId,
-        );
-
+        const service = getTeamService();
+        const updated = service.setPhase(teamId, phase, reason);
         return reply.code(200).send(updated);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to set team phase');
         return reply.code(500).send({
           error: 'Internal Server Error',
@@ -1172,52 +801,13 @@ const teamsRoutes: FastifyPluginCallback = (
           });
         }
 
-        const db = getDatabase();
-        const team = db.getTeam(teamId);
-        if (!team) {
-          return reply.code(404).send({
-            error: 'Not Found',
-            message: `Team ${teamId} not found`,
-          });
-        }
-
-        // Only acknowledge stuck or failed teams
-        if (team.status !== 'stuck' && team.status !== 'failed') {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: `Team ${teamId} is not stuck or failed (current status: ${team.status})`,
-          });
-        }
-
-        const previousStatus = team.status;
-
-        // Transition stuck -> idle (so it can be re-evaluated), failed -> done
-        const newStatus = team.status === 'stuck' ? 'idle' : 'done';
-        db.insertTransition({
-          teamId,
-          fromStatus: previousStatus,
-          toStatus: newStatus,
-          trigger: 'pm_action',
-          reason: previousStatus === 'stuck' ? 'PM acknowledged stuck alert' : 'PM acknowledged failed alert',
-        });
-        const updated = db.updateTeam(teamId, {
-          status: newStatus,
-          lastEventAt: new Date().toISOString(),
-        });
-
-        // Broadcast status change
-        sseBroker.broadcast(
-          'team_status_changed',
-          {
-            team_id: teamId,
-            status: newStatus,
-            previous_status: previousStatus,
-          },
-          teamId,
-        );
-
+        const service = getTeamService();
+        const updated = service.acknowledgeAlert(teamId);
         return reply.code(200).send(updated);
       } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
         request.log.error(err, 'Failed to acknowledge team alert');
         return reply.code(500).send({
           error: 'Internal Server Error',

--- a/src/server/services/diagnostics-service.ts
+++ b/src/server/services/diagnostics-service.ts
@@ -1,0 +1,209 @@
+// =============================================================================
+// Fleet Commander — Diagnostics Service
+// =============================================================================
+// Provides fleet health diagnostics: blocked teams, health summaries,
+// and factory reset capability. Used by system routes and future MCP tools.
+// =============================================================================
+
+import { getDatabase } from '../db.js';
+import { getTeamManager } from './team-manager.js';
+import { sseBroker } from './sse-broker.js';
+import { getIssueFetcher } from './issue-fetcher.js';
+import { uninstallHooks } from '../utils/hook-installer.js';
+import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
+import config from '../config.js';
+import { ServiceError, validationError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A team that is blocked by CI failures exceeding the threshold */
+export interface BlockedTeam {
+  teamId: number;
+  worktreeName: string;
+  issueNumber: number;
+  issueTitle: string | null;
+  status: string;
+  phase: string;
+  prNumber: number;
+  ciStatus: string;
+  ciFailCount: number;
+  maxAllowed: number;
+}
+
+/** Fleet health summary with counts by status and phase */
+export interface HealthSummary {
+  totalTeams: number;
+  activeTeams: number;
+  stuckOrIdle: number;
+  byStatus: Record<string, number>;
+  byPhase: Record<string, number>;
+}
+
+/** Result of a factory reset operation */
+export interface FactoryResetResult {
+  status: string;
+  message: string;
+  templatesSeeded: number;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class DiagnosticsService {
+  /**
+   * Get active teams that are blocked by CI failures exceeding the threshold.
+   *
+   * @returns Object with threshold config and list of blocked teams
+   */
+  getBlockedTeams(): { maxUniqueCiFailures: number; count: number; teams: BlockedTeam[] } {
+    const db = getDatabase();
+    const teams = db.getActiveTeams();
+    const blockedTeams: BlockedTeam[] = [];
+
+    for (const team of teams) {
+      if (!team.prNumber) continue;
+
+      const pr = db.getPullRequest(team.prNumber);
+      if (!pr) continue;
+
+      if (pr.ciStatus === 'failing' && pr.ciFailCount >= config.maxUniqueCiFailures) {
+        blockedTeams.push({
+          teamId: team.id,
+          worktreeName: team.worktreeName,
+          issueNumber: team.issueNumber,
+          issueTitle: team.issueTitle,
+          status: team.status,
+          phase: team.phase,
+          prNumber: pr.prNumber,
+          ciStatus: pr.ciStatus,
+          ciFailCount: pr.ciFailCount,
+          maxAllowed: config.maxUniqueCiFailures,
+        });
+      }
+    }
+
+    return {
+      maxUniqueCiFailures: config.maxUniqueCiFailures,
+      count: blockedTeams.length,
+      teams: blockedTeams,
+    };
+  }
+
+  /**
+   * Get a fleet health summary with counts by status and phase.
+   *
+   * @returns Health summary object
+   */
+  getHealthSummary(): HealthSummary {
+    const db = getDatabase();
+    const allTeams = db.getTeams();
+
+    const statusCounts: Record<string, number> = {};
+    for (const team of allTeams) {
+      statusCounts[team.status] = (statusCounts[team.status] ?? 0) + 1;
+    }
+
+    const phaseCounts: Record<string, number> = {};
+    for (const team of allTeams) {
+      phaseCounts[team.phase] = (phaseCounts[team.phase] ?? 0) + 1;
+    }
+
+    const activeTeams = db.getActiveTeams();
+    const stuckCandidates = db.getStuckCandidates(
+      config.idleThresholdMin,
+      config.stuckThresholdMin,
+    );
+
+    return {
+      totalTeams: allTeams.length,
+      activeTeams: activeTeams.length,
+      stuckOrIdle: stuckCandidates.length,
+      byStatus: statusCounts,
+      byPhase: phaseCounts,
+    };
+  }
+
+  /**
+   * Perform a full factory reset: stop all teams, uninstall hooks,
+   * delete all data, re-seed default templates, and clear caches.
+   *
+   * @param confirm - Must be 'FACTORY_RESET' to proceed
+   * @returns Result indicating success and number of templates seeded
+   * @throws ServiceError with code VALIDATION if confirmation is missing
+   */
+  async factoryReset(confirm: string): Promise<FactoryResetResult> {
+    if (confirm !== 'FACTORY_RESET') {
+      throw validationError('Factory reset requires confirm = "FACTORY_RESET"');
+    }
+
+    const db = getDatabase();
+    const manager = getTeamManager();
+
+    // 1. Stop all running teams
+    const activeTeams = db.getActiveTeams();
+    for (const team of activeTeams) {
+      try {
+        await manager.stop(team.id);
+      } catch {
+        // Best-effort -- continue stopping remaining teams
+      }
+    }
+
+    // 2. Uninstall hooks from all projects before deleting them
+    const projects = db.getProjects();
+    for (const project of projects) {
+      // uninstallHooks requires a logger; use a minimal console-based one
+      uninstallHooks(project.repoPath, _minimalLogger);
+    }
+
+    // 3. Delete all data and re-seed default templates
+    const templatesSeeded = db.factoryReset(
+      DEFAULT_MESSAGE_TEMPLATES.map((t) => ({ id: t.id, template: t.template })),
+    );
+
+    // 4. Clear in-memory caches
+    const issueFetcher = getIssueFetcher();
+    issueFetcher.stop();
+    issueFetcher.clearAll();
+
+    // 5. Broadcast empty state to all SSE clients
+    sseBroker.broadcast('snapshot', { teams: [] });
+
+    return {
+      status: 'ok',
+      message: 'Factory reset complete. All projects, teams, and data have been cleared.',
+      templatesSeeded,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal logger for use outside Fastify request context
+// ---------------------------------------------------------------------------
+
+const _minimalLogger = {
+  info: (...args: unknown[]) => console.log('[DiagnosticsService]', ...args),
+  warn: (...args: unknown[]) => console.warn('[DiagnosticsService]', ...args),
+  error: (...args: unknown[]) => console.error('[DiagnosticsService]', ...args),
+} as any;
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: DiagnosticsService | null = null;
+
+/**
+ * Get the singleton DiagnosticsService instance.
+ *
+ * @returns DiagnosticsService singleton
+ */
+export function getDiagnosticsService(): DiagnosticsService {
+  if (!_instance) {
+    _instance = new DiagnosticsService();
+  }
+  return _instance;
+}

--- a/src/server/services/message-template-service.ts
+++ b/src/server/services/message-template-service.ts
@@ -1,0 +1,114 @@
+// =============================================================================
+// Fleet Commander — Message Template Service
+// =============================================================================
+// Manages PM->TL message templates used by the state machine.
+// Templates are stored in the DB with fallbacks to shared defaults.
+// =============================================================================
+
+import { getDatabase } from '../db.js';
+import { DEFAULT_MESSAGE_TEMPLATES } from '../../shared/message-templates.js';
+import { ServiceError, notFoundError, validationError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Enriched message template returned by listTemplates */
+export interface EnrichedMessageTemplate {
+  id: string;
+  template: string;
+  enabled: boolean;
+  description: string;
+  placeholders: string[];
+  isDefault: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class MessageTemplateService {
+  /**
+   * List all message templates, merging DB overrides with shared defaults.
+   * Every default template is always returned, even if no DB row exists.
+   *
+   * @returns Array of enriched message templates
+   */
+  listTemplates(): EnrichedMessageTemplate[] {
+    const db = getDatabase();
+    const dbTemplates = db.getMessageTemplates();
+    const dbMap = new Map(dbTemplates.map((t) => [t.id, t]));
+
+    return DEFAULT_MESSAGE_TEMPLATES.map((def) => {
+      const dbRow = dbMap.get(def.id);
+      return {
+        id: def.id,
+        template: dbRow?.template ?? def.template,
+        enabled: dbRow?.enabled ?? true,
+        description: def.description,
+        placeholders: def.placeholders,
+        isDefault: !dbRow,
+      };
+    });
+  }
+
+  /**
+   * Insert or update a message template in the database.
+   * If the template ID does not exist in defaults, throws NOT_FOUND.
+   *
+   * @param id - Template identifier (must match a default template ID)
+   * @param data - Fields to update (template text and/or enabled flag)
+   * @returns The updated template row from the database
+   * @throws ServiceError with code VALIDATION if body is empty
+   * @throws ServiceError with code NOT_FOUND if template ID is unknown
+   */
+  upsertTemplate(
+    id: string,
+    data: { template?: string; enabled?: boolean },
+  ): Record<string, unknown> {
+    if (data.template === undefined && data.enabled === undefined) {
+      throw validationError('Body must include at least one of: template, enabled');
+    }
+
+    const db = getDatabase();
+    const existing = db.getMessageTemplate(id);
+
+    if (existing) {
+      db.updateMessageTemplate(id, {
+        template: data.template,
+        enabled: data.enabled,
+      });
+    } else {
+      const defaultTmpl = DEFAULT_MESSAGE_TEMPLATES.find((t) => t.id === id);
+      if (!defaultTmpl) {
+        throw notFoundError(`No message template found for id '${id}'`);
+      }
+
+      db.insertMessageTemplate({
+        id,
+        template: data.template ?? defaultTmpl.template,
+        enabled: data.enabled ?? true,
+      });
+    }
+
+    return db.getMessageTemplate(id)!;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: MessageTemplateService | null = null;
+
+/**
+ * Get the singleton MessageTemplateService instance.
+ *
+ * @returns MessageTemplateService singleton
+ */
+export function getMessageTemplateService(): MessageTemplateService {
+  if (!_instance) {
+    _instance = new MessageTemplateService();
+  }
+  return _instance;
+}

--- a/src/server/services/pr-service.ts
+++ b/src/server/services/pr-service.ts
@@ -1,0 +1,245 @@
+// =============================================================================
+// Fleet Commander — PR Service
+// =============================================================================
+// Manages pull request operations: auto-merge enable/disable, branch updates.
+// All GitHub operations use the `gh` CLI (never Octokit) per project conventions.
+// =============================================================================
+
+import { execSync } from 'child_process';
+import { getDatabase } from '../db.js';
+import { sseBroker } from './sse-broker.js';
+import { ServiceError, notFoundError, validationError, externalError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Validate a GitHub repo slug (owner/repo) to prevent injection */
+const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
+function validateGithubRepo(repo: string): boolean {
+  return GITHUB_REPO_RE.test(repo);
+}
+
+/** Execute a gh CLI command, returning { ok, stdout?, error? } */
+interface GHResult {
+  ok: boolean;
+  stdout?: string;
+  error?: string;
+}
+
+function execGH(command: string): GHResult {
+  try {
+    const stdout = execSync(command, {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    let stderr = message;
+    if (err && typeof err === 'object' && 'stderr' in err) {
+      const rawStderr = (err as { stderr: string | Buffer }).stderr;
+      stderr = typeof rawStderr === 'string' ? rawStderr : rawStderr.toString('utf-8');
+    }
+    return { ok: false, error: stderr.trim() || message };
+  }
+}
+
+/**
+ * Resolve the github_repo for a PR by looking up the team's project.
+ * Throws ServiceError if the PR, team, or project cannot be found.
+ */
+function resolveGithubRepoForPR(prNumber: number): { githubRepo: string; teamId: number } {
+  const db = getDatabase();
+  const pr = db.getPullRequest(prNumber);
+  if (!pr || !pr.teamId) {
+    throw notFoundError(
+      `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
+    );
+  }
+
+  const team = db.getTeam(pr.teamId);
+  if (!team || !team.projectId) {
+    throw notFoundError(
+      `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
+    );
+  }
+
+  const project = db.getProject(team.projectId);
+  if (!project?.githubRepo) {
+    throw notFoundError(
+      `Cannot resolve GitHub repo for PR #${prNumber} — team or project not found`,
+    );
+  }
+
+  if (!validateGithubRepo(project.githubRepo)) {
+    throw validationError(`Invalid GitHub repo slug: ${project.githubRepo}`);
+  }
+
+  return { githubRepo: project.githubRepo, teamId: pr.teamId };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class PRService {
+  /**
+   * Enable auto-merge (squash) for a pull request via gh CLI.
+   * Updates the DB record and broadcasts an SSE event.
+   *
+   * @param prNumber - The PR number to enable auto-merge on
+   * @returns Success result with output from gh CLI
+   * @throws ServiceError if PR/repo not found or gh CLI fails
+   */
+  enableAutoMerge(prNumber: number): { ok: boolean; message: string; output: string } {
+    const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
+
+    const result = execGH(
+      `gh pr merge ${prNumber} --auto --squash --repo ${githubRepo}`,
+    );
+
+    if (!result.ok) {
+      throw externalError(
+        `Failed to enable auto-merge for PR #${prNumber}`,
+        result.error,
+      );
+    }
+
+    // Update the database record
+    const db = getDatabase();
+    const pr = db.getPullRequest(prNumber);
+    if (pr) {
+      db.updatePullRequest(prNumber, { autoMerge: true });
+    }
+
+    // Broadcast SSE event
+    sseBroker.broadcast(
+      'pr_updated',
+      {
+        pr_number: prNumber,
+        team_id: pr?.teamId ?? 0,
+        action: 'auto_merge_enabled',
+        auto_merge: true,
+      },
+      pr?.teamId ?? undefined,
+    );
+
+    return {
+      ok: true,
+      message: `Auto-merge enabled for PR #${prNumber}`,
+      output: result.stdout?.trim() ?? '',
+    };
+  }
+
+  /**
+   * Disable auto-merge for a pull request via gh CLI.
+   * Updates the DB record and broadcasts an SSE event.
+   *
+   * @param prNumber - The PR number to disable auto-merge on
+   * @returns Success result with output from gh CLI
+   * @throws ServiceError if PR/repo not found or gh CLI fails
+   */
+  disableAutoMerge(prNumber: number): { ok: boolean; message: string; output: string } {
+    const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
+
+    const result = execGH(
+      `gh pr merge ${prNumber} --disable-auto --repo ${githubRepo}`,
+    );
+
+    if (!result.ok) {
+      throw externalError(
+        `Failed to disable auto-merge for PR #${prNumber}`,
+        result.error,
+      );
+    }
+
+    // Update the database record
+    const db = getDatabase();
+    const pr = db.getPullRequest(prNumber);
+    if (pr) {
+      db.updatePullRequest(prNumber, { autoMerge: false });
+    }
+
+    // Broadcast SSE event
+    sseBroker.broadcast(
+      'pr_updated',
+      {
+        pr_number: prNumber,
+        team_id: pr?.teamId ?? 0,
+        action: 'auto_merge_disabled',
+        auto_merge: false,
+      },
+      pr?.teamId ?? undefined,
+    );
+
+    return {
+      ok: true,
+      message: `Auto-merge disabled for PR #${prNumber}`,
+      output: result.stdout?.trim() ?? '',
+    };
+  }
+
+  /**
+   * Update a PR's branch to be current with the base branch via GitHub API.
+   * Broadcasts an SSE event on success.
+   *
+   * @param prNumber - The PR number whose branch to update
+   * @returns Success result with output from gh CLI
+   * @throws ServiceError if PR/repo not found or gh CLI fails
+   */
+  updateBranch(prNumber: number): { ok: boolean; message: string; output: string } {
+    const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
+
+    const result = execGH(
+      `gh api repos/${githubRepo}/pulls/${prNumber}/update-branch -X PUT`,
+    );
+
+    if (!result.ok) {
+      throw externalError(
+        `Failed to update branch for PR #${prNumber}`,
+        result.error,
+      );
+    }
+
+    // Broadcast SSE event
+    const db = getDatabase();
+    const pr = db.getPullRequest(prNumber);
+
+    sseBroker.broadcast(
+      'pr_updated',
+      {
+        pr_number: prNumber,
+        team_id: pr?.teamId ?? 0,
+        action: 'branch_updated',
+      },
+      pr?.teamId ?? undefined,
+    );
+
+    return {
+      ok: true,
+      message: `Branch updated for PR #${prNumber}`,
+      output: result.stdout?.trim() ?? '',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: PRService | null = null;
+
+/**
+ * Get the singleton PRService instance.
+ *
+ * @returns PRService singleton
+ */
+export function getPRService(): PRService {
+  if (!_instance) {
+    _instance = new PRService();
+  }
+  return _instance;
+}

--- a/src/server/services/project-group-service.ts
+++ b/src/server/services/project-group-service.ts
@@ -1,0 +1,85 @@
+// =============================================================================
+// Fleet Commander — Project Group Service
+// =============================================================================
+// Manages project group operations: list with counts, get with projects.
+// Project groups allow organizing projects into logical collections.
+// =============================================================================
+
+import { getDatabase } from '../db.js';
+import type { ProjectGroup } from '../../shared/types.js';
+import { notFoundError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A project group enriched with the count of linked projects */
+export interface ProjectGroupWithCount extends ProjectGroup {
+  projectCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ProjectGroupService {
+  /**
+   * List all project groups with their project counts.
+   *
+   * @returns Array of project groups enriched with project counts
+   */
+  listWithCounts(): ProjectGroupWithCount[] {
+    const db = getDatabase();
+    const groups = db.getProjectGroups();
+    const allProjects = db.getProjects();
+
+    return groups.map((g: ProjectGroup) => {
+      const linked = allProjects.filter((p) => p.groupId === g.id);
+      return {
+        ...g,
+        projectCount: linked.length,
+      };
+    });
+  }
+
+  /**
+   * Get a single project group with its linked projects.
+   *
+   * @param groupId - The project group ID
+   * @returns Group details with projects array
+   * @throws ServiceError with code NOT_FOUND if group doesn't exist
+   */
+  getWithProjects(groupId: number): ProjectGroup & { projects: unknown[] } {
+    const db = getDatabase();
+    const group = db.getProjectGroup(groupId);
+    if (!group) {
+      throw notFoundError(`Project group ${groupId} not found`);
+    }
+
+    const allProjects = db.getProjects();
+    const projects = allProjects.filter((p) => p.groupId === groupId);
+
+    return {
+      ...group,
+      projects,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: ProjectGroupService | null = null;
+
+/**
+ * Get the singleton ProjectGroupService instance.
+ *
+ * @returns ProjectGroupService singleton
+ */
+export function getProjectGroupService(): ProjectGroupService {
+  if (!_instance) {
+    _instance = new ProjectGroupService();
+  }
+  return _instance;
+}

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -1,0 +1,541 @@
+// =============================================================================
+// Fleet Commander — Project Service
+// =============================================================================
+// Manages project CRUD operations, hook installation, and prompt file I/O.
+// Owns all business logic, DB calls, SSE broadcasts, filesystem operations,
+// and CLI calls related to projects.
+// =============================================================================
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { getDatabase } from '../db.js';
+import { getTeamManager } from './team-manager.js';
+import { getIssueFetcher } from './issue-fetcher.js';
+import { sseBroker } from './sse-broker.js';
+import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
+import config from '../config.js';
+import type { ProjectStatus, InstallStatus, InstallFileStatus } from '../../shared/types.js';
+import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a file path to use forward slashes (cross-platform).
+ */
+function normalizePath(p: string): string {
+  return path.resolve(p).replace(/\\/g, '/');
+}
+
+/**
+ * Check if a directory is a git repository.
+ */
+function isGitRepo(dirPath: string): boolean {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', {
+      cwd: dirPath,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Auto-detect the GitHub repo (owner/name) for a local git repo via gh CLI.
+ * Returns null if detection fails (non-fatal).
+ */
+function detectGithubRepo(dirPath: string): string | null {
+  try {
+    const result = execSync(
+      'gh repo view --json nameWithOwner -q .nameWithOwner',
+      { cwd: dirPath, encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
+    ).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether a file contains CRLF line endings by reading its first 512 bytes.
+ */
+function fileHasCrlf(filePath: string): boolean {
+  try {
+    const buf = Buffer.alloc(512);
+    const fd = fs.openSync(filePath, 'r');
+    const bytesRead = fs.readSync(fd, buf, 0, 512, 0);
+    fs.closeSync(fd);
+    return buf.subarray(0, bytesRead).includes(0x0D);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check the install status of artifacts deployed by install.sh:
+ * hooks directory and workflow prompt.
+ * Returns detailed file-level breakdown for tooltip display.
+ *
+ * @param repoPath - Absolute path to the target repository
+ * @returns InstallStatus with hooks, prompt, agents, guides, and settings info
+ */
+export function checkInstallStatus(repoPath: string): InstallStatus {
+  const hookNames = [
+    'send_event.sh',
+    'on_session_start.sh',
+    'on_session_end.sh',
+    'on_stop.sh',
+    'on_stop_failure.sh',
+    'on_subagent_start.sh',
+    'on_subagent_stop.sh',
+    'on_notification.sh',
+    'on_post_tool_use.sh',
+    'on_tool_error.sh',
+    'on_pre_compact.sh',
+    'on_teammate_idle.sh',
+  ];
+
+  const hooksDir = path.join(repoPath, '.claude', 'hooks', 'fleet-commander');
+  const hookFiles: InstallFileStatus[] = hookNames.map((name) => {
+    const filePath = path.join(hooksDir, name);
+    const exists = fs.existsSync(filePath);
+    return {
+      name,
+      exists,
+      hasCrlf: exists ? fileHasCrlf(filePath) : false,
+    };
+  });
+  const hookFoundCount = hookFiles.filter((f) => f.exists).length;
+  const hookHasCrlf = hookFiles.some((f) => f.hasCrlf);
+
+  const promptFiles: InstallFileStatus[] = [
+    {
+      name: 'fleet-workflow.md',
+      exists: fs.existsSync(path.join(repoPath, '.claude', 'prompts', 'fleet-workflow.md')),
+    },
+  ];
+
+  const agentNames = [
+    'fleet-planner.md',
+    'fleet-dev.md',
+    'fleet-reviewer.md',
+  ];
+  const agentsDir = path.join(repoPath, '.claude', 'agents');
+  const agentFiles: InstallFileStatus[] = agentNames.map((name) => ({
+    name,
+    exists: fs.existsSync(path.join(agentsDir, name)),
+  }));
+
+  const guidesDir = path.join(repoPath, '.claude', 'guides');
+  const guideFiles: InstallFileStatus[] = fs.existsSync(guidesDir)
+    ? fs.readdirSync(guidesDir)
+        .filter((f) => f.endsWith('.md'))
+        .map((name) => ({ name, exists: true }))
+    : [];
+
+  const settingsFile: InstallFileStatus = {
+    name: 'settings.json',
+    exists: fs.existsSync(path.join(repoPath, '.claude', 'settings.json')),
+  };
+
+  return {
+    hooks: {
+      installed: hookFoundCount === hookNames.length && !hookHasCrlf,
+      total: hookNames.length,
+      found: hookFoundCount,
+      files: hookFiles,
+    },
+    prompt: {
+      installed: promptFiles.every((f) => f.exists),
+      files: promptFiles,
+    },
+    agents: {
+      installed: agentFiles.every((f) => f.exists),
+      files: agentFiles,
+    },
+    guides: {
+      installed: guideFiles.length > 0,
+      files: guideFiles,
+    },
+    settings: settingsFile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal logger for use outside Fastify request context
+// ---------------------------------------------------------------------------
+
+const _minimalLogger = {
+  info: (...args: unknown[]) => console.log('[ProjectService]', ...args),
+  warn: (...args: unknown[]) => console.warn('[ProjectService]', ...args),
+  error: (...args: unknown[]) => console.error('[ProjectService]', ...args),
+} as any;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ProjectService {
+  /**
+   * List all projects with team counts and live install status.
+   * Optionally filter by project status.
+   *
+   * @param statusFilter - Optional status to filter by ('active' | 'archived')
+   * @returns Array of project summaries enriched with install status
+   * @throws ServiceError with code VALIDATION if status filter is invalid
+   */
+  listProjects(statusFilter?: ProjectStatus): unknown[] {
+    if (statusFilter) {
+      const validStatuses: ProjectStatus[] = ['active', 'archived'];
+      if (!validStatuses.includes(statusFilter)) {
+        throw validationError(
+          `Invalid status filter. Must be one of: ${validStatuses.join(', ')}`,
+        );
+      }
+    }
+
+    const db = getDatabase();
+    const summaries = db.getProjectSummaries();
+    const filtered = statusFilter
+      ? summaries.filter((p) => p.status === statusFilter)
+      : summaries;
+
+    return filtered.map((p) => ({
+      ...p,
+      installStatus: checkInstallStatus(p.repoPath),
+    }));
+  }
+
+  /**
+   * Create a new project with full orchestration:
+   * validate input, detect GitHub repo, create prompt file, insert DB record,
+   * install hooks, and broadcast SSE event.
+   *
+   * @param data - Project creation data
+   * @returns The created project record
+   * @throws ServiceError with code VALIDATION for invalid input
+   * @throws ServiceError with code CONFLICT for duplicate repo path
+   */
+  createProject(data: {
+    name: string;
+    repoPath: string;
+    githubRepo?: string;
+    maxActiveTeams?: number;
+    model?: string;
+  }): unknown {
+    const { name, repoPath, githubRepo, maxActiveTeams, model } = data;
+
+    // Validate name
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw validationError('name is required and must be a non-empty string');
+    }
+
+    // Validate repoPath
+    if (!repoPath || typeof repoPath !== 'string' || repoPath.trim().length === 0) {
+      throw validationError('repoPath is required and must be a non-empty string');
+    }
+
+    const normalizedPath = normalizePath(repoPath);
+
+    if (!fs.existsSync(normalizedPath)) {
+      throw validationError(`Path does not exist: ${normalizedPath}`);
+    }
+
+    if (!isGitRepo(normalizedPath)) {
+      throw validationError(`Path is not a git repository: ${normalizedPath}`);
+    }
+
+    // Check for duplicate repo_path
+    const db = getDatabase();
+    const existing = db.getProjectByRepoPath(normalizedPath);
+    if (existing) {
+      throw conflictError(
+        `A project already exists for this path: ${normalizedPath} (project: ${existing.name})`,
+      );
+    }
+
+    // Auto-detect githubRepo if not provided
+    const resolvedGithubRepo = githubRepo || detectGithubRepo(normalizedPath);
+
+    // Validate maxActiveTeams if provided
+    if (maxActiveTeams !== undefined) {
+      if (typeof maxActiveTeams !== 'number' || maxActiveTeams < 1 || maxActiveTeams > 50) {
+        throw validationError('maxActiveTeams must be a number between 1 and 50');
+      }
+    }
+
+    // Create project-specific prompt file from default template
+    const slug = name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const promptRelPath = `prompts/${slug}-prompt.md`;
+    const promptAbsPath = path.join(config.fleetCommanderRoot, promptRelPath);
+    const defaultPromptPath = path.join(config.fleetCommanderRoot, 'prompts', 'default-prompt.md');
+
+    try {
+      fs.mkdirSync(path.join(config.fleetCommanderRoot, 'prompts'), { recursive: true });
+
+      if (!fs.existsSync(promptAbsPath)) {
+        if (fs.existsSync(defaultPromptPath)) {
+          fs.copyFileSync(defaultPromptPath, promptAbsPath);
+        } else {
+          fs.writeFileSync(promptAbsPath,
+            'Read the ENTIRE file `.claude/prompts/fleet-workflow.md` before taking any actions.\n' +
+            'You are the TL. There is NO coordinator — you orchestrate the Diamond team directly.\n' +
+            'Phase 0: Spawn fleet-planner. Wait for plan. Phase 1: Spawn fleet-dev WITH the planner\'s plan. Wait for ready. Phase 2: Spawn fleet-reviewer. Planner stays alive for p2p questions.\n' +
+            'Issue: #{{ISSUE_NUMBER}}\n',
+            'utf-8',
+          );
+        }
+      }
+    } catch (promptErr: unknown) {
+      console.warn('[ProjectService] Failed to create project prompt file (non-fatal):', promptErr);
+    }
+
+    // Insert the project
+    const project = db.insertProject({
+      name: name.trim(),
+      repoPath: normalizedPath,
+      githubRepo: resolvedGithubRepo,
+      maxActiveTeams: maxActiveTeams ?? 5,
+      promptFile: promptRelPath,
+      model: model?.trim() || null,
+    });
+
+    // Install hooks (non-fatal)
+    const installResult = installHooks(normalizedPath, _minimalLogger);
+    if (!installResult.ok) {
+      console.warn(`[ProjectService] Hook installation failed for ${normalizedPath}: ${installResult.stderr}`);
+    }
+
+    // Verify artifacts were actually installed
+    const status = checkInstallStatus(normalizedPath);
+    const allInstalled = status.hooks.installed && status.prompt.installed;
+    if (allInstalled) {
+      db.updateProject(project.id, { hooksInstalled: true });
+    }
+
+    // Re-fetch to get updated hooks_installed
+    const finalProject = db.getProject(project.id)!;
+
+    // Ensure the issue fetcher's polling loop is running
+    const issueFetcher = getIssueFetcher();
+    issueFetcher.start();
+
+    // Broadcast SSE event
+    sseBroker.broadcast('project_added', {
+      project_id: finalProject.id,
+      name: finalProject.name,
+      repo_path: finalProject.repoPath,
+    });
+
+    return finalProject;
+  }
+
+  /**
+   * Get detailed project info with team counts.
+   *
+   * @param projectId - The project ID
+   * @returns Project detail with team counts
+   * @throws ServiceError with code NOT_FOUND if project doesn't exist
+   */
+  getProjectDetail(projectId: number): unknown {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    const teams = db.getTeams({ projectId });
+    const activeStatuses = ['launching', 'running', 'idle', 'stuck'];
+    const activeCount = teams.filter((t) => activeStatuses.includes(t.status)).length;
+    const queuedCount = teams.filter((t) => t.status === 'queued').length;
+
+    return {
+      ...project,
+      teamCount: teams.length,
+      activeTeamCount: activeCount,
+      queuedTeamCount: queuedCount,
+    };
+  }
+
+  /**
+   * Delete a project with full teardown: stop teams, uninstall hooks,
+   * clear caches, delete DB records, broadcast SSE.
+   *
+   * @param projectId - The project ID to delete
+   * @throws ServiceError with code NOT_FOUND if project doesn't exist
+   */
+  async deleteProject(projectId: number): Promise<void> {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    // Mark queued teams as failed before deletion
+    const queuedTeams = db.getQueuedTeamsByProject(projectId);
+    for (const t of queuedTeams) {
+      db.updateTeam(t.id, { status: 'failed' });
+    }
+
+    // Stop all active teams for this project
+    const activeTeams = db.getTeams({ projectId }).filter((t) =>
+      ['launching', 'running', 'idle', 'stuck'].includes(t.status),
+    );
+
+    const manager = getTeamManager();
+    for (const team of activeTeams) {
+      try {
+        await manager.stop(team.id);
+      } catch {
+        // Continue stopping other teams even if one fails
+      }
+    }
+
+    // Uninstall hooks
+    uninstallHooks(project.repoPath, _minimalLogger);
+
+    // Clear cached issues for this project
+    const issueFetcher = getIssueFetcher();
+    issueFetcher.clearProject(projectId);
+
+    // Delete all teams and related records
+    db.deleteTeamsByProject(projectId);
+
+    // Delete the project from DB
+    db.deleteProject(projectId);
+
+    // Broadcast SSE event
+    sseBroker.broadcast('project_removed', {
+      project_id: projectId,
+    });
+  }
+
+  /**
+   * (Re)install hooks for a project. Verifies artifacts on disk after install
+   * and updates the DB accordingly.
+   *
+   * @param projectId - The project ID
+   * @returns Install result with status details
+   * @throws ServiceError with code NOT_FOUND if project doesn't exist
+   */
+  installHooksForProject(projectId: number): {
+    ok: boolean;
+    output: string;
+    error?: string;
+    installStatus: InstallStatus;
+  } {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    const result = installHooks(project.repoPath, _minimalLogger);
+
+    // Check what actually landed on disk
+    const status = checkInstallStatus(project.repoPath);
+    const allInstalled = status.hooks.installed && status.prompt.installed;
+    db.updateProject(project.id, { hooksInstalled: allInstalled });
+
+    // Broadcast so UI refreshes badges
+    sseBroker.broadcast('project_updated', {
+      project_id: projectId,
+      name: project.name,
+      status: project.status,
+    });
+
+    return {
+      ok: result.ok,
+      output: result.stdout.trim(),
+      error: result.stderr.trim() || undefined,
+      installStatus: status,
+    };
+  }
+
+  /**
+   * Read the contents of a project's prompt file.
+   * Falls back to the default prompt if the project-specific one is missing.
+   *
+   * @param projectId - The project ID
+   * @returns Prompt file contents and metadata
+   * @throws ServiceError with code NOT_FOUND if project or prompt file not found
+   */
+  getPrompt(projectId: number): { promptFile: string; content: string; isDefault: boolean } {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    if (!project.promptFile) {
+      throw notFoundError(`No prompt file configured for project ${projectId}`);
+    }
+
+    const absPath = path.join(config.fleetCommanderRoot, project.promptFile);
+    if (!fs.existsSync(absPath)) {
+      const defaultPath = path.join(config.fleetCommanderRoot, 'prompts', 'default-prompt.md');
+      if (fs.existsSync(defaultPath)) {
+        const content = fs.readFileSync(defaultPath, 'utf-8');
+        return { promptFile: project.promptFile, content, isDefault: true };
+      }
+      throw notFoundError(`Prompt file not found: ${project.promptFile}`);
+    }
+
+    const content = fs.readFileSync(absPath, 'utf-8');
+    return { promptFile: project.promptFile, content, isDefault: false };
+  }
+
+  /**
+   * Save content to a project's prompt file.
+   *
+   * @param projectId - The project ID
+   * @param content - The prompt content to write
+   * @returns Prompt file path and saved content
+   * @throws ServiceError with code NOT_FOUND if project not found
+   * @throws ServiceError with code VALIDATION if content is missing or no prompt file configured
+   */
+  savePrompt(projectId: number, content: string): { promptFile: string; content: string } {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    if (content === undefined || typeof content !== 'string') {
+      throw validationError('content is required and must be a string');
+    }
+
+    if (!project.promptFile) {
+      throw validationError(`No prompt file configured for project ${projectId}`);
+    }
+
+    const absPath = path.join(config.fleetCommanderRoot, project.promptFile);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, content, 'utf-8');
+
+    return { promptFile: project.promptFile, content };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: ProjectService | null = null;
+
+/**
+ * Get the singleton ProjectService instance.
+ *
+ * @returns ProjectService singleton
+ */
+export function getProjectService(): ProjectService {
+  if (!_instance) {
+    _instance = new ProjectService();
+  }
+  return _instance;
+}

--- a/src/server/services/service-error.ts
+++ b/src/server/services/service-error.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// Fleet Commander — ServiceError base class
+// =============================================================================
+// Typed error class for service layer exceptions. Routes catch ServiceError
+// instances and map them to HTTP responses based on the statusCode.
+// This decouples business logic errors from HTTP transport concerns.
+// =============================================================================
+
+/**
+ * Base error class for service-layer failures.
+ *
+ * @param message - Human-readable error description
+ * @param code - Machine-readable error code (e.g. 'NOT_FOUND', 'VALIDATION')
+ * @param statusCode - HTTP status code to return (e.g. 400, 404, 409, 502)
+ */
+export class ServiceError extends Error {
+  /** Machine-readable error code */
+  readonly code: string;
+  /** Suggested HTTP status code for the error */
+  readonly statusCode: number;
+  /** Optional extra details (e.g. CLI stderr output) */
+  readonly details?: string;
+
+  constructor(message: string, code: string, statusCode: number, details?: string) {
+    super(message);
+    this.name = 'ServiceError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience factory functions for common error types
+// ---------------------------------------------------------------------------
+
+/** 400 Bad Request — validation failures */
+export function validationError(message: string): ServiceError {
+  return new ServiceError(message, 'VALIDATION', 400);
+}
+
+/** 404 Not Found — entity lookup failures */
+export function notFoundError(message: string): ServiceError {
+  return new ServiceError(message, 'NOT_FOUND', 404);
+}
+
+/** 409 Conflict — duplicate or state-conflict errors */
+export function conflictError(message: string): ServiceError {
+  return new ServiceError(message, 'CONFLICT', 409);
+}
+
+/** 502 Bad Gateway — external tool/CLI failures */
+export function externalError(message: string, details?: string): ServiceError {
+  return new ServiceError(message, 'EXTERNAL_ERROR', 502, details);
+}

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -1,0 +1,561 @@
+// =============================================================================
+// Fleet Commander — Team Service
+// =============================================================================
+// Manages team operations: launch, batch launch, detail assembly, status,
+// timeline, export, messaging, phase setting, and alert acknowledgment.
+// Owns all business logic, DB calls, SSE broadcasts, and filesystem ops.
+// =============================================================================
+
+import fs from 'fs';
+import path from 'path';
+import { getTeamManager } from './team-manager.js';
+import { getIssueFetcher } from './issue-fetcher.js';
+import { githubPoller } from './github-poller.js';
+import { getDatabase } from '../db.js';
+import { sseBroker } from './sse-broker.js';
+import config from '../config.js';
+import type { TeamPhase, IssueDependencyInfo } from '../../shared/types.js';
+import { buildTimeline } from '../utils/build-timeline.js';
+import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Produce a short one-line summary of a stream event for text export. */
+function summarize(e: Record<string, unknown>): string {
+  if (typeof e.message === 'string') return e.message;
+  if (typeof e.tool === 'string') return `tool:${e.tool}`;
+  if (typeof e.content === 'string') return e.content.slice(0, 120);
+  return '';
+}
+
+/**
+ * Check whether an issue has unresolved dependencies.
+ * Returns the dependency info, or null if dependencies cannot be determined
+ * (which is treated as "no blockers" -- permissive fallback).
+ */
+async function checkDependencies(projectId: number, issueNumber: number): Promise<IssueDependencyInfo | null> {
+  try {
+    const fetcher = getIssueFetcher();
+    return await fetcher.fetchDependenciesForIssue(projectId, issueNumber);
+  } catch (err) {
+    console.error(
+      `[TeamService] Dependency check failed for issue #${issueNumber}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class TeamService {
+  /**
+   * Launch a single team for an issue. Checks dependencies (unless force=true),
+   * tracks blocked issues for resolution detection, and delegates to TeamManager.
+   *
+   * @param params - Launch parameters
+   * @returns The launched team record
+   * @throws ServiceError with code VALIDATION for invalid input
+   * @throws ServiceError with code CONFLICT if blocked by dependencies or already active
+   */
+  async launchTeam(params: {
+    projectId: number;
+    issueNumber: number;
+    issueTitle?: string;
+    prompt?: string;
+    headless?: boolean;
+    force?: boolean;
+  }): Promise<unknown> {
+    const { projectId, issueNumber, issueTitle, prompt, headless, force } = params;
+
+    if (!projectId || typeof projectId !== 'number' || projectId < 1) {
+      throw validationError('projectId is required and must be a positive integer');
+    }
+
+    if (!issueNumber || typeof issueNumber !== 'number' || issueNumber < 1) {
+      throw validationError('issueNumber is required and must be a positive integer');
+    }
+
+    // Dependency check -- block launch if unresolved dependencies exist
+    if (!force) {
+      const depInfo = await checkDependencies(projectId, issueNumber);
+      if (depInfo && !depInfo.resolved) {
+        const blockerNumbers = depInfo.blockedBy
+          .filter((b) => b.state === 'open')
+          .map((b) => b.number);
+        githubPoller.trackBlockedIssue(projectId, issueNumber, blockerNumbers);
+
+        throw new ServiceError(
+          `Issue #${issueNumber} is blocked by ${depInfo.openCount} unresolved dependency${depInfo.openCount !== 1 ? 'ies' : ''}`,
+          'BLOCKED_BY_DEPENDENCIES',
+          409,
+        );
+      }
+    }
+
+    const manager = getTeamManager();
+    return await manager.launch(projectId, issueNumber, issueTitle, prompt, headless, force);
+  }
+
+  /**
+   * Launch multiple teams in a batch. Checks dependencies for each issue,
+   * separating blocked from launchable issues. Intra-batch dependencies
+   * are allowed (deferred to queue ordering).
+   *
+   * @param params - Batch launch parameters
+   * @returns Object with launched teams and any blocked issues
+   * @throws ServiceError with code VALIDATION for invalid input
+   */
+  async launchBatch(params: {
+    projectId: number;
+    issues: Array<{ number: number; title?: string }>;
+    prompt?: string;
+    delayMs?: number;
+    headless?: boolean;
+  }): Promise<{ launched: unknown[]; blocked?: Array<{ issueNumber: number; dependencies: IssueDependencyInfo }> }> {
+    const { projectId, issues, prompt, delayMs, headless } = params;
+
+    if (!projectId || typeof projectId !== 'number' || projectId < 1) {
+      throw validationError('projectId is required and must be a positive integer');
+    }
+
+    if (!issues || !Array.isArray(issues) || issues.length === 0) {
+      throw validationError('issues array is required and must not be empty');
+    }
+
+    for (const issue of issues) {
+      if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
+        throw validationError(`Invalid issue number: ${JSON.stringify(issue)}`);
+      }
+    }
+
+    // Dependency check for batch launch
+    const blocked: Array<{ issueNumber: number; dependencies: IssueDependencyInfo }> = [];
+    const launchable: Array<{ number: number; title?: string }> = [];
+    const batchNumbers = new Set(issues.map((i) => i.number));
+
+    for (const issue of issues) {
+      const depInfo = await checkDependencies(projectId, issue.number);
+      if (depInfo && !depInfo.resolved) {
+        const allBlockersInBatch = depInfo.blockedBy
+          .filter((b) => b.state === 'open')
+          .every((b) => batchNumbers.has(b.number));
+
+        if (allBlockersInBatch) {
+          launchable.push(issue);
+        } else {
+          blocked.push({ issueNumber: issue.number, dependencies: depInfo });
+        }
+      } else {
+        launchable.push(issue);
+      }
+    }
+
+    const manager = getTeamManager();
+    const teams = launchable.length > 0
+      ? await manager.launchBatch(projectId, launchable, prompt, delayMs, headless)
+      : [];
+
+    return {
+      launched: teams,
+      blocked: blocked.length > 0 ? blocked : undefined,
+    };
+  }
+
+  /**
+   * Assemble a full TeamDetail response with project info, duration,
+   * PR detail, recent events, and output tail.
+   *
+   * @param teamId - The team ID
+   * @returns Full team detail object
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getTeamDetail(teamId: number): unknown {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    // Look up project to get model and GitHub repo
+    let projectModel: string | null = null;
+    let projectGithubRepo: string | null = null;
+    if (team.projectId) {
+      const project = db.getProject(team.projectId);
+      if (project) {
+        projectModel = project.model ?? null;
+        projectGithubRepo = project.githubRepo ?? null;
+      }
+    }
+
+    // Compute duration & idle in minutes
+    const launchedAt = team.launchedAt ? new Date(team.launchedAt) : null;
+    const now = new Date();
+    const durationMin = launchedAt
+      ? Math.round((now.getTime() - launchedAt.getTime()) / 60_000)
+      : 0;
+
+    const lastEventAt = team.lastEventAt ? new Date(team.lastEventAt) : null;
+    const idleMin = lastEventAt
+      ? Math.round((now.getTime() - lastEventAt.getTime()) / 60_000 * 10) / 10
+      : null;
+
+    // Pull request detail
+    let prDetail = null;
+    if (team.prNumber) {
+      const pr = db.getPullRequest(team.prNumber);
+      if (pr) {
+        let checks: Array<{ name: string; status: string; conclusion: string | null }> = [];
+        if (pr.checksJson) {
+          try {
+            checks = JSON.parse(pr.checksJson);
+          } catch {
+            // Malformed JSON -- leave empty
+          }
+        }
+
+        prDetail = {
+          number: pr.prNumber,
+          state: pr.state,
+          mergeStatus: pr.mergeStatus,
+          ciStatus: pr.ciStatus,
+          ciFailCount: pr.ciFailCount,
+          checks,
+          autoMerge: pr.autoMerge,
+        };
+      }
+    }
+
+    // Recent events
+    const recentEvents = db.getEventsByTeam(teamId, 20);
+
+    // Output tail
+    const manager = getTeamManager();
+    const outputLines = manager.getOutput(teamId, 50);
+    const outputTail = outputLines.length > 0 ? outputLines.join('\n') : null;
+
+    return {
+      id: team.id,
+      issueNumber: team.issueNumber,
+      issueTitle: team.issueTitle,
+      model: projectModel,
+      githubRepo: projectGithubRepo,
+      status: team.status,
+      phase: team.phase,
+      pid: team.pid,
+      sessionId: team.sessionId,
+      worktreeName: team.worktreeName,
+      branchName: team.branchName,
+      prNumber: team.prNumber,
+      launchedAt: team.launchedAt,
+      stoppedAt: team.stoppedAt,
+      lastEventAt: team.lastEventAt,
+      durationMin,
+      idleMin,
+      totalInputTokens: team.totalInputTokens,
+      totalOutputTokens: team.totalOutputTokens,
+      totalCacheCreationTokens: team.totalCacheCreationTokens,
+      totalCacheReadTokens: team.totalCacheReadTokens,
+      totalCostUsd: team.totalCostUsd,
+      pr: prDetail,
+      recentEvents,
+      outputTail,
+    };
+  }
+
+  /**
+   * Get compact team status with pending commands (MCP-compatible).
+   * Supports lookup by integer ID or worktree name.
+   *
+   * @param idOrWorktree - Team ID (number) or worktree name (string)
+   * @returns Compact status object with pending commands
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getTeamStatus(idOrWorktree: string): unknown {
+    const db = getDatabase();
+    const teamId = parseInt(idOrWorktree, 10);
+
+    let team;
+    if (!isNaN(teamId) && teamId > 0) {
+      team = db.getTeam(teamId);
+    }
+    if (!team) {
+      team = db.getTeamByWorktree(idOrWorktree);
+    }
+    if (!team) {
+      throw notFoundError(`Team ${idOrWorktree} not found`);
+    }
+
+    const pendingCommands = db.getPendingCommands(team.id);
+    const latestMessage = pendingCommands.length > 0 ? pendingCommands[0].message : null;
+
+    return {
+      id: team.id,
+      issueNumber: team.issueNumber,
+      worktreeName: team.worktreeName,
+      status: team.status,
+      phase: team.phase,
+      pid: team.pid,
+      prNumber: team.prNumber,
+      lastEventAt: team.lastEventAt,
+      pm_message: latestMessage,
+      pending_commands: pendingCommands.map((c) => ({
+        id: c.id,
+        message: c.message,
+        createdAt: c.createdAt,
+      })),
+    };
+  }
+
+  /**
+   * Build a unified timeline merging stream events and hook events.
+   *
+   * @param teamId - The team ID
+   * @param limit - Maximum number of timeline entries (default 500)
+   * @returns Timeline entries
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getTeamTimeline(teamId: number, limit = 500): unknown {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    const manager = getTeamManager();
+    const streamEvents = manager.getParsedEvents(teamId);
+    const hookEvents = db.getEventsByTeam(teamId, 500);
+
+    return buildTimeline(streamEvents, hookEvents, teamId, limit);
+  }
+
+  /**
+   * Export team logs in JSON or plain text format.
+   *
+   * @param teamId - The team ID
+   * @param format - Export format ('json' or 'txt', default 'json')
+   * @returns Export data object or plain text string
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  exportTeam(teamId: number, format = 'json'): { data: unknown; contentType: string; filename: string } {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    const events = db.getEventsByTeam(teamId);
+    const manager = getTeamManager();
+    const streamEvents = manager.getParsedEvents(teamId);
+    const outputLines = manager.getOutput(teamId);
+
+    if (format === 'txt') {
+      let text = `# Team ${team.worktreeName} - Export\n`;
+      text += `Issue: #${team.issueNumber} ${team.issueTitle ?? ''}\n`;
+      text += `Status: ${team.status}\n`;
+      text += `Launched: ${team.launchedAt ?? 'N/A'}\n\n`;
+      text += `## Stream Events\n`;
+      for (const e of streamEvents) {
+        text += `[${e.timestamp ?? ''}] ${e.type} ${summarize(e as unknown as Record<string, unknown>)}\n`;
+      }
+      text += `\n## Raw Output\n`;
+      text += outputLines.join('\n');
+
+      return {
+        data: text,
+        contentType: 'text/plain',
+        filename: `${team.worktreeName}-export.txt`,
+      };
+    }
+
+    return {
+      data: { team, events, streamEvents, output: outputLines },
+      contentType: 'application/json',
+      filename: `${team.worktreeName}-export.json`,
+    };
+  }
+
+  /**
+   * Send a PM message to a running team. Writes a .fleet-pm-message file,
+   * inserts a command record in the DB, and attempts stdin delivery.
+   *
+   * @param teamId - The team ID
+   * @param message - The message text to send
+   * @returns Command record with delivery status
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   * @throws ServiceError with code VALIDATION if message is empty
+   */
+  sendMessage(teamId: number, message: string): { command: unknown; delivered: boolean } {
+    if (!message || typeof message !== 'string' || message.trim().length === 0) {
+      throw validationError('message is required and must be a non-empty string');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    // Resolve worktree path from the team's project
+    let worktreePath: string;
+    if (team.projectId) {
+      const project = db.getProject(team.projectId);
+      worktreePath = project
+        ? path.join(project.repoPath, config.worktreeDir, team.worktreeName)
+        : path.join(config.worktreeDir, team.worktreeName);
+    } else {
+      worktreePath = path.join(config.worktreeDir, team.worktreeName);
+    }
+    const messagePath = path.join(worktreePath, '.fleet-pm-message');
+
+    try {
+      fs.writeFileSync(messagePath, message.trim(), 'utf-8');
+    } catch (fsErr: unknown) {
+      const fsMsg = fsErr instanceof Error ? fsErr.message : String(fsErr);
+      console.warn(`[TeamService] Failed to write .fleet-pm-message file: ${fsMsg}`);
+      // Continue anyway -- the command record is still useful
+    }
+
+    // Insert command row in the database
+    const command = db.insertCommand({
+      teamId,
+      message: message.trim(),
+    });
+
+    // Try to deliver via stdin pipe
+    const manager = getTeamManager();
+    const delivered = manager.sendMessage(teamId, message.trim(), 'user');
+    if (delivered) {
+      db.markCommandDelivered(command.id);
+      db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
+    }
+
+    return { command, delivered };
+  }
+
+  /**
+   * Set the phase of a team (e.g. 'analyzing', 'implementing', 'reviewing').
+   * Broadcasts SSE event for phase change.
+   *
+   * @param teamId - The team ID
+   * @param phase - The new phase
+   * @param reason - Optional reason for the phase change
+   * @returns Updated team record
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   * @throws ServiceError with code VALIDATION if phase is invalid
+   * @throws ServiceError with code CONFLICT if team is in terminal status
+   */
+  setPhase(teamId: number, phase: TeamPhase, reason?: string): unknown {
+    const validPhases: TeamPhase[] = [
+      'init', 'analyzing', 'implementing', 'reviewing', 'pr', 'done', 'blocked',
+    ];
+    if (!phase || !validPhases.includes(phase)) {
+      throw validationError(
+        `phase is required and must be one of: ${validPhases.join(', ')}`,
+      );
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    if (['done', 'failed'].includes(team.status)) {
+      throw conflictError(
+        `Cannot set phase on a ${team.status} team. Use restart to reactivate.`,
+      );
+    }
+
+    const previousPhase = team.phase;
+    const updated = db.updateTeam(teamId, { phase });
+
+    sseBroker.broadcast(
+      'team_status_changed',
+      {
+        team_id: teamId,
+        status: team.status,
+        previous_status: team.status,
+        phase,
+        previous_phase: previousPhase,
+        reason: reason ?? undefined,
+      },
+      teamId,
+    );
+
+    return updated;
+  }
+
+  /**
+   * Acknowledge a stuck or failed team alert. Transitions stuck->idle
+   * or failed->done and broadcasts SSE event.
+   *
+   * @param teamId - The team ID
+   * @returns Updated team record
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   * @throws ServiceError with code VALIDATION if team is not stuck or failed
+   */
+  acknowledgeAlert(teamId: number): unknown {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    if (team.status !== 'stuck' && team.status !== 'failed') {
+      throw validationError(
+        `Team ${teamId} is not stuck or failed (current status: ${team.status})`,
+      );
+    }
+
+    const previousStatus = team.status;
+    const newStatus = team.status === 'stuck' ? 'idle' : 'done';
+
+    db.insertTransition({
+      teamId,
+      fromStatus: previousStatus,
+      toStatus: newStatus,
+      trigger: 'pm_action',
+      reason: previousStatus === 'stuck' ? 'PM acknowledged stuck alert' : 'PM acknowledged failed alert',
+    });
+
+    const updated = db.updateTeam(teamId, {
+      status: newStatus,
+      lastEventAt: new Date().toISOString(),
+    });
+
+    sseBroker.broadcast(
+      'team_status_changed',
+      {
+        team_id: teamId,
+        status: newStatus,
+        previous_status: previousStatus,
+      },
+      teamId,
+    );
+
+    return updated;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: TeamService | null = null;
+
+/**
+ * Get the singleton TeamService instance.
+ *
+ * @returns TeamService singleton
+ */
+export function getTeamService(): TeamService {
+  if (!_instance) {
+    _instance = new TeamService();
+  }
+  return _instance;
+}


### PR DESCRIPTION
Closes #276

## Summary
- Extract inline business logic from 30 API route handlers into dedicated service classes
- Create 7 new service files: `ServiceError`, `MessageTemplateService`, `PRService`, `DiagnosticsService`, `ProjectService`, `ProjectGroupService`, `TeamService`
- Route handlers now contain only HTTP concerns: input parsing, service call, response mapping
- Preparation for MCP (Model Context Protocol) — service methods can be called by both REST routes and future MCP tools without logic duplication

## Changes
- **New:** `src/server/services/service-error.ts` — Base error class with HTTP status code mapping
- **New:** `src/server/services/message-template-service.ts` — Template merge and upsert logic
- **New:** `src/server/services/pr-service.ts` — Auto-merge, branch update operations
- **New:** `src/server/services/diagnostics-service.ts` — Health summary, blocked teams, factory reset
- **New:** `src/server/services/project-service.ts` — Full project CRUD, hooks, prompts
- **New:** `src/server/services/project-group-service.ts` — Enriched group queries
- **New:** `src/server/services/team-service.ts` — Launch, detail, messaging, phase, timeline, export
- **Updated:** 7 route files refactored to delegate to service methods

## Test plan
- [ ] `npm run build` compiles with zero TypeScript errors
- [ ] `npm test` passes all existing tests
- [ ] Manual smoke test: launch a team, send message, check team detail, create/delete project
- [ ] Verify no API behavior changes (pure refactoring)