### PR TITLE
Issue #393: Fix stuck detector tests to use updated idle/stuck thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ fleet-commander/
         event-collector.ts  # Hook event processing -> DB -> SSE broadcast
         github-poller.ts    # gh CLI polling (PRs, CI, merges) every 30s
         issue-fetcher.ts    # GraphQL issue fetch with 60s cache
-        stuck-detector.ts   # Idle (3min) and stuck (5min) detection
+        stuck-detector.ts   # Idle (5min) and stuck (10min) detection
         sse-broker.ts       # SSE connection management, 14 event types, 30s heartbeat
         usage-tracker.ts    # Usage percentage polling
         startup-recovery.ts # Recover team state on server restart
@@ -171,11 +171,11 @@ Plus one view: `v_team_dashboard` (joins teams + projects + PRs for the grid).
 |------------|---------|
 | `queued` -> `launching` | Slot available, spawn begins |
 | `launching` -> `running` | CC process started, first event received |
-| `running` -> `idle` | No events for 3 minutes |
+| `running` -> `idle` | No events for 5 minutes |
 | `running` -> `done` | Session ends normally |
 | `running` -> `failed` | Process crashes or exits non-zero |
 | `idle` -> `running` | New event received |
-| `idle` -> `stuck` | No events for 5 minutes |
+| `idle` -> `stuck` | No events for 10 minutes |
 | `stuck` -> `running` | New event received |
 
 Team ID format: `{project_slug}-{issue_number}` (used as worktree name).
@@ -205,8 +205,8 @@ The SSE broker emits 14 event types:
 |----------|---------|-------------|
 | `PORT` | `4680` | Server port |
 | `FLEET_HOST` | `0.0.0.0` | Network interface to bind to |
-| `FLEET_IDLE_THRESHOLD_MIN` | `3` | Minutes before idle status |
-| `FLEET_STUCK_THRESHOLD_MIN` | `5` | Minutes before stuck status |
+| `FLEET_IDLE_THRESHOLD_MIN` | `5` | Minutes before idle status |
+| `FLEET_STUCK_THRESHOLD_MIN` | `10` | Minutes before stuck status |
 | `FLEET_LAUNCH_TIMEOUT_MIN` | `5` | Minutes before a launching team is marked failed |
 | `FLEET_MAX_CI_FAILURES` | `3` | Unique CI failures before blocking |
 | `FLEET_EARLY_CRASH_THRESHOLD_SEC` | `120` | Seconds before a SubagentStop is considered an early crash |

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -8,8 +8,8 @@
 // (single source of truth for CI status).
 //
 // State machine transitions (from docs/state-machines.md):
-//   running   -> idle    after IDLE_THRESHOLD_MIN    (3 min default)
-//   idle      -> stuck   after STUCK_THRESHOLD_MIN   (5 min default)
+//   running   -> idle    after IDLE_THRESHOLD_MIN    (5 min default)
+//   idle      -> stuck   after STUCK_THRESHOLD_MIN   (10 min default)
 //   launching -> failed  after LAUNCH_TIMEOUT_MIN    (5 min default)
 // =============================================================================
 

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -44,8 +44,8 @@ vi.mock('../../src/server/utils/resolve-message.js', () => ({
 vi.mock('../../src/server/config.js', () => ({
   default: {
     stuckCheckIntervalMs: 60000,
-    idleThresholdMin: 3,
-    stuckThresholdMin: 5,
+    idleThresholdMin: 5,
+    stuckThresholdMin: 10,
     launchTimeoutMin: 5,
   },
 }));
@@ -237,7 +237,7 @@ describe('Existing idle/stuck detection', () => {
   it('transitions running -> idle when lastEventAt exceeds idle threshold', () => {
     const team = makeTeam({
       status: 'running',
-      lastEventAt: minutesAgo(4), // 4 min ago, past the 3 min idle threshold
+      lastEventAt: minutesAgo(6), // 6 min ago, past the 5 min idle threshold
     });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
@@ -256,7 +256,7 @@ describe('Existing idle/stuck detection', () => {
   it('transitions idle -> stuck when lastEventAt exceeds stuck threshold', () => {
     const team = makeTeam({
       status: 'idle',
-      lastEventAt: minutesAgo(6), // 6 min ago, past the 5 min stuck threshold
+      lastEventAt: minutesAgo(11), // 11 min ago, past the 10 min stuck threshold
     });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
@@ -281,20 +281,20 @@ describe('Idle nudge message', () => {
   it('sends idle_nudge message when running -> idle and resolveMessage returns a message', async () => {
     const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
     const mockedResolveMessage = vi.mocked(resolveMessage);
-    mockedResolveMessage.mockReturnValue('FC status check: idle for 4 minutes');
+    mockedResolveMessage.mockReturnValue('FC status check: idle for 6 minutes');
 
     const team = makeTeam({
       status: 'running',
-      lastEventAt: minutesAgo(4), // 4 min ago, past the 3 min idle threshold
+      lastEventAt: minutesAgo(6), // 6 min ago, past the 5 min idle threshold
     });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
     stuckDetector.check();
 
     expect(mockedResolveMessage).toHaveBeenCalledWith('idle_nudge', {
-      IDLE_MINUTES: '4',
+      IDLE_MINUTES: '6',
     });
-    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'FC status check: idle for 4 minutes', 'fc', 'idle_nudge');
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'FC status check: idle for 6 minutes', 'fc', 'idle_nudge');
 
     // Reset mock to default
     mockedResolveMessage.mockReturnValue(null);
@@ -307,7 +307,7 @@ describe('Idle nudge message', () => {
 
     const team = makeTeam({
       status: 'running',
-      lastEventAt: minutesAgo(4),
+      lastEventAt: minutesAgo(6),
     });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
@@ -327,7 +327,7 @@ describe('Idle nudge message', () => {
 
     const team = makeTeam({
       status: 'idle',
-      lastEventAt: minutesAgo(6),
+      lastEventAt: minutesAgo(11),
     });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
@@ -349,7 +349,7 @@ describe('Idle nudge message', () => {
 
     const team = makeTeam({
       status: 'running',
-      lastEventAt: minutesAgo(4),
+      lastEventAt: minutesAgo(6),
       prNumber: 42,
     });
     mockDb.getActiveTeams.mockReturnValue([team]);


### PR DESCRIPTION
Closes #393

## Summary
- Updated config mock in `stuck-detector.test.ts` from old thresholds (3/5 min) to current defaults (5/10 min)
- Adjusted all `minutesAgo()` calls: 4→6 for idle tests, 6→11 for stuck tests
- Updated assertion values to match new thresholds
- Fixed stale header comments in `stuck-detector.ts`
- Updated 5 threshold references in `CLAUDE.md`

## Test plan
- [x] All 16 stuck-detector tests pass
- [x] Build succeeds