### PR TITLE
Issue #383: Fix Ctrl+C not killing fleet-commander process on Windows

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ import { recoverOnStartup } from './services/startup-recovery.js';
 import { usagePoller } from './services/usage-tracker.js';
 import config from './config.js';
 import { resolveClaudePath } from './utils/resolve-claude-path.js';
+import { getTeamManager } from './services/team-manager.js';
 import { DEFAULT_MESSAGE_TEMPLATES } from '../shared/message-templates.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -34,6 +35,7 @@ const __dirname = path.dirname(__filename);
 async function main() {
   const server = Fastify({
     logger: { level: config.logLevel },
+    forceCloseConnections: true,
   });
 
   // Centralized error handler
@@ -154,10 +156,17 @@ async function main() {
     }, 5000);
     forceTimer.unref();
 
-    // Close SSE connections BEFORE server.close() so the HTTP server
-    // doesn't hang waiting for long-lived connections to end.
-    sseBroker.stop();
+    // Kill all child processes immediately so their stdio streams don't
+    // keep the event loop alive. This is the fast-path for server shutdown.
+    try {
+      getTeamManager().killAll();
+    } catch {
+      // Ignore errors — best-effort cleanup
+    }
 
+    // server.close() triggers the onClose hook which stops SSE broker,
+    // pollers, and closes the database. forceCloseConnections: true
+    // ensures open SSE sockets are destroyed immediately.
     try {
       await server.close();
     } catch {

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -101,10 +101,11 @@ class SSEBroker {
       this.heartbeatInterval = null;
     }
 
-    // Close all client connections
+    // Close all client connections — use destroy() for immediate socket
+    // teardown without waiting for a graceful FIN/ACK handshake.
     for (const [id, client] of this.clients) {
       try {
-        client.reply.raw.end();
+        client.reply.raw.destroy();
       } catch {
         // Client may already be disconnected — ignore
       }

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -614,6 +614,58 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // killAll — immediately kill all child processes (server shutdown fast-path)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Immediately kill all tracked child processes without waiting for graceful
+   * shutdown. This is the fast-path used during server shutdown (Ctrl+C) to
+   * ensure the Node.js event loop can exit promptly.
+   *
+   * Unlike stopAll(), this method:
+   * - Does NOT wait for graceful stdin EOF / 5s timeout per team
+   * - Does NOT update the database or broadcast SSE events
+   * - DOES unref all stdio streams so they don't keep the event loop alive
+   */
+  killAll(): void {
+    // Clear any pending merge-shutdown timers
+    this.clearShutdownTimers();
+
+    for (const [teamId, child] of this.childProcesses) {
+      try {
+        // Destroy stdio streams so they stop holding the event loop
+        if (child.stdin && !child.stdin.destroyed) {
+          child.stdin.destroy();
+        }
+        if (child.stdout) {
+          child.stdout.destroy();
+        }
+        if (child.stderr) {
+          child.stderr.destroy();
+        }
+
+        // Kill the process tree
+        if (child.pid) {
+          this.killProcess(child.pid);
+        }
+
+        // Unref the child process itself so it doesn't block exit
+        child.unref();
+      } catch {
+        // Ignore errors during shutdown — best-effort cleanup
+      }
+    }
+
+    // Clear all tracking maps
+    this.childProcesses.clear();
+    this.stdinPipes.clear();
+    this.outputBuffers.clear();
+    this.parsedEvents.clear();
+    this.tokenCounters.clear();
+    this.agentMaps.clear();
+  }
+
+  // -------------------------------------------------------------------------
   // queueTeam — insert a team with 'queued' status without spawning
   // -------------------------------------------------------------------------
 

--- a/tests/server/sse-broker.test.ts
+++ b/tests/server/sse-broker.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 interface MockRaw {
   write: ReturnType<typeof vi.fn>;
   end: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
 }
 
 interface MockReply {
@@ -30,6 +31,7 @@ function createMockReply(): MockReply {
     raw: {
       write: vi.fn().mockReturnValue(true),
       end: vi.fn(),
+      destroy: vi.fn(),
     },
   };
 }
@@ -258,7 +260,7 @@ describe('Heartbeat timer', () => {
     sseBroker.stop();
 
     expect(sseBroker.getClientCount()).toBe(0);
-    expect(reply.raw.end).toHaveBeenCalled();
+    expect(reply.raw.destroy).toHaveBeenCalled();
   });
 
   it('sends heartbeat events at interval', async () => {


### PR DESCRIPTION
Closes #383

## Summary
- Add `forceCloseConnections: true` to Fastify options so `server.close()` forcibly destroys open SSE sockets
- Change `end()` to `destroy()` in SSE broker's `stop()` method for immediate socket teardown
- Add `killAll()` method to TeamManager that destroys stdio streams, kills process trees, and unrefs child processes
- Call `killAll()` in the shutdown signal handler before `server.close()`
- Remove redundant `sseBroker.stop()` from signal handler (already called via Fastify `onClose` hook)
- Update SSE broker tests to match `destroy()` change

## Test plan
- [x] All 648 server tests pass
- [x] TypeScript compiles without errors
- [ ] Manual test: run fleet-commander on Windows, press Ctrl+C — process should exit cleanly within 5s