### PR TITLE
Issue #395: Store fleet.db in platform user data directory instead of CWD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ The SSE broker emits 14 event types:
 | `FLEET_EARLY_CRASH_THRESHOLD_SEC` | `120` | Seconds before a SubagentStop is considered an early crash |
 | `FLEET_EARLY_CRASH_MIN_TOOLS` | `5` | Minimum tool-use events for a subagent to be considered healthy |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub poll interval |
-| `FLEET_DB_PATH` | `./fleet.db` | Database file location |
+| `FLEET_DB_PATH` | (platform data dir) | Database file location. Defaults to platform user data dir |
 | `FLEET_TERMINAL` | `auto` | Windows terminal preference (`auto`/`wt`/`cmd`) |
 | `FLEET_CLAUDE_CMD` | `claude` | Claude Code CLI command |
 | `FLEET_SKIP_PERMISSIONS` | `true` | Skip CC permission prompts |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,7 +1,33 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+/**
+ * Return the platform-appropriate default path for the Fleet Commander database.
+ *
+ * - Windows:  %APPDATA%\fleet-commander\fleet.db
+ * - macOS:    ~/Library/Application Support/fleet-commander/fleet.db
+ * - Linux:    $XDG_DATA_HOME/fleet-commander/fleet.db  (default ~/.local/share)
+ */
+export function defaultDbPath(): string {
+  const DB_NAME = 'fleet.db';
+  const APP_DIR = 'fleet-commander';
+
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
+    return path.join(appData, APP_DIR, DB_NAME);
+  }
+
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', APP_DIR, DB_NAME);
+  }
+
+  // Linux / other
+  const dataHome = process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share');
+  return path.join(dataHome, APP_DIR, DB_NAME);
+}
 
 /**
  * Determine the Fleet Commander package root directory.
@@ -90,7 +116,7 @@ const config = Object.freeze({
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',
   enableAgentTeams: process.env['FLEET_ENABLE_AGENT_TEAMS'] !== 'false',
 
-  dbPath: process.env['FLEET_DB_PATH'] || path.join(fleetCommanderRoot, 'fleet.db'),
+  dbPath: process.env['FLEET_DB_PATH'] || defaultDbPath(),
 
   logLevel: process.env['LOG_LEVEL'] || 'info',
 
@@ -119,6 +145,9 @@ const config = Object.freeze({
    */
   terminalCmd: (process.env['FLEET_TERMINAL'] || 'auto') as 'auto' | 'wt' | 'cmd',
 });
+
+// Ensure the database directory exists before any DB access
+fs.mkdirSync(path.dirname(config.dbPath), { recursive: true });
 
 // Validate config
 export function validateConfig(): void {

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -251,9 +251,8 @@ export interface AgentMessageInsert {
 export class FleetDatabase {
   private db: Database.Database;
 
-  constructor(dbPath?: string) {
-    const resolvedPath = dbPath ?? process.env['FLEET_DB_PATH'] ?? 'fleet.db';
-    this.db = new Database(resolvedPath);
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
 
     // Enable WAL mode for better concurrent read performance
     this.db.pragma('journal_mode = WAL');
@@ -1956,10 +1955,13 @@ let _instance: FleetDatabase | null = null;
 
 /**
  * Get or create the singleton database instance.
- * Call with a path to override the default on first use.
+ * A dbPath is required on the first call; subsequent calls return the existing instance.
  */
 export function getDatabase(dbPath?: string): FleetDatabase {
   if (!_instance) {
+    if (!dbPath) {
+      throw new Error('getDatabase() requires a dbPath argument on first call');
+    }
     _instance = new FleetDatabase(dbPath);
     _instance.initSchema();
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -75,7 +75,7 @@ async function main() {
   }
 
   // Initialize default message templates from the standalone template list
-  const db = getDatabase();
+  const db = getDatabase(config.dbPath);
   db.initDefaultTemplates(
     DEFAULT_MESSAGE_TEMPLATES.map((t) => ({ id: t.id, template: t.template }))
   );

--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -71,7 +71,7 @@ export async function startMcpServer(): Promise<void> {
   registerLaunchTeamTool(mcpServer);
 
   // Initialize database
-  const db = getDatabase();
+  const db = getDatabase(config.dbPath);
   db.initDefaultTemplates(
     DEFAULT_MESSAGE_TEMPLATES.map((t) => ({ id: t.id, template: t.template })),
   );

--- a/tests/server/config.test.ts
+++ b/tests/server/config.test.ts
@@ -3,7 +3,8 @@
 // =============================================================================
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { safeParseInt, validateConfig } from '../../src/server/config.js';
+import path from 'path';
+import { safeParseInt, validateConfig, defaultDbPath } from '../../src/server/config.js';
 
 // ---------------------------------------------------------------------------
 // safeParseInt
@@ -119,5 +120,55 @@ describe('safeParseInt edge cases', () => {
   it('handles large numbers', () => {
     expect(safeParseInt('300000', 'TEST')).toBe(300000);
     expect(safeParseInt('65535', 'TEST')).toBe(65535);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultDbPath
+// ---------------------------------------------------------------------------
+
+describe('defaultDbPath', () => {
+  it('returns an absolute path', () => {
+    expect(path.isAbsolute(defaultDbPath())).toBe(true);
+  });
+
+  it('contains the fleet-commander directory segment', () => {
+    const dbPath = defaultDbPath();
+    expect(dbPath).toContain('fleet-commander');
+  });
+
+  it('ends with fleet.db', () => {
+    const dbPath = defaultDbPath();
+    expect(dbPath.endsWith('fleet.db')).toBe(true);
+  });
+
+  it('returns a path under the platform data directory', () => {
+    const dbPath = defaultDbPath();
+    if (process.platform === 'win32') {
+      // Should be under APPDATA or the fallback AppData\Roaming
+      expect(dbPath).toMatch(/AppData/i);
+    } else if (process.platform === 'darwin') {
+      expect(dbPath).toContain(path.join('Library', 'Application Support'));
+    } else {
+      // Linux: should be under XDG_DATA_HOME or ~/.local/share
+      expect(dbPath).toMatch(/\.local[/\\]share|XDG_DATA_HOME/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FLEET_DB_PATH env override
+// ---------------------------------------------------------------------------
+
+describe('FLEET_DB_PATH env override', () => {
+  it('config.dbPath respects FLEET_DB_PATH when set', async () => {
+    const mod = await import('../../src/server/config.js');
+    // If FLEET_DB_PATH is set in the env, config should use it;
+    // otherwise it should use the platform default
+    if (process.env['FLEET_DB_PATH']) {
+      expect(mod.default.dbPath).toBe(process.env['FLEET_DB_PATH']);
+    } else {
+      expect(mod.default.dbPath).toBe(defaultDbPath());
+    }
   });
 });


### PR DESCRIPTION
Closes #395

## Summary
- Replace CWD-relative `./fleet.db` default with platform-standard user data directories:
  - **Windows:** `%APPDATA%\fleet-commander\fleet.db`
  - **macOS:** `~/Library/Application Support/fleet-commander/fleet.db`
  - **Linux:** `$XDG_DATA_HOME/fleet-commander/fleet.db`
- Auto-create the database directory on startup via `fs.mkdirSync({ recursive: true })`
- Make `FleetDatabase` constructor require an explicit `dbPath` argument (remove dangerous fallback)
- `FLEET_DB_PATH` env var still works as override for custom setups

## Changes
- `src/server/config.ts` — Added exported `defaultDbPath()` with platform detection + directory creation
- `src/server/db.ts` — Constructor now requires `dbPath: string`, `getDatabase()` throws if no path on first call
- `src/server/index.ts` — Pass `config.dbPath` to `getDatabase()`
- `src/server/mcp/index.ts` — Pass `config.dbPath` to `getDatabase()`
- `tests/server/config.test.ts` — Tests for `defaultDbPath()` and env override
- `CLAUDE.md` — Updated `FLEET_DB_PATH` documentation

## Test plan
- [x] All 653 server tests pass
- [x] Build and type-check clean
- [x] `defaultDbPath()` returns absolute path with `fleet-commander` segment
- [x] Platform-specific paths verified in tests