### PR TITLE
Issue #326: skip prepare script during CI npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Build native dependencies
+        run: npm rebuild better-sqlite3
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Build native dependencies
+        run: npm rebuild better-sqlite3
+
       - name: Typecheck
         run: npm run typecheck
 


### PR DESCRIPTION
Closes #326

## Summary
- Add `--ignore-scripts` to `npm ci` in both `ci.yml` and `release.yml` to skip the `prepare` script that triggers a redundant full build (TypeScript + Vite) during dependency installation
- Add `npm rebuild better-sqlite3` step after install to ensure the native addon is properly built despite `--ignore-scripts`

## Changes
- `.github/workflows/ci.yml` — `npm ci --ignore-scripts` + `npm rebuild better-sqlite3`
- `.github/workflows/release.yml` — same

## Test plan
- [ ] CI passes with the new workflow (no missing native addon errors)
- [ ] Build step still produces correct output
- [ ] `prepare` script no longer runs during `npm ci` step