### PR TITLE
Issue #388: Guard event collector against terminal state transitions

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1654,6 +1654,11 @@ export class FleetDatabase {
 
   /**
    * Record a team state transition for history/audit purposes.
+   *
+   * Safety net: validates that the team's current DB status matches
+   * fromStatus before inserting. If mismatched, logs a warning and
+   * skips the insert (does not throw). This catches stale-state races
+   * that slip past the event-collector guards.
    */
   insertTransition(data: {
     teamId: number;
@@ -1662,6 +1667,14 @@ export class FleetDatabase {
     trigger: string;
     reason: string;
   }): void {
+    // Validate fromStatus matches actual DB state
+    const team = this.getTeam(data.teamId);
+    if (team && team.status !== data.fromStatus) {
+      console.warn(
+        `[DB] insertTransition: fromStatus mismatch for team ${data.teamId}: expected ${data.fromStatus}, actual ${team.status}. Skipping.`
+      );
+      return;
+    }
     this.db.prepare(
       'INSERT INTO team_transitions (team_id, from_status, to_status, trigger, reason) VALUES (?, ?, ?, ?, ?)'
     ).run(data.teamId, data.fromStatus, data.toStatus, data.trigger, data.reason);

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -16,6 +16,7 @@
  */
 
 import type { TeamStatus } from '../../shared/types.js';
+import { TERMINAL_STATUSES } from '../../shared/types.js';
 import type { SSEEventType, SSEEventPayloads } from './sse-broker.js';
 import config from '../config.js';
 
@@ -205,6 +206,12 @@ export function processEvent(
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
 
+  // ── Terminal state guard ───────────────────────────────────────────
+  // Teams in terminal states (done, failed) must NOT be transitioned
+  // by hook events. The event data is still recorded (below) for
+  // debugging, but all transition logic is skipped.
+  const isTerminal = TERMINAL_STATUSES.has(team.status);
+
   // ── State transition: idle/stuck -> running on activity events ─────
   // Most events from an idle or stuck team prove it is alive and doing
   // work. However, dormancy-indicating events (stop, session_end) mean
@@ -218,35 +225,16 @@ export function processEvent(
   const DORMANCY_EVENTS = new Set(['stop', 'stop_failure', 'session_end']);
   const eventNameLower = payload.event.toLowerCase();
 
-  if ((team.status === 'idle' || team.status === 'stuck') && !DORMANCY_EVENTS.has(eventNameLower)) {
-    db.insertTransition({
-      teamId,
-      fromStatus: team.status,
-      toStatus: 'running',
-      trigger: 'hook',
-      reason: `Activity resumed (${payload.event} event received)`,
-    });
-    db.updateTeam(teamId, {
-      status: 'running',
-    });
-    sse.broadcast('team_status_changed', {
-      team_id: teamId,
-      status: 'running',
-      previous_status: team.status,
-    }, teamId);
-  }
-
-  // ── State transition: launching -> running only on session_start/subagent_start
-  // Other events during launching may be noise; wait for an actual session start.
-  if (team.status === 'launching') {
-    const evt = payload.event.toLowerCase();
-    if (evt === 'session_start' || evt === 'subagent_start') {
+  if (!isTerminal && (team.status === 'idle' || team.status === 'stuck') && !DORMANCY_EVENTS.has(eventNameLower)) {
+    // Re-read from DB to avoid stale state (another service may have transitioned the team)
+    const freshTeam = db.getTeamByWorktree(payload.team);
+    if (freshTeam && (freshTeam.status === 'idle' || freshTeam.status === 'stuck') && !TERMINAL_STATUSES.has(freshTeam.status)) {
       db.insertTransition({
         teamId,
-        fromStatus: 'launching',
+        fromStatus: freshTeam.status,
         toStatus: 'running',
         trigger: 'hook',
-        reason: `First ${evt} event received`,
+        reason: `Activity resumed (${payload.event} event received)`,
       });
       db.updateTeam(teamId, {
         status: 'running',
@@ -254,8 +242,35 @@ export function processEvent(
       sse.broadcast('team_status_changed', {
         team_id: teamId,
         status: 'running',
-        previous_status: 'launching',
+        previous_status: freshTeam.status,
       }, teamId);
+    }
+  }
+
+  // ── State transition: launching -> running only on session_start/subagent_start
+  // Other events during launching may be noise; wait for an actual session start.
+  if (!isTerminal && team.status === 'launching') {
+    const evt = payload.event.toLowerCase();
+    if (evt === 'session_start' || evt === 'subagent_start') {
+      // Re-read from DB to avoid stale state (launch timeout may have fired)
+      const freshTeam = db.getTeamByWorktree(payload.team);
+      if (freshTeam && freshTeam.status === 'launching') {
+        db.insertTransition({
+          teamId,
+          fromStatus: 'launching',
+          toStatus: 'running',
+          trigger: 'hook',
+          reason: `First ${evt} event received`,
+        });
+        db.updateTeam(teamId, {
+          status: 'running',
+        });
+        sse.broadcast('team_status_changed', {
+          team_id: teamId,
+          status: 'running',
+          previous_status: 'launching',
+        }, teamId);
+      }
     }
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,9 @@
 /** Team operational status */
 export type TeamStatus = 'queued' | 'launching' | 'running' | 'idle' | 'stuck' | 'done' | 'failed';
 
+/** Terminal statuses — teams in these states should not be transitioned by hook events */
+export const TERMINAL_STATUSES: ReadonlySet<TeamStatus> = new Set(['done', 'failed']);
+
 /** Team domain phase */
 export type TeamPhase = 'init' | 'analyzing' | 'implementing' | 'reviewing' | 'pr' | 'done' | 'blocked';
 

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -425,6 +425,175 @@ describe('State transitions', () => {
 });
 
 // =============================================================================
+// Terminal state guards (Issue #388)
+// =============================================================================
+
+describe('Terminal state guards', () => {
+  it('should NOT transition done team to running on activity event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'done' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'tool_use' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have inserted a transition or changed status
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('should NOT transition failed team to running on session_start', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'failed', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_start' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have inserted a transition or changed status
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('should NOT transition failed team to running on subagent_start', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'failed', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have inserted a transition or changed status
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('should still record events for terminal teams', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'done' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'notification' });
+
+    const result = processEvent(payload, db, sse);
+
+    // Event should still be inserted and broadcast
+    expect(result.processed).toBe(true);
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'Notification' }),
+    );
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_event',
+      expect.objectContaining({ event_type: 'Notification' }),
+    );
+    // No status transition should have occurred
+    expect(db.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('should still update lastEventAt for terminal teams', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'failed', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'tool_use' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ lastEventAt: expect.any(String) }),
+    );
+  });
+
+  it('should handle stale launching->failed race (fresh re-read prevents transition)', () => {
+    let callCount = 0;
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: team appears to be launching
+          return { id: 1, status: 'launching', phase: 'init' };
+        }
+        // Second call (fresh re-read): launch timeout already fired, team is now failed
+        return { id: 1, status: 'failed', phase: 'init' };
+      }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_start' });
+
+    processEvent(payload, db, sse);
+
+    // The fresh re-read should prevent the transition
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('should still allow legitimate launching->running transition', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'launching', phase: 'init' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'session_start' });
+
+    processEvent(payload, db, sse);
+
+    // The transition should proceed normally
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'launching',
+        toStatus: 'running',
+        trigger: 'hook',
+      }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'running' }),
+    );
+  });
+
+  it('should handle stale idle->done race (fresh re-read prevents transition)', () => {
+    let callCount = 0;
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return { id: 1, status: 'idle', phase: 'implementing' };
+        }
+        // Fresh re-read: poller already transitioned team to done
+        return { id: 1, status: 'done', phase: 'done' };
+      }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'tool_use' });
+
+    processEvent(payload, db, sse);
+
+    // The fresh re-read should prevent the transition
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+});
+
+// =============================================================================
 // tool_use throttling
 // =============================================================================
 


### PR DESCRIPTION
Closes #388

## Summary
- Add `TERMINAL_STATUSES` constant in `types.ts` as single source of truth for terminal states (`done`, `failed`)
- Guard `processEvent()` to skip all transition logic for teams in terminal states (still records events)
- Re-read team status from DB before `idle/stuck→running` and `launching→running` transitions to prevent stale-state race conditions
- Add `fromStatus` validation in `insertTransition()` as DB-layer safety net (warn + skip on mismatch)
- 8 new test cases covering terminal blocking, race conditions, and happy paths

## Test plan
- [x] All 604 server tests pass
- [x] Build succeeds (`npm run build`)
- [x] New tests cover: terminal state guard, stale-read race condition, event recording for terminal teams, legitimate transition preservation