### PR TITLE
Issue #307: normalize font sizes in UnifiedTimeline

### DIFF
--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -299,9 +299,9 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
     const hasDetail = detail !== null;
 
     return (
-      <div>
+      <div className="text-[10px]">
         <div
-          className={`py-0.5 leading-relaxed flex items-center gap-1.5${hasDetail ? ' cursor-pointer' : ''}`}
+          className={`py-0 leading-snug flex items-center gap-1.5${hasDetail ? ' cursor-pointer' : ''}`}
           onClick={hasDetail ? () => setExpanded((prev) => !prev) : undefined}
           role={hasDetail ? 'button' : undefined}
           aria-expanded={hasDetail ? expanded : undefined}
@@ -320,7 +320,7 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
             style={{ backgroundColor: color }}
           />
           <span style={{ color }} className="font-semibold">{label}</span>
-          <span className="text-xs text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
+          <span className="text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
             {entry.tool.name}
           </span>
         </div>
@@ -337,7 +337,7 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
   if (entry.streamType === 'result' || entry.streamType === 'tool_result') {
     const { color, label } = getStreamStyle(entry.streamType);
     return (
-      <div className="py-0.5 leading-relaxed">
+      <div className="py-0 leading-snug text-[10px] text-dark-muted">
         <span className="text-dark-muted">
           {formatLocalTime(entry.timestamp)}
         </span>
@@ -351,7 +351,7 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
   if (text) {
     const { color, label } = getStreamStyle(entry.streamType);
     return (
-      <div className="py-0.5 leading-relaxed">
+      <div className="py-0 leading-snug text-[10px] text-dark-muted">
         <span className="text-dark-muted">
           {formatLocalTime(entry.timestamp)}
         </span>


### PR DESCRIPTION
Closes #307

## Summary
- Set `text-[10px]` on tool_use, result/tool_result, and generic fallback entries in UnifiedTimeline to match existing task_progress sizing
- Tighten padding (`py-0`) and line-height (`leading-snug`) for visual consistency across operational entries
- Remove redundant `text-xs` from tool badge span (now inherits from parent)
- TL text messages (assistant, user, fc) remain at 12px as primary content — operational events are secondary at 10px (Option B from issue)

## Test plan
- [x] All 10 existing UnifiedTimeline tests pass
- [x] CSS-only change — no logic changes
- [ ] Visual verification: TL messages at 12px, operational entries at 10px, consistent spacing