### PR TITLE
Issue #315: add npm publishing workflow (release on tag push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: Tag version (v$TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $PKG_VERSION"
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create tarball
+        run: npm pack
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: fleet-commander-*.tgz

--- a/bin/fleet-commander.js
+++ b/bin/fleet-commander.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// Fleet Commander CLI entry point.
+//
+// When installed globally via npm, `git rev-parse --show-toplevel` will not
+// resolve to the package root. This wrapper sets FLEET_COMMANDER_ROOT to the
+// package directory before loading the server so that config.ts, db.ts, and
+// hook-installer.ts can locate schema.sql, hooks/, scripts/, prompts/, etc.
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Point FLEET_COMMANDER_ROOT at the package root (one level up from bin/)
+if (!process.env['FLEET_COMMANDER_ROOT']) {
+  process.env['FLEET_COMMANDER_ROOT'] = path.resolve(__dirname, '..');
+}
+
+// Import the server entry point — this starts Fastify and all services.
+await import('../dist/server/index.js');

--- a/package.json
+++ b/package.json
@@ -3,16 +3,47 @@
   "version": "0.1.0",
   "description": "Web dashboard for orchestrating Claude Code agent teams",
   "type": "module",
+  "main": "dist/server/index.js",
+  "bin": {
+    "fleet-commander": "./bin/fleet-commander.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "hooks",
+    "scripts",
+    "templates",
+    "prompts",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hubertciebiada/fleet-commander.git"
+  },
+  "author": {
+    "name": "Hubert Ciebiada",
+    "url": "https://github.com/hciebiada"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "concurrently -n server,client -c blue,green \"npx tsx --watch src/server/index.ts\" \"npx vite --config vite.config.ts\"",
     "build": "tsc -p tsconfig.json && vite build --config vite.config.ts",
+    "postbuild": "node -e \"const fs=require('fs');const path=require('path');const src=path.join('src','server','schema.sql');const dest=path.join('dist','server','schema.sql');fs.mkdirSync(path.dirname(dest),{recursive:true});fs.copyFileSync(src,dest);console.log('Copied schema.sql to dist/server/')\"",
     "start": "node dist/server/index.js",
     "launch": "node scripts/launch.js",
     "test": "vitest run",
     "test:client": "vitest run --config vitest.client.config.ts",
     "test:watch": "vitest",
     "test:e2e": "bash tests/e2e/smoke-test.sh",
-    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.client.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.client.json",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.3",


### PR DESCRIPTION
## Summary

- Add tag-triggered (`v*`) release workflow (`.github/workflows/release.yml`) that runs typecheck, tests, build, publishes to npm, and creates a GitHub Release with tarball
- Add `bin/fleet-commander.js` CLI entry point wrapper that sets `FLEET_COMMANDER_ROOT` for global npm installs (avoids `git rev-parse` dependency)
- Update `package.json` with `bin`, `files`, `engines`, `repository`, `publishConfig`, `author`, `license`, `main`, and lifecycle scripts (`prepare`, `prepublishOnly`, `postbuild`)
- Cross-platform `postbuild` script copies `schema.sql` to `dist/server/` (tsc ignores .sql files)

Closes #315