### PR TITLE
Issue #306: fix 6 failing test assertions across 3 test files

### DIFF
--- a/tests/client/StatusBadge.test.tsx
+++ b/tests/client/StatusBadge.test.tsx
@@ -18,7 +18,7 @@ const STATUS_EXPECTATIONS: Record<TeamStatus, { label: string; color: string }> 
   idle:      { label: 'Idle',      color: '#D29922' },
   done:      { label: 'Done',      color: '#A371F7' },
   failed:    { label: 'Failed',    color: '#F85149' },
-  launching: { label: 'Launching', color: '#58A6FF' },
+  launching: { label: 'Launching', color: '#D29922' },
   queued:    { label: 'Queued',    color: '#8B949E' },
 };
 

--- a/tests/integration/api-endpoints.test.ts
+++ b/tests/integration/api-endpoints.test.ts
@@ -274,7 +274,7 @@ describe('Events API', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it('POST /api/events returns 400 for unknown team', async () => {
+  it('POST /api/events returns 404 for unknown team', async () => {
     const res = await server.inject({
       method: 'POST',
       url: '/api/events',
@@ -284,7 +284,7 @@ describe('Events API', () => {
       },
     });
 
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(404);
     const body = res.json();
     expect(body.message).toContain('not found');
   });

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -84,7 +84,8 @@ describe('Valid payload processing', () => {
     'subagent_stop',
     'notification',
     'teammate_idle',
-    'cost_update',
+    'tool_error',
+    'pre_compact',
   ];
 
   const normalizedTypes: Record<string, string> = {
@@ -97,7 +98,8 @@ describe('Valid payload processing', () => {
     subagent_stop: 'SubagentStop',
     notification: 'Notification',
     teammate_idle: 'TeammateIdle',
-    cost_update: 'CostUpdate',
+    tool_error: 'ToolError',
+    pre_compact: 'PreCompact',
   };
 
   for (const eventType of eventTypes) {
@@ -1026,6 +1028,8 @@ describe('Subagent crash detection', () => {
     expect(sender.sendMessage).toHaveBeenCalledWith(
       1,
       expect.stringContaining("Subagent 'fleet-dev' appears to have crashed"),
+      'fc',
+      'subagent_crash',
     );
   });
 
@@ -1129,6 +1133,8 @@ describe('Subagent crash detection', () => {
     expect(sender.sendMessage).toHaveBeenCalledWith(
       1,
       expect.stringContaining("'fleet-dev'"),
+      'fc',
+      'subagent_crash',
     );
 
     sender.sendMessage.mockClear();


### PR DESCRIPTION
Closes #306

## Summary
- Fix 3 failing assertions in `tests/server/event-collector.test.ts`: replace removed `cost_update` normalization entry with `tool_error`/`pre_compact`, update 2 `sendMessage` assertions from 2-arg to 4-arg form
- Fix 2 failing assertions in `tests/client/StatusBadge.test.tsx`: correct `launching` status expected color from `#58A6FF` to `#D29922`
- Fix 1 failing assertion in `tests/integration/api-endpoints.test.ts`: update expected status from 400 to 404 for unknown team events endpoint

## Test plan
- [x] All tests pass locally (`npm test` exits 0)
- [x] Only test files modified — no source code changes
- [x] Assertion values cross-referenced against source files