### PR TITLE
Issue #333: redesign Session Log expandable entries — badge-click expand, collapsible errors

### DIFF
--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -3,7 +3,7 @@ import { useApi } from '../hooks/useApi';
 import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry, TeamMember } from '../../shared/types';
 import { agentColor } from '../utils/constants';
 import { AgentFilterBar } from './AgentFilterBar';
-import { ChevronRightIcon, SettingsIcon } from './Icons';
+import { SettingsIcon } from './Icons';
 
 // ---------------------------------------------------------------------------
 // Helpers — agent name display
@@ -300,18 +300,7 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
 
     return (
       <div>
-        <div
-          className={`py-0 leading-snug flex items-center gap-1.5${hasDetail ? ' cursor-pointer' : ''}`}
-          onClick={hasDetail ? () => setExpanded((prev) => !prev) : undefined}
-          role={hasDetail ? 'button' : undefined}
-          aria-expanded={hasDetail ? expanded : undefined}
-        >
-          {hasDetail && (
-            <ChevronRightIcon
-              size={10}
-              className={`text-dark-muted shrink-0 transition-transform duration-150${expanded ? ' rotate-90' : ''}`}
-            />
-          )}
+        <div className="py-0 leading-snug flex items-center gap-1.5">
           <span className="text-dark-muted">
             {formatLocalTime(entry.timestamp)}
           </span>
@@ -320,7 +309,14 @@ function StreamEntryRow({ entry }: { entry: StreamTimelineEntry }) {
             style={{ backgroundColor: color }}
           />
           <span style={{ color }} className="font-semibold">{label}</span>
-          <span className="text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded">
+          <span
+            className={`text-dark-muted bg-dark-border/30 px-1.5 py-0.5 rounded${hasDetail ? ' cursor-pointer border-b border-dotted border-dark-border hover:bg-dark-border/50' : ''}`}
+            onClick={hasDetail ? () => setExpanded((prev) => !prev) : undefined}
+            onKeyDown={hasDetail ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded((prev) => !prev); } } : undefined}
+            role={hasDetail ? 'button' : undefined}
+            tabIndex={hasDetail ? 0 : undefined}
+            aria-expanded={hasDetail ? expanded : undefined}
+          >
             {entry.tool.name}
           </span>
         </div>
@@ -372,6 +368,7 @@ function HookEntryRow({ entry }: { entry: HookTimelineEntry }) {
   const isError = ERROR_TYPES.has(entry.eventType);
   const errorMsg = isError ? extractPayloadError(entry.payload) : null;
   const { label, color } = resolveHookAgentLabel(entry);
+  const [expanded, setExpanded] = useState(false);
 
   // Lifecycle events — agent dot + name + event badge
   if (isLifecycle) {
@@ -397,8 +394,10 @@ function HookEntryRow({ entry }: { entry: HookTimelineEntry }) {
     );
   }
 
-  // Error events — agent dot + name + red error info
+  // Error events — collapsible, click error badge to expand/collapse
   if (isError) {
+    const hasErrorDetail = errorMsg !== null;
+
     return (
       <div className="py-0 leading-snug text-dark-muted">
         <div className="flex items-center gap-1.5">
@@ -408,7 +407,14 @@ function HookEntryRow({ entry }: { entry: HookTimelineEntry }) {
             style={{ backgroundColor: color }}
           />
           <span style={{ color }} className="font-medium">{label}</span>
-          <span className="font-normal text-[#F85149]">
+          <span
+            className={`font-normal bg-red-500/20 text-red-400 px-1.5 py-0.5 rounded${hasErrorDetail ? ' cursor-pointer border-b border-dotted border-red-400/40 hover:bg-red-500/30' : ''}`}
+            onClick={hasErrorDetail ? () => setExpanded((prev) => !prev) : undefined}
+            onKeyDown={hasErrorDetail ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded((prev) => !prev); } } : undefined}
+            role={hasErrorDetail ? 'button' : undefined}
+            tabIndex={hasErrorDetail ? 0 : undefined}
+            aria-expanded={hasErrorDetail ? expanded : undefined}
+          >
             {entry.eventType}
           </span>
           {entry.toolName && (
@@ -417,7 +423,7 @@ function HookEntryRow({ entry }: { entry: HookTimelineEntry }) {
             </span>
           )}
         </div>
-        {errorMsg && (
+        {expanded && errorMsg && (
           <div className="ml-[52px] text-[#F85149] mt-0.5 line-clamp-2">
             {errorMsg}
           </div>

--- a/tests/client/UnifiedTimeline.test.tsx
+++ b/tests/client/UnifiedTimeline.test.tsx
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import type { TimelineEntry, StreamTimelineEntry } from '../../src/shared/types';
+import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry } from '../../src/shared/types';
 
 // ---------------------------------------------------------------------------
 // jsdom polyfill — scrollIntoView is not implemented
@@ -67,16 +67,16 @@ function makeToolUseEntryNoInput(
 }
 
 // ---------------------------------------------------------------------------
-// Helper to find the expandable tool row (role="button" with aria-expanded)
+// Helper to find the expandable badge (role="button" with aria-expanded)
 // ---------------------------------------------------------------------------
 
-function getExpandableRow() {
-  // Our expandable row has role="button" with aria-expanded, while
+function getExpandableBadge() {
+  // Our expandable badge has role="button" with aria-expanded, while
   // the Copy button is a native <button> without aria-expanded.
   return screen.getByRole('button', { expanded: false });
 }
 
-function getExpandedRow() {
+function getExpandedBadge() {
   return screen.getByRole('button', { expanded: true });
 }
 
@@ -105,7 +105,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
     expect(screen.queryByText('npm test')).not.toBeInTheDocument();
   });
 
-  it('shows detail text when tool_use entry with input is clicked', async () => {
+  it('shows detail text when tool badge is clicked', async () => {
     mockEntries = [
       makeToolUseEntry('Bash', { command: 'npm test' }, { id: 'stream-0' }),
     ];
@@ -114,15 +114,15 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Bash')).toBeInTheDocument();
     });
 
-    // Click the tool row to expand
-    fireEvent.click(getExpandableRow());
+    // Click the tool badge to expand
+    fireEvent.click(getExpandableBadge());
 
     await waitFor(() => {
       expect(screen.getByText('npm test')).toBeInTheDocument();
     });
   });
 
-  it('hides detail text when clicked again (collapse)', async () => {
+  it('hides detail text when badge is clicked again (collapse)', async () => {
     mockEntries = [
       makeToolUseEntry('Bash', { command: 'npm test' }, { id: 'stream-0' }),
     ];
@@ -132,19 +132,19 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
     });
 
     // Click to expand
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText('npm test')).toBeInTheDocument();
     });
 
     // Click to collapse (now aria-expanded="true")
-    fireEvent.click(getExpandedRow());
+    fireEvent.click(getExpandedBadge());
     await waitFor(() => {
       expect(screen.queryByText('npm test')).not.toBeInTheDocument();
     });
   });
 
-  it('does not show expand chevron for tool_use entries without input', async () => {
+  it('does not make badge expandable for tool_use entries without input', async () => {
     mockEntries = [
       makeToolUseEntryNoInput('Bash', { id: 'stream-0' }),
     ];
@@ -153,7 +153,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Bash')).toBeInTheDocument();
     });
 
-    // No expandable row should exist (no aria-expanded attribute on any div)
+    // Badge should exist but not be expandable (no aria-expanded attribute)
     expect(screen.queryByRole('button', { expanded: false })).not.toBeInTheDocument();
   });
 
@@ -166,7 +166,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Read')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText('/src/index.ts')).toBeInTheDocument();
     });
@@ -181,7 +181,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Grep')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText('/TODO/ in /src')).toBeInTheDocument();
     });
@@ -196,7 +196,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Glob')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText('**/*.ts')).toBeInTheDocument();
     });
@@ -215,7 +215,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Edit')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText(/\/src\/app\.ts/)).toBeInTheDocument();
       expect(screen.getByText(/foo -> bar/)).toBeInTheDocument();
@@ -231,7 +231,7 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Write')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       expect(screen.getByText('/src/new-file.ts')).toBeInTheDocument();
     });
@@ -247,13 +247,168 @@ describe('UnifiedTimeline — tool detail expand/collapse', () => {
       expect(screen.getByText('Bash')).toBeInTheDocument();
     });
 
-    fireEvent.click(getExpandableRow());
+    fireEvent.click(getExpandableBadge());
     await waitFor(() => {
       // Should show truncated version (120 chars + '...')
       const detail = screen.getByText(/^a+\.\.\.$/);
       expect(detail).toBeInTheDocument();
       // Should not show the full 200-char string
       expect(screen.queryByText(longCommand)).not.toBeInTheDocument();
+    });
+  });
+
+  it('expands tool badge via keyboard Enter key', async () => {
+    mockEntries = [
+      makeToolUseEntry('Bash', { command: 'npm test' }, { id: 'stream-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('Bash')).toBeInTheDocument();
+    });
+
+    // Press Enter on the badge to expand
+    fireEvent.keyDown(getExpandableBadge(), { key: 'Enter' });
+    await waitFor(() => {
+      expect(screen.getByText('npm test')).toBeInTheDocument();
+    });
+  });
+
+  it('expands tool badge via keyboard Space key', async () => {
+    mockEntries = [
+      makeToolUseEntry('Bash', { command: 'npm test' }, { id: 'stream-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('Bash')).toBeInTheDocument();
+    });
+
+    // Press Space on the badge to expand
+    fireEvent.keyDown(getExpandableBadge(), { key: ' ' });
+    await waitFor(() => {
+      expect(screen.getByText('npm test')).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook error entry factory
+// ---------------------------------------------------------------------------
+
+function makeErrorHookEntry(
+  eventType: string,
+  payload: string | undefined,
+  overrides: Partial<HookTimelineEntry> = {},
+): HookTimelineEntry {
+  return {
+    id: `hook-${Math.random().toString(36).slice(2)}`,
+    source: 'hook',
+    timestamp: '2026-03-20T10:00:00.000Z',
+    teamId: 1,
+    eventType,
+    payload,
+    ...overrides,
+  };
+}
+
+describe('UnifiedTimeline — error entry collapse/expand', () => {
+  beforeEach(() => {
+    mockEntries = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders ToolError badge collapsed by default (no error text visible)', async () => {
+    mockEntries = [
+      makeErrorHookEntry('ToolError', JSON.stringify({ error: 'Something broke' }), { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('ToolError')).toBeInTheDocument();
+    });
+
+    // Error message should NOT be visible when collapsed
+    expect(screen.queryByText('Something broke')).not.toBeInTheDocument();
+  });
+
+  it('shows error message when error badge is clicked', async () => {
+    mockEntries = [
+      makeErrorHookEntry('ToolError', JSON.stringify({ error: 'Something broke' }), { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('ToolError')).toBeInTheDocument();
+    });
+
+    // Click the error badge to expand
+    fireEvent.click(getExpandableBadge());
+    await waitFor(() => {
+      expect(screen.getByText('Something broke')).toBeInTheDocument();
+    });
+  });
+
+  it('hides error message when error badge is clicked again', async () => {
+    mockEntries = [
+      makeErrorHookEntry('ToolError', JSON.stringify({ error: 'Something broke' }), { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('ToolError')).toBeInTheDocument();
+    });
+
+    // Expand
+    fireEvent.click(getExpandableBadge());
+    await waitFor(() => {
+      expect(screen.getByText('Something broke')).toBeInTheDocument();
+    });
+
+    // Collapse
+    fireEvent.click(getExpandedBadge());
+    await waitFor(() => {
+      expect(screen.queryByText('Something broke')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders StopFailure error badge collapsed by default', async () => {
+    mockEntries = [
+      makeErrorHookEntry('StopFailure', JSON.stringify({ error: 'Process killed' }), { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('StopFailure')).toBeInTheDocument();
+    });
+
+    // Error message should NOT be visible when collapsed
+    expect(screen.queryByText('Process killed')).not.toBeInTheDocument();
+  });
+
+  it('does not make error badge expandable when no error payload exists', async () => {
+    mockEntries = [
+      makeErrorHookEntry('ToolError', undefined, { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('ToolError')).toBeInTheDocument();
+    });
+
+    // Badge should exist but not be expandable (no aria-expanded attribute)
+    expect(screen.queryByRole('button', { expanded: false })).not.toBeInTheDocument();
+  });
+
+  it('expands error badge via keyboard Enter key', async () => {
+    mockEntries = [
+      makeErrorHookEntry('ToolError', JSON.stringify({ error: 'Something broke' }), { id: 'hook-0' }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+    await waitFor(() => {
+      expect(screen.getByText('ToolError')).toBeInTheDocument();
+    });
+
+    // Press Enter on the error badge to expand
+    fireEvent.keyDown(getExpandableBadge(), { key: 'Enter' });
+    await waitFor(() => {
+      expect(screen.getByText('Something broke')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Closes #333

## Summary
- Removed `ChevronRightIcon` from tool_use entries, eliminating the "wave" misalignment where expandable and non-expandable rows started at different horizontal positions
- Made the tool badge (e.g., `Bash`, `Edit`, `Read`) the expand/collapse trigger instead of the chevron — with subtle hover cues (dotted border, background highlight) and keyboard accessibility (Enter/Space)
- Made ToolError/StopFailure entries collapsible (collapsed by default with red-tinted badge, click to expand error message)

## Test plan
- [x] All 18 tests pass (12 updated + 6 new)
- [ ] Visual check: all Session Log entries align at same horizontal position
- [ ] Click tool badge to expand/collapse tool details
- [ ] Hover over expandable badge shows visual cue
- [ ] ToolError entries collapsed by default, click red badge to expand
- [ ] Non-expandable entries have no click behavior
- [ ] Keyboard: Tab to badge, Enter/Space to toggle