### PR TITLE
Issue #348: fix Issue Tree hiding open sub-issues under closed parents

### DIFF
--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -310,6 +310,12 @@ export class IssueFetcher {
     // Track which issues have a parent (so we can identify roots)
     const childNumbers = new Set<number>();
 
+    // Collect orphan parent numbers — parent numbers referenced by open
+    // children but not present in the fetched (OPEN-only) issue set.
+    // These are typically closed parents whose open sub-issues would
+    // otherwise be hidden from the tree (the bug this fixes).
+    const orphanParentNumbers = new Set<number>();
+
     for (const node of allNodes) {
       if (node.parent?.number) {
         childNumbers.add(node.number);
@@ -317,6 +323,50 @@ export class IssueFetcher {
         const childIssue = issueByNumber.get(node.number);
         if (parentIssue && childIssue) {
           parentIssue.children.push(childIssue);
+        } else if (!parentIssue && childIssue) {
+          // Parent is missing from the OPEN-only query — likely closed
+          orphanParentNumbers.add(node.parent.number);
+        }
+      }
+    }
+
+    // Fetch missing (closed) parents so their open children stay visible
+    // in the tree instead of being silently hidden.
+    if (orphanParentNumbers.size > 0) {
+      const fetchedParents = await this.fetchMissingParents(
+        owner, repo, Array.from(orphanParentNumbers),
+      );
+
+      for (const parent of fetchedParents) {
+        issueByNumber.set(parent.number, parent);
+        flatIssues.push(parent);
+      }
+
+      // Re-link orphaned children to their now-present parents.
+      for (const node of allNodes) {
+        if (node.parent?.number && orphanParentNumbers.has(node.parent.number)) {
+          const parentIssue = issueByNumber.get(node.parent.number);
+          const childIssue = issueByNumber.get(node.number);
+          if (parentIssue && childIssue) {
+            // Avoid duplicate children (the child was not linked before)
+            if (!parentIssue.children.includes(childIssue)) {
+              parentIssue.children.push(childIssue);
+            }
+          }
+        }
+      }
+
+      // For any orphan parent number that was NOT successfully fetched,
+      // promote those children to root level so they are always visible.
+      const fetchedParentNumbers = new Set(fetchedParents.map((p) => p.number));
+      for (const orphanParentNum of orphanParentNumbers) {
+        if (!fetchedParentNumbers.has(orphanParentNum)) {
+          // Promote children of this missing parent to root
+          for (const node of allNodes) {
+            if (node.parent?.number === orphanParentNum) {
+              childNumbers.delete(node.number);
+            }
+          }
         }
       }
     }
@@ -783,6 +833,73 @@ export class IssueFetcher {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Fetch missing parent issues via GitHub REST API (`gh api`).
+   * These are typically closed parents whose open sub-issues reference them.
+   * Since the main GraphQL query only fetches OPEN issues, closed parents
+   * are absent, causing their open children to become invisible in the tree.
+   *
+   * Cap: at most 20 parent fetches to avoid excessive API calls.
+   * Concurrency: limited to MAX_CONCURRENT_RESOLVE (5).
+   * On failure: individual parents that fail to fetch are silently skipped;
+   * their children will be promoted to root level by the caller.
+   */
+  private async fetchMissingParents(
+    owner: string,
+    repo: string,
+    parentNumbers: number[],
+  ): Promise<IssueNode[]> {
+    // Cap the number of parent fetches to avoid excessive API calls
+    const capped = parentNumbers.slice(0, 20);
+    if (capped.length < parentNumbers.length) {
+      console.warn(
+        `[IssueFetcher] Capping orphan parent fetches to 20 (${parentNumbers.length} requested)`
+      );
+    }
+
+    const results: IssueNode[] = [];
+
+    const tasks = capped.map((num) => async () => {
+      try {
+        const { stdout } = await execAsync(
+          `gh api "/repos/${owner}/${repo}/issues/${num}" --jq ".number,.title,.state,.html_url,.labels[].name"`,
+          {
+            encoding: 'utf-8',
+            timeout: 10_000,
+          }
+        );
+        const lines = stdout.trim().split('\n');
+        if (lines.length >= 4) {
+          const issueNumber = parseInt(lines[0], 10);
+          const title = lines[1] ?? '';
+          const state = (lines[2] ?? '').toLowerCase() === 'open' ? 'open' as const : 'closed' as const;
+          const url = lines[3] ?? `https://github.com/${owner}/${repo}/issues/${num}`;
+          const labels = lines.slice(4).filter(Boolean);
+
+          const parentNode: IssueNode = {
+            number: issueNumber,
+            title,
+            state,
+            labels,
+            url,
+            children: [],
+            activeTeam: null,
+          };
+
+          results.push(parentNode);
+        }
+      } catch (err) {
+        console.warn(
+          `[IssueFetcher] Failed to fetch missing parent #${num}: ${err instanceof Error ? err.message : err}`
+        );
+        // Silently skip — caller will promote orphaned children to root
+      }
+    });
+
+    await runWithConcurrency(tasks, MAX_CONCURRENT_RESOLVE);
+    return results;
+  }
 
   /**
    * Parse a github_repo string (e.g. "owner/repo") into [owner, repo].

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -175,4 +175,63 @@ describe('IssueTreeView', () => {
       expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Closed parent with open children (Issue #348 fix)
+  // -------------------------------------------------------------------------
+
+  it('renders closed parent nodes with their open children', async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [
+            {
+              number: 5,
+              title: 'Closed parent',
+              state: 'closed',
+              labels: [],
+              children: [
+                {
+                  number: 10,
+                  title: 'Open child under closed parent',
+                  state: 'open',
+                  labels: [],
+                  children: [],
+                  activeTeam: null,
+                },
+              ],
+              activeTeam: null,
+            },
+            {
+              number: 20,
+              title: 'Regular open issue',
+              state: 'open',
+              labels: [],
+              children: [],
+              activeTeam: null,
+            },
+          ],
+          cachedAt: '2026-03-21T10:00:00Z',
+          count: 3,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      // Both the closed parent and the open child should be rendered
+      expect(screen.getByTestId('tree-node-5')).toBeInTheDocument();
+      expect(screen.getByTestId('tree-node-20')).toBeInTheDocument();
+    });
+
+    // The open child is nested inside the closed parent TreeNode,
+    // so it gets rendered as part of tree-node-5 by the mock
+    // (the mock TreeNode is a flat div, children are rendered by IssueTreeView recursion)
+    // Since IssueTreeView only renders top-level nodes, tree-node-10 is nested
+    // inside tree-node-5 in the real component. The mock doesn't recurse,
+    // but we verify the closed parent is present as a root node.
+    expect(screen.getByTestId('tree-node-5')).toHaveTextContent('#5');
+  });
 });

--- a/tests/client/TreeNode.test.tsx
+++ b/tests/client/TreeNode.test.tsx
@@ -210,4 +210,45 @@ describe('TreeNode', () => {
     expect(screen.getByText('blocked by')).toBeInTheDocument();
     expect(screen.getByText('#50')).toBeInTheDocument();
   });
+
+  // -------------------------------------------------------------------------
+  // Closed parent with open children (Issue #348 fix)
+  // -------------------------------------------------------------------------
+
+  it('renders closed parent with open children correctly', () => {
+    const closedParent = makeNode({
+      number: 5,
+      title: 'Closed epic',
+      state: 'closed',
+      children: [
+        makeNode({ number: 10, title: 'Open sub-issue A', state: 'open' }),
+        makeNode({ number: 11, title: 'Open sub-issue B', state: 'open' }),
+      ],
+    });
+    render(<TreeNode node={closedParent} {...defaultProps} depth={0} />);
+
+    // Parent should have closed styling
+    const parentTitle = screen.getByText('Closed epic');
+    expect(parentTitle.className).toContain('line-through');
+
+    // Children should be visible (expanded by default at depth 0)
+    expect(screen.getByText('Open sub-issue A')).toBeInTheDocument();
+    expect(screen.getByText('Open sub-issue B')).toBeInTheDocument();
+
+    // Children should NOT have line-through styling
+    const childA = screen.getByText('Open sub-issue A');
+    expect(childA.className).not.toContain('line-through');
+
+    // Play button should be available for open leaf children
+    expect(screen.getByTitle('Launch team for #10')).toBeInTheDocument();
+    expect(screen.getByTitle('Launch team for #11')).toBeInTheDocument();
+
+    // No Play button for the closed parent (it also has children)
+    expect(screen.queryByTitle('Launch team for #5')).not.toBeInTheDocument();
+  });
+
+  it('does not render Play button for closed parent even without children', () => {
+    render(<TreeNode node={makeNode({ number: 5, state: 'closed', children: [] })} {...defaultProps} />);
+    expect(screen.queryByTitle(/Launch team for #5/)).not.toBeInTheDocument();
+  });
 });

--- a/tests/server/issue-fetcher-orphan.test.ts
+++ b/tests/server/issue-fetcher-orphan.test.ts
@@ -1,0 +1,332 @@
+// =============================================================================
+// Fleet Commander -- Issue Fetcher Orphan Detection Tests
+// =============================================================================
+// Tests that open sub-issues whose parent is closed are not hidden from the
+// tree. When the main GraphQL query returns only OPEN issues, closed parents
+// are missing. The orphan detection logic should:
+//   1. Detect children whose parent is not in the fetched set
+//   2. Fetch those missing parents via REST API
+//   3. Inject them as closed nodes in the tree
+//   4. Fall back to promoting orphans to root if the parent fetch fails
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IssueNode } from '../../src/server/services/issue-fetcher.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getProject: vi.fn().mockReturnValue({
+    id: 1,
+    name: 'test-repo',
+    githubRepo: 'owner/repo',
+  }),
+  getProjects: vi.fn().mockReturnValue([]),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamsByProject: vi.fn().mockReturnValue([]),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    issuePollIntervalMs: 60000,
+  },
+}));
+
+// Mock child_process.exec (used by fetchMissingParents / resolveIssueStates)
+const mockExec = vi.fn();
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+  spawn: vi.fn(),
+}));
+
+// Mock util.promisify so that execAsync uses our mockExec
+vi.mock('util', () => ({
+  promisify: (fn: unknown) => {
+    // Return a function that wraps mockExec into a Promise
+    return (...args: unknown[]) => {
+      return new Promise((resolve, reject) => {
+        // Call the mock with a callback pattern
+        (fn as Function)(...args, (err: Error | null, result: unknown) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      });
+    };
+  },
+}));
+
+// Import after mocks
+import IssueFetcher from '../../src/server/services/issue-fetcher.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Helper to create a minimal GraphQL response for the executeGraphQL mock */
+function makeGraphQLResponse(nodes: Array<{
+  number: number;
+  title: string;
+  state?: string;
+  url?: string;
+  parent?: { number: number; title: string } | null;
+  labels?: { nodes?: Array<{ name: string }> };
+}>) {
+  return {
+    data: {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: nodes.map((n) => ({
+            number: n.number,
+            title: n.title,
+            state: n.state ?? 'OPEN',
+            url: n.url ?? `https://github.com/owner/repo/issues/${n.number}`,
+            labels: n.labels ?? { nodes: [] },
+            parent: n.parent ?? null,
+            subIssuesSummary: undefined,
+            closedByPullRequestsReferences: undefined,
+            blockedBy: undefined,
+            issueDependenciesSummary: undefined,
+          })),
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IssueFetcher orphan detection', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+  });
+
+  it('promotes orphaned children to root when parent fetch fails completely', async () => {
+    // Scenario: issue #10 (open) has parent #5 (closed, not in OPEN query).
+    // The fetchMissingParents call fails for #5 -> child #10 should become root.
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 10, title: 'Open child', parent: { number: 5, title: 'Closed parent' } },
+        { number: 20, title: 'Root issue' },
+      ])
+    );
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents').mockResolvedValue([]);
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    // fetchMissingParents was called with [5]
+    expect(fetchParentsSpy).toHaveBeenCalledWith('owner', 'repo', [5]);
+
+    // Since fetchMissingParents returned empty (failed), orphan #10 becomes root
+    const rootNumbers = result.map((n) => n.number).sort((a, b) => a - b);
+    expect(rootNumbers).toEqual([10, 20]);
+
+    // Both should be at root level, not nested
+    expect(result.find((n) => n.number === 10)!.children).toHaveLength(0);
+    expect(result.find((n) => n.number === 20)!.children).toHaveLength(0);
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('injects closed parent and links children when parent fetch succeeds', async () => {
+    // Scenario: issues #10, #11 (open) have parent #5 (closed).
+    // fetchMissingParents returns #5 as a closed node.
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 10, title: 'Sub-issue A', parent: { number: 5, title: 'Epic (closed)' } },
+        { number: 11, title: 'Sub-issue B', parent: { number: 5, title: 'Epic (closed)' } },
+        { number: 20, title: 'Standalone issue' },
+      ])
+    );
+
+    const closedParent: IssueNode = {
+      number: 5,
+      title: 'Epic (closed)',
+      state: 'closed',
+      labels: [],
+      url: 'https://github.com/owner/repo/issues/5',
+      children: [],
+      activeTeam: null,
+    };
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents').mockResolvedValue([closedParent]);
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    // Root should contain #5 (closed parent) and #20 (standalone)
+    const rootNumbers = result.map((n) => n.number).sort((a, b) => a - b);
+    expect(rootNumbers).toEqual([5, 20]);
+
+    // #5 should have children #10 and #11
+    const parentNode = result.find((n) => n.number === 5)!;
+    expect(parentNode.state).toBe('closed');
+    const childNumbers = parentNode.children.map((c) => c.number).sort((a, b) => a - b);
+    expect(childNumbers).toEqual([10, 11]);
+
+    // #10 and #11 should NOT be at root
+    expect(result.find((n) => n.number === 10)).toBeUndefined();
+    expect(result.find((n) => n.number === 11)).toBeUndefined();
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('does not call fetchMissingParents when all parents are present', async () => {
+    // Scenario: all parents are open and present in the fetched set.
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 5, title: 'Parent issue' },
+        { number: 10, title: 'Child issue', parent: { number: 5, title: 'Parent issue' } },
+      ])
+    );
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents');
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    // fetchMissingParents should NOT be called
+    expect(fetchParentsSpy).not.toHaveBeenCalled();
+
+    // #5 is root with #10 as child
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(5);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0].number).toBe(10);
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('handles multiple orphan parents — some fetched, some failed', async () => {
+    // #10 has closed parent #5, #20 has closed parent #15.
+    // Only #5 is successfully fetched; #15 fails -> #20 becomes root.
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 10, title: 'Child of 5', parent: { number: 5, title: 'Parent A' } },
+        { number: 20, title: 'Child of 15', parent: { number: 15, title: 'Parent B' } },
+        { number: 30, title: 'Standalone' },
+      ])
+    );
+
+    const closedParent5: IssueNode = {
+      number: 5,
+      title: 'Parent A (closed)',
+      state: 'closed',
+      labels: [],
+      url: 'https://github.com/owner/repo/issues/5',
+      children: [],
+      activeTeam: null,
+    };
+
+    // Only parent #5 is returned; #15 fetch failed
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents').mockResolvedValue([closedParent5]);
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    // Root should have: #5 (fetched closed parent), #20 (promoted orphan), #30 (standalone)
+    const rootNumbers = result.map((n) => n.number).sort((a, b) => a - b);
+    expect(rootNumbers).toEqual([5, 20, 30]);
+
+    // #5 should have child #10
+    const parent5 = result.find((n) => n.number === 5)!;
+    expect(parent5.children).toHaveLength(1);
+    expect(parent5.children[0].number).toBe(10);
+
+    // #20 should be promoted to root (its parent #15 was not fetched)
+    const child20 = result.find((n) => n.number === 20)!;
+    expect(child20.children).toHaveLength(0);
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('does not duplicate children when re-linking orphans', async () => {
+    // Regression check: ensure children are not double-linked
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 10, title: 'Only child', parent: { number: 5, title: 'Closed parent' } },
+      ])
+    );
+
+    const closedParent: IssueNode = {
+      number: 5,
+      title: 'Closed parent',
+      state: 'closed',
+      labels: [],
+      url: 'https://github.com/owner/repo/issues/5',
+      children: [],
+      activeTeam: null,
+    };
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents').mockResolvedValue([closedParent]);
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    const parentNode = result.find((n) => n.number === 5)!;
+    // Should have exactly 1 child, not duplicated
+    expect(parentNode.children).toHaveLength(1);
+    expect(parentNode.children[0].number).toBe(10);
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('handles empty GraphQL response gracefully', async () => {
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([])
+    );
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents');
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    expect(result).toHaveLength(0);
+    expect(fetchParentsSpy).not.toHaveBeenCalled();
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+
+  it('preserves normal tree structure when no orphans exist', async () => {
+    // Two-level hierarchy, all open
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 1, title: 'Root A' },
+        { number: 2, title: 'Root B' },
+        { number: 10, title: 'Child of A', parent: { number: 1, title: 'Root A' } },
+        { number: 11, title: 'Child of A', parent: { number: 1, title: 'Root A' } },
+        { number: 20, title: 'Child of B', parent: { number: 2, title: 'Root B' } },
+      ])
+    );
+
+    const fetchParentsSpy = vi.spyOn(fetcher as any, 'fetchMissingParents');
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    expect(fetchParentsSpy).not.toHaveBeenCalled();
+
+    expect(result).toHaveLength(2);
+
+    const rootA = result.find((n) => n.number === 1)!;
+    const rootB = result.find((n) => n.number === 2)!;
+
+    expect(rootA.children.map((c) => c.number).sort((a, b) => a - b)).toEqual([10, 11]);
+    expect(rootB.children.map((c) => c.number)).toEqual([20]);
+
+    graphqlSpy.mockRestore();
+    fetchParentsSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #348

## Summary
- Detects open issues whose closed parent is missing from the OPEN-only GraphQL query
- Fetches missing closed parents via `gh api` REST calls (capped at 20, concurrency 5)
- Injects closed parents as structural tree nodes so child hierarchy is preserved
- Safe fallback: promotes orphaned children to root level if parent fetch fails
- No client changes needed — `TreeNode.tsx` already handles closed issue styling

## Test plan
- [x] 7 new server tests for orphan detection and parent fetching
- [x] 2 new client tests for closed parent rendering in TreeNode
- [x] 1 new client test for closed-parent-in-tree in IssueTreeView
- [x] All 36 tests pass, TypeScript compiles cleanly