### PR TITLE
Issue #304: add missing server-side test coverage for critical services

### DIFF
--- a/tests/server/cleanup.test.ts
+++ b/tests/server/cleanup.test.ts
@@ -1,0 +1,473 @@
+// =============================================================================
+// Fleet Commander — Cleanup Service Tests
+// =============================================================================
+// Tests for getCleanupPreview() and executeCleanup() — the two-phase cleanup
+// that scans for orphan worktrees, signal files, stale branches, and team
+// records for selective removal.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Team, Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getProject: vi.fn(),
+  getTeams: vi.fn().mockReturnValue([]),
+  getTeamByWorktree: vi.fn(),
+  deleteTeamAndRelated: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    worktreeDir: '.claude/worktrees',
+  },
+}));
+
+// Mock child_process.execSync
+const mockExecSync = vi.fn();
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// Mock fs
+const mockFs = {
+  existsSync: vi.fn().mockReturnValue(false),
+  readdirSync: vi.fn().mockReturnValue([]),
+  rmSync: vi.fn(),
+  unlinkSync: vi.fn(),
+};
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (...args: unknown[]) => mockFs.existsSync(...args),
+    readdirSync: (...args: unknown[]) => mockFs.readdirSync(...args),
+    rmSync: (...args: unknown[]) => mockFs.rmSync(...args),
+    unlinkSync: (...args: unknown[]) => mockFs.unlinkSync(...args),
+  },
+}));
+
+// Import after mocks
+const { getCleanupPreview, executeCleanup } = await import(
+  '../../src/server/services/cleanup.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides?: Partial<Project>): Project {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 2,
+    promptFile: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Project;
+}
+
+function makeTeam(overrides?: Partial<Team>): Team {
+  return {
+    id: 1,
+    issueNumber: 10,
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'done',
+    phase: 'done',
+    pid: null,
+    sessionId: null,
+    worktreeName: 'test-project-10',
+    branchName: 'feat/10-test',
+    prNumber: null,
+    customPrompt: null,
+    headless: true,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCostUsd: 0,
+    launchedAt: null,
+    stoppedAt: null,
+    lastEventAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to create a mock Dirent-like object.
+ */
+function makeDirent(name: string, isDir: boolean = true) {
+  return { name, isDirectory: () => isDir };
+}
+
+/**
+ * Normalize path separators for matching in mocks (handles Windows backslashes).
+ */
+function pathContains(p: unknown, fragment: string): boolean {
+  if (typeof p !== 'string') return false;
+  return p.replace(/\\/g, '/').includes(fragment);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.existsSync.mockReturnValue(false);
+  mockFs.readdirSync.mockReturnValue([]);
+  mockExecSync.mockReturnValue('');
+});
+
+// =============================================================================
+// getCleanupPreview
+// =============================================================================
+
+describe('getCleanupPreview', () => {
+  it('throws when project not found', () => {
+    mockDb.getProject.mockReturnValue(undefined);
+
+    expect(() => getCleanupPreview(999)).toThrow('Project not found');
+  });
+
+  it('returns empty items when worktree dir does not exist', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    expect(result.projectId).toBe(1);
+    expect(result.projectName).toBe('test-project');
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('identifies orphan worktrees not tracked in DB', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    // Worktree dir exists with one orphan directory
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-42')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const worktreeItems = result.items.filter((i) => i.type === 'worktree');
+    expect(worktreeItems.length).toBe(1);
+    expect(worktreeItems[0]!.name).toBe('test-project-42');
+    expect(worktreeItems[0]!.reason).toContain('orphan');
+  });
+
+  it('identifies worktrees for done/failed teams', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamByWorktree.mockReturnValue(team);
+
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-10')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const worktreeItems = result.items.filter((i) => i.type === 'worktree');
+    expect(worktreeItems.length).toBe(1);
+    expect(worktreeItems[0]!.reason).toContain('done');
+  });
+
+  it('skips worktrees for active teams', () => {
+    const project = makeProject();
+    const activeTeam = makeTeam({ id: 10, status: 'running', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([activeTeam]);
+    mockDb.getTeamByWorktree.mockReturnValue(activeTeam);
+
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-10')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const worktreeItems = result.items.filter((i) => i.type === 'worktree');
+    expect(worktreeItems.length).toBe(0);
+  });
+
+  it('identifies stale branches without worktrees', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+
+    // Worktree dir exists but is empty
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees') && !pathContains(p, 'test-project-10')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((_p: string, opts?: unknown) => {
+      if (opts) return []; // Dirent mode for worktree dir scan
+      return [];
+    });
+
+    // git branch --list returns a stale branch
+    mockExecSync.mockReturnValue('  worktree-test-project-10\n');
+
+    const result = getCleanupPreview(1);
+
+    const branchItems = result.items.filter((i) => i.type === 'stale_branch');
+    expect(branchItems.length).toBe(1);
+    expect(branchItems[0]!.name).toBe('worktree-test-project-10');
+  });
+
+  it('includes team records when resetTeams is true', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1, true);
+
+    const teamItems = result.items.filter((i) => i.type === 'team_record');
+    expect(teamItems.length).toBe(1);
+    expect(teamItems[0]!.path).toBe('db:teams:10');
+  });
+
+  it('does not include team records when resetTeams is false', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1, false);
+
+    const teamItems = result.items.filter((i) => i.type === 'team_record');
+    expect(teamItems.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// executeCleanup
+// =============================================================================
+
+describe('executeCleanup', () => {
+  it('throws when project not found', () => {
+    mockDb.getProject.mockReturnValue(undefined);
+
+    expect(() => executeCleanup(999, [])).toThrow('Project not found');
+  });
+
+  it('removes worktree via git worktree remove', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    // Setup: worktree dir has an orphan
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-42')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    const normalizedPath = '/tmp/repo/.claude/worktrees/test-project-42';
+    const result = executeCleanup(1, [normalizedPath]);
+
+    expect(result.removed).toContain('test-project-42');
+  });
+
+  it('falls back to fs.rmSync when git worktree remove fails', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-42')];
+      }
+      return [];
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
+        throw new Error('worktree locked');
+      }
+      return '';
+    });
+
+    const normalizedPath = '/tmp/repo/.claude/worktrees/test-project-42';
+    const result = executeCleanup(1, [normalizedPath]);
+
+    expect(mockFs.rmSync).toHaveBeenCalled();
+    expect(result.removed).toContain('test-project-42');
+  });
+
+  it('deletes stale branches via git branch -D', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+
+    // Worktree dir exists but empty
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees') && !pathContains(p, 'test-project-10')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((_p: string, opts?: unknown) => {
+      if (opts) return [];
+      return [];
+    });
+
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('branch --list')) {
+        return '  worktree-test-project-10\n';
+      }
+      return '';
+    });
+
+    const result = executeCleanup(1, ['worktree-test-project-10']);
+
+    expect(result.removed).toContain('worktree-test-project-10');
+    // Verify git branch -D was called
+    const branchDeleteCalls = mockExecSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('branch -D'),
+    );
+    expect(branchDeleteCalls.length).toBe(1);
+  });
+
+  it('deletes team records when included in itemPaths', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = executeCleanup(1, ['db:teams:10'], true);
+
+    expect(mockDb.deleteTeamAndRelated).toHaveBeenCalledWith(10);
+    expect(result.removed.length).toBe(1);
+  });
+
+  it('reports failures without aborting other items', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    // Two orphan worktrees
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-1'), makeDirent('test-project-2')];
+      }
+      return [];
+    });
+
+    // First worktree fails, second succeeds
+    let removeCount = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
+        removeCount++;
+        if (removeCount === 1) throw new Error('locked');
+        return '';
+      }
+      if (typeof cmd === 'string' && cmd.includes('worktree prune')) return '';
+      return '';
+    });
+    // For the first worktree, rmSync fallback also fails
+    mockFs.rmSync.mockImplementationOnce(() => {
+      throw new Error('EACCES');
+    });
+
+    const result = executeCleanup(1, [
+      '/tmp/repo/.claude/worktrees/test-project-1',
+      '/tmp/repo/.claude/worktrees/test-project-2',
+    ]);
+
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0]!.name).toBe('test-project-1');
+    expect(result.removed).toContain('test-project-2');
+  });
+
+  it('only removes items the user selected', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-1'), makeDirent('test-project-2')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    // Only select one of the two
+    const result = executeCleanup(1, ['/tmp/repo/.claude/worktrees/test-project-1']);
+
+    expect(result.removed).toContain('test-project-1');
+    expect(result.removed).not.toContain('test-project-2');
+  });
+});

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -1,0 +1,823 @@
+// =============================================================================
+// Fleet Commander — GitHub Poller Tests
+// =============================================================================
+// Tests for the GitHubPoller service: PR state transitions, CI status
+// derivation, CI failure counting, merge detection, poll lifecycle, and
+// dependency resolution tracking.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Team, Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getProjects: vi.fn().mockReturnValue([]),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getTeam: vi.fn(),
+  getPullRequest: vi.fn(),
+  updateTeam: vi.fn(),
+  updatePullRequest: vi.fn(),
+  insertPullRequest: vi.fn(),
+  insertTransition: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    githubPollIntervalMs: 30000,
+    maxUniqueCiFailures: 3,
+    mergeShutdownGraceMs: 120000,
+    worktreeDir: '.claude/worktrees',
+  },
+}));
+
+const mockSseBroker = {
+  broadcast: vi.fn(),
+};
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue(null),
+}));
+
+const mockManager = {
+  sendMessage: vi.fn(),
+  gracefulShutdown: vi.fn(),
+  processQueue: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: () => mockManager,
+}));
+
+const mockFetcher = {
+  fetchDependenciesForIssue: vi.fn().mockResolvedValue(null),
+};
+vi.mock('../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: () => mockFetcher,
+}));
+
+// Mock child_process for execGH and detectWorktreeBranch
+const mockExecSync = vi.fn().mockReturnValue(null);
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// Import after mocks
+const { githubPoller } = await import(
+  '../../src/server/services/github-poller.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides?: Partial<Team>): Partial<Team> {
+  return {
+    id: 1,
+    issueNumber: 10,
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-1',
+    worktreeName: 'proj-10',
+    branchName: 'feat/10-test',
+    prNumber: 42,
+    customPrompt: null,
+    launchedAt: new Date().toISOString(),
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeProject(overrides?: Partial<Project>): Partial<Project> {
+  return {
+    id: 1,
+    name: 'my-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 2,
+    promptFile: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeGHPRViewResult(overrides?: Record<string, unknown>) {
+  return JSON.stringify({
+    number: 42,
+    title: 'Test PR',
+    state: 'OPEN',
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [],
+    autoMergeRequest: null,
+    headRefName: 'feat/10-test',
+    mergedAt: null,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  mockDb.getProjects.mockReturnValue([]);
+  mockDb.getActiveTeams.mockReturnValue([]);
+});
+
+afterEach(() => {
+  githubPoller.stop();
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// PR state transitions
+// =============================================================================
+
+describe('PR state transitions', () => {
+  it('detects open -> merged transition and marks team done', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // Team should be marked done
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        toStatus: 'done',
+        trigger: 'poller',
+        reason: expect.stringContaining('merged'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        status: 'done',
+        phase: 'done',
+      }),
+    );
+
+    // Graceful shutdown should be initiated
+    expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
+  });
+
+  it('detects new PR state (no existing PR record) and inserts it', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue(undefined);
+
+    mockExecSync.mockReturnValue(makeGHPRViewResult());
+
+    await githubPoller.poll();
+
+    expect(mockDb.insertPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        teamId: 1,
+        state: 'open',
+      }),
+    );
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'pr_updated',
+      expect.objectContaining({ pr_number: 42 }),
+      1,
+    );
+  });
+
+  it('does not update when nothing changed', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(makeGHPRViewResult());
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).not.toHaveBeenCalled();
+    expect(mockSseBroker.broadcast).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// CI status derivation
+// =============================================================================
+
+describe('CI status derivation', () => {
+  it('derives passing when all checks succeed', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+          { name: 'lint', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'passing' }),
+    );
+  });
+
+  it('derives failing when any check has FAILURE conclusion', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+          { name: 'test', conclusion: 'FAILURE', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'failing' }),
+    );
+  });
+
+  it('derives failing for CANCELLED conclusion', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'deploy', conclusion: 'CANCELLED', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'failing' }),
+    );
+  });
+
+  it('derives pending when checks are in progress', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: null, status: 'IN_PROGRESS' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'pending' }),
+    );
+  });
+
+  it('derives none when no checks exist', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({ statusCheckRollup: [] }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'none' }),
+    );
+  });
+
+  it('counts NEUTRAL and SKIPPED as passing', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'optional', conclusion: 'NEUTRAL' },
+          { name: 'skipped', conclusion: 'SKIPPED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'passing' }),
+    );
+  });
+});
+
+// =============================================================================
+// CI failure counting
+// =============================================================================
+
+describe('CI failure counting', () => {
+  it('counts unique CI failures and tracks cumulative max', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 1,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'FAILURE' },
+          { name: 'test', conclusion: 'FAILURE' },
+          { name: 'lint', conclusion: 'SUCCESS' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciFailCount: 2 }),
+    );
+  });
+
+  it('resets ciFailCount to 0 when CI is green', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'failing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 2,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS' },
+          { name: 'test', conclusion: 'SUCCESS' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciFailCount: 0 }),
+    );
+  });
+
+  it('marks team stuck+blocked when CI failures exceed threshold', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 2,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, phase: 'implementing' });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'FAILURE' },
+          { name: 'test', conclusion: 'FAILURE' },
+          { name: 'lint', conclusion: 'FAILURE' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        toStatus: 'stuck',
+        trigger: 'poller',
+        reason: expect.stringContaining('CI blocked'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ phase: 'blocked', status: 'stuck' }),
+    );
+  });
+});
+
+// =============================================================================
+// PR detection by branch
+// =============================================================================
+
+describe('PR detection by branch', () => {
+  it('detects PR for a team without prNumber', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: null, branchName: 'feat/10-test' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('gh pr list')) {
+        return JSON.stringify([{ number: 55 }]);
+      }
+      if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+        return 'feat/10-test\n';
+      }
+      return null;
+    });
+
+    await githubPoller.poll();
+
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { prNumber: 55 });
+  });
+
+  it('does nothing when no PR found for branch', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: null, branchName: 'feat/10-test' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('gh pr list')) {
+        return JSON.stringify([]);
+      }
+      if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+        return 'feat/10-test\n';
+      }
+      return null;
+    });
+
+    await githubPoller.poll();
+
+    expect(mockDb.updateTeam).not.toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ prNumber: expect.anything() }),
+    );
+  });
+});
+
+// =============================================================================
+// Error handling
+// =============================================================================
+
+describe('Error handling', () => {
+  it('continues polling other teams when one team fails', async () => {
+    const project = makeProject();
+    const team1 = makeTeam({ id: 1, prNumber: 42 });
+    const team2 = makeTeam({ id: 2, prNumber: 43, issueNumber: 11 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team1, team2]);
+
+    let callCount = 0;
+    mockExecSync.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error('gh CLI timeout');
+      }
+      return makeGHPRViewResult({ number: 43 });
+    });
+    mockDb.getPullRequest.mockReturnValue(undefined);
+
+    await githubPoller.poll();
+
+    expect(mockDb.insertPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ prNumber: 43 }),
+    );
+  });
+
+  it('handles malformed JSON from gh CLI gracefully', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    mockExecSync.mockReturnValue('not valid json {{{');
+
+    await expect(githubPoller.poll()).resolves.not.toThrow();
+  });
+
+  it('handles gh CLI throwing error gracefully', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    mockExecSync.mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+
+    await expect(githubPoller.poll()).resolves.not.toThrow();
+  });
+});
+
+// =============================================================================
+// Auto-merge detection
+// =============================================================================
+
+describe('Auto-merge detection', () => {
+  it('detects auto-merge enabled', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ autoMerge: true }),
+    );
+  });
+});
+
+// =============================================================================
+// Poll lifecycle (start/stop)
+// =============================================================================
+
+describe('Poll lifecycle', () => {
+  it('start() is idempotent', () => {
+    githubPoller.start();
+    githubPoller.start();
+    githubPoller.stop();
+  });
+
+  it('stop() is safe when not started', () => {
+    expect(() => githubPoller.stop()).not.toThrow();
+  });
+
+  it('stop() clears the timer after start()', () => {
+    githubPoller.start();
+    githubPoller.stop();
+  });
+});
+
+// =============================================================================
+// Dependency tracking
+// =============================================================================
+
+describe('Dependency tracking', () => {
+  it('trackBlockedIssue and untrackBlockedIssue do not throw', () => {
+    githubPoller.trackBlockedIssue(1, 42, [5, 8]);
+    githubPoller.untrackBlockedIssue(1, 42);
+  });
+
+  it('broadcasts dependency_resolved when all blockers close', async () => {
+    githubPoller.trackBlockedIssue(1, 42, [5]);
+
+    mockFetcher.fetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 42,
+      blockedBy: [{ number: 5, owner: 'o', repo: 'r', state: 'closed', title: 'Done' }],
+      resolved: true,
+      openCount: 0,
+    });
+
+    mockDb.getProjects.mockReturnValue([makeProject()]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    await githubPoller.poll();
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'dependency_resolved',
+      expect.objectContaining({
+        issue_number: 42,
+        project_id: 1,
+        previously_blocked_by: [5],
+      }),
+    );
+  });
+
+  it('triggers processQueue after dependency resolution', async () => {
+    githubPoller.trackBlockedIssue(1, 42, [5]);
+
+    mockFetcher.fetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 42,
+      blockedBy: [],
+      resolved: true,
+      openCount: 0,
+    });
+
+    mockDb.getProjects.mockReturnValue([makeProject()]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    await githubPoller.poll();
+
+    expect(mockManager.processQueue).toHaveBeenCalledWith(1);
+  });
+});
+
+// =============================================================================
+// Team skipping
+// =============================================================================
+
+describe('Team skipping', () => {
+  it('skips teams whose project has no githubRepo', async () => {
+    const project = makeProject({ githubRepo: null });
+    const team = makeTeam({ prNumber: 42, projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    await githubPoller.poll();
+
+    expect(mockDb.getPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no active projects exist', async () => {
+    mockDb.getProjects.mockReturnValue([]);
+    mockDb.getActiveTeams.mockReturnValue([makeTeam()]);
+
+    await githubPoller.poll();
+
+    expect(mockDb.getPullRequest).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Merge state SSE broadcast
+// =============================================================================
+
+describe('Merge detection SSE', () => {
+  it('broadcasts team_status_changed when PR is merged', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecSync.mockReturnValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2024-01-01T00:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({
+        team_id: 1,
+        status: 'done',
+        previous_status: 'running',
+      }),
+      1,
+    );
+  });
+});

--- a/tests/server/resolve-message.test.ts
+++ b/tests/server/resolve-message.test.ts
@@ -1,0 +1,181 @@
+// =============================================================================
+// Fleet Commander — resolveMessage() Tests
+// =============================================================================
+// Tests for the message template resolver that reads templates from the DB,
+// substitutes {{PLACEHOLDER}} variables, and respects the enabled flag.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getMessageTemplate: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+// Import after mocks are set up
+const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// Basic placeholder substitution
+// =============================================================================
+
+describe('Placeholder substitution', () => {
+  it('substitutes a single placeholder', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'ci_green',
+      template: 'CI passed on PR #{{PR_NUMBER}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('ci_green', { PR_NUMBER: '42' });
+    expect(result).toBe('CI passed on PR #42.');
+  });
+
+  it('substitutes multiple placeholders', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'ci_red',
+      template: 'CI failed on PR #{{PR_NUMBER}}. Fails: {{FAIL_COUNT}}/{{MAX_FAILURES}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('ci_red', {
+      PR_NUMBER: '99',
+      FAIL_COUNT: '2',
+      MAX_FAILURES: '3',
+    });
+    expect(result).toBe('CI failed on PR #99. Fails: 2/3.');
+  });
+
+  it('substitutes all occurrences of the same placeholder', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'test',
+      template: 'Issue #{{NUM}} is about #{{NUM}} again.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('test', { NUM: '7' });
+    expect(result).toBe('Issue #7 is about #7 again.');
+  });
+
+  it('leaves unreferenced placeholders in vars without error', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'simple',
+      template: 'Hello {{NAME}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('simple', { NAME: 'World', EXTRA: 'unused' });
+    expect(result).toBe('Hello World.');
+  });
+});
+
+// =============================================================================
+// Missing placeholders
+// =============================================================================
+
+describe('Missing placeholder handling', () => {
+  it('leaves unresolved placeholders in the output when vars are missing', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'partial',
+      template: 'PR #{{PR_NUMBER}} by {{AUTHOR}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('partial', { PR_NUMBER: '10' });
+    // {{AUTHOR}} was not provided — left as-is
+    expect(result).toBe('PR #10 by {{AUTHOR}}.');
+  });
+
+  it('returns template as-is when vars is empty', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'no_vars',
+      template: 'Static message with {{PLACEHOLDER}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('no_vars', {});
+    expect(result).toBe('Static message with {{PLACEHOLDER}}.');
+  });
+});
+
+// =============================================================================
+// Template enabled/disabled
+// =============================================================================
+
+describe('Template enabled/disabled', () => {
+  it('returns null when template is disabled', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'ci_green',
+      template: 'CI passed.',
+      enabled: false,
+    });
+
+    const result = resolveMessage('ci_green', { PR_NUMBER: '1' });
+    expect(result).toBeNull();
+  });
+
+  it('returns the resolved message when template is enabled', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'ci_green',
+      template: 'CI passed on PR #{{PR_NUMBER}}.',
+      enabled: true,
+    });
+
+    const result = resolveMessage('ci_green', { PR_NUMBER: '1' });
+    expect(result).toBe('CI passed on PR #1.');
+  });
+});
+
+// =============================================================================
+// Template not found
+// =============================================================================
+
+describe('Template not found', () => {
+  it('returns null when template ID does not exist', () => {
+    mockDb.getMessageTemplate.mockReturnValue(undefined);
+
+    const result = resolveMessage('nonexistent', { KEY: 'value' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when getMessageTemplate returns null', () => {
+    mockDb.getMessageTemplate.mockReturnValue(null);
+
+    const result = resolveMessage('also_missing', {});
+    expect(result).toBeNull();
+  });
+});
+
+// =============================================================================
+// DB lookup
+// =============================================================================
+
+describe('DB template lookup', () => {
+  it('calls getMessageTemplate with the correct template ID', () => {
+    mockDb.getMessageTemplate.mockReturnValue({
+      id: 'idle_nudge',
+      template: 'Idle for {{IDLE_MINUTES}} min.',
+      enabled: true,
+    });
+
+    resolveMessage('idle_nudge', { IDLE_MINUTES: '5' });
+
+    expect(mockDb.getMessageTemplate).toHaveBeenCalledTimes(1);
+    expect(mockDb.getMessageTemplate).toHaveBeenCalledWith('idle_nudge');
+  });
+});

--- a/tests/server/startup-recovery.test.ts
+++ b/tests/server/startup-recovery.test.ts
@@ -1,0 +1,375 @@
+// =============================================================================
+// Fleet Commander — Startup Recovery Tests
+// =============================================================================
+// Tests for recoverOnStartup() which reconciles DB state with OS processes
+// and filesystem state on server restart.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Team, Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getActiveTeams: vi.fn<() => Partial<Team>[]>().mockReturnValue([]),
+  getProjects: vi.fn<() => Partial<Project>[]>().mockReturnValue([]),
+  getTeamByWorktree: vi.fn(),
+  getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  insertTransition: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    worktreeDir: '.claude/worktrees',
+  },
+}));
+
+// Mock child_process.execSync for isProcessAlive
+const mockExecSync = vi.fn();
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// Mock fs for worktree scanning
+const mockFs = {
+  existsSync: vi.fn().mockReturnValue(false),
+  readdirSync: vi.fn().mockReturnValue([]),
+};
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (...args: unknown[]) => mockFs.existsSync(...args),
+    readdirSync: (...args: unknown[]) => mockFs.readdirSync(...args),
+  },
+}));
+
+// Mock team-manager (dynamic import in startup-recovery.ts)
+const mockProcessQueue = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: () => ({
+    processQueue: mockProcessQueue,
+  }),
+}));
+
+// Import after mocks are set up
+const { recoverOnStartup } = await import(
+  '../../src/server/services/startup-recovery.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides: Partial<Team>): Partial<Team> {
+  return {
+    id: 1,
+    issueNumber: 100,
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-abc',
+    worktreeName: 'test-100',
+    branchName: 'feat/100-test',
+    prNumber: null,
+    customPrompt: null,
+    launchedAt: new Date().toISOString(),
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeProject(overrides?: Partial<Project>): Partial<Project> {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 2,
+    promptFile: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.getActiveTeams.mockReturnValue([]);
+  mockDb.getProjects.mockReturnValue([]);
+  mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+  mockFs.existsSync.mockReturnValue(false);
+  mockFs.readdirSync.mockReturnValue([]);
+});
+
+// =============================================================================
+// Process reconciliation — dead PIDs
+// =============================================================================
+
+describe('Dead PID recovery', () => {
+  it('marks running team with dead PID as idle', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 9999 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    // Simulate dead process: execSync throws (Windows) or process.kill throws (POSIX)
+    mockExecSync.mockImplementation(() => {
+      throw new Error('process not found');
+    });
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'idle',
+        trigger: 'system',
+        reason: expect.stringContaining('no longer alive'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, expect.objectContaining({
+      status: 'idle',
+      pid: null,
+    }));
+  });
+
+  it('marks launching team with dead PID as failed', async () => {
+    const team = makeTeam({ id: 2, status: 'launching', pid: 8888 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('process not found');
+    });
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 2,
+        fromStatus: 'launching',
+        toStatus: 'failed',
+        trigger: 'system',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(2, expect.objectContaining({
+      status: 'failed',
+      pid: null,
+    }));
+  });
+
+  it('marks idle team with dead PID as idle (keeps idle)', async () => {
+    const team = makeTeam({ id: 3, status: 'idle', pid: 7777 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('process not found');
+    });
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 3,
+        fromStatus: 'idle',
+        toStatus: 'idle',
+        trigger: 'system',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(3, expect.objectContaining({
+      status: 'idle',
+      pid: null,
+    }));
+  });
+
+  it('marks stuck team with dead PID as idle', async () => {
+    const team = makeTeam({ id: 4, status: 'stuck', pid: 6666 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('process not found');
+    });
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 4,
+        fromStatus: 'stuck',
+        toStatus: 'idle',
+        trigger: 'system',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(4, expect.objectContaining({
+      status: 'idle',
+      pid: null,
+    }));
+  });
+});
+
+// =============================================================================
+// Process reconciliation — alive PIDs
+// =============================================================================
+
+describe('Alive PID recovery', () => {
+  it('updates lastEventAt for running team with alive PID', async () => {
+    const team = makeTeam({ id: 5, status: 'running', pid: 5555 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    // Simulate alive process on Windows: tasklist returns output containing the PID
+    mockExecSync.mockReturnValue(`node.exe    5555 Console    1    50,000 K`);
+
+    await recoverOnStartup();
+
+    // Should not change status
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    // Should update lastEventAt
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(5, expect.objectContaining({
+      lastEventAt: expect.any(String),
+    }));
+    // Should NOT set status or pid
+    const updateCall = mockDb.updateTeam.mock.calls[0]![1];
+    expect(updateCall).not.toHaveProperty('status');
+    expect(updateCall).not.toHaveProperty('pid');
+  });
+});
+
+// =============================================================================
+// No PID recorded
+// =============================================================================
+
+describe('No PID recovery', () => {
+  it('marks team with no PID as idle', async () => {
+    const team = makeTeam({ id: 6, status: 'running', pid: null });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 6,
+        fromStatus: 'running',
+        toStatus: 'idle',
+        trigger: 'system',
+        reason: expect.stringContaining('no PID'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(6, expect.objectContaining({
+      status: 'idle',
+    }));
+  });
+
+  it('skips queued teams entirely', async () => {
+    const team = makeTeam({ id: 7, status: 'queued', pid: null });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Orphan worktree detection
+// =============================================================================
+
+describe('Orphan worktree detection', () => {
+  it('logs warning for orphan worktrees not tracked in database', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const project = makeProject({ id: 1, name: 'test-project', repoPath: '/tmp/repo' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readdirSync.mockReturnValue(['test-project-42']);
+    mockDb.getTeamByWorktree.mockReturnValue(undefined);
+
+    await recoverOnStartup();
+
+    // The warning is a single string containing both "Orphan worktree" and the dir name
+    const orphanCalls = consoleSpy.mock.calls.filter(
+      (call) => String(call[0]).includes('Orphan worktree') && String(call[0]).includes('test-project-42'),
+    );
+    expect(orphanCalls.length).toBe(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn for worktrees tracked in database', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const project = makeProject({ id: 1, name: 'test-project', repoPath: '/tmp/repo' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readdirSync.mockReturnValue(['test-project-42']);
+    mockDb.getTeamByWorktree.mockReturnValue({ id: 10 });
+
+    await recoverOnStartup();
+
+    // No orphan warning
+    const orphanCalls = consoleSpy.mock.calls.filter(
+      (call) => String(call[0]).includes('Orphan'),
+    );
+    expect(orphanCalls.length).toBe(0);
+    consoleSpy.mockRestore();
+  });
+
+  it('skips worktree scan when no active projects exist', async () => {
+    mockDb.getProjects.mockReturnValue([]);
+
+    await recoverOnStartup();
+
+    expect(mockFs.existsSync).not.toHaveBeenCalled();
+    expect(mockFs.readdirSync).not.toHaveBeenCalled();
+  });
+
+  it('skips project when worktree directory does not exist', async () => {
+    const project = makeProject({ id: 1, name: 'test-project', repoPath: '/tmp/repo' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+    mockFs.existsSync.mockReturnValue(false);
+
+    await recoverOnStartup();
+
+    expect(mockDb.getTeamByWorktree).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Queue re-processing after recovery
+// =============================================================================
+
+describe('Queue re-processing after recovery', () => {
+  it('triggers processQueue when queued teams exist', async () => {
+    const project = makeProject({ id: 1, name: 'test-project', repoPath: '/tmp/repo' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockDb.getQueuedTeamsByProject.mockReturnValue([
+      makeTeam({ id: 10, status: 'queued' }),
+    ]);
+
+    await recoverOnStartup();
+
+    expect(mockProcessQueue).toHaveBeenCalledWith(1);
+  });
+
+  it('does not trigger processQueue when no queued teams exist', async () => {
+    const project = makeProject({ id: 1, name: 'test-project', repoPath: '/tmp/repo' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+
+    await recoverOnStartup();
+
+    expect(mockProcessQueue).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/state-machine.test.ts
+++ b/tests/server/state-machine.test.ts
@@ -1,0 +1,281 @@
+// =============================================================================
+// Fleet Commander — State Machine Tests (data validation, transition coverage)
+// =============================================================================
+// Pure data-structure validation — no mocks needed. Validates the state machine
+// definitions in src/shared/state-machine.ts for completeness and correctness.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import {
+  STATE_MACHINE_TRANSITIONS,
+  STATES,
+  type StateMachineTransition,
+} from '../../src/shared/state-machine.js';
+import type { TeamStatus } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Valid statuses (from types.ts)
+// ---------------------------------------------------------------------------
+
+const ALL_STATUSES: TeamStatus[] = [
+  'queued',
+  'launching',
+  'running',
+  'idle',
+  'stuck',
+  'done',
+  'failed',
+];
+
+// =============================================================================
+// Transition IDs
+// =============================================================================
+
+describe('State machine transition IDs', () => {
+  it('all transitions have unique IDs', () => {
+    const ids = STATE_MACHINE_TRANSITIONS.map((t) => t.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('all transitions have non-empty IDs', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      expect(t.id).toBeTruthy();
+      expect(typeof t.id).toBe('string');
+      expect(t.id.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// =============================================================================
+// Status validity
+// =============================================================================
+
+describe('State machine status validity', () => {
+  it('all "from" statuses are valid TeamStatus values or wildcard "*"', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      if (t.from === '*') continue; // wildcard is valid
+      expect(ALL_STATUSES).toContain(t.from);
+    }
+  });
+
+  it('all "to" statuses are valid TeamStatus values', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      expect(ALL_STATUSES).toContain(t.to);
+    }
+  });
+
+  it('STATES array covers all TeamStatus values', () => {
+    const stateIds = STATES.map((s) => s.id);
+    for (const status of ALL_STATUSES) {
+      expect(stateIds).toContain(status);
+    }
+  });
+
+  it('STATES array contains no extra/unknown statuses', () => {
+    for (const state of STATES) {
+      expect(ALL_STATUSES).toContain(state.id as TeamStatus);
+    }
+  });
+});
+
+// =============================================================================
+// Lifecycle completeness — reachability from 'queued'
+// =============================================================================
+
+describe('State machine lifecycle completeness', () => {
+  it('every non-queued status is reachable from queued (BFS)', () => {
+    // Build a graph from transitions (excluding wildcards — handle separately)
+    const graph = new Map<string, Set<string>>();
+    for (const status of ALL_STATUSES) {
+      graph.set(status, new Set());
+    }
+
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      if (t.from === '*') {
+        // Wildcard: the transition can happen from any status
+        for (const status of ALL_STATUSES) {
+          graph.get(status)?.add(t.to);
+        }
+      } else {
+        graph.get(t.from)?.add(t.to);
+      }
+    }
+
+    // BFS from 'queued'
+    const visited = new Set<string>();
+    const queue = ['queued'];
+    visited.add('queued');
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const neighbors = graph.get(current) ?? new Set();
+      for (const neighbor of neighbors) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    for (const status of ALL_STATUSES) {
+      expect(visited.has(status)).toBe(true);
+    }
+  });
+
+  it('terminal states (done, failed) have outgoing transitions or are intentionally terminal', () => {
+    // done and failed should have some outgoing transitions (for PM recovery)
+    const doneTransitions = STATE_MACHINE_TRANSITIONS.filter(
+      (t) => t.from === 'done',
+    );
+    const failedTransitions = STATE_MACHINE_TRANSITIONS.filter(
+      (t) => t.from === 'failed',
+    );
+
+    // 'failed' has outgoing: failed->done, failed->queued, failed->launching
+    expect(failedTransitions.length).toBeGreaterThan(0);
+
+    // 'done' is terminal — no outgoing transitions expected from the state machine
+    // (but wildcard transitions can target done from any state)
+    // This is a design choice — just document it
+    expect(doneTransitions.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// Transition trigger types
+// =============================================================================
+
+describe('State machine trigger types', () => {
+  const validTriggers = ['hook', 'timer', 'poller', 'pm_action', 'system'];
+
+  it('all transitions have a valid trigger type', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      expect(validTriggers).toContain(t.trigger);
+    }
+  });
+
+  it('all transitions have non-empty triggerLabel and description', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      expect(t.triggerLabel.trim().length).toBeGreaterThan(0);
+      expect(t.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all transitions have a non-empty condition string', () => {
+    for (const t of STATE_MACHINE_TRANSITIONS) {
+      expect(t.condition.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// =============================================================================
+// Required transitions exist
+// =============================================================================
+
+describe('Required transitions exist', () => {
+  function findTransition(from: string, to: string): StateMachineTransition | undefined {
+    return STATE_MACHINE_TRANSITIONS.find(
+      (t) => (t.from === from || t.from === '*') && t.to === to,
+    );
+  }
+
+  it('queued -> launching exists', () => {
+    expect(findTransition('queued', 'launching')).toBeDefined();
+  });
+
+  it('launching -> running exists', () => {
+    expect(findTransition('launching', 'running')).toBeDefined();
+  });
+
+  it('running -> idle exists', () => {
+    expect(findTransition('running', 'idle')).toBeDefined();
+  });
+
+  it('idle -> stuck exists', () => {
+    expect(findTransition('idle', 'stuck')).toBeDefined();
+  });
+
+  it('running -> done exists', () => {
+    expect(findTransition('running', 'done')).toBeDefined();
+  });
+
+  it('running -> failed exists', () => {
+    expect(findTransition('running', 'failed')).toBeDefined();
+  });
+
+  it('idle -> running exists', () => {
+    expect(findTransition('idle', 'running')).toBeDefined();
+  });
+
+  it('stuck -> running exists', () => {
+    expect(findTransition('stuck', 'running')).toBeDefined();
+  });
+
+  it('launching -> failed exists', () => {
+    expect(findTransition('launching', 'failed')).toBeDefined();
+  });
+
+  it('PR merged wildcard transition to done exists', () => {
+    const prMerged = STATE_MACHINE_TRANSITIONS.find(
+      (t) => t.id === 'pr_merged' && t.from === '*' && t.to === 'done',
+    );
+    expect(prMerged).toBeDefined();
+  });
+
+  it('CI blocked wildcard transition to stuck exists', () => {
+    const ciBlocked = STATE_MACHINE_TRANSITIONS.find(
+      (t) => t.id === 'ci_blocked' && t.from === '*' && t.to === 'stuck',
+    );
+    expect(ciBlocked).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Self-transitions (from === to)
+// =============================================================================
+
+describe('Self-transitions', () => {
+  it('CI green/red and merge conflict are self-transitions on running', () => {
+    const selfTransitions = STATE_MACHINE_TRANSITIONS.filter(
+      (t) => t.from === t.to,
+    );
+    expect(selfTransitions.length).toBeGreaterThan(0);
+
+    const ciGreen = selfTransitions.find((t) => t.id === 'ci_green');
+    expect(ciGreen).toBeDefined();
+    expect(ciGreen!.from).toBe('running');
+    expect(ciGreen!.to).toBe('running');
+
+    const ciRed = selfTransitions.find((t) => t.id === 'ci_red');
+    expect(ciRed).toBeDefined();
+    expect(ciRed!.from).toBe('running');
+    expect(ciRed!.to).toBe('running');
+  });
+
+  it('queued-blocked is a self-transition', () => {
+    const queuedBlocked = STATE_MACHINE_TRANSITIONS.find(
+      (t) => t.id === 'queued-blocked',
+    );
+    expect(queuedBlocked).toBeDefined();
+    expect(queuedBlocked!.from).toBe('queued');
+    expect(queuedBlocked!.to).toBe('queued');
+  });
+});
+
+// =============================================================================
+// STATES metadata
+// =============================================================================
+
+describe('STATES metadata', () => {
+  it('each state has a non-empty label and color', () => {
+    for (const state of STATES) {
+      expect(state.label.trim().length).toBeGreaterThan(0);
+      expect(state.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it('STATES has exactly the expected count', () => {
+    expect(STATES.length).toBe(ALL_STATUSES.length);
+  });
+});

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -1,0 +1,574 @@
+// =============================================================================
+// Fleet Commander — TeamManager Lifecycle Tests (stop, sendMessage, process exit)
+// =============================================================================
+// Tests for stop(), sendMessage(), attachProcessHandlers exit/error handling,
+// and gracefulShutdown. Does NOT duplicate queue/env tests from other files.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { EventEmitter } from 'events';
+import type { Writable } from 'stream';
+import type { Team } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures these are available when vi.mock factories run
+// ---------------------------------------------------------------------------
+
+const mockDb = vi.hoisted(() => ({
+  getProject: vi.fn(),
+  getTeam: vi.fn(),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamCountByProject: vi.fn().mockReturnValue(0),
+  getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  insertTransition: vi.fn(),
+  getPullRequest: vi.fn(),
+  insertEvent: vi.fn(),
+}));
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    worktreeDir: '.claude/worktrees',
+    outputBufferLines: 500,
+    claudeCmd: 'claude',
+    skipPermissions: true,
+    terminal: 'auto',
+    mergeShutdownGraceMs: 120000,
+    fleetCommanderRoot: '/tmp/fleet',
+  },
+}));
+
+const mockSseBroker = vi.hoisted(() => ({
+  broadcast: vi.fn(),
+  getSnapshot: vi.fn().mockReturnValue([]),
+}));
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+vi.mock('../../src/server/utils/find-git-bash.js', () => ({
+  findGitBash: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue('Shutdown message for PR'),
+}));
+
+vi.mock('../../src/server/services/usage-tracker.js', () => ({
+  getUsageZone: vi.fn().mockReturnValue('green'),
+}));
+
+vi.mock('../../src/server/utils/resolve-claude-path.js', () => ({
+  resolveClaudePath: vi.fn().mockReturnValue('claude'),
+}));
+
+vi.mock('../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: () => ({
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue({
+      issueNumber: 0, blockedBy: [], resolved: true, openCount: 0,
+    }),
+  }),
+  detectCircularDependencies: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+import { TeamManager } from '../../src/server/services/team-manager.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides?: Partial<Team>): Team {
+  return {
+    id: 1,
+    issueNumber: 10,
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-1',
+    worktreeName: 'proj-10',
+    branchName: 'feat/10-test',
+    prNumber: null,
+    customPrompt: null,
+    headless: true,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCostUsd: 0,
+    launchedAt: new Date().toISOString(),
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockStdin(): Writable & { write: Mock; end: Mock; destroyed: boolean } {
+  return {
+    write: vi.fn().mockReturnValue(true),
+    end: vi.fn(),
+    destroyed: false,
+  } as unknown as Writable & { write: Mock; end: Mock; destroyed: boolean };
+}
+
+function createMockChildProcess() {
+  const child = new EventEmitter();
+  (child as any).stdin = createMockStdin();
+  (child as any).stdout = new EventEmitter();
+  (child as any).stderr = new EventEmitter();
+  (child as any).pid = 99999;
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TeamManager.stop', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    tm = new TeamManager();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('throws when team not found', async () => {
+    mockDb.getTeam.mockReturnValue(undefined);
+
+    await expect(tm.stop(999)).rejects.toThrow('Team 999 not found');
+  });
+
+  it('cancels a queued team by marking it failed', async () => {
+    const team = makeTeam({ id: 1, status: 'queued', pid: null });
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.updateTeam.mockReturnValue(team);
+
+    await tm.stop(1);
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'queued',
+        toStatus: 'failed',
+        trigger: 'pm_action',
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+
+  it('sends stdin EOF for graceful shutdown of running team', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+    const mockStdin = createMockStdin();
+
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).childProcesses.set(1, createMockChildProcess());
+
+    mockDb.getTeam
+      .mockReturnValueOnce(team)
+      .mockReturnValueOnce({ ...team, pid: 12345 })
+      .mockReturnValueOnce({ ...team, status: 'running' })
+      .mockReturnValueOnce(team);
+    mockDb.updateTeam.mockReturnValue(team);
+
+    // stop() has a 5s setTimeout inside — advance fake timers to avoid timeout
+    const stopPromise = tm.stop(1);
+    await vi.advanceTimersByTimeAsync(6000);
+    await stopPromise;
+
+    expect(mockStdin.end).toHaveBeenCalled();
+  });
+
+  it('broadcasts team_stopped SSE event after stop', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+
+    (tm as any).stdinPipes.set(1, createMockStdin());
+    (tm as any).childProcesses.set(1, createMockChildProcess());
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.updateTeam.mockReturnValue(team);
+
+    const stopPromise = tm.stop(1);
+    await vi.advanceTimersByTimeAsync(6000);
+    await stopPromise;
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_stopped',
+      { team_id: 1 },
+      1,
+    );
+  });
+});
+
+// =============================================================================
+// sendMessage
+// =============================================================================
+
+describe('TeamManager.sendMessage', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('returns false when no stdin pipe exists', () => {
+    const result = tm.sendMessage(1, 'hello');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when stdin is destroyed', () => {
+    const mockStdin = createMockStdin();
+    mockStdin.destroyed = true;
+    (tm as any).stdinPipes.set(1, mockStdin);
+
+    const result = tm.sendMessage(1, 'hello');
+    expect(result).toBe(false);
+  });
+
+  it('writes a stream-json message to stdin and returns true', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).parsedEvents.set(1, []);
+
+    const result = tm.sendMessage(1, 'Fix the tests');
+    expect(result).toBe(true);
+    expect(mockStdin.write).toHaveBeenCalledTimes(1);
+
+    const written = mockStdin.write.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(written.trimEnd());
+    expect(parsed.type).toBe('user');
+    expect(parsed.message.content).toBe('Fix the tests');
+  });
+
+  it('injects synthetic event into parsedEvents for session log', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    const events: unknown[] = [];
+    (tm as any).parsedEvents.set(1, events);
+
+    tm.sendMessage(1, 'Check status', 'user');
+
+    expect(events.length).toBe(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.type).toBe('user');
+    expect(event.agentName).toBe('__pm__');
+  });
+
+  it('tags FC messages with __fc__ agent name and subtype', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    const events: unknown[] = [];
+    (tm as any).parsedEvents.set(1, events);
+
+    tm.sendMessage(1, 'CI passed', 'fc', 'ci_green');
+
+    expect(events.length).toBe(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.type).toBe('fc');
+    expect(event.agentName).toBe('__fc__');
+    expect(event.subtype).toBe('ci_green');
+  });
+
+  it('broadcasts team_output SSE event for the message', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).parsedEvents.set(1, []);
+
+    tm.sendMessage(1, 'Hello team');
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_output',
+      expect.objectContaining({ team_id: 1 }),
+      1,
+    );
+  });
+
+  it('returns false and does not throw when stdin.write throws', () => {
+    const mockStdin = createMockStdin();
+    mockStdin.write.mockImplementation(() => {
+      throw new Error('Broken pipe');
+    });
+    (tm as any).stdinPipes.set(1, mockStdin);
+
+    const result = tm.sendMessage(1, 'test');
+    expect(result).toBe(false);
+  });
+});
+
+// =============================================================================
+// attachProcessHandlers — process exit
+// =============================================================================
+
+describe('TeamManager.attachProcessHandlers (exit)', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('marks team done on exit code 0', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('exit', 0, null);
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'done',
+        trigger: 'system',
+        reason: expect.stringContaining('code 0'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done', pid: null }),
+    );
+  });
+
+  it('marks team failed on non-zero exit code', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('exit', 1, null);
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'failed',
+        trigger: 'system',
+        reason: expect.stringContaining('code 1'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed', pid: null }),
+    );
+  });
+
+  it('includes signal in reason when process exits with signal', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('exit', null, 'SIGTERM');
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'failed',
+        reason: expect.stringContaining('SIGTERM'),
+      }),
+    );
+  });
+
+  it('does nothing when team is already done or failed', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'done' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('exit', 0, null);
+
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts team_stopped on process exit', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('exit', 0, null);
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_stopped',
+      { team_id: 1 },
+      1,
+    );
+  });
+
+  it('does not throw when team not found in DB on exit', () => {
+    const child = createMockChildProcess();
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(undefined);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    expect(() => child.emit('exit', 0, null)).not.toThrow();
+  });
+});
+
+// =============================================================================
+// attachProcessHandlers — process error
+// =============================================================================
+
+describe('TeamManager.attachProcessHandlers (error)', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('marks team failed on process error', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('error', new Error('ENOENT'));
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'failed',
+        trigger: 'system',
+        reason: expect.stringContaining('ENOENT'),
+      }),
+    );
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed', pid: null }),
+    );
+  });
+
+  it('cleans up internal maps on process error', () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+
+    (tm as any).childProcesses.set(1, child);
+    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).parsedEvents.set(1, []);
+    (tm as any).stdinPipes.set(1, createMockStdin());
+    (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+
+    child.emit('error', new Error('spawn error'));
+
+    expect((tm as any).childProcesses.has(1)).toBe(false);
+    expect((tm as any).stdinPipes.has(1)).toBe(false);
+    expect((tm as any).outputBuffers.has(1)).toBe(false);
+    expect((tm as any).parsedEvents.has(1)).toBe(false);
+  });
+});
+
+// =============================================================================
+// gracefulShutdown
+// =============================================================================
+
+describe('TeamManager.gracefulShutdown', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    tm = new TeamManager();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends pr_merged_shutdown message via stdin', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).parsedEvents.set(1, []);
+
+    tm.gracefulShutdown(1, 42, 120000);
+
+    expect(mockStdin.write).toHaveBeenCalled();
+  });
+
+  it('clears existing shutdown timer before setting new one', () => {
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).parsedEvents.set(1, []);
+
+    tm.gracefulShutdown(1, 42, 120000);
+    tm.gracefulShutdown(1, 43, 60000);
+
+    expect((tm as any).shutdownTimers.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #304

## Summary
- Add 6 new test files with 113 tests covering critical server services that had zero or near-zero test coverage
- **state-machine.test.ts** (26 tests) — transition validity, reachability, trigger types, STATES metadata
- **resolve-message.test.ts** (11 tests) — placeholder substitution, enabled/disabled templates, missing template handling
- **startup-recovery.test.ts** (13 tests) — dead/alive PID recovery, orphan worktree warnings, queue re-processing
- **github-poller.test.ts** (27 tests) — PR state transitions, CI status derivation, failure counting, auto-merge, dependency resolution
- **team-manager-lifecycle.test.ts** (21 tests) — stop(), sendMessage(), attachProcessHandlers(), gracefulShutdown()
- **cleanup.test.ts** (15 tests) — getCleanupPreview(), executeCleanup(), partial cleanup error handling

## Test plan
- [x] All 113 tests pass locally via `npm test`
- [ ] CI passes on this PR