### PR TITLE
Issue #385: Convert blocking execSync calls to async exec

### DIFF
--- a/src/server/mcp/tools/add-project.ts
+++ b/src/server/mcp/tools/add-project.ts
@@ -35,7 +35,7 @@ export function registerAddProjectTool(server: McpServer): void {
     async ({ repoPath, name, githubRepo, maxActiveTeams, model }) => {
       try {
         const service = getProjectService();
-        const project = service.createProject({
+        const project = await service.createProject({
           name: name ?? path.basename(repoPath),
           repoPath,
           githubRepo,

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -94,7 +94,7 @@ const projectsRoutes: FastifyPluginCallback = (
     ) => {
       try {
         const service = getProjectService();
-        const project = service.createProject(request.body);
+        const project = await service.createProject(request.body);
         return reply.code(201).send(project);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
@@ -171,7 +171,7 @@ const projectsRoutes: FastifyPluginCallback = (
         }
 
         const service = getProjectService();
-        const settings = service.getRepoSettings(projectId);
+        const settings = await service.getRepoSettings(projectId);
         return reply.code(200).send(settings ?? null);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {

--- a/src/server/routes/prs.ts
+++ b/src/server/routes/prs.ts
@@ -142,7 +142,7 @@ const prsRoutes: FastifyPluginCallback = (
         }
 
         const service = getPRService();
-        const result = service.enableAutoMerge(prNumber);
+        const result = await service.enableAutoMerge(prNumber);
         return reply.code(200).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
@@ -180,7 +180,7 @@ const prsRoutes: FastifyPluginCallback = (
         }
 
         const service = getPRService();
-        const result = service.disableAutoMerge(prNumber);
+        const result = await service.disableAutoMerge(prNumber);
         return reply.code(200).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
@@ -218,7 +218,7 @@ const prsRoutes: FastifyPluginCallback = (
         }
 
         const service = getPRService();
-        const result = service.updateBranch(prNumber);
+        const result = await service.updateBranch(prNumber);
         return reply.code(200).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -13,12 +13,12 @@
 // crashes the service.
 // =============================================================================
 
-import { execSync } from 'child_process';
 import path from 'path';
 import { getDatabase } from '../db.js';
 import config from '../config.js';
 import { sseBroker } from './sse-broker.js';
 import { resolveMessage } from '../utils/resolve-message.js';
+import { execGHAsync, execGitAsync } from '../utils/exec-gh.js';
 import type { PRState, CIStatus, MergeStatus } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -180,12 +180,12 @@ class GitHubPoller {
             continue;
           }
 
-          // Sync branch name: the agent may have renamed the branch after launch.
           // Check the actual worktree branch and update DB if it differs.
+          // The agent may have renamed the branch after launch.
           if (team.projectId && !team.prNumber) {
             const repoPath = projectPathMap.get(team.projectId);
             if (repoPath && team.worktreeName) {
-              const actualBranch = this.detectWorktreeBranch(repoPath, team.worktreeName);
+              const actualBranch = await this.detectWorktreeBranch(repoPath, team.worktreeName);
               if (actualBranch && actualBranch !== team.branchName) {
                 console.log(
                   `[GitHubPoller] Branch name updated for team ${team.id}: "${team.branchName}" -> "${actualBranch}"`
@@ -206,7 +206,7 @@ class GitHubPoller {
           } else if (team.branchName) {
             // Fast-poll when awaiting PR detection
             wantFast = true;
-            this.detectPR(team.branchName, team.id, githubRepo);
+            await this.detectPR(team.branchName, team.id, githubRepo);
           }
         } catch (err) {
           // Log and continue — never let one team's failure stop the others
@@ -232,7 +232,7 @@ class GitHubPoller {
 
   private async pollPR(prNumber: number, teamId: number, githubRepo: string): Promise<void> {
     // Use gh pr view to get PR status, CI checks, merge state, and auto-merge
-    const result = this.execGH(
+    const result = await execGHAsync(
       `gh pr view ${prNumber} --repo ${githubRepo} ` +
         `--json number,title,state,mergeStateStatus,statusCheckRollup,autoMergeRequest,headRefName,mergedAt`
     );
@@ -603,26 +603,20 @@ class GitHubPoller {
    * to "refactor/fix/767-unit-user-role-logic"), so we must check the actual
    * git state rather than relying on the initially stored branch name.
    */
-  private detectWorktreeBranch(repoPath: string, worktreeName: string): string | null {
+  private async detectWorktreeBranch(repoPath: string, worktreeName: string): Promise<string | null> {
     const worktreeAbsPath = path.join(repoPath, config.worktreeDir, worktreeName);
-    try {
-      const branch = execSync(
-        `git -C "${worktreeAbsPath}" rev-parse --abbrev-ref HEAD`,
-        { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
-      ).trim();
-      return branch && branch !== 'HEAD' ? branch : null;
-    } catch {
-      // Worktree may not exist yet or git command failed — not an error
-      return null;
-    }
+    const branch = await execGitAsync(
+      `git -C "${worktreeAbsPath}" rev-parse --abbrev-ref HEAD`,
+    );
+    return branch && branch !== 'HEAD' ? branch : null;
   }
 
   // -------------------------------------------------------------------------
   // Private: detect a PR for a branch that doesn't have one yet
   // -------------------------------------------------------------------------
 
-  private detectPR(branchName: string, teamId: number, githubRepo: string): void {
-    const result = this.execGH(
+  private async detectPR(branchName: string, teamId: number, githubRepo: string): Promise<void> {
+    const result = await execGHAsync(
       `gh pr list --head ${branchName} --repo ${githubRepo} --state all --json number --limit 1`
     );
     if (!result) return; // gh CLI failed — skip
@@ -671,30 +665,9 @@ class GitHubPoller {
     return 'pending';
   }
 
-  // -------------------------------------------------------------------------
-  // Private: execute a gh CLI command safely
-  // -------------------------------------------------------------------------
-
-  /**
-   * Execute a `gh` CLI command and return stdout, or `null` on error.
-   * Errors are logged but never thrown — the caller decides how to proceed.
-   */
-  private execGH(command: string): string | null {
-    try {
-      return execSync(command, {
-        encoding: 'utf-8',
-        timeout: 15_000, // 15 seconds — generous timeout for slow connections
-        stdio: ['pipe', 'pipe', 'pipe'], // capture stderr too
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      // Only log if it's not a "no PRs found" type error
-      if (!message.includes('no pull requests match')) {
-        console.error(`[GitHubPoller] gh CLI error: ${message.slice(0, 200)}`);
-      }
-      return null;
-    }
-  }
+  // NOTE: The old synchronous execGH method has been removed.
+  // All gh CLI calls now use the shared async execGHAsync utility
+  // from src/server/utils/exec-gh.ts to avoid blocking the event loop.
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/pr-service.ts
+++ b/src/server/services/pr-service.ts
@@ -5,10 +5,10 @@
 // All GitHub operations use the `gh` CLI (never Octokit) per project conventions.
 // =============================================================================
 
-import { execSync } from 'child_process';
 import { getDatabase } from '../db.js';
 import { sseBroker } from './sse-broker.js';
 import { githubPoller } from './github-poller.js';
+import { execGHResult } from '../utils/exec-gh.js';
 import { ServiceError, notFoundError, validationError, externalError } from './service-error.js';
 
 // ---------------------------------------------------------------------------
@@ -20,32 +20,6 @@ const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
 function validateGithubRepo(repo: string): boolean {
   return GITHUB_REPO_RE.test(repo);
-}
-
-/** Execute a gh CLI command, returning { ok, stdout?, error? } */
-interface GHResult {
-  ok: boolean;
-  stdout?: string;
-  error?: string;
-}
-
-function execGH(command: string): GHResult {
-  try {
-    const stdout = execSync(command, {
-      encoding: 'utf-8',
-      timeout: 15_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { ok: true, stdout };
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    let stderr = message;
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      const rawStderr = (err as { stderr: string | Buffer }).stderr;
-      stderr = typeof rawStderr === 'string' ? rawStderr : rawStderr.toString('utf-8');
-    }
-    return { ok: false, error: stderr.trim() || message };
-  }
 }
 
 /**
@@ -95,10 +69,10 @@ export class PRService {
    * @returns Success result with output from gh CLI
    * @throws ServiceError if PR/repo not found or gh CLI fails
    */
-  enableAutoMerge(prNumber: number): { ok: boolean; message: string; output: string } {
+  async enableAutoMerge(prNumber: number): Promise<{ ok: boolean; message: string; output: string }> {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
-    const result = execGH(
+    const result = await execGHResult(
       `gh pr merge ${prNumber} --auto --squash --repo ${githubRepo}`,
     );
 
@@ -143,10 +117,10 @@ export class PRService {
    * @returns Success result with output from gh CLI
    * @throws ServiceError if PR/repo not found or gh CLI fails
    */
-  disableAutoMerge(prNumber: number): { ok: boolean; message: string; output: string } {
+  async disableAutoMerge(prNumber: number): Promise<{ ok: boolean; message: string; output: string }> {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
-    const result = execGH(
+    const result = await execGHResult(
       `gh pr merge ${prNumber} --disable-auto --repo ${githubRepo}`,
     );
 
@@ -191,10 +165,10 @@ export class PRService {
    * @returns Success result with output from gh CLI
    * @throws ServiceError if PR/repo not found or gh CLI fails
    */
-  updateBranch(prNumber: number): { ok: boolean; message: string; output: string } {
+  async updateBranch(prNumber: number): Promise<{ ok: boolean; message: string; output: string }> {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
-    const result = execGH(
+    const result = await execGHResult(
       `gh api repos/${githubRepo}/pulls/${prNumber}/update-branch -X PUT`,
     );
 

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -6,7 +6,6 @@
 // and CLI calls related to projects.
 // =============================================================================
 
-import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { getDatabase } from '../db.js';
@@ -15,6 +14,7 @@ import { getIssueFetcher } from './issue-fetcher.js';
 import { sseBroker } from './sse-broker.js';
 import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
+import { execGitAsync, execGHAsync, execGHResult } from '../utils/exec-gh.js';
 import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings } from '../../shared/types.js';
 import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
 import { getPackageVersion } from '../utils/version.js';
@@ -33,35 +33,23 @@ function normalizePath(p: string): string {
 }
 
 /**
- * Check if a directory is a git repository.
+ * Check if a directory is a git repository (async to avoid blocking event loop).
  */
-function isGitRepo(dirPath: string): boolean {
-  try {
-    execSync('git rev-parse --is-inside-work-tree', {
-      cwd: dirPath,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-    });
-    return true;
-  } catch {
-    return false;
-  }
+async function isGitRepo(dirPath: string): Promise<boolean> {
+  const result = await execGitAsync('git rev-parse --is-inside-work-tree', { cwd: dirPath });
+  return result !== null;
 }
 
 /**
  * Auto-detect the GitHub repo (owner/name) for a local git repo via gh CLI.
- * Returns null if detection fails (non-fatal).
+ * Returns null if detection fails (non-fatal). Async to avoid blocking event loop.
  */
-function detectGithubRepo(dirPath: string): string | null {
-  try {
-    const result = execSync(
-      'gh repo view --json nameWithOwner -q .nameWithOwner',
-      { cwd: dirPath, encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
-    ).trim();
-    return result || null;
-  } catch {
-    return null;
-  }
+async function detectGithubRepo(dirPath: string): Promise<string | null> {
+  const result = await execGHAsync(
+    'gh repo view --json nameWithOwner -q .nameWithOwner',
+    { cwd: dirPath, timeout: 10_000 },
+  );
+  return result?.trim() || null;
 }
 
 /**
@@ -82,20 +70,23 @@ function fileHasCrlf(filePath: string): boolean {
 /**
  * Check GitHub repository settings (auto-merge, branch protection) via `gh api`.
  * Returns undefined if githubRepo is not provided or the `gh` CLI call fails.
+ * Async to avoid blocking the event loop.
  *
  * @param githubRepo - GitHub repo slug (e.g. "owner/repo"), or null/undefined
  * @returns RepoSettings or undefined on failure
  */
-export function checkRepoSettings(githubRepo: string | null | undefined): RepoSettings | undefined {
+export async function checkRepoSettings(githubRepo: string | null | undefined): Promise<RepoSettings | undefined> {
   if (!githubRepo) return undefined;
 
   try {
-    const repoJson = execSync(
+    const repoJson = await execGHAsync(
       `gh api repos/${githubRepo} --jq "{allow_auto_merge, default_branch}"`,
-      { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
-    ).trim();
+      { timeout: 10_000 },
+    );
 
-    const repoData = JSON.parse(repoJson) as {
+    if (!repoJson) return undefined;
+
+    const repoData = JSON.parse(repoJson.trim()) as {
       allow_auto_merge?: boolean;
       default_branch?: string;
     };
@@ -107,30 +98,34 @@ export function checkRepoSettings(githubRepo: string | null | undefined): RepoSe
     };
 
     // Branch protection may not be configured — 404 is expected
-    try {
-      const protectionJson = execSync(
-        `gh api repos/${githubRepo}/branches/${defaultBranch}/protection --jq "{required_status_checks}"`,
-        { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
-      ).trim();
+    const protectionJson = await execGHAsync(
+      `gh api repos/${githubRepo}/branches/${defaultBranch}/protection --jq "{required_status_checks}"`,
+      { timeout: 10_000 },
+    );
 
-      const protectionData = JSON.parse(protectionJson) as {
-        required_status_checks?: {
-          contexts?: string[];
-        } | null;
-      };
+    if (protectionJson) {
+      try {
+        const protectionData = JSON.parse(protectionJson.trim()) as {
+          required_status_checks?: {
+            contexts?: string[];
+          } | null;
+        };
 
-      result.branchProtection = {
-        enabled: true,
-        requiredChecks: protectionData.required_status_checks?.contexts ?? [],
-      };
-    } catch {
+        result.branchProtection = {
+          enabled: true,
+          requiredChecks: protectionData.required_status_checks?.contexts ?? [],
+        };
+      } catch {
+        result.branchProtection = { enabled: false, requiredChecks: [] };
+      }
+    } else {
       // Branch protection not configured or not accessible — that's fine
       result.branchProtection = { enabled: false, requiredChecks: [] };
     }
 
     return result;
   } catch {
-    // gh CLI unavailable or repo not accessible
+    // JSON parse error or other unexpected failure
     return undefined;
   }
 }
@@ -388,13 +383,13 @@ export class ProjectService {
    * @throws ServiceError with code VALIDATION for invalid input
    * @throws ServiceError with code CONFLICT for duplicate repo path
    */
-  createProject(data: {
+  async createProject(data: {
     name: string;
     repoPath: string;
     githubRepo?: string;
     maxActiveTeams?: number;
     model?: string;
-  }): unknown {
+  }): Promise<unknown> {
     const { name, repoPath, githubRepo, maxActiveTeams, model } = data;
 
     // Validate name
@@ -413,7 +408,7 @@ export class ProjectService {
       throw validationError(`Path does not exist: ${normalizedPath}`);
     }
 
-    if (!isGitRepo(normalizedPath)) {
+    if (!(await isGitRepo(normalizedPath))) {
       throw validationError(`Path is not a git repository: ${normalizedPath}`);
     }
 
@@ -427,7 +422,7 @@ export class ProjectService {
     }
 
     // Auto-detect githubRepo if not provided
-    const resolvedGithubRepo = githubRepo || detectGithubRepo(normalizedPath);
+    const resolvedGithubRepo = githubRepo || await detectGithubRepo(normalizedPath);
 
     // Validate maxActiveTeams if provided
     if (maxActiveTeams !== undefined) {
@@ -541,7 +536,7 @@ export class ProjectService {
    * @returns RepoSettings or undefined if not available
    * @throws ServiceError with code NOT_FOUND if project doesn't exist
    */
-  getRepoSettings(projectId: number): RepoSettings | undefined {
+  async getRepoSettings(projectId: number): Promise<RepoSettings | undefined> {
     const db = getDatabase();
     const project = db.getProject(projectId);
     if (!project) {

--- a/src/server/utils/exec-gh.ts
+++ b/src/server/utils/exec-gh.ts
@@ -1,0 +1,119 @@
+// =============================================================================
+// Fleet Commander — Async GH/Git CLI Execution Utility
+// =============================================================================
+// Shared async utility for executing `gh` and `git` CLI commands without
+// blocking the Node.js event loop. Replaces the various per-file `execSync`
+// helpers that were causing event-loop stalls (see issue #385).
+//
+// Uses `promisify(child_process.exec)` — the same pattern as issue-fetcher.ts
+// and team-manager.ts.
+// =============================================================================
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import type { ExecOptions } from 'child_process';
+
+/** Promisified exec for async child_process calls */
+const execAsync = promisify(exec);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ExecResult {
+  ok: boolean;
+  stdout?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a `gh` CLI command asynchronously and return stdout, or `null` on error.
+ * Errors are logged but never thrown — the caller decides how to proceed.
+ *
+ * This is the async replacement for the synchronous `execSync` patterns that
+ * were blocking the event loop during GitHub polling.
+ *
+ * @param command - Full CLI command string (e.g. "gh pr view 42 --repo owner/repo ...")
+ * @param options - Optional ExecOptions overrides (timeout defaults to 15s)
+ * @returns stdout string on success, or null on error
+ */
+export async function execGHAsync(
+  command: string,
+  options?: Partial<ExecOptions>,
+): Promise<string | null> {
+  try {
+    const result = await execAsync(command, {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      ...options,
+    });
+    return String(result.stdout);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Only log if it's not a benign "no PRs found" type error
+    if (!message.includes('no pull requests match')) {
+      console.error(`[execGHAsync] CLI error: ${message.slice(0, 200)}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Execute a CLI command asynchronously and return a structured result with
+ * ok/stdout/error fields. Suitable for callers that need to distinguish
+ * between success and failure and inspect stderr.
+ *
+ * @param command - Full CLI command string
+ * @param options - Optional ExecOptions overrides (timeout defaults to 15s)
+ * @returns ExecResult with ok, stdout, and error fields
+ */
+export async function execGHResult(
+  command: string,
+  options?: Partial<ExecOptions>,
+): Promise<ExecResult> {
+  try {
+    const result = await execAsync(command, {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      ...options,
+    });
+    return { ok: true, stdout: String(result.stdout) };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    let stderr = message;
+    if (err && typeof err === 'object' && 'stderr' in err) {
+      const rawStderr = (err as { stderr: string | Buffer }).stderr;
+      stderr = typeof rawStderr === 'string' ? rawStderr : rawStderr.toString('utf-8');
+    }
+    return { ok: false, error: stderr.trim() || message };
+  }
+}
+
+/**
+ * Execute a `git` command asynchronously and return trimmed stdout, or null on error.
+ * Convenience wrapper for git operations (e.g. detecting worktree branches).
+ *
+ * @param command - Full git command string (e.g. "git -C /path rev-parse --abbrev-ref HEAD")
+ * @param options - Optional ExecOptions overrides (timeout defaults to 5s)
+ * @returns Trimmed stdout on success, or null on error
+ */
+export async function execGitAsync(
+  command: string,
+  options?: Partial<ExecOptions>,
+): Promise<string | null> {
+  try {
+    const result = await execAsync(command, {
+      encoding: 'utf-8',
+      timeout: 5_000,
+      ...options,
+    });
+    const str = String(result.stdout).trim();
+    return str || null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/server/exec-gh.test.ts
+++ b/tests/server/exec-gh.test.ts
@@ -1,0 +1,198 @@
+// =============================================================================
+// Fleet Commander — exec-gh Utility Tests
+// =============================================================================
+// Tests for the shared async CLI execution utilities used by github-poller,
+// pr-service, and project-service.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock child_process.exec via promisify
+// ---------------------------------------------------------------------------
+
+const mockExec = vi.fn();
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+}));
+
+// We need to mock util.promisify to return our controllable mock.
+// Since exec-gh.ts calls promisify(exec) at module load, we control exec's
+// callback-based behavior via mockExec.
+vi.mock('util', async (importOriginal) => {
+  const original = await importOriginal<typeof import('util')>();
+  return {
+    ...original,
+    promisify: () => mockExec,
+  };
+});
+
+// Import after mocks
+const { execGHAsync, execGHResult, execGitAsync } = await import(
+  '../../src/server/utils/exec-gh.js'
+);
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// execGHAsync
+// =============================================================================
+
+describe('execGHAsync', () => {
+  it('returns stdout on success', async () => {
+    mockExec.mockResolvedValue({ stdout: '{"number": 42}\n', stderr: '' });
+
+    const result = await execGHAsync('gh pr view 42 --json number');
+
+    expect(result).toBe('{"number": 42}\n');
+    expect(mockExec).toHaveBeenCalledWith('gh pr view 42 --json number', {
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+  });
+
+  it('returns null on error', async () => {
+    mockExec.mockRejectedValue(new Error('gh not found'));
+
+    const result = await execGHAsync('gh pr view 42');
+
+    expect(result).toBeNull();
+  });
+
+  it('passes custom options through', async () => {
+    mockExec.mockResolvedValue({ stdout: 'ok', stderr: '' });
+
+    await execGHAsync('gh api repos/o/r', { timeout: 5000, cwd: '/tmp' });
+
+    expect(mockExec).toHaveBeenCalledWith('gh api repos/o/r', {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: '/tmp',
+    });
+  });
+
+  it('suppresses "no pull requests match" errors', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExec.mockRejectedValue(new Error('no pull requests match'));
+
+    await execGHAsync('gh pr list');
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('logs non-benign errors', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExec.mockRejectedValue(new Error('network timeout'));
+
+    await execGHAsync('gh pr list');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[execGHAsync]'),
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+// =============================================================================
+// execGHResult
+// =============================================================================
+
+describe('execGHResult', () => {
+  it('returns ok: true with stdout on success', async () => {
+    mockExec.mockResolvedValue({ stdout: 'merged', stderr: '' });
+
+    const result = await execGHResult('gh pr merge 42 --auto --squash');
+
+    expect(result).toEqual({ ok: true, stdout: 'merged' });
+  });
+
+  it('returns ok: false with error on failure', async () => {
+    mockExec.mockRejectedValue(new Error('merge conflict'));
+
+    const result = await execGHResult('gh pr merge 42 --auto --squash');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('merge conflict');
+  });
+
+  it('extracts stderr from error object when available', async () => {
+    const err = new Error('command failed') as Error & { stderr: string };
+    err.stderr = 'auto-merge is not allowed';
+    mockExec.mockRejectedValue(err);
+
+    const result = await execGHResult('gh pr merge 42');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('auto-merge is not allowed');
+  });
+
+  it('handles Buffer stderr', async () => {
+    const err = new Error('command failed') as Error & { stderr: Buffer };
+    err.stderr = Buffer.from('branch protection enabled');
+    mockExec.mockRejectedValue(err);
+
+    const result = await execGHResult('gh pr merge 42');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('branch protection enabled');
+  });
+});
+
+// =============================================================================
+// execGitAsync
+// =============================================================================
+
+describe('execGitAsync', () => {
+  it('returns trimmed stdout on success', async () => {
+    mockExec.mockResolvedValue({ stdout: 'feat/my-branch\n', stderr: '' });
+
+    const result = await execGitAsync('git rev-parse --abbrev-ref HEAD');
+
+    expect(result).toBe('feat/my-branch');
+  });
+
+  it('returns null on error', async () => {
+    mockExec.mockRejectedValue(new Error('not a git repo'));
+
+    const result = await execGitAsync('git rev-parse --is-inside-work-tree');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty stdout', async () => {
+    mockExec.mockResolvedValue({ stdout: '  \n', stderr: '' });
+
+    const result = await execGitAsync('git rev-parse --abbrev-ref HEAD');
+
+    expect(result).toBeNull();
+  });
+
+  it('uses 5s default timeout for git commands', async () => {
+    mockExec.mockResolvedValue({ stdout: 'main\n', stderr: '' });
+
+    await execGitAsync('git branch --show-current');
+
+    expect(mockExec).toHaveBeenCalledWith('git branch --show-current', {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
+  });
+
+  it('allows custom timeout override', async () => {
+    mockExec.mockResolvedValue({ stdout: 'main\n', stderr: '' });
+
+    await execGitAsync('git fetch', { timeout: 30_000 });
+
+    expect(mockExec).toHaveBeenCalledWith('git fetch', {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+  });
+});

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -4,6 +4,9 @@
 // Tests for the GitHubPoller service: PR state transitions, CI status
 // derivation, CI failure counting, merge detection, poll lifecycle, and
 // dependency resolution tracking.
+//
+// After issue #385, all gh/git CLI calls are async (via exec-gh.ts).
+// Tests mock the shared async utilities instead of child_process.execSync.
 // =============================================================================
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -64,10 +67,12 @@ vi.mock('../../src/server/services/issue-fetcher.js', () => ({
   getIssueFetcher: () => mockFetcher,
 }));
 
-// Mock child_process for execGH and detectWorktreeBranch
-const mockExecSync = vi.fn().mockReturnValue(null);
-vi.mock('child_process', () => ({
-  execSync: (...args: unknown[]) => mockExecSync(...args),
+// Mock the shared async exec utilities (replaces the old child_process mock)
+const mockExecGHAsync = vi.fn().mockResolvedValue(null);
+const mockExecGitAsync = vi.fn().mockResolvedValue(null);
+vi.mock('../../src/server/utils/exec-gh.js', () => ({
+  execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
+  execGitAsync: (...args: unknown[]) => mockExecGitAsync(...args),
 }));
 
 // Import after mocks
@@ -168,7 +173,7 @@ describe('PR state transitions', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'CLOSED',
         mergedAt: '2025-01-01T00:00:00Z',
@@ -205,7 +210,7 @@ describe('PR state transitions', () => {
     mockDb.getActiveTeams.mockReturnValue([team]);
     mockDb.getPullRequest.mockReturnValue(undefined);
 
-    mockExecSync.mockReturnValue(makeGHPRViewResult());
+    mockExecGHAsync.mockResolvedValue(makeGHPRViewResult());
 
     await githubPoller.poll();
 
@@ -237,7 +242,7 @@ describe('PR state transitions', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(makeGHPRViewResult());
+    mockExecGHAsync.mockResolvedValue(makeGHPRViewResult());
 
     await githubPoller.poll();
 
@@ -265,7 +270,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
@@ -296,7 +301,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
@@ -327,7 +332,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'deploy', conclusion: 'CANCELLED', status: 'COMPLETED' },
@@ -357,7 +362,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: null, status: 'IN_PROGRESS' },
@@ -387,7 +392,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({ statusCheckRollup: [] }),
     );
 
@@ -413,7 +418,7 @@ describe('CI status derivation', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'optional', conclusion: 'NEUTRAL' },
@@ -450,7 +455,7 @@ describe('CI failure counting', () => {
       ciFailCount: 1,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: 'FAILURE' },
@@ -482,7 +487,7 @@ describe('CI failure counting', () => {
       ciFailCount: 2,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: 'SUCCESS' },
@@ -514,7 +519,7 @@ describe('CI failure counting', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, phase: 'implementing' });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         statusCheckRollup: [
           { name: 'build', conclusion: 'FAILURE' },
@@ -552,15 +557,10 @@ describe('PR detection by branch', () => {
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
 
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('gh pr list')) {
-        return JSON.stringify([{ number: 55 }]);
-      }
-      if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
-        return 'feat/10-test\n';
-      }
-      return null;
-    });
+    // detectWorktreeBranch uses execGitAsync
+    mockExecGitAsync.mockResolvedValue('feat/10-test');
+    // detectPR uses execGHAsync
+    mockExecGHAsync.mockResolvedValue(JSON.stringify([{ number: 55 }]));
 
     await githubPoller.poll();
 
@@ -573,15 +573,8 @@ describe('PR detection by branch', () => {
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
 
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('gh pr list')) {
-        return JSON.stringify([]);
-      }
-      if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
-        return 'feat/10-test\n';
-      }
-      return null;
-    });
+    mockExecGitAsync.mockResolvedValue('feat/10-test');
+    mockExecGHAsync.mockResolvedValue(JSON.stringify([]));
 
     await githubPoller.poll();
 
@@ -605,10 +598,10 @@ describe('Error handling', () => {
     mockDb.getActiveTeams.mockReturnValue([team1, team2]);
 
     let callCount = 0;
-    mockExecSync.mockImplementation(() => {
+    mockExecGHAsync.mockImplementation(async () => {
       callCount++;
       if (callCount === 1) {
-        throw new Error('gh CLI timeout');
+        return null; // simulate gh CLI failure (returns null)
       }
       return makeGHPRViewResult({ number: 43 });
     });
@@ -627,20 +620,18 @@ describe('Error handling', () => {
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
 
-    mockExecSync.mockReturnValue('not valid json {{{');
+    mockExecGHAsync.mockResolvedValue('not valid json {{{');
 
     await expect(githubPoller.poll()).resolves.not.toThrow();
   });
 
-  it('handles gh CLI throwing error gracefully', async () => {
+  it('handles gh CLI returning null gracefully', async () => {
     const project = makeProject();
     const team = makeTeam({ prNumber: 42 });
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
 
-    mockExecSync.mockImplementation(() => {
-      throw new Error('gh not found');
-    });
+    mockExecGHAsync.mockResolvedValue(null);
 
     await expect(githubPoller.poll()).resolves.not.toThrow();
   });
@@ -665,7 +656,7 @@ describe('Auto-merge detection', () => {
       ciFailCount: 0,
     });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
       }),
@@ -801,7 +792,7 @@ describe('Merge detection SSE', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    mockExecSync.mockReturnValue(
+    mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'CLOSED',
         mergedAt: '2024-01-01T00:00:00Z',
@@ -819,5 +810,27 @@ describe('Merge detection SSE', () => {
       }),
       1,
     );
+  });
+});
+
+// =============================================================================
+// Branch detection (async)
+// =============================================================================
+
+describe('Branch detection', () => {
+  it('updates branch name when worktree branch differs from stored', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: null, branchName: 'old-branch', worktreeName: 'proj-10' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    // detectWorktreeBranch returns a different branch
+    mockExecGitAsync.mockResolvedValue('new-branch');
+    // detectPR returns empty
+    mockExecGHAsync.mockResolvedValue(JSON.stringify([]));
+
+    await githubPoller.poll();
+
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { branchName: 'new-branch' });
   });
 });


### PR DESCRIPTION
Closes #385

## Summary
- **Root cause**: Synchronous `execSync` calls to `gh` CLI and `git` in the GitHub poller, PR service, and project service blocked the Node.js event loop for 1-3s each, causing all HTTP requests (including trivial `GET /api/teams/:id`) to queue for up to ~44s
- Created shared async utility `src/server/utils/exec-gh.ts` with `execGHAsync`, `execGHResult`, `execGitAsync`
- Converted all hot-path sync calls in `github-poller.ts`, `pr-service.ts`, and `project-service.ts` to async
- Updated all route handlers and MCP tools to `await` the now-async service methods
- Left startup-only `execSync` calls untouched (they run once, not during request handling)

## Test plan
- [x] TypeScript compilation clean (no errors)
- [x] All 42 existing tests pass
- [x] 14 new tests for `exec-gh.ts` async utility
- [x] Updated `github-poller.test.ts` mocks for async pattern