### PR TITLE
Issue #344: add MCP tools for fleet_list_teams and fleet_get_team

### DIFF
--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -28,6 +28,8 @@ import { registerListIssuesTool } from './tools/list-issues.js';
 import { registerListProjectsTool } from './tools/list-projects.js';
 import { registerAddProjectTool } from './tools/add-project.js';
 import { registerGetUsageTool } from './tools/get-usage.js';
+import { registerListTeamsTool } from './tools/list-teams.js';
+import { registerGetTeamTool } from './tools/get-team.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -69,6 +71,8 @@ export async function startMcpServer(): Promise<void> {
   registerListProjectsTool(mcpServer);
   registerAddProjectTool(mcpServer);
   registerGetUsageTool(mcpServer);
+  registerListTeamsTool(mcpServer);
+  registerGetTeamTool(mcpServer);
 
   // Initialize database
   const db = getDatabase();

--- a/src/server/mcp/tools/get-team.ts
+++ b/src/server/mcp/tools/get-team.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_get_team
+// =============================================================================
+// Returns full detail for a single team including project info, duration,
+// PR detail, recent events, and output tail.
+//
+// Input:  { teamId: number }
+// Output: JSON team detail object
+//
+// Service method: TeamService.getTeamDetail(teamId)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_get_team` tool on the given MCP server.
+ *
+ * This tool accepts a team ID and returns the full team detail including
+ * project info, duration, PR detail, recent events, and output tail.
+ */
+export function registerGetTeamTool(server: McpServer): void {
+  server.tool(
+    'fleet_get_team',
+    'Returns full detail for a single team including project info, PR, events, and output',
+    {
+      teamId: z.number().describe('The team ID to get details for'),
+    },
+    async ({ teamId }) => {
+      try {
+        const service = getTeamService();
+        const detail = service.getTeamDetail(teamId);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(detail, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/list-teams.ts
+++ b/src/server/mcp/tools/list-teams.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// MCP Tool: fleet_list_teams
+// =============================================================================
+// Returns all teams with dashboard data, with optional filtering by project
+// and/or status.
+//
+// Input:  { projectId?: number, status?: string }
+// Output: JSON array of team dashboard records
+//
+// Service method: TeamService.listTeams()
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+
+/**
+ * Registers the `fleet_list_teams` tool on the given MCP server.
+ *
+ * This tool returns all teams with dashboard data. Optionally filters
+ * by projectId and/or status.
+ */
+export function registerListTeamsTool(server: McpServer): void {
+  server.tool(
+    'fleet_list_teams',
+    'Returns all teams with dashboard data, optionally filtered by project and/or status',
+    {
+      projectId: z.number().optional().describe('Filter teams by project ID'),
+      status: z.string().optional().describe('Filter teams by status (e.g. running, idle, stuck, done, failed)'),
+    },
+    async ({ projectId, status }) => {
+      const service = getTeamService();
+      let teams = service.listTeams();
+
+      if (projectId !== undefined) {
+        teams = teams.filter((t) => (t as Record<string, unknown>).project_id === projectId);
+      }
+
+      if (status !== undefined) {
+        teams = teams.filter((t) => (t as Record<string, unknown>).status === status);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(teams, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/tests/server/mcp/get-team.test.ts
+++ b/tests/server/mcp/get-team.test.ts
@@ -1,0 +1,173 @@
+// =============================================================================
+// Fleet Commander — MCP get-team Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_get_team MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockTeamDetail = {
+  id: 1,
+  issueNumber: 42,
+  issueTitle: 'Add feature X',
+  model: 'opus',
+  githubRepo: 'owner/repo',
+  status: 'running',
+  phase: 'implementing',
+  pid: 1234,
+  sessionId: 'sess-abc',
+  worktreeName: 'repo-42',
+  branchName: 'feat/42-add-feature-x',
+  prNumber: 100,
+  launchedAt: '2025-01-01T00:00:00Z',
+  stoppedAt: null,
+  lastEventAt: '2025-01-01T01:00:00Z',
+  durationMin: 60,
+  idleMin: 5,
+  totalInputTokens: 10000,
+  totalOutputTokens: 5000,
+  totalCacheCreationTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCostUsd: 1.5,
+  pr: { number: 100, state: 'open', mergeStatus: 'unknown', ciStatus: 'pass', ciFailCount: 0, checks: [], autoMerge: false },
+  recentEvents: [],
+  outputTail: 'some output',
+};
+
+const mockGetTeamDetail = vi.fn().mockReturnValue(mockTeamDetail);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    getTeamDetail: mockGetTeamDetail,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerGetTeamTool } = await import(
+  '../../../src/server/mcp/tools/get-team.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_get_team MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerGetTeamTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_get_team');
+  });
+
+  it('registers with a description', () => {
+    registerGetTeamTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns valid team detail JSON', async () => {
+    registerGetTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 1 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockTeamDetail);
+  });
+
+  it('handler passes teamId to service', async () => {
+    registerGetTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ teamId: 42 });
+
+    expect(mockGetTeamDetail).toHaveBeenCalledWith(42);
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockGetTeamDetail.mockImplementationOnce(() => {
+      throw new ServiceError('Team 999 not found', 'NOT_FOUND', 404);
+    });
+
+    registerGetTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 999 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Team 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockGetTeamDetail.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerGetTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ teamId: 1 })).rejects.toThrow('unexpected');
+  });
+
+  it('handler returns properly formatted JSON with indentation', async () => {
+    registerGetTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 1 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const text = result.content[0]!.text;
+    expect(text).toContain('\n');
+    expect(text).toContain('  ');
+    expect(text).toBe(JSON.stringify(mockTeamDetail, null, 2));
+  });
+});

--- a/tests/server/mcp/list-teams.test.ts
+++ b/tests/server/mcp/list-teams.test.ts
@@ -1,0 +1,168 @@
+// =============================================================================
+// Fleet Commander — MCP list-teams Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_list_teams MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockTeams = [
+  { id: 1, project_id: 1, issue_number: 10, status: 'running', worktree_name: 'proj-10' },
+  { id: 2, project_id: 1, issue_number: 20, status: 'done', worktree_name: 'proj-20' },
+  { id: 3, project_id: 2, issue_number: 30, status: 'running', worktree_name: 'other-30' },
+  { id: 4, project_id: 2, issue_number: 40, status: 'idle', worktree_name: 'other-40' },
+];
+
+const mockListTeams = vi.fn().mockReturnValue(mockTeams);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    listTeams: mockListTeams,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerListTeamsTool } = await import(
+  '../../../src/server/mcp/tools/list-teams.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_list_teams MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_list_teams');
+  });
+
+  it('registers with a description', () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns all teams when no filters are provided', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: undefined, status: undefined })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockTeams);
+  });
+
+  it('handler filters by projectId', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 2, status: undefined })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].project_id).toBe(2);
+    expect(parsed[1].project_id).toBe(2);
+  });
+
+  it('handler filters by status', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: undefined, status: 'running' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.every((t: Record<string, unknown>) => t.status === 'running')).toBe(true);
+  });
+
+  it('handler filters by both projectId and status', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, status: 'running' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe(1);
+    expect(parsed[0].project_id).toBe(1);
+    expect(parsed[0].status).toBe('running');
+  });
+
+  it('handler returns empty array when no teams match filters', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 99, status: undefined })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual([]);
+  });
+
+  it('handler returns properly formatted JSON with indentation', async () => {
+    registerListTeamsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: undefined, status: undefined })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const text = result.content[0]!.text;
+    expect(text).toContain('\n');
+    expect(text).toContain('  ');
+    expect(text).toBe(JSON.stringify(mockTeams, null, 2));
+  });
+});


### PR DESCRIPTION
Closes #344

## Summary
- Add `fleet_list_teams` MCP tool with optional `projectId`/`status` filtering (delegates to `TeamService.listTeams()`)
- Add `fleet_get_team` MCP tool accepting `teamId` parameter (delegates to `TeamService.getTeamDetail()` with ServiceError handling)
- Register both tools in MCP server entry point
- 15 new tests (8 for list-teams, 7 for get-team) covering filtering, error handling, and JSON formatting

## Test plan
- [x] `npm run build` passes
- [x] All 51 MCP tests pass (`npx vitest run tests/server/mcp/`)
- [x] Rebased on latest main (resolved conflict with get-usage tool addition)