### PR TITLE
Issue #275: add comprehensive API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,7 +81,7 @@ Complete reference for the Fleet Commander REST API (71 endpoints) and SSE strea
   - [PUT /api/message-templates/:id](#put-apimessage-templatesid)
 - [Query (1 endpoint)](#query)
   - [POST /api/query/:queryName](#post-apiqueryqueryname)
-- [System and Diagnostics (8 endpoints)](#system-and-diagnostics)
+- [System and Diagnostics (9 endpoints)](#system-and-diagnostics)
   - [GET /api/health](#get-apihealth)
   - [GET /api/status](#get-apistatus)
   - [GET /api/settings](#get-apisettings)
@@ -1031,9 +1031,6 @@ Send a PM (project manager) message to a running team. The message is written to
 
 ```json
 {
-  "id": 10,
-  "teamId": 1,
-  "message": "Please focus on the failing test",
   "error": "Unprocessable Entity",
   "message": "Team is not running \u2014 message not delivered"
 }


### PR DESCRIPTION
Closes #275

## Summary
- Created `docs/api.md` — a comprehensive 3,980-line API reference covering all 71 REST endpoints and 16 SSE event types
- Every endpoint documented with HTTP method, path, URL/query params, request body schema, response body schema, status codes, and curl example
- All 16 SSE event types documented with trigger descriptions, payload schemas (matching `SSEEventPayloads` interface), and JSON examples
- Includes quick reference table, 3 workflow examples (launch team, send message, monitor via SSE), and TypeScript types reference
- Authentication and rate limit sections present (noting "none" for both)

## Test plan
- [ ] Verify `docs/api.md` renders correctly on GitHub
- [ ] Spot-check curl examples against running instance
- [ ] Verify table of contents anchor links work
- [ ] Confirm JSON examples are syntactically valid