### PR TITLE
Issue #346: add MCP tools for team actions (stop, restart, send message)

### DIFF
--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -30,6 +30,9 @@ import { registerAddProjectTool } from './tools/add-project.js';
 import { registerGetUsageTool } from './tools/get-usage.js';
 import { registerListTeamsTool } from './tools/list-teams.js';
 import { registerGetTeamTool } from './tools/get-team.js';
+import { registerStopTeamTool } from './tools/stop-team.js';
+import { registerRestartTeamTool } from './tools/restart-team.js';
+import { registerSendMessageTool } from './tools/send-message.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -73,6 +76,9 @@ export async function startMcpServer(): Promise<void> {
   registerGetUsageTool(mcpServer);
   registerListTeamsTool(mcpServer);
   registerGetTeamTool(mcpServer);
+  registerStopTeamTool(mcpServer);
+  registerRestartTeamTool(mcpServer);
+  registerSendMessageTool(mcpServer);
 
   // Initialize database
   const db = getDatabase();

--- a/src/server/mcp/tools/restart-team.ts
+++ b/src/server/mcp/tools/restart-team.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// MCP Tool: fleet_restart_team
+// =============================================================================
+// Restarts a stopped or failed team by ID.
+//
+// Input:  { teamId: number }
+// Output: JSON result from TeamService.restartTeam
+//
+// Service method: TeamService.restartTeam(teamId)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_restart_team` tool on the given MCP server.
+ *
+ * This tool restarts a stopped or failed team identified by its numeric team ID.
+ */
+export function registerRestartTeamTool(server: McpServer): void {
+  server.tool(
+    'fleet_restart_team',
+    'Restarts a stopped or failed team by its numeric ID',
+    {
+      teamId: z.number().describe('Numeric ID of the team to restart'),
+    },
+    async ({ teamId }) => {
+      try {
+        const service = getTeamService();
+        const result = await service.restartTeam(teamId);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/send-message.ts
+++ b/src/server/mcp/tools/send-message.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_send_message
+// =============================================================================
+// Sends a message to a running team's Claude Code session via stdin.
+//
+// Input:  { teamId: number, message: string }
+// Output: JSON { command, delivered }
+//
+// Service method: TeamService.sendMessage(teamId, message)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_send_message` tool on the given MCP server.
+ *
+ * This tool sends a text message to a running team's Claude Code session
+ * via the stdin pipe.
+ */
+export function registerSendMessageTool(server: McpServer): void {
+  server.tool(
+    'fleet_send_message',
+    'Sends a message to a running team\'s Claude Code session via stdin',
+    {
+      teamId: z.number().describe('Numeric ID of the team to message'),
+      message: z.string().describe('The message text to send to the team'),
+    },
+    async ({ teamId, message }) => {
+      try {
+        const service = getTeamService();
+        const result = service.sendMessage(teamId, message);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/stop-team.ts
+++ b/src/server/mcp/tools/stop-team.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// MCP Tool: fleet_stop_team
+// =============================================================================
+// Stops a running team by ID.
+//
+// Input:  { teamId: number }
+// Output: JSON result from TeamService.stopTeam
+//
+// Service method: TeamService.stopTeam(teamId)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_stop_team` tool on the given MCP server.
+ *
+ * This tool stops a running team identified by its numeric team ID.
+ */
+export function registerStopTeamTool(server: McpServer): void {
+  server.tool(
+    'fleet_stop_team',
+    'Stops a running team by its numeric ID',
+    {
+      teamId: z.number().describe('Numeric ID of the team to stop'),
+    },
+    async ({ teamId }) => {
+      try {
+        const service = getTeamService();
+        const result = await service.stopTeam(teamId);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/tests/server/mcp/restart-team.test.ts
+++ b/tests/server/mcp/restart-team.test.ts
@@ -1,0 +1,152 @@
+// =============================================================================
+// Fleet Commander — MCP restart-team Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_restart_team MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockRestartedTeam = {
+  id: 42,
+  teamSlug: 'my-repo-123',
+  status: 'launching',
+};
+
+const mockRestartTeam = vi.fn().mockResolvedValue(mockRestartedTeam);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    restartTeam: mockRestartTeam,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerRestartTeamTool } = await import(
+  '../../../src/server/mcp/tools/restart-team.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_restart_team MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerRestartTeamTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_restart_team');
+  });
+
+  it('registers with a description', () => {
+    registerRestartTeamTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns valid JSON result', async () => {
+    registerRestartTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 42 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockRestartedTeam);
+  });
+
+  it('handler passes teamId to restartTeam', async () => {
+    registerRestartTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ teamId: 42 });
+
+    expect(mockRestartTeam).toHaveBeenCalledWith(42);
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockRestartTeam.mockRejectedValueOnce(
+      new ServiceError('Team not found', 'NOT_FOUND', 404),
+    );
+
+    registerRestartTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 999 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Team not found');
+  });
+
+  it('handler returns isError on conflict ServiceError', async () => {
+    mockRestartTeam.mockRejectedValueOnce(
+      new ServiceError('Team is already completed', 'CONFLICT', 409),
+    );
+
+    registerRestartTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 42 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('already completed');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockRestartTeam.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerRestartTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ teamId: 42 })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/send-message.test.ts
+++ b/tests/server/mcp/send-message.test.ts
@@ -1,0 +1,153 @@
+// =============================================================================
+// Fleet Commander — MCP send-message Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_send_message MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockSendResult = {
+  command: { id: 1, teamId: 42, message: 'Hello agent', deliveredAt: null },
+  delivered: true,
+};
+
+const mockSendMessage = vi.fn().mockReturnValue(mockSendResult);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    sendMessage: mockSendMessage,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerSendMessageTool } = await import(
+  '../../../src/server/mcp/tools/send-message.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_send_message MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerSendMessageTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_send_message');
+  });
+
+  it('registers with a description', () => {
+    registerSendMessageTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns valid JSON result', async () => {
+    registerSendMessageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 42, message: 'Hello agent' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockSendResult);
+  });
+
+  it('handler passes teamId and message to sendMessage', async () => {
+    registerSendMessageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ teamId: 42, message: 'Hello agent' });
+
+    expect(mockSendMessage).toHaveBeenCalledWith(42, 'Hello agent');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockSendMessage.mockImplementationOnce(() => {
+      throw new ServiceError('message is required and must be a non-empty string', 'VALIDATION', 400);
+    });
+
+    registerSendMessageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 42, message: '' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('message is required');
+  });
+
+  it('handler returns isError on not-found ServiceError', async () => {
+    mockSendMessage.mockImplementationOnce(() => {
+      throw new ServiceError('Team not found', 'NOT_FOUND', 404);
+    });
+
+    registerSendMessageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 999, message: 'hello' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Team not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockSendMessage.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerSendMessageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ teamId: 42, message: 'hello' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/stop-team.test.ts
+++ b/tests/server/mcp/stop-team.test.ts
@@ -1,0 +1,135 @@
+// =============================================================================
+// Fleet Commander — MCP stop-team Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_stop_team MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockStoppedTeam = {
+  id: 42,
+  teamSlug: 'my-repo-123',
+  status: 'done',
+};
+
+const mockStopTeam = vi.fn().mockResolvedValue(mockStoppedTeam);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    stopTeam: mockStopTeam,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerStopTeamTool } = await import(
+  '../../../src/server/mcp/tools/stop-team.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_stop_team MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerStopTeamTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_stop_team');
+  });
+
+  it('registers with a description', () => {
+    registerStopTeamTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns valid JSON result', async () => {
+    registerStopTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 42 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockStoppedTeam);
+  });
+
+  it('handler passes teamId to stopTeam', async () => {
+    registerStopTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ teamId: 42 });
+
+    expect(mockStopTeam).toHaveBeenCalledWith(42);
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockStopTeam.mockRejectedValueOnce(
+      new ServiceError('Team not found', 'NOT_FOUND', 404),
+    );
+
+    registerStopTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ teamId: 999 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Team not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockStopTeam.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerStopTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ teamId: 42 })).rejects.toThrow('unexpected');
+  });
+});


### PR DESCRIPTION
Closes #346

## Summary
- Add `fleet_stop_team` MCP tool — stops a running team gracefully via `TeamService.stopTeam()`
- Add `fleet_restart_team` MCP tool — restarts a stuck/failed team via `TeamService.restartTeam()`
- Add `fleet_send_message` MCP tool — sends a message to a running team's stdin via `TeamService.sendMessage()`
- All 3 tools registered in MCP server index
- Tests for all 3 tools (20 tests total)

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 20 new tests pass
- [x] Existing tests unaffected
- [x] Follows established MCP tool pattern from `add-project.ts`