### PR TITLE
Issue #449: Move version stamp inside YAML frontmatter for agent files

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,8 +203,8 @@ if [ -d "$AGENTS_SRC" ]; then
   for AGENT_FILE in "$AGENTS_SRC"/*.md; do
     [ -f "$AGENT_FILE" ] || continue
     AGENT_NAME="$(basename "$AGENT_FILE")"
-    # Source files already carry a stamp on line 1; replace it with install-time version
-    sed -e "1s|^<!-- fleet-commander v.* -->|<!-- fleet-commander v${FC_VERSION} -->|" \
+    # Source files carry _fleetCommanderVersion inside YAML frontmatter; replace it with install-time version
+    sed -e "s|^_fleetCommanderVersion:.*|_fleetCommanderVersion: \"${FC_VERSION}\"|" \
         -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" \
         -e "s|{{project_slug}}|$project_slug|g" \
         -e "s|{{BASE_BRANCH}}|$BASE_BRANCH|g" \

--- a/scripts/verify-version-stamps.sh
+++ b/scripts/verify-version-stamps.sh
@@ -29,6 +29,18 @@ check_md() {
   fi
 }
 
+# ── Check agent markdown files (.md) ────────────────────────────
+# Expected YAML frontmatter field: _fleetCommanderVersion: "X.Y.Z"
+check_agent_md() {
+  local file="$1"
+  local rel="${file#$ROOT/}"
+  local expected="_fleetCommanderVersion: \"${PKG_VERSION}\""
+  if ! grep -q "^${expected}$" "$file" 2>/dev/null; then
+    echo "::error file=${rel}::Version stamp mismatch: expected '${expected}' in YAML frontmatter"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
 # ── Check shell files (.sh) ─────────────────────────────────────
 # Expected second line: # fleet-commander vX.Y.Z
 check_sh() {
@@ -44,9 +56,10 @@ check_sh() {
 }
 
 # ── Markdown files to check ─────────────────────────────────────
+# Agent files use YAML frontmatter field instead of line 1 HTML comment
 for f in "$ROOT"/templates/agents/*.md; do
   [ -f "$f" ] || continue
-  check_md "$f"
+  check_agent_md "$f"
 done
 
 for f in "$ROOT"/templates/guides/*.md; do

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -132,24 +132,29 @@ export async function checkRepoSettings(githubRepo: string | null | undefined): 
 
 /**
  * Extract Fleet Commander version stamp from the first few lines of a file.
- * Supports shell scripts (`# fleet-commander vX.Y.Z`) and markdown
- * files (`<!-- fleet-commander vX.Y.Z -->`).
+ * Supports shell scripts (`# fleet-commander vX.Y.Z`), markdown
+ * files (`<!-- fleet-commander vX.Y.Z -->`), and YAML frontmatter
+ * fields (`_fleetCommanderVersion: "X.Y.Z"`).
  * For shell scripts the stamp is on line 2 (after the shebang); for
- * markdown files it is on line 1.
+ * markdown files it is on line 1 or inside YAML frontmatter.
  *
  * @param filePath - Absolute path to the installed file
  * @returns The version string (e.g. "0.0.6") or undefined if not found
  */
 function extractVersionStamp(filePath: string): string | undefined {
   try {
-    // Read first 512 bytes — the stamp is within the first 2 lines
+    // Read first 512 bytes — the stamp is within the first few lines
     const buf = Buffer.alloc(512);
     const fd = fs.openSync(filePath, 'r');
     const bytesRead = fs.readSync(fd, buf, 0, 512, 0);
     fs.closeSync(fd);
     const header = buf.subarray(0, bytesRead).toString('utf-8');
+    // Try HTML comment / shell comment format first
     const match = header.match(/fleet-commander v(\d+\.\d+\.\d+)/);
-    return match ? match[1] : undefined;
+    if (match) return match[1];
+    // Try YAML frontmatter field (used by agent .md files)
+    const yamlMatch = header.match(/_fleetCommanderVersion:\s*"(\d+\.\d+\.\d+)"/);
+    return yamlMatch ? yamlMatch[1] : undefined;
   } catch {
     return undefined;
   }

--- a/templates/agents/fleet-dev.md
+++ b/templates/agents/fleet-dev.md
@@ -1,10 +1,10 @@
-<!-- fleet-commander v0.0.7 -->
 ---
 name: fleet-dev
 description: Generalist developer agent. Dynamically specializes via guidebook files provided in the planner's plan. Handles any language, framework, or infrastructure work.
 preferred_plugins: playwright, context7
 color: "#3FB950"
 model: inherit
+_fleetCommanderVersion: "0.0.7"
 ---
 
 # Developer

--- a/templates/agents/fleet-planner.md
+++ b/templates/agents/fleet-planner.md
@@ -1,8 +1,8 @@
-<!-- fleet-commander v0.0.7 -->
 ---
 name: fleet-planner
 model: inherit
 description: "Implementation planner. Reads the issue, explores the codebase and guidebooks, and produces a concrete step-by-step implementation plan with architectural decisions. Stays alive to answer questions from dev and reviewer."
+_fleetCommanderVersion: "0.0.7"
 ---
 
 # Fleet Planner

--- a/templates/agents/fleet-reviewer.md
+++ b/templates/agents/fleet-reviewer.md
@@ -1,9 +1,9 @@
-<!-- fleet-commander v0.0.7 -->
 ---
 name: fleet-reviewer
 description: Code reviewer with direct p2p dev communication. Two-pass review (code quality + acceptance criteria). READ-ONLY — never edits files.
 model: inherit
 color: "#D29922"
+_fleetCommanderVersion: "0.0.7"
 ---
 
 # Fleet Reviewer


### PR DESCRIPTION
Closes #449

## Summary
- Moved version stamp from HTML comment on line 1 to `_fleetCommanderVersion` YAML field inside frontmatter for agent template files (`fleet-planner.md`, `fleet-dev.md`, `fleet-reviewer.md`)
- Updated `install.sh` agent sed section to replace the YAML field value instead of a line-1 HTML comment
- Updated `extractVersionStamp()` in `project-service.ts` to detect both HTML comment and YAML field formats (backward compatible)
- Added `check_agent_md()` function in `verify-version-stamps.sh` for agent-specific YAML field validation

## Test plan
- [x] TypeScript build passes (`npm run build`)
- [x] All tests pass (`npm test`) — 3 pre-existing cc-spawn failures confirmed on main
- [x] `verify-version-stamps.sh` passes with updated agent file checks
- [x] Agent template files start with `---` on line 1 (no HTML comment before frontmatter)
- [ ] Reinstall on a project to verify CC discovers agent types correctly