### PR TITLE
Issue #325: fix startup-recovery test for cross-platform CI

### DIFF
--- a/src/server/services/startup-recovery.ts
+++ b/src/server/services/startup-recovery.ts
@@ -11,11 +11,11 @@
 // projects are configured (fresh install).
 // =============================================================================
 
-import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { getDatabase } from '../db.js';
 import config from '../config.js';
+import { isProcessAlive } from '../utils/process-utils.js';
 
 /**
  * Run recovery checks during server initialisation.
@@ -139,31 +139,3 @@ export async function recoverOnStartup(): Promise<void> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Check whether a process with the given PID is still alive.
- *
- * - On Windows: uses `tasklist /FI "PID eq …"` and checks for the PID in the
- *   output.  This avoids false positives from recycled PIDs.
- * - On POSIX:  sends signal 0 via `process.kill`.  This does not kill the
- *   process — it only checks whether the process exists.
- */
-function isProcessAlive(pid: number): boolean {
-  try {
-    if (process.platform === 'win32') {
-      const result = execSync(`tasklist /FI "PID eq ${pid}" /NH`, {
-        encoding: 'utf-8',
-        timeout: 5000,
-      });
-      return result.includes(String(pid));
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
-  } catch {
-    return false;
-  }
-}

--- a/src/server/utils/process-utils.ts
+++ b/src/server/utils/process-utils.ts
@@ -1,0 +1,32 @@
+// =============================================================================
+// Fleet Commander — Process Utilities
+// =============================================================================
+// Cross-platform helpers for inspecting OS processes.
+// =============================================================================
+
+import { execSync } from 'child_process';
+
+/**
+ * Check whether a process with the given PID is still alive.
+ *
+ * - On Windows: uses `tasklist /FI "PID eq …"` and checks for the PID in the
+ *   output.  This avoids false positives from recycled PIDs.
+ * - On POSIX:  sends signal 0 via `process.kill`.  This does not kill the
+ *   process — it only checks whether the process exists.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    if (process.platform === 'win32') {
+      const result = execSync(`tasklist /FI "PID eq ${pid}" /NH`, {
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+      return result.includes(String(pid));
+    } else {
+      process.kill(pid, 0);
+      return true;
+    }
+  } catch {
+    return false;
+  }
+}

--- a/tests/server/startup-recovery.test.ts
+++ b/tests/server/startup-recovery.test.ts
@@ -31,10 +31,10 @@ vi.mock('../../src/server/config.js', () => ({
   },
 }));
 
-// Mock child_process.execSync for isProcessAlive
-const mockExecSync = vi.fn();
-vi.mock('child_process', () => ({
-  execSync: (...args: unknown[]) => mockExecSync(...args),
+// Mock isProcessAlive directly (avoids platform-specific child_process / process.kill differences)
+const mockIsProcessAlive = vi.fn<(pid: number) => boolean>().mockReturnValue(false);
+vi.mock('../../src/server/utils/process-utils.js', () => ({
+  isProcessAlive: (pid: number) => mockIsProcessAlive(pid),
 }));
 
 // Mock fs for worktree scanning
@@ -114,6 +114,7 @@ beforeEach(() => {
   mockDb.getActiveTeams.mockReturnValue([]);
   mockDb.getProjects.mockReturnValue([]);
   mockDb.getQueuedTeamsByProject.mockReturnValue([]);
+  mockIsProcessAlive.mockReturnValue(false);
   mockFs.existsSync.mockReturnValue(false);
   mockFs.readdirSync.mockReturnValue([]);
 });
@@ -126,10 +127,7 @@ describe('Dead PID recovery', () => {
   it('marks running team with dead PID as idle', async () => {
     const team = makeTeam({ id: 1, status: 'running', pid: 9999 });
     mockDb.getActiveTeams.mockReturnValue([team]);
-    // Simulate dead process: execSync throws (Windows) or process.kill throws (POSIX)
-    mockExecSync.mockImplementation(() => {
-      throw new Error('process not found');
-    });
+    mockIsProcessAlive.mockReturnValue(false);
 
     await recoverOnStartup();
 
@@ -151,9 +149,7 @@ describe('Dead PID recovery', () => {
   it('marks launching team with dead PID as failed', async () => {
     const team = makeTeam({ id: 2, status: 'launching', pid: 8888 });
     mockDb.getActiveTeams.mockReturnValue([team]);
-    mockExecSync.mockImplementation(() => {
-      throw new Error('process not found');
-    });
+    mockIsProcessAlive.mockReturnValue(false);
 
     await recoverOnStartup();
 
@@ -174,9 +170,7 @@ describe('Dead PID recovery', () => {
   it('marks idle team with dead PID as idle (keeps idle)', async () => {
     const team = makeTeam({ id: 3, status: 'idle', pid: 7777 });
     mockDb.getActiveTeams.mockReturnValue([team]);
-    mockExecSync.mockImplementation(() => {
-      throw new Error('process not found');
-    });
+    mockIsProcessAlive.mockReturnValue(false);
 
     await recoverOnStartup();
 
@@ -197,9 +191,7 @@ describe('Dead PID recovery', () => {
   it('marks stuck team with dead PID as idle', async () => {
     const team = makeTeam({ id: 4, status: 'stuck', pid: 6666 });
     mockDb.getActiveTeams.mockReturnValue([team]);
-    mockExecSync.mockImplementation(() => {
-      throw new Error('process not found');
-    });
+    mockIsProcessAlive.mockReturnValue(false);
 
     await recoverOnStartup();
 
@@ -226,8 +218,7 @@ describe('Alive PID recovery', () => {
   it('updates lastEventAt for running team with alive PID', async () => {
     const team = makeTeam({ id: 5, status: 'running', pid: 5555 });
     mockDb.getActiveTeams.mockReturnValue([team]);
-    // Simulate alive process on Windows: tasklist returns output containing the PID
-    mockExecSync.mockReturnValue(`node.exe    5555 Console    1    50,000 K`);
+    mockIsProcessAlive.mockReturnValue(true);
 
     await recoverOnStartup();
 


### PR DESCRIPTION
## Summary
- Extracted `isProcessAlive()` from `startup-recovery.ts` into `src/server/utils/process-utils.ts` so it can be cleanly mocked at the module boundary
- Updated `startup-recovery.test.ts` to mock the extracted function instead of `child_process.execSync`, making all 13 tests platform-independent (fixes Linux CI failures)
- Fixed CI workflow to use `npm ci --ignore-scripts` + `npm rebuild better-sqlite3` for reliable native module builds

Closes #325

## Test plan
- [x] All 13 startup-recovery tests pass locally
- [ ] CI passes on Ubuntu runner (the previously failing environment)