### PR TITLE
Issue #353: unify project group collapse with useCollapseState

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -333,9 +333,13 @@ export function IssueTreeView() {
   }, [groups, search, statusFilter]);
 
   // Collect all node IDs from the full (unfiltered) tree for Collapse All
+  // Includes project group IDs (project-{id}) so Collapse All covers project groups too
   const allNodeIds = useMemo(() => {
     if (groups.length > 0) {
-      return groups.flatMap((g) => collectAllNodeIds(g.tree));
+      return groups.flatMap((g) => [
+        `project-${g.projectId}`,
+        ...collectAllNodeIds(g.tree),
+      ]);
     }
     return collectAllNodeIds(tree);
   }, [tree, groups]);
@@ -761,7 +765,8 @@ interface ProjectGroupProps {
 
 function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: ProjectGroupProps) {
   const api = useApi();
-  const [expanded, setExpanded] = React.useState(true);
+  const projectNodeId = `project-${group.projectId}`;
+  const expanded = !collapsedNodes.has(projectNodeId);
   const prioritization = usePrioritization();
 
   const displayTree = useMemo(() => {
@@ -774,7 +779,7 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
       {/* Project section header */}
       <div className="flex items-center gap-2 py-2 px-2 rounded hover:bg-dark-surface/60 transition-colors">
         <button
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => onToggleCollapse(projectNodeId)}
           className="flex items-center gap-2 flex-1 text-left min-w-0"
         >
           {/* Expand/collapse arrow */}

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -283,4 +283,86 @@ describe('IssueTreeView', () => {
     fireEvent.click(screen.getByText('Collapse All'));
     expect(mockCollapseAll).toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // Collapse All includes project groups (Issue #353)
+  // -------------------------------------------------------------------------
+
+  it('collapseAll includes project group IDs when groups are present', async () => {
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 20, title: 'Issue B', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'project-alpha',
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 2,
+              projectName: 'project-beta',
+              tree: [issueB],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-22T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Collapse All')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Collapse All'));
+
+    // collapseAll should be called with an array that includes project-1, project-2,
+    // plus the issue node IDs (10, 20)
+    expect(mockCollapseAll).toHaveBeenCalledWith(
+      expect.arrayContaining(['project-1', 'project-2', '10', '20']),
+    );
+  });
+
+  it('project group toggle calls onToggleCollapse with project node ID', async () => {
+    const groupIssue = { number: 1, title: 'Issue 1', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [groupIssue],
+          groups: [
+            {
+              projectId: 5,
+              projectName: 'my-repo',
+              tree: [groupIssue],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-22T10:00:00Z',
+          count: 1,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('my-repo')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    // Click the project group header to toggle
+    fireEvent.click(screen.getByText('my-repo'));
+    expect(mockToggleCollapse).toHaveBeenCalledWith('project-5');
+  });
 });


### PR DESCRIPTION
## Summary
- Replaced `ProjectGroup`'s local `useState(true)` with the shared `useCollapseState` system using synthetic `project-{projectId}` node IDs
- Updated `allNodeIds` memo to include project group IDs so Collapse All/Expand All covers project groups
- Added tests verifying grouped collapse behavior

Closes #353