### PR TITLE
Issue #369: Add CI verification for version stamps in templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build native dependencies
         run: npm rebuild better-sqlite3
 
+      - name: Verify version stamps
+        run: bash scripts/verify-version-stamps.sh
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build native dependencies
         run: npm rebuild better-sqlite3
 
+      - name: Verify version stamps
+        run: bash scripts/verify-version-stamps.sh
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/hooks/on_notification.sh
+++ b/hooks/on_notification.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: Notification
 # Detects idle prompts, permission prompts, and other notifications.
 # These are important for detecting teams that are stuck waiting for input.

--- a/hooks/on_post_tool_use.sh
+++ b/hooks/on_post_tool_use.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: PostToolUse
 # THE primary heartbeat signal. Every tool use proves the team is alive.
 # Dashboard uses this to compute "last_seen" for stuck detection.

--- a/hooks/on_pre_compact.sh
+++ b/hooks/on_pre_compact.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: PreCompact
 # Fires when context window is about to be compacted.
 # This is a leading indicator of context pressure — the agent is running

--- a/hooks/on_session_end.sh
+++ b/hooks/on_session_end.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: SessionEnd
 # Detects team finish. Clean shutdown signal.
 # stdin JSON example: {"session_id":"abc123"}

--- a/hooks/on_session_start.sh
+++ b/hooks/on_session_start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: SessionStart
 # Detects team startup. Captures session_id, worktree, model info.
 # stdin JSON example: {"session_id":"abc123","agent_type":"main"}

--- a/hooks/on_stop.sh
+++ b/hooks/on_stop.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: Stop
 # Fires when the main agent stops — could mean task complete, error, or stuck.
 # stdin JSON example: {"session_id":"abc123","stop_reason":"end_turn"}

--- a/hooks/on_stop_failure.sh
+++ b/hooks/on_stop_failure.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: StopFailure
 # Fires when the agent stops due to rate limits or API errors.
 # stdin JSON example: {"session_id":"abc123","error_details":"rate_limit","last_assistant_message":"..."}

--- a/hooks/on_subagent_start.sh
+++ b/hooks/on_subagent_start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: SubagentStart
 # Tracks internal team agent spawn (e.g., kea-csharp-dev joining the team).
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}

--- a/hooks/on_subagent_stop.sh
+++ b/hooks/on_subagent_stop.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: SubagentStop
 # Tracks internal team agent departure.
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}

--- a/hooks/on_teammate_idle.sh
+++ b/hooks/on_teammate_idle.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: TeammateIdle
 # Fires when a subagent goes idle. Provides explicit per-subagent idle tracking.
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev"}

--- a/hooks/on_tool_error.sh
+++ b/hooks/on_tool_error.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# fleet-commander v0.0.6
 # Fleet Commander hook: PostToolUseFailure (aliased as "tool_error")
 # Tracks tool failures — repeated errors indicate the team is struggling.
 # stdin JSON example: {"session_id":"abc123","tool_name":"Bash","error":"exit code 1","tool_use_id":"toolu_123"}

--- a/hooks/send_event.sh
+++ b/hooks/send_event.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# fleet-commander v0.0.6
 # Fleet Commander: Universal event sender for Claude Code hooks.
 # POSTs a JSON event to the Fleet Commander dashboard server.
 #

--- a/prompts/default-prompt.md
+++ b/prompts/default-prompt.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 Read the ENTIRE file `.claude/prompts/fleet-workflow.md` before taking any actions.
 
 You are the Team Lead (TL). Your job:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,24 +75,12 @@ echo ""
 HOOK_DIR="$TARGET/.claude/hooks/fleet-commander"
 mkdir -p "$HOOK_DIR"
 
-# Copy all .sh files from the hooks directory with version stamps
+# Copy all .sh files from the hooks directory, updating version stamps.
+# Source files already carry a stamp on line 2; replace it with the install-time version.
 for SH_FILE in "$FC_ROOT/hooks/"*.sh; do
   [ -f "$SH_FILE" ] || continue
   SH_NAME="$(basename "$SH_FILE")"
-  # Insert version stamp AFTER the shebang line (shebang must stay on line 1)
-  FIRST_LINE="$(head -1 "$SH_FILE")"
-  if echo "$FIRST_LINE" | grep -q '^#!'; then
-    {
-      echo "$FIRST_LINE"
-      echo "# fleet-commander v${FC_VERSION}"
-      tail -n +2 "$SH_FILE"
-    } > "$HOOK_DIR/$SH_NAME"
-  else
-    {
-      echo "# fleet-commander v${FC_VERSION}"
-      cat "$SH_FILE"
-    } > "$HOOK_DIR/$SH_NAME"
-  fi
+  sed "2s|^# fleet-commander v.*|# fleet-commander v${FC_VERSION}|" "$SH_FILE" > "$HOOK_DIR/$SH_NAME"
 done
 # Ensure LF line endings — bash on Windows chokes on CRLF shebangs
 sed -i 's/\r$//' "$HOOK_DIR/"*.sh
@@ -166,10 +154,13 @@ if [ -z "$BASE_BRANCH" ]; then
   BASE_BRANCH="main"
 fi
 
-# Copy workflow template with placeholder replacement + version stamp
+# Copy workflow template with placeholder replacement + version stamp.
+# Source file already carries a stamp on line 1; strip it before replacement
+# and prepend the install-time version stamp.
 WORKFLOW_TARGET="$PROMPTS_DIR/fleet-workflow.md"
 VERSION_STAMP="<!-- fleet-commander v${FC_VERSION} -->"
-TEMPLATE_CONTENT=$(sed -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+TEMPLATE_CONTENT=$(sed -e '1{/^<!-- fleet-commander v/d}' \
+    -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
     -e "s|{{project_slug}}|$project_slug|g" \
     -e "s|{{BASE_BRANCH}}|$BASE_BRANCH|g" \
     "$FC_ROOT/templates/workflow.md")
@@ -212,13 +203,12 @@ if [ -d "$AGENTS_SRC" ]; then
   for AGENT_FILE in "$AGENTS_SRC"/*.md; do
     [ -f "$AGENT_FILE" ] || continue
     AGENT_NAME="$(basename "$AGENT_FILE")"
-    {
-      echo "<!-- fleet-commander v${FC_VERSION} -->"
-      sed -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
-          -e "s|{{project_slug}}|$project_slug|g" \
-          -e "s|{{BASE_BRANCH}}|$BASE_BRANCH|g" \
-          "$AGENT_FILE"
-    } > "$AGENTS_DIR/$AGENT_NAME"
+    # Source files already carry a stamp on line 1; replace it with install-time version
+    sed -e "1s|^<!-- fleet-commander v.* -->|<!-- fleet-commander v${FC_VERSION} -->|" \
+        -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
+        -e "s|{{project_slug}}|$project_slug|g" \
+        -e "s|{{BASE_BRANCH}}|$BASE_BRANCH|g" \
+        "$AGENT_FILE" > "$AGENTS_DIR/$AGENT_NAME"
     AGENT_COUNT=$((AGENT_COUNT + 1))
   done
   echo "  Installed $AGENT_COUNT agent templates to $AGENTS_DIR (v${FC_VERSION})"
@@ -237,10 +227,9 @@ if [ -d "$GUIDES_SRC" ]; then
     [ -f "$GUIDE_FILE" ] || continue
     GUIDE_NAME="$(basename "$GUIDE_FILE")"
     if [ ! -f "$GUIDES_DIR/$GUIDE_NAME" ]; then
-      {
-        echo "<!-- fleet-commander v${FC_VERSION} -->"
-        cat "$GUIDE_FILE"
-      } > "$GUIDES_DIR/$GUIDE_NAME"
+      # Source files already carry a stamp on line 1; replace it with install-time version
+      sed "1s|^<!-- fleet-commander v.* -->|<!-- fleet-commander v${FC_VERSION} -->|" \
+          "$GUIDE_FILE" > "$GUIDES_DIR/$GUIDE_NAME"
       GUIDE_COUNT=$((GUIDE_COUNT + 1))
     fi
   done

--- a/scripts/verify-version-stamps.sh
+++ b/scripts/verify-version-stamps.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Verify that all template, hook, and prompt files carry a version stamp
+# matching the version in package.json.
+#
+# Usage: bash scripts/verify-version-stamps.sh
+#   Exits 0 if all stamps match, 1 if any mismatch is found.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PKG_VERSION="$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).version)" "$ROOT/package.json")"
+ERRORS=0
+
+echo "Verifying version stamps match package.json v${PKG_VERSION} ..."
+
+# ── Check markdown files (.md) ──────────────────────────────────
+# Expected first line: <!-- fleet-commander vX.Y.Z -->
+check_md() {
+  local file="$1"
+  local rel="${file#$ROOT/}"
+  local first_line
+  first_line="$(head -1 "$file")"
+  local expected="<!-- fleet-commander v${PKG_VERSION} -->"
+  if [ "$first_line" != "$expected" ]; then
+    echo "::error file=${rel}::Version stamp mismatch: expected '${expected}', got '${first_line}'"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# ── Check shell files (.sh) ─────────────────────────────────────
+# Expected second line: # fleet-commander vX.Y.Z
+check_sh() {
+  local file="$1"
+  local rel="${file#$ROOT/}"
+  local second_line
+  second_line="$(sed -n '2p' "$file")"
+  local expected="# fleet-commander v${PKG_VERSION}"
+  if [ "$second_line" != "$expected" ]; then
+    echo "::error file=${rel}::Version stamp mismatch: expected '${expected}', got '${second_line}'"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# ── Markdown files to check ─────────────────────────────────────
+for f in "$ROOT"/templates/agents/*.md; do
+  [ -f "$f" ] || continue
+  check_md "$f"
+done
+
+for f in "$ROOT"/templates/guides/*.md; do
+  [ -f "$f" ] || continue
+  check_md "$f"
+done
+
+check_md "$ROOT/templates/workflow.md"
+check_md "$ROOT/prompts/default-prompt.md"
+
+# ── Shell files to check ────────────────────────────────────────
+for f in "$ROOT"/hooks/*.sh; do
+  [ -f "$f" ] || continue
+  check_sh "$f"
+done
+
+# ── Summary ──────────────────────────────────────────────────────
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "FAILED: ${ERRORS} file(s) have mismatched version stamps."
+  exit 1
+else
+  echo "OK: All version stamps match v${PKG_VERSION}."
+  exit 0
+fi

--- a/templates/agents/fleet-dev.md
+++ b/templates/agents/fleet-dev.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 ---
 name: fleet-dev
 description: Generalist developer agent. Dynamically specializes via guidebook files provided in the planner's plan. Handles any language, framework, or infrastructure work.

--- a/templates/agents/fleet-planner.md
+++ b/templates/agents/fleet-planner.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 ---
 name: fleet-planner
 model: inherit

--- a/templates/agents/fleet-reviewer.md
+++ b/templates/agents/fleet-reviewer.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 ---
 name: fleet-reviewer
 description: Code reviewer with direct p2p dev communication. Two-pass review (code quality + acceptance criteria). READ-ONLY — never edits files.

--- a/templates/guides/api-design.md
+++ b/templates/guides/api-design.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # API Design Conventions
 
 > Applies to: REST API route handlers, request/response schemas, middleware

--- a/templates/guides/csharp-conventions.md
+++ b/templates/guides/csharp-conventions.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # C# / .NET Conventions
 
 > Applies to: `*.cs`, `*.csproj`, `Directory.Build.props`

--- a/templates/guides/devops-conventions.md
+++ b/templates/guides/devops-conventions.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # DevOps / Infrastructure Conventions
 
 > Applies to: `.github/workflows/*.yml`, `Dockerfile`, `docker-compose.yml`, `*.sh`, `*.ps1`, `Makefile`

--- a/templates/guides/fsharp-conventions.md
+++ b/templates/guides/fsharp-conventions.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # F# Conventions
 
 > Applies to: `*.fs`, `*.fsi`, `*.fsx`, `*.fsproj`

--- a/templates/guides/python-conventions.md
+++ b/templates/guides/python-conventions.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # Python Conventions
 
 > Applies to: `*.py`, `pyproject.toml`, `requirements.txt`, `setup.cfg`

--- a/templates/guides/sql-database.md
+++ b/templates/guides/sql-database.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # SQL & Database Conventions
 
 > Applies to: `*.sql`, migration files, ORM model definitions, database access code

--- a/templates/guides/testing-strategies.md
+++ b/templates/guides/testing-strategies.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # Testing Strategies
 
 > Applies to: all test files regardless of language or framework

--- a/templates/guides/typescript-conventions.md
+++ b/templates/guides/typescript-conventions.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 # TypeScript / JavaScript Conventions
 
 > Applies to: `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `package.json`, `tsconfig.json`

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -1,3 +1,4 @@
+<!-- fleet-commander v0.0.6 -->
 <!-- Fleet Commander workflow template. Installed by Fleet Commander into your project. -->
 <!-- Placeholders {{PROJECT_NAME}}, {{project_slug}}, {{BASE_BRANCH}}, {{ISSUE_NUMBER}} are replaced during installation. -->
 


### PR DESCRIPTION
Closes #369

## Summary
- Add version stamps (`<!-- fleet-commander v0.0.6 -->` for markdown, `# fleet-commander v0.0.6` for shell) to all 25 template/hook/prompt source files
- New `scripts/verify-version-stamps.sh` that checks all stamps match `package.json` version, with `::error::` GitHub Actions annotations on mismatch
- Added "Verify version stamps" CI step to both `release.yml` (before publish) and `ci.yml` (before typecheck)
- Updated `scripts/install.sh` to replace existing stamps via sed instead of prepending, preventing double-stamping on re-install

## Test plan
- [ ] `bash scripts/verify-version-stamps.sh` exits 0 locally
- [ ] CI passes on this PR (stamp check + existing tests)
- [ ] Changing a stamp in one file and running the script shows `::error::` and exits 1