### PR TITLE
Issue #390: Replace output buffer array.shift() with circular buffer

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -22,6 +22,7 @@ import { resolveClaudePath } from '../utils/resolve-claude-path.js';
 import type { Team, Project } from '../../shared/types.js';
 import { getUsageZone } from './usage-tracker.js';
 import { resolveMessage } from '../utils/resolve-message.js';
+import { CircularBuffer } from '../utils/circular-buffer.js';
 
 const execAsync = promisify(execCallback);
 
@@ -60,14 +61,6 @@ function summarizeEvent(event: StreamEvent): string {
 }
 
 // ---------------------------------------------------------------------------
-// Output buffer: circular array of last N lines per team
-// ---------------------------------------------------------------------------
-
-interface OutputBuffer {
-  lines: string[];
-}
-
-// ---------------------------------------------------------------------------
 // TeamManager
 // ---------------------------------------------------------------------------
 
@@ -80,7 +73,7 @@ interface TokenCounter {
 }
 
 export class TeamManager {
-  private outputBuffers: Map<number, OutputBuffer> = new Map();
+  private outputBuffers: Map<number, CircularBuffer<string>> = new Map();
   private childProcesses: Map<number, ChildProcess> = new Map();
   private stdinPipes: Map<number, Writable> = new Map();
   private parsedEvents: Map<number, StreamEvent[]> = new Map();
@@ -1051,11 +1044,11 @@ export class TeamManager {
       return [];
     }
 
-    if (lines && lines > 0 && lines < buffer.lines.length) {
-      return buffer.lines.slice(-lines);
+    if (lines && lines > 0 && lines < buffer.length) {
+      return buffer.last(lines);
     }
 
-    return [...buffer.lines];
+    return buffer.toArray();
   }
 
   // -------------------------------------------------------------------------
@@ -1822,7 +1815,7 @@ export class TeamManager {
   }
 
   private initOutputBuffer(teamId: number): void {
-    this.outputBuffers.set(teamId, { lines: [] });
+    this.outputBuffers.set(teamId, new CircularBuffer<string>(MAX_OUTPUT_LINES));
   }
 
   private captureOutput(teamId: number, child: ChildProcess): void {
@@ -1874,11 +1867,8 @@ export class TeamManager {
           const trimmed = line.trim();
           if (!trimmed) continue;
 
-          // Store raw line in output buffer
-          buffer.lines.push(line);
-          while (buffer.lines.length > MAX_OUTPUT_LINES) {
-            buffer.lines.shift();
-          }
+          // Store raw line in output buffer (O(1) circular overwrite)
+          buffer.push(line);
 
           // Try to parse as JSON (NDJSON from stream-json output)
           try {
@@ -1995,10 +1985,7 @@ export class TeamManager {
       child.stdout.on('end', () => {
         if (stdoutPartial.trim()) {
           const trimmed = stdoutPartial.trim();
-          buffer.lines.push(stdoutPartial);
-          while (buffer.lines.length > MAX_OUTPUT_LINES) {
-            buffer.lines.shift();
-          }
+          buffer.push(stdoutPartial);
           try {
             const event: StreamEvent = JSON.parse(trimmed);
             console.log(`[CC:${logPrefix}] ${event.type}: ${summarizeEvent(event)}`);
@@ -2053,10 +2040,7 @@ export class TeamManager {
         for (let idx = 0; idx < newLines.length; idx++) {
           const line = newLines[idx]!;
           if (line === '' && idx === newLines.length - 1) continue;
-          buffer.lines.push(line);
-          while (buffer.lines.length > MAX_OUTPUT_LINES) {
-            buffer.lines.shift();
-          }
+          buffer.push(line);
         }
       });
     }

--- a/src/server/utils/circular-buffer.ts
+++ b/src/server/utils/circular-buffer.ts
@@ -1,0 +1,95 @@
+// =============================================================================
+// Fleet Commander — CircularBuffer<T>
+// =============================================================================
+// A fixed-capacity ring buffer with O(1) push and ordered iteration.
+// Used by TeamManager to store the last N output lines per team without
+// the O(n) cost of Array.shift() on every line.
+// =============================================================================
+
+export class CircularBuffer<T> {
+  private readonly _buf: (T | undefined)[];
+  private readonly _capacity: number;
+  private _head: number = 0;   // next write position
+  private _count: number = 0;  // current number of items
+
+  constructor(capacity: number) {
+    if (capacity < 1) {
+      throw new Error('CircularBuffer capacity must be >= 1');
+    }
+    this._capacity = capacity;
+    this._buf = new Array<T | undefined>(capacity);
+  }
+
+  /** Current number of items in the buffer. */
+  get length(): number {
+    return this._count;
+  }
+
+  /** Maximum number of items the buffer can hold. */
+  get capacity(): number {
+    return this._capacity;
+  }
+
+  /** Push an item. When full, the oldest item is silently overwritten. O(1). */
+  push(item: T): void {
+    this._buf[this._head] = item;
+    this._head = (this._head + 1) % this._capacity;
+    if (this._count < this._capacity) {
+      this._count++;
+    }
+  }
+
+  /** Return all items in insertion order (oldest first). */
+  toArray(): T[] {
+    if (this._count === 0) return [];
+
+    const result: T[] = new Array(this._count);
+    // Start of the oldest item
+    const start = this._count < this._capacity
+      ? 0
+      : this._head; // when full, head points to oldest
+
+    for (let i = 0; i < this._count; i++) {
+      result[i] = this._buf[(start + i) % this._capacity] as T;
+    }
+    return result;
+  }
+
+  /**
+   * Return the last `n` items in insertion order (oldest of the n first).
+   * If n >= length, returns all items.
+   */
+  last(n: number): T[] {
+    if (n <= 0) return [];
+    if (n >= this._count) return this.toArray();
+
+    const result: T[] = new Array(n);
+    // _head points to the next write slot, so the newest item is at _head - 1.
+    // We want the last n items: indices [_head - n .. _head - 1] mod capacity.
+    const startIdx = (this._head - n + this._capacity) % this._capacity;
+    for (let i = 0; i < n; i++) {
+      result[i] = this._buf[(startIdx + i) % this._capacity] as T;
+    }
+    return result;
+  }
+
+  /** Reset the buffer to empty. */
+  clear(): void {
+    this._head = 0;
+    this._count = 0;
+    // Clear references for GC
+    this._buf.fill(undefined);
+  }
+
+  /**
+   * Convenience factory: create a CircularBuffer pre-filled with items.
+   * If items.length > capacity, only the last `capacity` items are kept.
+   */
+  static from<T>(items: T[], capacity: number): CircularBuffer<T> {
+    const buf = new CircularBuffer<T>(capacity);
+    for (const item of items) {
+      buf.push(item);
+    }
+    return buf;
+  }
+}

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { EventEmitter } from 'events';
 import type { Writable } from 'stream';
 import type { Team } from '../../src/shared/types.js';
+import { CircularBuffer } from '../../src/server/utils/circular-buffer.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
@@ -333,7 +334,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -363,7 +364,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -393,7 +394,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -418,7 +419,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const team = makeTeam({ id: 1, status: 'done' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -436,7 +437,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -457,7 +458,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
     const child = createMockChildProcess();
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -486,7 +487,7 @@ describe('TeamManager.attachProcessHandlers (error)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });
 
@@ -516,7 +517,7 @@ describe('TeamManager.attachProcessHandlers (error)', () => {
     const team = makeTeam({ id: 1, status: 'running' });
 
     (tm as any).childProcesses.set(1, child);
-    (tm as any).outputBuffers.set(1, { lines: [] });
+    (tm as any).outputBuffers.set(1, new CircularBuffer<string>(500));
     (tm as any).parsedEvents.set(1, []);
     (tm as any).stdinPipes.set(1, createMockStdin());
     (tm as any).tokenCounters.set(1, { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, costUsd: 0 });

--- a/tests/server/utils/circular-buffer.test.ts
+++ b/tests/server/utils/circular-buffer.test.ts
@@ -1,0 +1,216 @@
+// =============================================================================
+// Fleet Commander — CircularBuffer Unit Tests
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { CircularBuffer } from '../../../src/server/utils/circular-buffer.js';
+
+describe('CircularBuffer', () => {
+  // ---------------------------------------------------------------------------
+  // Construction
+  // ---------------------------------------------------------------------------
+
+  it('throws when capacity is 0', () => {
+    expect(() => new CircularBuffer(0)).toThrow('capacity must be >= 1');
+  });
+
+  it('throws when capacity is negative', () => {
+    expect(() => new CircularBuffer(-5)).toThrow('capacity must be >= 1');
+  });
+
+  it('starts empty', () => {
+    const buf = new CircularBuffer<string>(10);
+    expect(buf.length).toBe(0);
+    expect(buf.capacity).toBe(10);
+    expect(buf.toArray()).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // push + toArray (below capacity)
+  // ---------------------------------------------------------------------------
+
+  it('stores items below capacity', () => {
+    const buf = new CircularBuffer<number>(5);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('stores items at exact capacity', () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(10);
+    buf.push(20);
+    buf.push(30);
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual([10, 20, 30]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // push + toArray (wrapping / overwrite)
+  // ---------------------------------------------------------------------------
+
+  it('overwrites oldest when exceeding capacity', () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.push(4); // overwrites 1
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual([2, 3, 4]);
+  });
+
+  it('wraps around multiple times correctly', () => {
+    const buf = new CircularBuffer<number>(3);
+    for (let i = 1; i <= 10; i++) {
+      buf.push(i);
+    }
+    // Should contain the last 3: [8, 9, 10]
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual([8, 9, 10]);
+  });
+
+  it('capacity of 1 always keeps the newest item', () => {
+    const buf = new CircularBuffer<string>(1);
+    buf.push('a');
+    expect(buf.toArray()).toEqual(['a']);
+    buf.push('b');
+    expect(buf.toArray()).toEqual(['b']);
+    buf.push('c');
+    expect(buf.length).toBe(1);
+    expect(buf.toArray()).toEqual(['c']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // last()
+  // ---------------------------------------------------------------------------
+
+  it('last(0) returns empty array', () => {
+    const buf = new CircularBuffer<number>(5);
+    buf.push(1);
+    buf.push(2);
+    expect(buf.last(0)).toEqual([]);
+  });
+
+  it('last(n) returns last n items in order', () => {
+    const buf = new CircularBuffer<number>(10);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.push(4);
+    buf.push(5);
+    expect(buf.last(3)).toEqual([3, 4, 5]);
+    expect(buf.last(1)).toEqual([5]);
+  });
+
+  it('last(n) where n >= length returns all items', () => {
+    const buf = new CircularBuffer<number>(10);
+    buf.push(1);
+    buf.push(2);
+    expect(buf.last(5)).toEqual([1, 2]);
+    expect(buf.last(2)).toEqual([1, 2]);
+  });
+
+  it('last() works correctly after wrapping', () => {
+    const buf = new CircularBuffer<number>(3);
+    for (let i = 1; i <= 7; i++) {
+      buf.push(i);
+    }
+    // Buffer contains [5, 6, 7]
+    expect(buf.last(2)).toEqual([6, 7]);
+    expect(buf.last(3)).toEqual([5, 6, 7]);
+    expect(buf.last(1)).toEqual([7]);
+  });
+
+  it('last() on empty buffer returns empty', () => {
+    const buf = new CircularBuffer<number>(5);
+    expect(buf.last(3)).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // clear()
+  // ---------------------------------------------------------------------------
+
+  it('clear resets the buffer', () => {
+    const buf = new CircularBuffer<number>(5);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.clear();
+    expect(buf.length).toBe(0);
+    expect(buf.toArray()).toEqual([]);
+    expect(buf.capacity).toBe(5);
+  });
+
+  it('push works correctly after clear', () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.clear();
+    buf.push(10);
+    buf.push(20);
+    expect(buf.length).toBe(2);
+    expect(buf.toArray()).toEqual([10, 20]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // static from()
+  // ---------------------------------------------------------------------------
+
+  it('from() creates a buffer pre-filled with items', () => {
+    const buf = CircularBuffer.from([1, 2, 3], 5);
+    expect(buf.length).toBe(3);
+    expect(buf.capacity).toBe(5);
+    expect(buf.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('from() with more items than capacity keeps the last N', () => {
+    const buf = CircularBuffer.from([1, 2, 3, 4, 5], 3);
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual([3, 4, 5]);
+  });
+
+  it('from() with empty array creates empty buffer', () => {
+    const buf = CircularBuffer.from<number>([], 5);
+    expect(buf.length).toBe(0);
+    expect(buf.toArray()).toEqual([]);
+  });
+
+  it('from() with exactly capacity items fills the buffer', () => {
+    const buf = CircularBuffer.from(['a', 'b', 'c'], 3);
+    expect(buf.length).toBe(3);
+    expect(buf.toArray()).toEqual(['a', 'b', 'c']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // toArray returns a new copy
+  // ---------------------------------------------------------------------------
+
+  it('toArray returns a fresh array each time', () => {
+    const buf = new CircularBuffer<number>(5);
+    buf.push(1);
+    buf.push(2);
+    const a = buf.toArray();
+    const b = buf.toArray();
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Generic type support
+  // ---------------------------------------------------------------------------
+
+  it('works with object types', () => {
+    interface Item { id: number; name: string }
+    const buf = new CircularBuffer<Item>(2);
+    buf.push({ id: 1, name: 'alpha' });
+    buf.push({ id: 2, name: 'beta' });
+    buf.push({ id: 3, name: 'gamma' });
+    expect(buf.toArray()).toEqual([
+      { id: 2, name: 'beta' },
+      { id: 3, name: 'gamma' },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #390

## Summary
- Added generic `CircularBuffer<T>` class (`src/server/utils/circular-buffer.ts`) with O(1) push that overwrites oldest entries when full
- Replaced all 3 `push()+while+shift()` patterns in `team-manager.ts` with `buffer.push()` — eliminates O(n) re-indexing on every line
- Updated `getOutput()` to use `buffer.last(n)` / `buffer.toArray()` instead of array slicing
- 21 new unit tests for CircularBuffer, 8 existing test sites updated

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 42 team-manager lifecycle tests pass
- [x] 21 new circular-buffer unit tests pass
- [ ] CI green