### PR TITLE
Issue #446: Use stdout stream events as fallback for idle/stuck detection

### DIFF
--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -56,8 +56,19 @@ class StuckDetector {
    */
   check(): void {
     const db = getDatabase();
+
+    // Sync stdout activity to DB before evaluating teams (#446)
+    // This ensures last_event_at reflects both hook events AND stdout activity
+    try {
+      const manager = getTeamManager();
+      manager.syncStreamActivityToDb();
+    } catch {
+      // TeamManager may not be initialized yet
+    }
+
     const activeTeams = db.getActiveTeams();
     const now = Date.now();
+    const idleThresholdMs = config.idleThresholdMin * 60_000;
 
     for (const team of activeTeams) {
       // --- Launch timeout detection ----------------------------------------
@@ -68,7 +79,20 @@ class StuckDetector {
         const launchedTime = new Date(team.launchedAt).getTime();
         const launchMinutes = (now - launchedTime) / 60_000;
 
+        // Check stdout activity before timing out — team may be alive without hooks
         if (launchMinutes > config.launchTimeoutMin) {
+          try {
+            const manager = getTeamManager();
+            const lastStream = manager.getLastStreamAt(team.id);
+            if (lastStream && (now - lastStream) < idleThresholdMs) {
+              console.log(
+                `[StuckDetector] Team ${team.id} has stdout activity (${Math.round((now - lastStream) / 1000)}s ago), skipping launch timeout`
+              );
+              continue;
+            }
+          } catch {
+            // TeamManager not available — proceed with timeout
+          }
           db.insertTransition({
             teamId: team.id,
             fromStatus: 'launching',

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -96,6 +96,8 @@ export class TeamManager {
   private thinkingStartTimes: Map<number, number> = new Map();
   /** Content block index of the active thinking block per team */
   private thinkingBlockIndex: Map<number, number> = new Map();
+  /** Timestamp of last meaningful stdout stream event per team (hook fallback) */
+  private lastStreamAt: Map<number, number> = new Map();
 
   // -------------------------------------------------------------------------
   // syncWithOrigin — fetch + pull before creating a worktree
@@ -445,6 +447,7 @@ export class TeamManager {
     this.parsedEvents.delete(teamId);
     this.agentMaps.delete(teamId);
     this.tokenCounters.delete(teamId);
+    this.lastStreamAt.delete(teamId);
 
     // Re-read to get the latest status (process exit handler may have already updated it)
     const stopTeam = db.getTeam(teamId);
@@ -693,6 +696,7 @@ export class TeamManager {
     this.parsedEvents.clear();
     this.tokenCounters.clear();
     this.agentMaps.clear();
+    this.lastStreamAt.clear();
   }
 
   // -------------------------------------------------------------------------
@@ -1285,6 +1289,35 @@ export class TeamManager {
     }
 
     return [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Stdout activity tracking (hook fallback for #446)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Return the timestamp of the last meaningful stdout stream event for a team.
+   * Used by stuck-detector as a fallback when hook events are missing.
+   */
+  getLastStreamAt(teamId: number): number | undefined {
+    return this.lastStreamAt.get(teamId);
+  }
+
+  /**
+   * Sync stdout activity timestamps to the DB's last_event_at column.
+   * Called periodically by stuck-detector before evaluating teams.
+   * Only updates when stdout activity is more recent than the existing value.
+   */
+  syncStreamActivityToDb(): void {
+    const db = getDatabase();
+    for (const [teamId, lastTs] of this.lastStreamAt) {
+      const team = db.getTeam(teamId);
+      if (!team || ['done', 'failed'].includes(team.status)) continue;
+      const lastEventMs = team.lastEventAt ? new Date(team.lastEventAt).getTime() : 0;
+      if (lastTs > lastEventMs) {
+        db.updateTeam(teamId, { lastEventAt: new Date(lastTs).toISOString() });
+      }
+    }
   }
 
   /**
@@ -1992,6 +2025,36 @@ export class TeamManager {
                 team_id: teamId,
                 event: timestampedEvent,
               }, teamId);
+            }
+
+            // Track stdout activity for hook fallback (#446)
+            if (['assistant', 'tool_use', 'tool_result', 'system'].includes(event.type)) {
+              this.lastStreamAt.set(teamId, Date.now());
+
+              // Fallback: transition launching→running from stdout when hooks don't fire
+              try {
+                const db = getDatabase();
+                const team = db.getTeam(teamId);
+                if (team && team.status === 'launching') {
+                  db.insertTransition({
+                    teamId,
+                    fromStatus: 'launching',
+                    toStatus: 'running',
+                    trigger: 'system',
+                    reason: 'Stdout stream event received (hook fallback)',
+                  });
+                  db.updateTeam(teamId, { status: 'running', lastEventAt: new Date().toISOString() });
+                  sseBroker.broadcast('team_status_changed', {
+                    team_id: teamId,
+                    status: 'running',
+                    previous_status: 'launching',
+                    reason: 'Stdout stream event received (hook fallback)',
+                  });
+                  console.log(`[TeamManager] Team ${teamId} transitioned launching→running via stdout fallback`);
+                }
+              } catch (err) {
+                console.error(`[TeamManager] Stdout fallback transition failed for team ${teamId}:`, err);
+              }
             }
           } catch {
             // Not valid JSON — raw text output (e.g. startup messages)


### PR DESCRIPTION
## Summary
- Added `lastStreamAt` tracking in TeamManager — updates on meaningful stdout events (`assistant`, `tool_use`, `tool_result`, `system`)
- Teams stuck in `launching` now auto-transition to `running` when stdout stream events arrive (hook fallback)
- Stuck detector syncs stdout activity to `last_event_at` before evaluating, preventing false idle/stuck marks
- Launch timeout respects stdout activity — won't kill a team that's actively producing output

## Why
CC 2.1.80+ has a regression (anthropics/claude-code#36793) where hooks from `.claude/settings.json` don't fire in worktrees. This caused teams to stay in `launching` forever and get marked idle despite being active.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Launch team in headless mode — verify status changes to `running` even without hook events
- [ ] Verify stuck detector doesn't mark stdout-active teams as idle
- [ ] Verify stuck detector still catches genuinely idle teams

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)