### PR TITLE
Issue #378: Fix factory reset confirm parameter and add typed confirmation dialog

### DIFF
--- a/src/client/views/SettingsPage.tsx
+++ b/src/client/views/SettingsPage.tsx
@@ -208,6 +208,8 @@ export function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [resetting, setResetting] = useState(false);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [resetConfirmText, setResetConfirmText] = useState('');
 
   const fetchSettings = useCallback(async () => {
     try {
@@ -226,19 +228,9 @@ export function SettingsPage() {
   }, [fetchSettings]);
 
   const handleFactoryReset = async () => {
-    const confirmed = window.confirm(
-      'FACTORY RESET\n\nThis will:\n- Stop all running teams\n- Uninstall hooks from all projects\n- Delete ALL data (projects, teams, events)\n\nThis cannot be undone. Continue?',
-    );
-    if (!confirmed) return;
-
-    const doubleConfirm = window.confirm(
-      'Are you absolutely sure? All data will be permanently deleted.',
-    );
-    if (!doubleConfirm) return;
-
     setResetting(true);
     try {
-      await api.post('system/factory-reset');
+      await api.post('system/factory-reset', { confirm: 'FACTORY_RESET' });
       window.location.href = '/';
     } catch (err) {
       alert('Factory reset failed: ' + (err instanceof Error ? err.message : String(err)));
@@ -368,13 +360,52 @@ export function SettingsPage() {
           Factory reset will stop all running teams, uninstall hooks from all projects,
           and delete all data. The database will be recreated fresh with default settings.
         </p>
-        <button
-          onClick={handleFactoryReset}
-          disabled={resetting}
-          className="px-4 py-2 text-sm bg-[#F85149]/10 text-[#F85149] border border-[#F85149]/40 rounded hover:bg-[#F85149]/20 disabled:opacity-50"
-        >
-          {resetting ? 'Resetting...' : 'Factory Reset'}
-        </button>
+
+        {!showResetConfirm ? (
+          <button
+            onClick={() => setShowResetConfirm(true)}
+            disabled={resetting}
+            className="px-4 py-2 text-sm bg-[#F85149]/10 text-[#F85149] border border-[#F85149]/40 rounded hover:bg-[#F85149]/20 disabled:opacity-50"
+          >
+            Factory Reset
+          </button>
+        ) : (
+          <div className="mt-2 p-3 bg-[#F85149]/5 border border-[#F85149]/30 rounded">
+            <p className="text-[#F85149] text-sm font-medium mb-1">
+              This action cannot be undone.
+            </p>
+            <p className="text-[#8B949E] text-sm mb-3">
+              Type <code className="font-mono text-xs bg-dark-base/50 px-1.5 py-0.5 rounded text-dark-accent">FACTORY_RESET</code> to confirm.
+            </p>
+            <input
+              type="text"
+              value={resetConfirmText}
+              onChange={(e) => setResetConfirmText(e.target.value)}
+              placeholder="FACTORY_RESET"
+              autoFocus
+              className="w-full px-3 py-1.5 text-sm font-mono bg-dark-base border border-dark-border rounded text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-[#F85149]/60 mb-3"
+            />
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleFactoryReset}
+                disabled={resetting || resetConfirmText !== 'FACTORY_RESET'}
+                className="px-4 py-1.5 text-sm font-medium rounded border border-[#F85149]/40 text-[#F85149] bg-[#F85149]/10 hover:bg-[#F85149]/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {resetting ? 'Resetting...' : 'Confirm Factory Reset'}
+              </button>
+              <button
+                onClick={() => {
+                  setShowResetConfirm(false);
+                  setResetConfirmText('');
+                }}
+                disabled={resetting}
+                className="px-3 py-1.5 text-sm rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/tests/client/SettingsPage.test.tsx
+++ b/tests/client/SettingsPage.test.tsx
@@ -3,7 +3,7 @@
 // =============================================================================
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 // ---------------------------------------------------------------------------
@@ -160,5 +160,105 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Launch Prompt')).toBeInTheDocument();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Factory Reset typed-confirmation tests
+  // -------------------------------------------------------------------------
+
+  it('shows confirmation input when Factory Reset button is clicked', async () => {
+    mockGet.mockResolvedValue(makeSettings());
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Factory Reset'));
+
+    expect(screen.getByPlaceholderText('FACTORY_RESET')).toBeInTheDocument();
+    expect(screen.getByText('Confirm Factory Reset')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('disables confirm button until FACTORY_RESET is typed exactly', async () => {
+    mockGet.mockResolvedValue(makeSettings());
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Factory Reset'));
+
+    const confirmBtn = screen.getByText('Confirm Factory Reset');
+    const input = screen.getByPlaceholderText('FACTORY_RESET');
+
+    // Button should be disabled initially
+    expect(confirmBtn).toBeDisabled();
+
+    // Type partial text — still disabled
+    fireEvent.change(input, { target: { value: 'FACTORY' } });
+    expect(confirmBtn).toBeDisabled();
+
+    // Type the full text — now enabled
+    fireEvent.change(input, { target: { value: 'FACTORY_RESET' } });
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('sends correct API call with confirm body when confirmed', async () => {
+    mockGet.mockResolvedValue(makeSettings());
+    mockPost.mockResolvedValue({ ok: true });
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Factory Reset'));
+
+    const input = screen.getByPlaceholderText('FACTORY_RESET');
+    fireEvent.change(input, { target: { value: 'FACTORY_RESET' } });
+    fireEvent.click(screen.getByText('Confirm Factory Reset'));
+
+    expect(mockPost).toHaveBeenCalledWith('system/factory-reset', { confirm: 'FACTORY_RESET' });
+  });
+
+  it('dismisses confirmation when Cancel is clicked', async () => {
+    mockGet.mockResolvedValue(makeSettings());
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+    });
+
+    // Open confirmation
+    fireEvent.click(screen.getByText('Factory Reset'));
+    expect(screen.getByPlaceholderText('FACTORY_RESET')).toBeInTheDocument();
+
+    // Cancel
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Confirmation should be gone, original button back
+    expect(screen.queryByPlaceholderText('FACTORY_RESET')).not.toBeInTheDocument();
+    expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+  });
+
+  it('clears input text when Cancel is clicked and reopened', async () => {
+    mockGet.mockResolvedValue(makeSettings());
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Factory Reset')).toBeInTheDocument();
+    });
+
+    // Open, type partial text, then cancel
+    fireEvent.click(screen.getByText('Factory Reset'));
+    fireEvent.change(screen.getByPlaceholderText('FACTORY_RESET'), { target: { value: 'FACT' } });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Reopen — input should be empty
+    fireEvent.click(screen.getByText('Factory Reset'));
+    expect(screen.getByPlaceholderText('FACTORY_RESET')).toHaveValue('');
   });
 });


### PR DESCRIPTION
## Summary
- Fix factory reset button failing with "requires confirm = FACTORY_RESET" error
- Replace `window.confirm()` dialogs with inline typed-confirmation UI requiring user to type `FACTORY_RESET`
- Send `{ confirm: "FACTORY_RESET" }` in POST body to `/api/system/factory-reset`

Closes #378

## Changes
- `src/client/views/SettingsPage.tsx` — add typed confirmation form, pass confirm body to API
- `tests/client/SettingsPage.test.tsx` — add 5 test cases covering confirmation flow

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 15 SettingsPage tests pass
- [x] Typed confirmation requires exact "FACTORY_RESET" input
- [x] Cancel dismisses confirmation and clears input
- [x] API receives correct `{ confirm: "FACTORY_RESET" }` body