### PR TITLE
Issue #450: Verify .claude/ files committed to default branch

### DIFF
--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -35,6 +35,10 @@ function getInstallHealthColor(project: ProjectSummary): HealthColor {
   if (!project.installStatus) return '#8B949E';
   const s = project.installStatus;
 
+  // Git commit status takes priority when red
+  const gitHealth = s.gitCommitStatus?.health;
+  if (gitHealth === 'red') return '#F85149';
+
   const hooksOk = s.hooks?.installed ?? false;
   const hooksCrlf = s.hooks?.files?.some((f: { hasCrlf?: boolean }) => f.hasCrlf) ?? false;
   const promptOk = s.prompt?.installed ?? false;
@@ -43,9 +47,10 @@ function getInstallHealthColor(project: ProjectSummary): HealthColor {
 
   const allOk = hooksOk && !hooksCrlf && promptOk && agentsOk && settingsOk;
   if (allOk) {
-    // All files present — but check if any are outdated
+    // All files present — but check if any are outdated or git commit is amber
     const outdated = s.outdatedCount ?? 0;
-    return outdated > 0 ? '#D29922' : '#3FB950';
+    if (outdated > 0 || gitHealth === 'amber') return '#D29922';
+    return '#3FB950';
   }
 
   const anyInstalled = hooksOk || promptOk || agentsOk || settingsOk;
@@ -55,6 +60,16 @@ function getInstallHealthColor(project: ProjectSummary): HealthColor {
 }
 
 function getInstallHealthLabel(color: HealthColor, project?: ProjectSummary): string {
+  // Show git commit status message when it drives the color
+  if (project?.installStatus?.gitCommitStatus) {
+    const gcs = project.installStatus.gitCommitStatus;
+    if (gcs.health === 'red' && color === '#F85149') {
+      return gcs.message;
+    }
+    if (gcs.health === 'amber' && color === '#D29922') {
+      return gcs.message;
+    }
+  }
   if (color === '#D29922' && project?.installStatus) {
     const s = project.installStatus;
     const hooksOk = s.hooks?.installed ?? false;
@@ -241,6 +256,57 @@ function InstallHealthDetail({ project, repoSettings }: { project: ProjectSummar
           </div>
         );
       })}
+      {/* Git commit status badge */}
+      {s.gitCommitStatus && (
+        <div className="relative group shrink-0">
+          <span
+            className="cursor-default"
+            style={{
+              color: s.gitCommitStatus.health === 'green' ? '#3FB950'
+                : s.gitCommitStatus.health === 'amber' ? '#D29922'
+                : s.gitCommitStatus.health === 'red' ? '#F85149'
+                : '#8B949E',
+            }}
+          >
+            {s.gitCommitStatus.health === 'green' ? '\u2713'
+              : s.gitCommitStatus.health === 'amber' ? '\u26A0'
+              : s.gitCommitStatus.health === 'red' ? '\u2717'
+              : '?'} committed
+          </span>
+          {/* Tooltip on hover */}
+          <div className="hidden group-hover:block absolute z-10 bottom-full right-0 mb-1 p-2 rounded bg-[#1C2128] border border-[#30363D] shadow-lg text-xs min-w-56 max-h-64 overflow-auto">
+            <div className="font-medium mb-1 text-[#C9D1D9]">
+              Git Commit Status ({s.gitCommitStatus.defaultBranch})
+            </div>
+            <div className="text-[#8B949E] mb-1">{s.gitCommitStatus.message}</div>
+            {s.gitCommitStatus.gitignored && (
+              <div className="flex items-center gap-1.5 py-0.5">
+                <span style={{ color: '#F85149' }}>{'\u2717'}</span>
+                <span className="text-[#8B949E]">.claude/ is in .gitignore</span>
+              </div>
+            )}
+            {s.gitCommitStatus.files.map((f) => {
+              const fileColor = f.committed
+                ? (f.committedVersion && f.committedVersion !== f.currentVersion ? '#D29922' : '#3FB950')
+                : '#F85149';
+              const fileIcon = f.committed
+                ? (f.committedVersion && f.committedVersion !== f.currentVersion ? '\u26A0' : '\u2713')
+                : '\u2717';
+              const versionSuffix = f.committed && f.committedVersion && f.committedVersion !== f.currentVersion
+                ? ` (v${f.committedVersion} \u2192 v${f.currentVersion})`
+                : '';
+              return (
+                <div key={f.path} className="flex items-center gap-1.5 py-0.5">
+                  <span style={{ color: fileColor }}>{fileIcon}</span>
+                  <span className="text-[#8B949E] font-mono text-[11px]">
+                    {f.path}{versionSuffix}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
       {/* GitHub repo settings badge */}
       {repoSettings && (
         <div className="relative group shrink-0">
@@ -307,6 +373,7 @@ function ProjectCard({
   onEditPrompt,
   onGroupChange,
   fetchRepoSettings,
+  onCommitClaudeFiles,
 }: {
   project: ProjectSummary;
   groups: ProjectGroupWithCount[];
@@ -320,9 +387,12 @@ function ProjectCard({
   onEditPrompt: (id: number) => void;
   onGroupChange: (projectId: number, groupId: number | null) => void;
   fetchRepoSettings: (projectId: number) => Promise<RepoSettings | null>;
+  onCommitClaudeFiles: (projectId: number) => Promise<{ ok: boolean; error?: string }>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [repoSettings, setRepoSettings] = useState<RepoSettings | null | undefined>(undefined);
+  const [committing, setCommitting] = useState(false);
+  const [commitResult, setCommitResult] = useState<{ ok: boolean; error?: string } | null>(null);
   const [repoSettingsLoaded, setRepoSettingsLoaded] = useState(false);
   const limitEdit = useInlineEdit<number>(project.maxActiveTeams);
   const modelEdit = useInlineEdit<string>(project.model ?? '');
@@ -452,6 +522,68 @@ function ProjectCard({
           {reinstallResult.ok
             ? 'Installation completed successfully'
             : `Installation failed: ${reinstallResult.error}`}
+        </div>
+      )}
+
+      {/* Git commit status banner */}
+      {project.installStatus?.gitCommitStatus &&
+        (project.installStatus.gitCommitStatus.health === 'red' ||
+          project.installStatus.gitCommitStatus.health === 'amber') && (
+        <div
+          className={`mx-4 mb-2 px-3 py-1.5 rounded text-xs flex items-center gap-2 ${
+            project.installStatus.gitCommitStatus.health === 'red'
+              ? 'border border-[#F85149]/30 bg-[#F85149]/10 text-[#F85149]'
+              : 'border border-[#D29922]/30 bg-[#D29922]/10 text-[#D29922]'
+          }`}
+        >
+          <span className="flex-1">
+            {project.installStatus.gitCommitStatus.message}
+            {project.installStatus.gitCommitStatus.health === 'red' &&
+              !project.installStatus.gitCommitStatus.gitignored &&
+              ' \u2014 hooks and agents won\'t work in worktrees'}
+          </span>
+          <button
+            onClick={async (e) => {
+              e.stopPropagation();
+              setCommitting(true);
+              setCommitResult(null);
+              try {
+                const result = await onCommitClaudeFiles(project.id);
+                setCommitResult(result);
+              } catch (err: unknown) {
+                setCommitResult({ ok: false, error: err instanceof Error ? err.message : String(err) });
+              } finally {
+                setCommitting(false);
+              }
+            }}
+            disabled={committing}
+            className={`shrink-0 px-2 py-0.5 rounded border text-xs font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+              project.installStatus.gitCommitStatus.health === 'red'
+                ? 'border-[#F85149]/40 text-[#F85149] bg-[#F85149]/10 hover:bg-[#F85149]/20'
+                : 'border-[#D29922]/40 text-[#D29922] bg-[#D29922]/10 hover:bg-[#D29922]/20'
+            }`}
+          >
+            {committing
+              ? 'Committing...'
+              : project.installStatus.gitCommitStatus.health === 'amber'
+                ? 'Update & Commit'
+                : 'Fix'}
+          </button>
+        </div>
+      )}
+
+      {/* Commit result banner */}
+      {commitResult && (
+        <div
+          className={`mx-4 mb-2 px-3 py-1.5 rounded text-xs ${
+            commitResult.ok
+              ? 'border border-[#3FB950]/30 bg-[#3FB950]/10 text-[#3FB950]'
+              : 'border border-[#F85149]/30 bg-[#F85149]/10 text-[#F85149]'
+          }`}
+        >
+          {commitResult.ok
+            ? '.claude/ files committed successfully'
+            : `Commit failed: ${commitResult.error}`}
         </div>
       )}
 
@@ -964,6 +1096,23 @@ export function ProjectsPage() {
     [api],
   );
 
+  const handleCommitClaudeFiles = useCallback(
+    async (projectId: number): Promise<{ ok: boolean; error?: string }> => {
+      try {
+        const result = await api.post<{ ok: boolean; error?: string }>(
+          `projects/${projectId}/commit-claude-files`,
+          {},
+        );
+        // Refresh projects to update install status (and git commit status)
+        await fetchProjects();
+        return result;
+      } catch (err: unknown) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    [api, fetchProjects],
+  );
+
   const handleCleanup = useCallback((project: ProjectSummary) => {
     setCleanupProjectId(project.id);
   }, []);
@@ -1075,6 +1224,7 @@ export function ProjectsPage() {
     onEditPrompt: setEditingPromptId,
     onGroupChange: handleGroupChange,
     fetchRepoSettings,
+    onCommitClaudeFiles: handleCommitClaudeFiles,
   };
 
   // --- Render ---

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -289,6 +289,40 @@ const projectsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // POST /api/projects/:id/commit-claude-files — commit .claude/ to repo
+  // -------------------------------------------------------------------------
+  fastify.post(
+    '/api/projects/:id/commit-claude-files',
+    async (
+      request: FastifyRequest<{ Params: ProjectIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const projectId = parseInt(request.params.id, 10);
+        if (isNaN(projectId) || projectId < 1) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Invalid project ID',
+          });
+        }
+
+        const service = getProjectService();
+        const result = service.commitClaudeFiles(projectId);
+        return reply.code(200).send(result);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to commit .claude/ files');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // GET /api/projects/:id/teams — teams for this project
   // -------------------------------------------------------------------------
   fastify.get(

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -15,7 +15,8 @@ import { sseBroker } from './sse-broker.js';
 import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
 import { execGitAsync, execGHAsync, execGHResult } from '../utils/exec-gh.js';
-import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings } from '../../shared/types.js';
+import { execSync } from 'child_process';
+import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings, GitCommitStatus, GitCommitFileStatus, GitCommitHealth } from '../../shared/types.js';
 import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
 import { getPackageVersion } from '../utils/version.js';
 import { getCleanupPreview as _getCleanupPreview, executeCleanup as _executeCleanup } from './cleanup.js';
@@ -178,6 +179,238 @@ function extractJsonVersionStamp(filePath: string): string | undefined {
 }
 
 /**
+ * Extract Fleet Commander version stamp from a string content (e.g. from `git show`).
+ * Supports shell comment (`# fleet-commander vX.Y.Z`), HTML comment
+ * (`<!-- fleet-commander vX.Y.Z -->`), YAML frontmatter (`_fleetCommanderVersion: "X.Y.Z"`),
+ * and JSON (`"_fleetCommanderVersion": "X.Y.Z"`).
+ *
+ * @param content - File content string (typically first 512 chars)
+ * @returns The version string (e.g. "0.0.6") or undefined if not found
+ */
+function extractVersionStampFromContent(content: string): string | undefined {
+  // Try HTML comment / shell comment format first
+  const match = content.match(/fleet-commander v(\d+\.\d+\.\d+)/);
+  if (match) return match[1];
+  // Try YAML frontmatter field (used by agent .md files)
+  const yamlMatch = content.match(/_fleetCommanderVersion:\s*"(\d+\.\d+\.\d+)"/);
+  if (yamlMatch) return yamlMatch[1];
+  // Try JSON field (used by settings.json)
+  const jsonMatch = content.match(/"_fleetCommanderVersion":\s*"(\d+\.\d+\.\d+)"/);
+  if (jsonMatch) return jsonMatch[1];
+  return undefined;
+}
+
+/**
+ * Detect the default branch for a git repository by checking `refs/remotes/origin/HEAD`.
+ * Falls back to `origin/main` then `origin/master` if symbolic-ref fails.
+ *
+ * @param repoPath - Absolute path to the git repository
+ * @returns The remote default branch ref (e.g. "origin/main") or undefined if not detectable
+ */
+function detectDefaultBranch(repoPath: string): string | undefined {
+  try {
+    const ref = execSync('git symbolic-ref refs/remotes/origin/HEAD --short', {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (ref) return ref;
+  } catch {
+    // symbolic-ref failed — try common branch names
+  }
+
+  // Try origin/main
+  try {
+    execSync('git rev-parse --verify origin/main', {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return 'origin/main';
+  } catch {
+    // origin/main does not exist
+  }
+
+  // Try origin/master
+  try {
+    execSync('git rev-parse --verify origin/master', {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return 'origin/master';
+  } catch {
+    // origin/master does not exist either
+  }
+
+  return undefined;
+}
+
+/**
+ * Check whether `.claude/` files are committed to the default branch of a git repository.
+ * Returns a GitCommitStatus describing:
+ * - whether .claude is gitignored
+ * - which expected files are committed
+ * - version stamps of committed files vs current FC version
+ * - overall health (green/amber/red)
+ *
+ * All git commands are wrapped in try/catch — if git fails (not a git repo,
+ * no remote), this returns `undefined` rather than crashing.
+ *
+ * @param repoPath - Absolute path to the target repository
+ * @returns GitCommitStatus or undefined if the check cannot be performed
+ */
+export function checkGitCommitStatus(repoPath: string): GitCommitStatus | undefined {
+  try {
+    // Detect default branch
+    const defaultBranch = detectDefaultBranch(repoPath);
+    if (!defaultBranch) return undefined;
+
+    const shortBranch = defaultBranch.replace(/^origin\//, '');
+    const currentVersion = getPackageVersion();
+
+    // Check if .claude/ is gitignored
+    let gitignored = false;
+    try {
+      execSync('git check-ignore .claude/', {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      // Exit code 0 means .claude/ IS ignored
+      gitignored = true;
+    } catch {
+      // Non-zero exit means .claude/ is NOT ignored (good)
+    }
+
+    if (gitignored) {
+      return {
+        health: 'red',
+        gitignored: true,
+        defaultBranch: shortBranch,
+        files: [],
+        message: `.claude/ in .gitignore — remove it and commit .claude/`,
+      };
+    }
+
+    // List committed .claude/ files on the default branch
+    let committedPaths: string[] = [];
+    try {
+      const output = execSync(`git ls-tree -r --name-only ${defaultBranch} -- .claude/`, {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      committedPaths = output ? output.split('\n').map((l) => l.trim()).filter(Boolean) : [];
+    } catch {
+      // ls-tree failed — the branch may not have any .claude/ files
+    }
+
+    const committedSet = new Set(committedPaths);
+
+    // Define the expected key files we check
+    const expectedFiles: string[] = [
+      '.claude/settings.json',
+      '.claude/prompts/fleet-workflow.md',
+      '.claude/agents/fleet-planner.md',
+      '.claude/agents/fleet-dev.md',
+      '.claude/agents/fleet-reviewer.md',
+      // Check a representative sample of hooks
+      '.claude/hooks/fleet-commander/send_event.sh',
+      '.claude/hooks/fleet-commander/on_session_start.sh',
+      '.claude/hooks/fleet-commander/on_session_end.sh',
+    ];
+
+    const fileStatuses: GitCommitFileStatus[] = [];
+    let allCommitted = true;
+    let anyOutdated = false;
+
+    for (const filePath of expectedFiles) {
+      const committed = committedSet.has(filePath);
+      const fileStatus: GitCommitFileStatus = {
+        path: filePath,
+        committed,
+        currentVersion,
+      };
+
+      if (committed) {
+        // Extract version stamp from committed copy
+        try {
+          const content = execSync(`git show ${defaultBranch}:${filePath}`, {
+            cwd: repoPath,
+            encoding: 'utf-8',
+            timeout: 5_000,
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+          // Only check first 512 chars for version stamp
+          const header = content.slice(0, 512);
+          fileStatus.committedVersion = extractVersionStampFromContent(header);
+          if (fileStatus.committedVersion && fileStatus.committedVersion !== currentVersion) {
+            anyOutdated = true;
+          }
+        } catch {
+          // git show failed — skip version check
+        }
+      } else {
+        allCommitted = false;
+      }
+
+      fileStatuses.push(fileStatus);
+    }
+
+    // Also check if ALL hooks from the fleet-commander directory are committed
+    const hookPrefix = '.claude/hooks/fleet-commander/';
+    const committedHooks = committedPaths.filter((p) => p.startsWith(hookPrefix));
+    // We don't need to individually list all hooks — just check the count
+    const hookFiles = [
+      'send_event.sh', 'on_session_start.sh', 'on_session_end.sh',
+      'on_stop.sh', 'on_stop_failure.sh', 'on_subagent_start.sh',
+      'on_subagent_stop.sh', 'on_notification.sh', 'on_post_tool_use.sh',
+      'on_tool_error.sh', 'on_pre_compact.sh', 'on_teammate_idle.sh',
+    ];
+    const missingHooks = hookFiles.filter((h) => !committedSet.has(hookPrefix + h));
+    if (missingHooks.length > 0) {
+      allCommitted = false;
+    }
+
+    // Compute health
+    let health: GitCommitHealth;
+    let message: string;
+
+    if (!allCommitted) {
+      health = 'red';
+      const missingCount = fileStatuses.filter((f) => !f.committed).length + missingHooks.length;
+      message = `${missingCount} .claude/ file${missingCount === 1 ? '' : 's'} not committed to ${shortBranch}`;
+    } else if (anyOutdated) {
+      health = 'amber';
+      const outdatedCount = fileStatuses.filter(
+        (f) => f.committed && f.committedVersion && f.committedVersion !== currentVersion,
+      ).length;
+      message = `Committed to ${shortBranch} but ${outdatedCount} file${outdatedCount === 1 ? '' : 's'} outdated`;
+    } else {
+      health = 'green';
+      message = `All .claude/ files committed to ${shortBranch}`;
+    }
+
+    return {
+      health,
+      gitignored: false,
+      defaultBranch: shortBranch,
+      files: fileStatuses,
+      message,
+    };
+  } catch {
+    // Any unexpected failure — return undefined (unknown)
+    return undefined;
+  }
+}
+
+/**
  * Check the install status of artifacts deployed by install.sh:
  * hooks directory and workflow prompt.
  * Returns detailed file-level breakdown for tooltip display.
@@ -277,6 +510,9 @@ export function checkInstallStatus(repoPath: string): InstallStatus {
     (f) => f.exists && f.installedVersion !== currentVersion,
   ).length;
 
+  // Check git commit status for .claude/ files on the default branch
+  const gitCommitStatus = checkGitCommitStatus(repoPath);
+
   return {
     hooks: {
       installed: hookFoundCount === hookNames.length && !hookHasCrlf,
@@ -299,6 +535,7 @@ export function checkInstallStatus(repoPath: string): InstallStatus {
     settings: settingsFile,
     outdatedCount,
     currentVersion,
+    gitCommitStatus,
   };
 }
 
@@ -646,6 +883,79 @@ export class ProjectService {
       error: result.stderr.trim() || undefined,
       installStatus: status,
     };
+  }
+
+  /**
+   * Commit .claude/ files to the current branch of the project repository.
+   * If `.claude` is in `.gitignore`, removes it first.
+   * Runs: `git add .claude/` + `git commit -m "..."`.
+   *
+   * @param projectId - The project ID
+   * @returns { ok: true } on success, { ok: false, error: string } on failure
+   * @throws ServiceError with code NOT_FOUND if project doesn't exist
+   */
+  commitClaudeFiles(projectId: number): { ok: boolean; error?: string } {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    const repoPath = project.repoPath;
+
+    try {
+      // Check if .claude is in .gitignore — remove it if so
+      const gitignorePath = path.join(repoPath, '.gitignore');
+      if (fs.existsSync(gitignorePath)) {
+        const content = fs.readFileSync(gitignorePath, 'utf-8');
+        const lines = content.split('\n');
+        const filtered = lines.filter((line) => {
+          const trimmed = line.trim();
+          return trimmed !== '.claude' && trimmed !== '.claude/' && trimmed !== '.claude/**';
+        });
+        if (filtered.length !== lines.length) {
+          fs.writeFileSync(gitignorePath, filtered.join('\n'), 'utf-8');
+          // Stage the updated .gitignore
+          execSync('git add .gitignore', {
+            cwd: repoPath,
+            encoding: 'utf-8',
+            timeout: 5_000,
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+        }
+      }
+
+      // Stage .claude/ directory
+      execSync('git add .claude/', {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      // Commit
+      execSync('git commit -m "Add Fleet Commander hooks and agents"', {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      // Invalidate the install status cache so the next check picks up the change
+      invalidateInstallStatusCache(repoPath);
+
+      // Broadcast so UI refreshes badges
+      sseBroker.broadcast('project_updated', {
+        project_id: projectId,
+        name: project.name,
+        status: project.status,
+      });
+
+      return { ok: true };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
   }
 
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,6 +92,35 @@ export interface RepoSettings {
   };
 }
 
+/** Health status for git commit check */
+export type GitCommitHealth = 'green' | 'amber' | 'red' | 'unknown';
+
+/** Per-file git commit status */
+export interface GitCommitFileStatus {
+  /** Relative path from repo root (e.g. ".claude/agents/fleet-planner.md") */
+  path: string;
+  /** Whether the file is committed to the default branch */
+  committed: boolean;
+  /** Version stamp found in the committed copy */
+  committedVersion?: string;
+  /** Current FC version for comparison */
+  currentVersion?: string;
+}
+
+/** Git commit status for .claude/ files on the default branch */
+export interface GitCommitStatus {
+  /** Overall health: red = not committed/gitignored, amber = outdated, green = all good */
+  health: GitCommitHealth;
+  /** Whether .claude is in .gitignore */
+  gitignored: boolean;
+  /** Default branch name used for the check */
+  defaultBranch: string;
+  /** Per-file commit status */
+  files: GitCommitFileStatus[];
+  /** Summary message for the UI */
+  message: string;
+}
+
 /** Detailed install status for the artifacts deployed by install.sh */
 export interface InstallStatus {
   hooks: InstallHooksStatus;
@@ -104,6 +133,8 @@ export interface InstallStatus {
   outdatedCount: number;
   /** Current Fleet Commander version */
   currentVersion: string;
+  /** Git commit status for .claude/ files on the default branch */
+  gitCommitStatus?: GitCommitStatus;
 }
 
 /** Project with team count for list view */


### PR DESCRIPTION
## Summary
- Add git commit status check that verifies `.claude/` files are committed to the project's default branch (not just present on disk)
- Show RED/AMBER/GREEN health indicator on Projects page with clear error messages
- Add "Fix" button that auto-commits `.claude/` files (removing `.gitignore` exclusion if present)

Closes #450

## Changes
- **`src/shared/types.ts`** — New types: `GitCommitHealth`, `GitCommitFileStatus`, `GitCommitStatus`; extended `InstallStatus`
- **`src/server/services/project-service.ts`** — `checkGitCommitStatus()`, `detectDefaultBranch()`, `extractVersionStampFromContent()`, `commitClaudeFiles()` service method
- **`src/server/routes/projects.ts`** — New `POST /api/projects/:id/commit-claude-files` endpoint
- **`src/client/views/ProjectsPage.tsx`** — Git commit health badge, RED/AMBER banners, Fix button with feedback

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (all existing tests)
- [ ] Manual: register a project where `.claude/` is NOT committed → verify RED banner appears
- [ ] Manual: click "Fix" button → verify files are committed and status turns GREEN
- [ ] Manual: add `.claude` to `.gitignore` → verify RED banner with gitignore message
- [ ] Manual: verify outdated committed files show AMBER status