### PR TITLE
Issue #366: add GitHub repo settings check to Projects page

### DIFF
--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -5,7 +5,7 @@ import { AddProjectDialog } from '../components/AddProjectDialog';
 import { CleanupModal } from '../components/CleanupModal';
 import { OverflowMenu } from '../components/OverflowMenu';
 import { ChevronRightIcon, PencilIcon } from '../components/Icons';
-import type { ProjectSummary, ProjectStatus, ProjectGroup } from '../../shared/types';
+import type { ProjectSummary, ProjectStatus, ProjectGroup, RepoSettings } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Status badge colors
@@ -126,6 +126,9 @@ function InstallHealthDetail({ project }: { project: ProjectSummary }) {
     },
   ];
 
+  // GitHub repo settings (auto-merge, branch protection)
+  const repoSettings: RepoSettings | undefined = s.repoSettings;
+
   return (
     <div className="flex items-center gap-3 text-xs flex-wrap">
       {detailedCategories.map((cat) => {
@@ -190,6 +193,51 @@ function InstallHealthDetail({ project }: { project: ProjectSummary }) {
           </div>
         );
       })}
+      {/* GitHub repo settings badge */}
+      {repoSettings && (
+        <div className="relative group shrink-0">
+          <span
+            className="cursor-default"
+            style={{ color: repoSettings.autoMergeEnabled ? '#3FB950' : '#D29922' }}
+          >
+            {repoSettings.autoMergeEnabled ? '\u2713' : '\u26A0'} github
+          </span>
+          {/* Tooltip on hover */}
+          <div className="hidden group-hover:block absolute z-10 bottom-full right-0 mb-1 p-2 rounded bg-[#1C2128] border border-[#30363D] shadow-lg text-xs min-w-52">
+            <div className="font-medium mb-1 text-[#C9D1D9]">
+              GitHub Repo Settings
+            </div>
+            <div className="flex items-center gap-1.5 py-0.5">
+              <span style={{ color: repoSettings.autoMergeEnabled ? '#3FB950' : '#D29922' }}>
+                {repoSettings.autoMergeEnabled ? '\u2713' : '\u26A0'}
+              </span>
+              <span className="text-[#8B949E]">
+                {repoSettings.autoMergeEnabled
+                  ? 'Auto-merge enabled'
+                  : 'Auto-merge disabled \u2014 required for gh pr merge --auto'}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 py-0.5">
+              <span style={{ color: '#8B949E' }}>{'\u2022'}</span>
+              <span className="text-[#8B949E]">
+                Default branch: {repoSettings.defaultBranch}
+              </span>
+            </div>
+            {repoSettings.branchProtection && (
+              <div className="flex items-center gap-1.5 py-0.5">
+                <span style={{ color: repoSettings.branchProtection.enabled ? '#3FB950' : '#8B949E' }}>
+                  {repoSettings.branchProtection.enabled ? '\u2713' : '\u2022'}
+                </span>
+                <span className="text-[#8B949E]">
+                  {repoSettings.branchProtection.enabled
+                    ? `Branch protection (${repoSettings.branchProtection.requiredChecks.length} required check${repoSettings.branchProtection.requiredChecks.length !== 1 ? 's' : ''})`
+                    : 'No branch protection'}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -15,7 +15,7 @@ import { getIssueFetcher } from './issue-fetcher.js';
 import { sseBroker } from './sse-broker.js';
 import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
-import type { ProjectStatus, InstallStatus, InstallFileStatus } from '../../shared/types.js';
+import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings } from '../../shared/types.js';
 import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
 import { getCleanupPreview as _getCleanupPreview, executeCleanup as _executeCleanup } from './cleanup.js';
 import type { CleanupPreview, CleanupResult } from '../../shared/types.js';
@@ -79,14 +79,71 @@ function fileHasCrlf(filePath: string): boolean {
 }
 
 /**
+ * Check GitHub repository settings (auto-merge, branch protection) via `gh api`.
+ * Returns undefined if githubRepo is not provided or the `gh` CLI call fails.
+ *
+ * @param githubRepo - GitHub repo slug (e.g. "owner/repo"), or null/undefined
+ * @returns RepoSettings or undefined on failure
+ */
+export function checkRepoSettings(githubRepo: string | null | undefined): RepoSettings | undefined {
+  if (!githubRepo) return undefined;
+
+  try {
+    const repoJson = execSync(
+      `gh api repos/${githubRepo} --jq "{allow_auto_merge, default_branch}"`,
+      { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
+    ).trim();
+
+    const repoData = JSON.parse(repoJson) as {
+      allow_auto_merge?: boolean;
+      default_branch?: string;
+    };
+
+    const defaultBranch = repoData.default_branch ?? 'main';
+    const result: RepoSettings = {
+      autoMergeEnabled: repoData.allow_auto_merge ?? false,
+      defaultBranch,
+    };
+
+    // Branch protection may not be configured — 404 is expected
+    try {
+      const protectionJson = execSync(
+        `gh api repos/${githubRepo}/branches/${defaultBranch}/protection --jq "{required_status_checks}"`,
+        { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
+      ).trim();
+
+      const protectionData = JSON.parse(protectionJson) as {
+        required_status_checks?: {
+          contexts?: string[];
+        } | null;
+      };
+
+      result.branchProtection = {
+        enabled: true,
+        requiredChecks: protectionData.required_status_checks?.contexts ?? [],
+      };
+    } catch {
+      // Branch protection not configured or not accessible — that's fine
+      result.branchProtection = { enabled: false, requiredChecks: [] };
+    }
+
+    return result;
+  } catch {
+    // gh CLI unavailable or repo not accessible
+    return undefined;
+  }
+}
+
+/**
  * Check the install status of artifacts deployed by install.sh:
  * hooks directory and workflow prompt.
  * Returns detailed file-level breakdown for tooltip display.
  *
  * @param repoPath - Absolute path to the target repository
- * @returns InstallStatus with hooks, prompt, agents, guides, and settings info
+ * @param githubRepo - Optional GitHub repo slug for repo settings check
+ * @returns InstallStatus with hooks, prompt, agents, guides, settings, and repo settings info
  */
-export function checkInstallStatus(repoPath: string): InstallStatus {
+export function checkInstallStatus(repoPath: string, githubRepo?: string | null): InstallStatus {
   const hookNames = [
     'send_event.sh',
     'on_session_start.sh',
@@ -165,6 +222,7 @@ export function checkInstallStatus(repoPath: string): InstallStatus {
       files: guideFiles,
     },
     settings: settingsFile,
+    repoSettings: checkRepoSettings(githubRepo),
   };
 }
 
@@ -209,7 +267,7 @@ export class ProjectService {
 
     return filtered.map((p) => ({
       ...p,
-      installStatus: checkInstallStatus(p.repoPath),
+      installStatus: checkInstallStatus(p.repoPath, p.githubRepo),
     }));
   }
 
@@ -439,8 +497,8 @@ export class ProjectService {
 
     const result = installHooks(project.repoPath, _minimalLogger);
 
-    // Check what actually landed on disk
-    const status = checkInstallStatus(project.repoPath);
+    // Check what actually landed on disk (include repo settings for UI)
+    const status = checkInstallStatus(project.repoPath, project.githubRepo);
     const allInstalled = status.hooks.installed && status.prompt.installed;
     db.updateProject(project.id, { hooksInstalled: allInstalled });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,16 @@ export interface InstallHooksStatus extends InstallCategoryStatus {
   found: number;
 }
 
+/** GitHub repository settings (auto-merge, branch protection) */
+export interface RepoSettings {
+  autoMergeEnabled: boolean;
+  defaultBranch: string;
+  branchProtection?: {
+    enabled: boolean;
+    requiredChecks: string[];
+  };
+}
+
 /** Detailed install status for the artifacts deployed by install.sh */
 export interface InstallStatus {
   hooks: InstallHooksStatus;
@@ -82,6 +92,7 @@ export interface InstallStatus {
   agents: InstallCategoryStatus;
   guides?: InstallCategoryStatus;
   settings: InstallFileStatus;
+  repoSettings?: RepoSettings;
 }
 
 /** Project with team count for list view */


### PR DESCRIPTION
## Summary

- Adds GitHub repository settings check (auto-merge enabled, branch protection) to the Projects page install status
- Server calls `gh api` to check `allow_auto_merge` and branch protection configuration
- Client shows a "github" badge with tooltip showing auto-merge status and branch protection details
- Auto-merge disabled shows as warning (yellow), not error — it's recommended but not blocking

Closes #366