### PR TITLE
Issue #345: add fleet_launch_team MCP tool for launching agent teams

### DIFF
--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -33,6 +33,7 @@ import { registerGetTeamTool } from './tools/get-team.js';
 import { registerStopTeamTool } from './tools/stop-team.js';
 import { registerRestartTeamTool } from './tools/restart-team.js';
 import { registerSendMessageTool } from './tools/send-message.js';
+import { registerLaunchTeamTool } from './tools/launch-team.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,6 +80,7 @@ export async function startMcpServer(): Promise<void> {
   registerStopTeamTool(mcpServer);
   registerRestartTeamTool(mcpServer);
   registerSendMessageTool(mcpServer);
+  registerLaunchTeamTool(mcpServer);
 
   // Initialize database
   const db = getDatabase();

--- a/src/server/mcp/tools/launch-team.ts
+++ b/src/server/mcp/tools/launch-team.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// MCP Tool: fleet_launch_team
+// =============================================================================
+// Launches a new agent team for a GitHub issue.
+//
+// Input:  { projectId: number, issueNumber: number, headless?: boolean, force?: boolean }
+// Output: JSON result from TeamService.launchTeam
+//
+// Service method: TeamService.launchTeam(params)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getTeamService } from '../../services/team-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_launch_team` tool on the given MCP server.
+ *
+ * This tool launches a new agent team for a GitHub issue within a project.
+ */
+export function registerLaunchTeamTool(server: McpServer): void {
+  server.tool(
+    'fleet_launch_team',
+    'Launches a new agent team for a GitHub issue within a project',
+    {
+      projectId: z.number().describe('Numeric ID of the project to launch the team in'),
+      issueNumber: z.number().describe('GitHub issue number to assign the team to'),
+      headless: z.boolean().optional().describe('Run without a visible terminal window'),
+      force: z.boolean().optional().describe('Bypass dependency checks and force launch'),
+    },
+    async ({ projectId, issueNumber, headless, force }) => {
+      try {
+        const service = getTeamService();
+        const result = await service.launchTeam({ projectId, issueNumber, headless, force });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/tests/server/mcp/launch-team.test.ts
+++ b/tests/server/mcp/launch-team.test.ts
@@ -1,0 +1,158 @@
+// =============================================================================
+// Fleet Commander — MCP launch-team Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_launch_team MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockLaunchedTeam = {
+  id: 7,
+  teamSlug: 'my-repo-42',
+  status: 'queued',
+  issueNumber: 42,
+};
+
+const mockLaunchTeam = vi.fn().mockResolvedValue(mockLaunchedTeam);
+
+vi.mock('../../../src/server/services/team-service.js', () => ({
+  getTeamService: () => ({
+    launchTeam: mockLaunchTeam,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerLaunchTeamTool } = await import(
+  '../../../src/server/mcp/tools/launch-team.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_launch_team MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_launch_team');
+  });
+
+  it('registers with a description', () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler launches a team with required params only', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueNumber: 42 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockLaunchedTeam);
+
+    expect(mockLaunchTeam).toHaveBeenCalledWith({
+      projectId: 1,
+      issueNumber: 42,
+      headless: undefined,
+      force: undefined,
+    });
+  });
+
+  it('handler launches a team with all optional params', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({
+      projectId: 2,
+      issueNumber: 99,
+      headless: true,
+      force: true,
+    })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockLaunchedTeam);
+
+    expect(mockLaunchTeam).toHaveBeenCalledWith({
+      projectId: 2,
+      issueNumber: 99,
+      headless: true,
+      force: true,
+    });
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockLaunchTeam.mockRejectedValueOnce(
+      new ServiceError('Issue #42 is blocked by 2 unresolved dependencies', 'BLOCKED_BY_DEPENDENCIES', 409),
+    );
+
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueNumber: 42 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Issue #42 is blocked by 2 unresolved dependencies');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockLaunchTeam.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueNumber: 42 })).rejects.toThrow('unexpected');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `fleet_launch_team` MCP tool that launches a new agent team to work on a GitHub issue
- Accepts `projectId`, `issueNumber` (required), plus `headless` and `force` (optional) parameters
- Maps to `TeamService.launchTeam()` with proper ServiceError handling
- Includes 6 tests covering success and error cases (77 total MCP tests passing)

Closes #345