### PR TITLE
Issue #314: add CI pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/hubertciebiada/fleet-commander/actions/workflows/ci.yml/badge.svg)
+
 # Fleet Commander
 
 One-click dashboard for orchestrating multiple Claude Code agent teams across repositories.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:client": "vitest run --config vitest.client.config.ts",
     "test:watch": "vitest",
-    "test:e2e": "bash tests/e2e/smoke-test.sh"
+    "test:e2e": "bash tests/e2e/smoke-test.sh",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.client.json"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.3",

--- a/src/client/components/CleanupModal.tsx
+++ b/src/client/components/CleanupModal.tsx
@@ -178,7 +178,7 @@ export function CleanupModal({ projectId, open, onClose, onDone }: CleanupModalP
   // -------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------
-  const groups = preview ? groupByType(preview.items) : new Map();
+  const groups: Map<CleanupItem['type'], CleanupItem[]> = preview ? groupByType(preview.items) : new Map();
 
   return (
     <div

--- a/src/client/components/CommGraph.tsx
+++ b/src/client/components/CommGraph.tsx
@@ -31,6 +31,8 @@ interface GraphNode {
   isTL: boolean;
   fx?: number;
   fy?: number;
+  x?: number;
+  y?: number;
 }
 
 interface GraphLink {
@@ -63,7 +65,7 @@ const FONT_SIZE_LABEL = 10;
 // ---------------------------------------------------------------------------
 
 export function CommGraph({ edges, agents }: CommGraphProps) {
-  const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink>>();
+  const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink>>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 500, height: 380 });
   const prevEdgesRef = useRef<MessageEdge[]>([]);

--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { StatusBadge } from './StatusBadge';
 import { PRBadge } from './PRBadge';
 import { PlayIcon, LockIcon } from './Icons';
-import type { TeamStatus, PrioritizedIssue, IssueDependencyInfo } from '../../shared/types';
+import type { TeamStatus, PrioritizedIssue, IssueDependencyInfo, CIStatus } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Types (mirrors IssueNode from the server issue-fetcher)
@@ -278,7 +278,7 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
           <span className="shrink-0 ml-1">
             {/* ciStatus: map PR state to a CI-like indicator when available;
                null means no CI data is present on the issue-tree node */}
-            <PRBadge prNumber={firstPR.number} ciStatus={firstPR.state ?? null} />
+            <PRBadge prNumber={firstPR.number} ciStatus={(firstPR.state as CIStatus) ?? null} />
           </span>
         )}
 

--- a/src/client/views/StateMachinePage.tsx
+++ b/src/client/views/StateMachinePage.tsx
@@ -155,14 +155,14 @@ function preprocessTransitions(
   states: StateNode[],
   rawTransitions: Transition[],
 ): PreprocessResult {
-  const stateIds = states.map((s) => s.id);
+  const stateIds = states.map((s) => s.id as Transition['from']);
 
   // Step 1: Expand wildcards — replace from:'*' with one transition per state
   const expanded: Transition[] = rawTransitions.flatMap((t) => {
     if (t.from === '*') {
       return stateIds.map((s) => ({
         ...t,
-        from: s as Transition['from'],
+        from: s,
         id: `${t.id}-${s}`,
       }));
     }


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with a `build-and-test` job (Node 20, ubuntu-latest) triggered on push to main and PRs
- Add `typecheck` script to `package.json` covering both server (`tsconfig.json`) and client (`tsconfig.client.json`) configs
- Add CI status badge to `README.md`
- Fix four pre-existing client type errors surfaced by the new strict typecheck

Closes #314

## Test plan

- [ ] CI workflow triggers on this PR and all steps pass (typecheck, test, build)
- [ ] CI badge renders correctly in README
- [ ] `npm run typecheck` passes locally against both tsconfigs