### PR TITLE
Issue #384: Add queue action for blocked issues with auto-launch on dependency resolution

### DIFF
--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -232,3 +232,12 @@ export function ChevronRightIcon({ size = 14, className }: IconProps) {
     </svg>
   );
 }
+
+export function QueueIcon({ size = 20, className }: IconProps) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10"/>
+      <polyline points="12 6 12 12 16 14"/>
+    </svg>
+  );
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -15,6 +15,7 @@ const STATUS_FILTERS = [
   { key: 'all', label: 'All' },
   { key: 'no-team', label: 'No Team' },
   { key: 'blocked-deps', label: 'Blocked', color: '#F85149' },
+  { key: 'queued', label: 'Queued', color: '#58A6FF' },
   { key: 'running', label: 'Running', color: '#3FB950' },
   { key: 'idle', label: 'Idle', color: '#D29922' },
   { key: 'stuck', label: 'Stuck', color: '#F85149' },
@@ -315,6 +316,54 @@ export function IssueTreeView() {
     }
   }, [api, depConfirm, fetchTree]);
 
+  // Handle queue launch (queue with blockers until dependencies resolve)
+  const handleQueueLaunch = useCallback(async () => {
+    if (!depConfirm) return;
+    const { issueNumber, title, projectId } = depConfirm;
+    setDepConfirm(null);
+    setLaunchingIssues(prev => new Set(prev).add(issueNumber));
+
+    try {
+      await api.post('teams/launch', {
+        issueNumber,
+        issueTitle: title,
+        projectId,
+        queue: true,
+      });
+      const tid = setTimeout(() => {
+        pendingTimeouts.current.delete(tid);
+        setLaunchingIssues(prev => {
+          const next = new Set(prev);
+          next.delete(issueNumber);
+          return next;
+        });
+        fetchTree();
+      }, 5000);
+      pendingTimeouts.current.add(tid);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLaunchingIssues(prev => {
+        const next = new Set(prev);
+        next.delete(issueNumber);
+        return next;
+      });
+      setLaunchErrors(prev => {
+        const next = new Map(prev);
+        next.set(issueNumber, message);
+        return next;
+      });
+      const tid = setTimeout(() => {
+        pendingTimeouts.current.delete(tid);
+        setLaunchErrors(prev => {
+          const next = new Map(prev);
+          next.delete(issueNumber);
+          return next;
+        });
+      }, 5000);
+      pendingTimeouts.current.add(tid);
+    }
+  }, [api, depConfirm, fetchTree]);
+
   // -------------------------------------------------------------------------
   // Filter tree by search query
   // -------------------------------------------------------------------------
@@ -564,6 +613,7 @@ export function IssueTreeView() {
           issueNumber={depConfirm.issueNumber}
           message={depConfirm.message}
           onForce={handleForceLaunch}
+          onQueue={handleQueueLaunch}
           onCancel={() => setDepConfirm(null)}
         />
       )}
@@ -575,10 +625,11 @@ export function IssueTreeView() {
 // DependencyConfirmDialog — shown when launching a blocked issue
 // ---------------------------------------------------------------------------
 
-function DependencyConfirmDialog({ issueNumber, message, onForce, onCancel }: {
+function DependencyConfirmDialog({ issueNumber, message, onForce, onQueue, onCancel }: {
   issueNumber: number;
   message: string;
   onForce: () => void;
+  onQueue: () => void;
   onCancel: () => void;
 }) {
   return (
@@ -598,7 +649,7 @@ function DependencyConfirmDialog({ issueNumber, message, onForce, onCancel }: {
             {message}
           </p>
           <p className="text-xs text-dark-muted">
-            You can force launch to bypass the dependency check, but the issue may not be ready to work on.
+            You can <strong>queue</strong> this issue to auto-launch when blockers resolve, or <strong>force launch</strong> to bypass the dependency check.
           </p>
         </div>
         <div className="flex items-center justify-end gap-3 px-5 py-3 border-t border-dark-border">
@@ -607,6 +658,12 @@ function DependencyConfirmDialog({ issueNumber, message, onForce, onCancel }: {
             className="px-3 py-1.5 text-sm rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted transition-colors"
           >
             Cancel
+          </button>
+          <button
+            onClick={onQueue}
+            className="px-4 py-1.5 text-sm font-medium rounded border border-[#58A6FF]/40 text-[#58A6FF] bg-[#58A6FF]/10 hover:bg-[#58A6FF]/20 transition-colors"
+          >
+            Queue
           </button>
           <button
             onClick={onForce}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -109,6 +109,7 @@ export interface TeamInsert {
   prNumber?: number | null;
   customPrompt?: string | null;
   headless?: boolean;
+  blockedByJson?: string | null;
   launchedAt?: string | null;
 }
 
@@ -122,6 +123,7 @@ export interface TeamUpdate {
   prNumber?: number | null;
   customPrompt?: string | null;
   headless?: boolean;
+  blockedByJson?: string | null;
   totalInputTokens?: number;
   totalOutputTokens?: number;
   totalCacheCreationTokens?: number;
@@ -318,6 +320,9 @@ export class FleetDatabase {
 
     // Add stream_events table if missing (v6 migration — persist session log)
     this.addStreamEventsTable();
+
+    // Add blocked_by_json column to teams if missing (v7 migration)
+    this.addBlockedByJsonColumn();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -642,6 +647,23 @@ export class FleetDatabase {
   }
 
   /**
+   * Add blocked_by_json column to teams table if it doesn't exist.
+   * Stores a JSON array of blocking issue numbers for queued teams.
+   * v7 migration.
+   */
+  private addBlockedByJsonColumn(): void {
+    try {
+      const columns = this.db.prepare("PRAGMA table_info(teams)").all() as Array<{ name: string }>;
+      const hasColumn = columns.some((c) => c.name === 'blocked_by_json');
+      if (!hasColumn) {
+        this.db.exec('ALTER TABLE teams ADD COLUMN blocked_by_json TEXT');
+      }
+    } catch {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
    * Migrate any projects with status 'paused' to 'active'.
    * The paused status was removed in issue #228.
    */
@@ -875,8 +897,8 @@ export class FleetDatabase {
   insertTeam(data: TeamInsert): Team {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(`
-      INSERT INTO teams (issue_number, issue_title, project_id, worktree_name, branch_name, status, phase, pid, session_id, pr_number, custom_prompt, headless, launched_at, created_at, updated_at)
-      VALUES (@issueNumber, @issueTitle, @projectId, @worktreeName, @branchName, @status, @phase, @pid, @sessionId, @prNumber, @customPrompt, @headless, @launchedAt, @createdAt, @updatedAt)
+      INSERT INTO teams (issue_number, issue_title, project_id, worktree_name, branch_name, status, phase, pid, session_id, pr_number, custom_prompt, headless, blocked_by_json, launched_at, created_at, updated_at)
+      VALUES (@issueNumber, @issueTitle, @projectId, @worktreeName, @branchName, @status, @phase, @pid, @sessionId, @prNumber, @customPrompt, @headless, @blockedByJson, @launchedAt, @createdAt, @updatedAt)
     `);
 
     const info = stmt.run({
@@ -892,6 +914,7 @@ export class FleetDatabase {
       prNumber: data.prNumber ?? null,
       customPrompt: data.customPrompt ?? null,
       headless: data.headless === false ? 0 : 1,
+      blockedByJson: data.blockedByJson ?? null,
       launchedAt: data.launchedAt ?? null,
       createdAt: now,
       updatedAt: now,
@@ -980,6 +1003,18 @@ export class FleetDatabase {
     return rows.map((r) => this.mapTeamRow(r));
   }
 
+  /**
+   * Get queued teams that have non-null blocked_by_json.
+   * Used by the GitHub poller to check DB-persisted blockers for resolution.
+   */
+  getQueuedBlockedTeams(): Team[] {
+    const stmt = this.db.prepare(
+      "SELECT * FROM teams WHERE status = 'queued' AND blocked_by_json IS NOT NULL ORDER BY created_at ASC"
+    );
+    const rows = stmt.all() as Record<string, unknown>[];
+    return rows.map((r) => this.mapTeamRow(r));
+  }
+
   updateTeam(id: number, fields: TeamUpdate): Team | undefined {
     const setClauses: string[] = [];
     const params: Record<string, unknown> = { id };
@@ -1019,6 +1054,10 @@ export class FleetDatabase {
     if (fields.headless !== undefined) {
       setClauses.push('headless = @headless');
       params.headless = fields.headless ? 1 : 0;
+    }
+    if (fields.blockedByJson !== undefined) {
+      setClauses.push('blocked_by_json = @blockedByJson');
+      params.blockedByJson = fields.blockedByJson;
     }
     if (fields.totalInputTokens !== undefined) {
       setClauses.push('total_input_tokens = @totalInputTokens');
@@ -1837,6 +1876,7 @@ export class FleetDatabase {
       totalCacheCreationTokens: (row.total_cache_creation_tokens as number | undefined) ?? 0,
       totalCacheReadTokens: (row.total_cache_read_tokens as number | undefined) ?? 0,
       totalCostUsd: (row.total_cost_usd as number | undefined) ?? 0,
+      blockedByJson: (row.blocked_by_json as string | null) ?? null,
       launchedAt: utcify(row.launched_at as string | null),
       stoppedAt: utcify(row.stopped_at as string | null),
       lastEventAt: utcify(row.last_event_at as string | null),

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -28,6 +28,7 @@ interface LaunchBody {
   prompt?: string;
   headless?: boolean;
   force?: boolean;
+  queue?: boolean;
 }
 
 interface LaunchBatchBody {
@@ -95,7 +96,7 @@ const teamsRoutes: FastifyPluginCallback = (
             return reply.code(409).send({
               error: 'Blocked by Dependencies',
               message: err.message,
-              hint: 'Set force: true to bypass dependency check',
+              hint: 'Set force: true to bypass dependency check, or queue: true to queue until blockers resolve',
             });
           }
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS teams (
   pr_number       INTEGER,
   custom_prompt   TEXT,                            -- custom prompt override (persisted for queued teams)
   headless        INTEGER NOT NULL DEFAULT 1,     -- 0=interactive terminal, 1=headless stream-json
+  blocked_by_json TEXT,                            -- JSON array of blocking issue numbers e.g. [368, 370]
   total_input_tokens INTEGER DEFAULT 0,
   total_output_tokens INTEGER DEFAULT 0,
   total_cache_creation_tokens INTEGER DEFAULT 0,
@@ -263,5 +264,5 @@ CREATE TABLE IF NOT EXISTS stream_events (
 
 CREATE INDEX IF NOT EXISTS idx_stream_events_team ON stream_events(team_id);
 
--- Insert schema version 6 (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (6);
+-- Insert schema version 7 (or upgrade from earlier versions)
+INSERT OR IGNORE INTO schema_version (version) VALUES (7);

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -88,6 +88,10 @@ class GitHubPoller {
       return; // already running
     }
 
+    // Reseed blocked issues from DB so dependency resolution detection
+    // survives server restarts
+    this.reseedBlockedFromDb();
+
     this.scheduleNextPoll();
 
     // Initial poll after a short delay so the server has time to finish setup
@@ -515,16 +519,25 @@ class GitHubPoller {
    * and triggers processQueue() to auto-launch newly unblocked teams.
    */
   private async checkDependencyResolution(): Promise<void> {
-    if (this.previouslyBlocked.size === 0) return;
-
     // Collect project IDs that had dependencies resolve so we can trigger
     // processQueue once per project after the loop.
     const resolvedProjectIds = new Set<number>();
+
+    // Also check DB-persisted blockers (queued teams with blocked_by_json).
+    // This covers teams queued with the "Queue" action whose blocker info
+    // survives server restarts, unlike the in-memory previouslyBlocked map.
+    const db = getDatabase();
+    const dbBlockedTeams = db.getQueuedBlockedTeams();
+    const hasInMemoryBlocked = this.previouslyBlocked.size > 0;
+    const hasDbBlocked = dbBlockedTeams.length > 0;
+
+    if (!hasInMemoryBlocked && !hasDbBlocked) return;
 
     try {
       const { getIssueFetcher } = await import('./issue-fetcher.js');
       const fetcher = getIssueFetcher();
 
+      // Check in-memory blocked issues
       for (const [key, entry] of this.previouslyBlocked) {
         try {
           const deps = await fetcher.fetchDependenciesForIssue(entry.projectId, entry.issueNumber);
@@ -550,6 +563,36 @@ class GitHubPoller {
           // Log and continue — don't let one failure stop others
           console.error(
             `[GitHubPoller] Failed to check dependencies for ${key}:`,
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+
+      // Check DB-persisted blocked teams
+      for (const team of dbBlockedTeams) {
+        if (!team.projectId) continue;
+
+        try {
+          const deps = await fetcher.fetchDependenciesForIssue(team.projectId, team.issueNumber);
+          if (deps && deps.resolved) {
+            // All blockers resolved — clear blocked_by_json and broadcast
+            db.updateTeam(team.id, { blockedByJson: null });
+
+            sseBroker.broadcast('dependency_resolved', {
+              issue_number: team.issueNumber,
+              project_id: team.projectId,
+              previously_blocked_by: JSON.parse(team.blockedByJson!),
+            });
+
+            console.log(
+              `[GitHubPoller] DB-persisted blockers resolved for team ${team.id} (issue #${team.issueNumber})`
+            );
+
+            resolvedProjectIds.add(team.projectId);
+          }
+        } catch (err) {
+          console.error(
+            `[GitHubPoller] Failed to check DB-persisted blockers for team ${team.id}:`,
             err instanceof Error ? err.message : err
           );
         }
@@ -599,6 +642,42 @@ class GitHubPoller {
   untrackBlockedIssue(projectId: number, issueNumber: number): void {
     const key = `${projectId}:${issueNumber}`;
     this.previouslyBlocked.delete(key);
+  }
+
+  /**
+   * Reseed the in-memory previouslyBlocked map from queued teams in the DB
+   * that have a non-null blocked_by_json column. Called on poller start so
+   * that dependency resolution detection survives server restarts.
+   */
+  reseedBlockedFromDb(): void {
+    try {
+      const db = getDatabase();
+      const queuedTeams = db.getTeams({ status: 'queued' });
+      let seeded = 0;
+
+      for (const team of queuedTeams) {
+        if (team.blockedByJson && team.projectId) {
+          try {
+            const blockerNumbers = JSON.parse(team.blockedByJson) as number[];
+            if (Array.isArray(blockerNumbers) && blockerNumbers.length > 0) {
+              this.trackBlockedIssue(team.projectId, team.issueNumber, blockerNumbers);
+              seeded++;
+            }
+          } catch {
+            // Malformed JSON — skip this team
+          }
+        }
+      }
+
+      if (seeded > 0) {
+        console.log(`[GitHubPoller] Reseeded ${seeded} blocked issue(s) from DB`);
+      }
+    } catch (err) {
+      console.error(
+        '[GitHubPoller] Failed to reseed blocked issues from DB:',
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -762,6 +762,116 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // queueTeamWithBlockers — queue a team with explicit blocker metadata
+  // -------------------------------------------------------------------------
+
+  /**
+   * Queue a team that has unresolved dependencies, storing the blocker
+   * issue numbers in the `blocked_by_json` column. This allows the GitHub
+   * poller to detect when blockers are resolved and trigger queue processing.
+   *
+   * Similar to queueTeam() but stores blocker metadata in the DB for
+   * persistence across server restarts.
+   */
+  async queueTeamWithBlockers(
+    projectId: number,
+    issueNumber: number,
+    blockerNumbers: number[],
+    issueTitle?: string,
+    headless?: boolean,
+    prompt?: string,
+  ): Promise<Team> {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw new Error(`Project ${projectId} not found`);
+    }
+
+    // Fetch title from GitHub if needed
+    if (!issueTitle && project.githubRepo) {
+      try {
+        const { stdout } = await execAsync(
+          `gh issue view ${issueNumber} --repo ${project.githubRepo} --json title --jq .title`,
+          { timeout: 10000 },
+        );
+        const result = stdout.trim();
+        if (result) issueTitle = result;
+      } catch {
+        issueTitle = `Issue #${issueNumber}`;
+      }
+    } else if (!issueTitle) {
+      issueTitle = `Issue #${issueNumber}`;
+    }
+
+    const { worktreeName, branchName } = this.deriveWorktreeNames(project, issueNumber);
+    const blockedByJson = JSON.stringify(blockerNumbers);
+
+    // Check for existing team
+    const existing = db.getTeamByWorktree(worktreeName);
+    if (existing) {
+      if (['running', 'launching', 'idle', 'stuck', 'queued'].includes(existing.status)) {
+        throw new Error(`Team already active for issue ${issueNumber} (status: ${existing.status})`);
+      }
+      if (existing.status === 'done') {
+        throw new Error(`Team already completed for issue ${issueNumber} — completed teams cannot be relaunched`);
+      }
+      // Terminal state (failed) — reuse the existing team record as queued
+      const now = new Date().toISOString();
+      db.updateTeam(existing.id, {
+        status: 'queued',
+        phase: 'init',
+        pid: null,
+        sessionId: null,
+        issueTitle: issueTitle ?? null,
+        customPrompt: prompt ?? null,
+        headless: headless !== false,
+        blockedByJson,
+        launchedAt: now,
+        stoppedAt: null,
+        lastEventAt: null,
+      });
+      db.insertTransition({
+        teamId: existing.id,
+        fromStatus: existing.status,
+        toStatus: 'queued',
+        trigger: 'pm_action',
+        reason: `Queued with blockers: ${blockerNumbers.map(n => '#' + n).join(', ')}`,
+      });
+      const team = db.getTeam(existing.id)!;
+      console.log(`[TeamManager] Team ${team.id} queued with blockers ${blockedByJson}`);
+      this.broadcastSnapshot();
+      return team;
+    }
+
+    // Fresh insert with queued status and blocker metadata
+    const now = new Date().toISOString();
+    const team = db.insertTeam({
+      projectId,
+      issueNumber,
+      issueTitle: issueTitle ?? null,
+      worktreeName,
+      branchName,
+      status: 'queued',
+      phase: 'init',
+      customPrompt: prompt ?? null,
+      headless: headless !== false,
+      blockedByJson,
+      launchedAt: now,
+    });
+    db.insertTransition({
+      teamId: team.id,
+      fromStatus: 'queued',
+      toStatus: 'queued',
+      trigger: 'pm_action',
+      reason: `Team created and queued with blockers: ${blockerNumbers.map(n => '#' + n).join(', ')}`,
+    });
+
+    console.log(`[TeamManager] Team ${team.id} queued with blockers ${blockedByJson}`);
+    this.broadcastSnapshot();
+    return team;
+  }
+
+  // -------------------------------------------------------------------------
   // forceLaunch — bypass usage gate and slot limits to launch a queued team
   // -------------------------------------------------------------------------
 
@@ -1048,7 +1158,8 @@ export class TeamManager {
 
     console.log(`[TeamManager] Worktree created for dequeued team: ${team.worktreeName}`);
 
-    db.updateTeam(team.id, { status: 'launching' });
+    // Clear blocker metadata now that the team is being launched
+    db.updateTeam(team.id, { status: 'launching', blockedByJson: null });
     this.broadcastSnapshot();
 
     // ── Step 2: Copy hooks and settings ──

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -69,8 +69,9 @@ export class TeamService {
     prompt?: string;
     headless?: boolean;
     force?: boolean;
+    queue?: boolean;
   }): Promise<unknown> {
-    const { projectId, issueNumber, issueTitle, prompt, headless, force } = params;
+    const { projectId, issueNumber, issueTitle, prompt, headless, force, queue } = params;
 
     if (!projectId || typeof projectId !== 'number' || projectId < 1) {
       throw validationError('projectId is required and must be a positive integer');
@@ -87,6 +88,16 @@ export class TeamService {
         const blockerNumbers = depInfo.blockedBy
           .filter((b) => b.state === 'open')
           .map((b) => b.number);
+
+        // Queue mode: queue the team with blocker metadata instead of rejecting
+        if (queue) {
+          githubPoller.trackBlockedIssue(projectId, issueNumber, blockerNumbers);
+          const manager = getTeamManager();
+          return await manager.queueTeamWithBlockers(
+            projectId, issueNumber, blockerNumbers, issueTitle, headless, prompt,
+          );
+        }
+
         githubPoller.trackBlockedIssue(projectId, issueNumber, blockerNumbers);
 
         throw new ServiceError(
@@ -97,6 +108,7 @@ export class TeamService {
       }
     }
 
+    // If queue was requested but no dependencies exist, just launch normally
     const manager = getTeamManager();
     return await manager.launch(projectId, issueNumber, issueTitle, prompt, headless, force);
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -137,6 +137,7 @@ export interface Team {
   launchedAt: string | null;
   stoppedAt: string | null;
   lastEventAt: string | null;
+  blockedByJson: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/client/Icons.test.tsx
+++ b/tests/client/Icons.test.tsx
@@ -31,6 +31,7 @@ import {
   MoreHorizontalIcon,
   LockIcon,
   ChevronRightIcon,
+  QueueIcon,
 } from '../../src/client/components/Icons';
 
 // ---------------------------------------------------------------------------
@@ -62,6 +63,7 @@ const icons = [
   { name: 'MoreHorizontalIcon', Component: MoreHorizontalIcon },
   { name: 'LockIcon', Component: LockIcon },
   { name: 'ChevronRightIcon', Component: ChevronRightIcon },
+  { name: 'QueueIcon', Component: QueueIcon },
 ];
 
 describe('Icons', () => {

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -81,8 +81,8 @@ describe('Schema', () => {
     expect(() => db.initSchema()).not.toThrow();
   });
 
-  it('sets schema version to 6', () => {
-    expect(db.getSchemaVersion()).toBe(6);
+  it('sets schema version to 7', () => {
+    expect(db.getSchemaVersion()).toBe(7);
   });
 });
 
@@ -1109,8 +1109,8 @@ describe('Schema includes stream_events', () => {
     expect(names).toContain('stream_events');
   });
 
-  it('sets schema version to 6', () => {
-    expect(db.getSchemaVersion()).toBe(6);
+  it('sets schema version to 7', () => {
+    expect(db.getSchemaVersion()).toBe(7);
   });
 });
 

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -20,11 +20,13 @@ const mockDb = {
   getProjects: vi.fn().mockReturnValue([]),
   getActiveTeams: vi.fn().mockReturnValue([]),
   getTeam: vi.fn(),
+  getTeams: vi.fn().mockReturnValue([]),
   getPullRequest: vi.fn(),
   updateTeam: vi.fn(),
   updatePullRequest: vi.fn(),
   insertPullRequest: vi.fn(),
   insertTransition: vi.fn(),
+  getQueuedBlockedTeams: vi.fn().mockReturnValue([]),
 };
 
 vi.mock('../../src/server/db.js', () => ({
@@ -746,6 +748,97 @@ describe('Dependency tracking', () => {
     await githubPoller.poll();
 
     expect(mockManager.processQueue).toHaveBeenCalledWith(1);
+  });
+
+  it('reseedBlockedFromDb populates previouslyBlocked from queued teams', async () => {
+    // Set up queued teams with blocked_by_json in the DB
+    mockDb.getTeams.mockReturnValue([
+      {
+        id: 10,
+        issueNumber: 100,
+        projectId: 1,
+        status: 'queued',
+        blockedByJson: JSON.stringify([50, 60]),
+        worktreeName: 'test-100',
+        branchName: null,
+        phase: 'init',
+        pid: null,
+        sessionId: null,
+        prNumber: null,
+        customPrompt: null,
+        headless: true,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalCostUsd: 0,
+        launchedAt: null,
+        stoppedAt: null,
+        lastEventAt: null,
+        issueTitle: null,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+
+    // Reseed from DB
+    githubPoller.reseedBlockedFromDb();
+
+    // Now when dependency resolves, it should broadcast
+    mockFetcher.fetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 100,
+      blockedBy: [],
+      resolved: true,
+      openCount: 0,
+    });
+
+    mockDb.getProjects.mockReturnValue([makeProject()]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    await githubPoller.poll();
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'dependency_resolved',
+      expect.objectContaining({
+        issue_number: 100,
+        project_id: 1,
+        previously_blocked_by: [50, 60],
+      }),
+    );
+  });
+
+  it('reseedBlockedFromDb skips teams without blockedByJson', () => {
+    mockDb.getTeams.mockReturnValue([
+      {
+        id: 11,
+        issueNumber: 200,
+        projectId: 1,
+        status: 'queued',
+        blockedByJson: null,
+        worktreeName: 'test-200',
+        branchName: null,
+        phase: 'init',
+        pid: null,
+        sessionId: null,
+        prNumber: null,
+        customPrompt: null,
+        headless: true,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalCostUsd: 0,
+        launchedAt: null,
+        stoppedAt: null,
+        lastEventAt: null,
+        issueTitle: null,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+
+    // Should not throw
+    githubPoller.reseedBlockedFromDb();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a **Queue** button to the dependency confirmation dialog, allowing users to queue blocked issues for automatic launch when blockers resolve
- New `queue: true` flag on `POST /api/teams/launch` creates a team with `status: queued` and persists blocker metadata (`blocked_by_json` column, schema v7)
- GitHubPoller reseeds blocked-issue tracking from DB on startup via `reseedBlockedFromDb()`, ensuring dependency resolution detection survives server restarts
- Existing `processQueue()` → `filterUnblockedTeams()` pipeline auto-launches queued teams when blockers close

## Test plan

- [ ] Verify schema migration to v7 adds `blocked_by_json` column
- [ ] Queue a blocked issue via the UI dialog — confirm team created with `status: queued`
- [ ] Close the blocking issue — confirm queued team auto-launches
- [ ] Restart server — confirm previously blocked teams are reseeded in the poller
- [ ] Force launch still works as before (bypasses dependency check)
- [ ] `npm test` passes

Closes #384