### PR TITLE
Issue #349: persist collapse state and add Expand/Collapse All buttons

### DIFF
--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -168,11 +168,18 @@ interface TreeNodeProps {
   onPrioritizeSubtree?: (subtreeChildren: IssueNode[]) => Promise<void>;
   /** Whether a prioritization request is in progress */
   prioritizing?: boolean;
+  /** Controlled collapse state: set of collapsed node IDs */
+  collapsedNodes?: Set<string>;
+  /** Callback when a node's collapse state is toggled (controlled mode) */
+  onToggleCollapse?: (nodeId: string) => void;
 }
 
-export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange, onPrioritizeSubtree, prioritizing }: TreeNodeProps) {
-  const [expanded, setExpanded] = useState(depth < 2);
-  const isExpanded = forceExpand || expanded;
+export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange, onPrioritizeSubtree, prioritizing, collapsedNodes, onToggleCollapse }: TreeNodeProps) {
+  const nodeId = node.number.toString();
+  const isControlled = collapsedNodes != null && onToggleCollapse != null;
+  const [localExpanded, setLocalExpanded] = useState(depth < 2);
+  const controlledExpanded = isControlled ? !collapsedNodes.has(nodeId) : localExpanded;
+  const isExpanded = forceExpand || controlledExpanded;
   const hasChildren = node.children.length > 0;
   const hasActiveTeam = node.activeTeam != null;
   const isBlocked = !!(node.dependencies && !node.dependencies.resolved && node.dependencies.openCount > 0);
@@ -200,7 +207,13 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
         {/* Expand/collapse arrow */}
         <button
           disabled={!hasChildren}
-          onClick={() => setExpanded(!isExpanded)}
+          onClick={() => {
+            if (isControlled) {
+              onToggleCollapse(nodeId);
+            } else {
+              setLocalExpanded(!isExpanded);
+            }
+          }}
           className={`w-4 h-4 flex items-center justify-center text-dark-muted shrink-0 transition-transform duration-150 ${
             hasChildren ? 'cursor-pointer hover:text-dark-text' : 'invisible'
           } ${isExpanded ? 'rotate-90' : ''}`}
@@ -376,6 +389,8 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
               onCheckChange={onCheckChange}
               onPrioritizeSubtree={onPrioritizeSubtree}
               prioritizing={prioritizing}
+              collapsedNodes={collapsedNodes}
+              onToggleCollapse={onToggleCollapse}
             />
           ))}
         </div>

--- a/src/client/hooks/useCollapseState.ts
+++ b/src/client/hooks/useCollapseState.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const STORAGE_KEY = 'fleet-issue-tree-collapsed';
+
+interface UseCollapseStateReturn {
+  /** Set of node IDs that are currently collapsed */
+  collapsedNodes: Set<string>;
+  /** Toggle a single node's collapsed state */
+  toggleCollapse: (nodeId: string) => void;
+  /** Expand all nodes (clear the collapsed set) */
+  expandAll: () => void;
+  /** Collapse all nodes (set all IDs as collapsed) */
+  collapseAll: (allNodeIds: string[]) => void;
+  /** Check if a specific node is collapsed */
+  isCollapsed: (nodeId: string) => boolean;
+}
+
+/** Read collapsed node IDs from localStorage */
+function readFromStorage(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((v): v is string => typeof v === 'string'));
+    }
+  } catch {
+    // Ignore corrupt data
+  }
+  return new Set();
+}
+
+/** Write collapsed node IDs to localStorage */
+function writeToStorage(set: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+/**
+ * Custom hook to manage collapse state for the issue tree.
+ * Persists collapsed node IDs to localStorage so state survives navigation.
+ */
+export function useCollapseState(): UseCollapseStateReturn {
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(() => readFromStorage());
+
+  // Use a ref to track whether the initial load from storage has happened,
+  // so we don't write back to storage on mount.
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      return;
+    }
+    writeToStorage(collapsedNodes);
+  }, [collapsedNodes]);
+
+  const toggleCollapse = useCallback((nodeId: string) => {
+    setCollapsedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  }, []);
+
+  const expandAll = useCallback(() => {
+    setCollapsedNodes(new Set());
+  }, []);
+
+  const collapseAll = useCallback((allNodeIds: string[]) => {
+    setCollapsedNodes(new Set(allNodeIds));
+  }, []);
+
+  const isCollapsed = useCallback(
+    (nodeId: string) => collapsedNodes.has(nodeId),
+    [collapsedNodes],
+  );
+
+  return {
+    collapsedNodes,
+    toggleCollapse,
+    expandAll,
+    collapseAll,
+    isCollapsed,
+  };
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useApi } from '../hooks/useApi';
 import { useSSE } from '../hooks/useSSE';
 import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritization';
+import { useCollapseState } from '../hooks/useCollapseState';
 import { TreeNode, type IssueNode } from '../components/TreeNode';
 import type { ProjectSummary } from '../../shared/types';
 
@@ -65,6 +66,9 @@ export function IssueTreeView() {
   const [groups, setGroups] = useState<ProjectIssueGroup[]>([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+
+  // Collapse state — persisted to localStorage
+  const collapseState = useCollapseState();
 
   // Dependency confirmation dialog state
   const [depConfirm, setDepConfirm] = useState<{
@@ -328,6 +332,14 @@ export function IssueTreeView() {
       .filter((g) => g.tree.length > 0);
   }, [groups, search, statusFilter]);
 
+  // Collect all node IDs from the full (unfiltered) tree for Collapse All
+  const allNodeIds = useMemo(() => {
+    if (groups.length > 0) {
+      return groups.flatMap((g) => collectAllNodeIds(g.tree));
+    }
+    return collectAllNodeIds(tree);
+  }, [tree, groups]);
+
   // -------------------------------------------------------------------------
   // Loading state
   // -------------------------------------------------------------------------
@@ -424,6 +436,30 @@ export function IssueTreeView() {
           ))}
         </div>
 
+        {/* Expand / Collapse All buttons */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <button
+            onClick={collapseState.expandAll}
+            className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent/50 transition-colors"
+            title="Expand all tree nodes"
+          >
+            <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8.177 14.323a.75.75 0 0 1-1.06-.146l-3.5-4.5A.75.75 0 0 1 4.211 8.5h7.578a.75.75 0 0 1 .594 1.177l-3.5 4.5a.75.75 0 0 1-.706.146ZM7.823 1.677a.75.75 0 0 1 1.06.146l3.5 4.5A.75.75 0 0 1 11.789 7.5H4.211a.75.75 0 0 1-.594-1.177l3.5-4.5a.75.75 0 0 1 .706-.146Z" />
+            </svg>
+            Expand All
+          </button>
+          <button
+            onClick={() => collapseState.collapseAll(allNodeIds)}
+            className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent/50 transition-colors"
+            title="Collapse all tree nodes"
+          >
+            <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M4.177 7.823a.75.75 0 0 1 .146-1.06l3.5-3.5A.75.75 0 0 1 8.5 3.557V7.5h-3.5a.75.75 0 0 1-.823-.677ZM11.823 7.823a.75.75 0 0 0-.146-1.06l-3.5-3.5A.75.75 0 0 0 7.5 3.557V7.5h3.5a.75.75 0 0 0 .823-.677ZM4.177 8.177a.75.75 0 0 0 .146 1.06l3.5 3.5a.75.75 0 0 0 .677.823V9.5H5a.75.75 0 0 0-.823.677ZM11.823 8.177a.75.75 0 0 1-.146 1.06l-3.5 3.5a.75.75 0 0 1-.677.823V9.5H11a.75.75 0 0 1 .823.677Z" />
+            </svg>
+            Collapse All
+          </button>
+        </div>
+
         <button
           onClick={handleRefresh}
           disabled={refreshing}
@@ -497,6 +533,8 @@ export function IssueTreeView() {
                 launchErrors={launchErrors}
                 forceExpand={!!search || statusFilter !== 'all'}
                 fetchTree={fetchTree}
+                collapsedNodes={collapseState.collapsedNodes}
+                onToggleCollapse={collapseState.toggleCollapse}
               />
             ))}
           </div>
@@ -510,6 +548,8 @@ export function IssueTreeView() {
             launchErrors={launchErrors}
             forceExpand={!!search || statusFilter !== 'all'}
             fetchTree={fetchTree}
+            collapsedNodes={collapseState.collapsedNodes}
+            onToggleCollapse={collapseState.toggleCollapse}
           />
         )}
       </div>
@@ -715,9 +755,11 @@ interface ProjectGroupProps {
   launchErrors: Map<number, string>;
   forceExpand: boolean;
   fetchTree: () => Promise<void>;
+  collapsedNodes: Set<string>;
+  onToggleCollapse: (nodeId: string) => void;
 }
 
-function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree }: ProjectGroupProps) {
+function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: ProjectGroupProps) {
   const api = useApi();
   const [expanded, setExpanded] = React.useState(true);
   const prioritization = usePrioritization();
@@ -789,6 +831,8 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
               onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
               onPrioritizeSubtree={prioritization.prioritizeSubtree}
               prioritizing={prioritization.loading}
+              collapsedNodes={collapsedNodes}
+              onToggleCollapse={onToggleCollapse}
             />
           ))}
         </div>
@@ -809,9 +853,11 @@ interface SingleProjectTreeProps {
   launchErrors: Map<number, string>;
   forceExpand: boolean;
   fetchTree: () => Promise<void>;
+  collapsedNodes: Set<string>;
+  onToggleCollapse: (nodeId: string) => void;
 }
 
-function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree }: SingleProjectTreeProps) {
+function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: SingleProjectTreeProps) {
   const api = useApi();
   const prioritization = usePrioritization();
 
@@ -859,6 +905,8 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
             onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
             onPrioritizeSubtree={prioritization.prioritizeSubtree}
             prioritizing={prioritization.loading}
+            collapsedNodes={collapsedNodes}
+            onToggleCollapse={onToggleCollapse}
           />
         ))}
       </div>
@@ -911,6 +959,18 @@ function filterTree(nodes: IssueNode[], query: string, statusFilter: string): Is
     }
     return acc;
   }, []);
+}
+
+/** Collect all node IDs (issue numbers as strings) from a tree recursively */
+function collectAllNodeIds(nodes: IssueNode[]): string[] {
+  const ids: string[] = [];
+  for (const node of nodes) {
+    ids.push(node.number.toString());
+    if (node.children.length > 0) {
+      ids.push(...collectAllNodeIds(node.children));
+    }
+  }
+  return ids;
 }
 
 /** Count nodes recursively */

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -43,6 +43,20 @@ vi.mock('../../src/client/hooks/usePrioritization', () => ({
   sortTreeByPriority: (tree: unknown[]) => tree,
 }));
 
+const mockExpandAll = vi.fn();
+const mockCollapseAll = vi.fn();
+const mockToggleCollapse = vi.fn();
+
+vi.mock('../../src/client/hooks/useCollapseState', () => ({
+  useCollapseState: () => ({
+    collapsedNodes: new Set<string>(),
+    toggleCollapse: mockToggleCollapse,
+    expandAll: mockExpandAll,
+    collapseAll: mockCollapseAll,
+    isCollapsed: () => false,
+  }),
+}));
+
 // Mock TreeNode to keep rendering lightweight
 vi.mock('../../src/client/components/TreeNode', () => ({
   TreeNode: (props: { node: { number: number; title: string } }) => (
@@ -233,5 +247,40 @@ describe('IssueTreeView', () => {
     // inside tree-node-5 in the real component. The mock doesn't recurse,
     // but we verify the closed parent is present as a root node.
     expect(screen.getByTestId('tree-node-5')).toHaveTextContent('#5');
+  });
+
+  // -------------------------------------------------------------------------
+  // Expand All / Collapse All buttons (Issue #349)
+  // -------------------------------------------------------------------------
+
+  it('renders Expand All and Collapse All buttons', async () => {
+    setupMockApi();
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Expand All')).toBeInTheDocument();
+      expect(screen.getByText('Collapse All')).toBeInTheDocument();
+    });
+  });
+
+  it('calls expandAll when Expand All button is clicked', async () => {
+    setupMockApi();
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Expand All')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Expand All'));
+    expect(mockExpandAll).toHaveBeenCalled();
+  });
+
+  it('calls collapseAll when Collapse All button is clicked', async () => {
+    setupMockApi();
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Collapse All')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Collapse All'));
+    expect(mockCollapseAll).toHaveBeenCalled();
   });
 });

--- a/tests/client/TreeNode.test.tsx
+++ b/tests/client/TreeNode.test.tsx
@@ -251,4 +251,128 @@ describe('TreeNode', () => {
     render(<TreeNode node={makeNode({ number: 5, state: 'closed', children: [] })} {...defaultProps} />);
     expect(screen.queryByTitle(/Launch team for #5/)).not.toBeInTheDocument();
   });
+
+  // -------------------------------------------------------------------------
+  // Controlled collapse state (Issue #349)
+  // -------------------------------------------------------------------------
+
+  it('uses controlled collapse state when collapsedNodes and onToggleCollapse are provided', () => {
+    const collapsedNodes = new Set<string>();
+    const onToggleCollapse = vi.fn();
+    const parent = makeNode({
+      number: 1,
+      title: 'Parent',
+      children: [makeNode({ number: 2, title: 'Child issue' })],
+    });
+
+    // Not in collapsed set = expanded
+    render(
+      <TreeNode
+        node={parent}
+        {...defaultProps}
+        depth={0}
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    expect(screen.getByText('Child issue')).toBeInTheDocument();
+  });
+
+  it('hides children when node is in collapsedNodes set', () => {
+    const collapsedNodes = new Set<string>(['1']);
+    const onToggleCollapse = vi.fn();
+    const parent = makeNode({
+      number: 1,
+      title: 'Parent',
+      children: [makeNode({ number: 2, title: 'Child issue' })],
+    });
+
+    render(
+      <TreeNode
+        node={parent}
+        {...defaultProps}
+        depth={0}
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    expect(screen.queryByText('Child issue')).not.toBeInTheDocument();
+  });
+
+  it('calls onToggleCollapse with nodeId when arrow is clicked in controlled mode', () => {
+    const collapsedNodes = new Set<string>();
+    const onToggleCollapse = vi.fn();
+    const parent = makeNode({
+      number: 42,
+      title: 'Parent',
+      children: [makeNode({ number: 2, title: 'Child' })],
+    });
+
+    render(
+      <TreeNode
+        node={parent}
+        {...defaultProps}
+        depth={0}
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+
+    const collapseBtn = screen.getAllByLabelText('Collapse')[0];
+    fireEvent.click(collapseBtn);
+    expect(onToggleCollapse).toHaveBeenCalledWith('42');
+  });
+
+  it('forceExpand overrides controlled collapse state', () => {
+    const collapsedNodes = new Set<string>(['1']);
+    const onToggleCollapse = vi.fn();
+    const parent = makeNode({
+      number: 1,
+      title: 'Parent',
+      children: [makeNode({ number: 2, title: 'Child issue' })],
+    });
+
+    render(
+      <TreeNode
+        node={parent}
+        {...defaultProps}
+        depth={0}
+        forceExpand
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    // Child should be visible because forceExpand overrides collapse
+    expect(screen.getByText('Child issue')).toBeInTheDocument();
+  });
+
+  it('passes collapsedNodes and onToggleCollapse to child TreeNodes', () => {
+    const collapsedNodes = new Set<string>(['2']);
+    const onToggleCollapse = vi.fn();
+    const parent = makeNode({
+      number: 1,
+      title: 'Parent',
+      children: [
+        makeNode({
+          number: 2,
+          title: 'Child',
+          children: [makeNode({ number: 3, title: 'Grandchild' })],
+        }),
+      ],
+    });
+
+    render(
+      <TreeNode
+        node={parent}
+        {...defaultProps}
+        depth={0}
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+
+    // Parent is expanded (not in collapsed set), Child (2) is collapsed
+    expect(screen.getByText('Child')).toBeInTheDocument();
+    expect(screen.queryByText('Grandchild')).not.toBeInTheDocument();
+  });
 });

--- a/tests/client/useCollapseState.test.ts
+++ b/tests/client/useCollapseState.test.ts
@@ -1,0 +1,141 @@
+// =============================================================================
+// Fleet Commander — useCollapseState Hook Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCollapseState } from '../../src/client/hooks/useCollapseState';
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const storageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((_index: number) => null),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', { value: storageMock });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useCollapseState', () => {
+  beforeEach(() => {
+    storageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('starts with empty collapsed set when localStorage is empty', () => {
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.collapsedNodes.size).toBe(0);
+  });
+
+  it('loads collapsed IDs from localStorage on mount', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', JSON.stringify(['1', '5', '10']));
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.collapsedNodes.size).toBe(3);
+    expect(result.current.isCollapsed('1')).toBe(true);
+    expect(result.current.isCollapsed('5')).toBe(true);
+    expect(result.current.isCollapsed('10')).toBe(true);
+    expect(result.current.isCollapsed('99')).toBe(false);
+  });
+
+  it('handles corrupt localStorage data gracefully', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', 'not-valid-json');
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.collapsedNodes.size).toBe(0);
+  });
+
+  it('handles non-array localStorage data gracefully', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', JSON.stringify({ foo: 'bar' }));
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.collapsedNodes.size).toBe(0);
+  });
+
+  it('toggleCollapse adds a node ID when not present', () => {
+    const { result } = renderHook(() => useCollapseState());
+    act(() => {
+      result.current.toggleCollapse('42');
+    });
+    expect(result.current.isCollapsed('42')).toBe(true);
+  });
+
+  it('toggleCollapse removes a node ID when already present', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', JSON.stringify(['42']));
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.isCollapsed('42')).toBe(true);
+    act(() => {
+      result.current.toggleCollapse('42');
+    });
+    expect(result.current.isCollapsed('42')).toBe(false);
+  });
+
+  it('expandAll clears all collapsed nodes', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', JSON.stringify(['1', '2', '3']));
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.collapsedNodes.size).toBe(3);
+    act(() => {
+      result.current.expandAll();
+    });
+    expect(result.current.collapsedNodes.size).toBe(0);
+  });
+
+  it('collapseAll sets all provided IDs as collapsed', () => {
+    const { result } = renderHook(() => useCollapseState());
+    act(() => {
+      result.current.collapseAll(['10', '20', '30']);
+    });
+    expect(result.current.collapsedNodes.size).toBe(3);
+    expect(result.current.isCollapsed('10')).toBe(true);
+    expect(result.current.isCollapsed('20')).toBe(true);
+    expect(result.current.isCollapsed('30')).toBe(true);
+  });
+
+  it('persists state to localStorage after toggle', () => {
+    const { result } = renderHook(() => useCollapseState());
+    act(() => {
+      result.current.toggleCollapse('7');
+    });
+    const stored = JSON.parse(storageMock.getItem('fleet-issue-tree-collapsed')!);
+    expect(stored).toEqual(['7']);
+  });
+
+  it('persists state to localStorage after expandAll', () => {
+    storageMock.setItem('fleet-issue-tree-collapsed', JSON.stringify(['1', '2']));
+    const { result } = renderHook(() => useCollapseState());
+    act(() => {
+      result.current.expandAll();
+    });
+    const stored = JSON.parse(storageMock.getItem('fleet-issue-tree-collapsed')!);
+    expect(stored).toEqual([]);
+  });
+
+  it('persists state to localStorage after collapseAll', () => {
+    const { result } = renderHook(() => useCollapseState());
+    act(() => {
+      result.current.collapseAll(['5', '15']);
+    });
+    const stored = JSON.parse(storageMock.getItem('fleet-issue-tree-collapsed')!);
+    expect(stored).toContain('5');
+    expect(stored).toContain('15');
+    expect(stored.length).toBe(2);
+  });
+
+  it('isCollapsed returns correct values', () => {
+    const { result } = renderHook(() => useCollapseState());
+    expect(result.current.isCollapsed('99')).toBe(false);
+    act(() => {
+      result.current.toggleCollapse('99');
+    });
+    expect(result.current.isCollapsed('99')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `useCollapseState` custom hook that persists tree node collapse/expand state to `localStorage` (key: `fleet-issue-tree-collapsed`)
- Make `TreeNode` accept optional controlled collapse props (`collapsedNodes`, `onToggleCollapse`) following the existing `checkedIssues`/`onCheckChange` pattern
- Add **Expand All** / **Collapse All** buttons next to Prioritize in both grouped and single-project views
- 20 new tests across hook, component, and view test suites

Closes #349