### PR TITLE
Issue #444: Add persistent hook execution log

### DIFF
--- a/hooks/on_notification.sh
+++ b/hooks/on_notification.sh
@@ -6,5 +6,7 @@
 # stdin JSON example: {"session_id":"abc123","message":"Permission requested..."}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | notification | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "notification"

--- a/hooks/on_post_tool_use.sh
+++ b/hooks/on_post_tool_use.sh
@@ -6,5 +6,7 @@
 # stdin JSON example: {"session_id":"abc123","tool_name":"Bash","agent_type":"main"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | tool_use | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "tool_use"

--- a/hooks/on_pre_compact.sh
+++ b/hooks/on_pre_compact.sh
@@ -7,5 +7,7 @@
 # stdin JSON example: {"session_id":"abc123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | pre_compact | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "pre_compact"

--- a/hooks/on_session_end.sh
+++ b/hooks/on_session_end.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | session_end | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "session_end"

--- a/hooks/on_session_start.sh
+++ b/hooks/on_session_start.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","agent_type":"main"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | session_start | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "session_start"

--- a/hooks/on_stop.sh
+++ b/hooks/on_stop.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","stop_reason":"end_turn"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | stop | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "stop"

--- a/hooks/on_stop_failure.sh
+++ b/hooks/on_stop_failure.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","error_details":"rate_limit","last_assistant_message":"..."}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | stop_failure | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "stop_failure"

--- a/hooks/on_subagent_start.sh
+++ b/hooks/on_subagent_start.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | subagent_start | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "subagent_start"

--- a/hooks/on_subagent_stop.sh
+++ b/hooks/on_subagent_stop.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | subagent_stop | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "subagent_stop"

--- a/hooks/on_teammate_idle.sh
+++ b/hooks/on_teammate_idle.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | teammate_idle | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "teammate_idle"

--- a/hooks/on_tool_error.sh
+++ b/hooks/on_tool_error.sh
@@ -5,5 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","tool_name":"Bash","error":"exit code 1","tool_use_id":"toolu_123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${HOOK_DIR}/../../../../hooks.log"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | tool_error | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "tool_error"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# fleet-commander v0.0.8
+# Universal hook wrapper — logs ENTER layer before executing the real hook.
+# Usage: run-hook.sh <event_type> <script_name>
+# Called from settings.json hook commands.
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+EVENT_TYPE="${1:-unknown}"
+SCRIPT="${2:-}"
+LOG="${HOOK_DIR}/../../../../hooks.log"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | ENTER | $EVENT_TYPE | ${FLEET_TEAM_ID:-?} | pid=$$" >> "$LOG" 2>/dev/null || true
+
+# Execute the actual hook script, forwarding stdin
+exec "$HOOK_DIR/$SCRIPT"

--- a/hooks/send_event.sh
+++ b/hooks/send_event.sh
@@ -108,12 +108,21 @@ PAYLOAD="${PAYLOAD}}"
 # ── Fire and forget ───────────────────────────────────────────────
 # curl with 2-second timeout. Errors are silenced completely.
 # The hook MUST NOT block Claude Code or cause visible failures.
+_LOG="$(cd "$(dirname "$0")" && pwd)/../../../../hooks.log"
 if command -v curl >/dev/null 2>&1; then
     curl -s -S --max-time 2 --connect-timeout 1 \
         -X POST \
         -H "Content-Type: application/json" \
         -d "$PAYLOAD" \
         "$FLEET_URL" >/dev/null 2>&1
+    CURL_RESULT=$?
+    if [ "$CURL_RESULT" -eq 0 ]; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | $EVENT_TYPE | $TEAM_NAME | curl=ok" >> "$_LOG" 2>/dev/null || true
+    else
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | $EVENT_TYPE | $TEAM_NAME | curl=fail($CURL_RESULT)" >> "$_LOG" 2>/dev/null || true
+    fi
+else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | $EVENT_TYPE | $TEAM_NAME | curl=missing" >> "$_LOG" 2>/dev/null || true
 fi
 
 # Always exit 0 — hooks must never fail

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_session_start.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh session_start on_session_start.sh"
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_session_end.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh session_end on_session_end.sh"
           }
         ]
       }
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_stop.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh stop on_stop.sh"
           }
         ]
       }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_stop_failure.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh stop_failure on_stop_failure.sh"
           }
         ]
       }
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_subagent_start.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh subagent_start on_subagent_start.sh"
           }
         ]
       }
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_subagent_stop.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh subagent_stop on_subagent_stop.sh"
           }
         ]
       }
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_notification.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh notification on_notification.sh"
           }
         ]
       }
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_pre_compact.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh pre_compact on_pre_compact.sh"
           }
         ]
       }
@@ -91,7 +91,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_post_tool_use.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh tool_use on_post_tool_use.sh"
           }
         ]
       }
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_teammate_idle.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh teammate_idle on_teammate_idle.sh"
           }
         ]
       }
@@ -111,7 +111,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/fleet-commander/on_tool_error.sh"
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh tool_error on_tool_error.sh"
           }
         ]
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -83,6 +83,26 @@ async function main() {
     DEFAULT_MESSAGE_TEMPLATES.map((t) => ({ id: t.id, template: t.template }))
   );
 
+  // Rotate hooks.log if > 10MB (prevents unbounded growth)
+  // Check all registered project paths for hooks.log files
+  try {
+    const projects = db.getProjects();
+    for (const project of projects) {
+      const hooksLog = path.join(project.repoPath, 'hooks.log');
+      try {
+        const stats = fs.statSync(hooksLog);
+        if (stats.size > 10 * 1024 * 1024) {
+          fs.truncateSync(hooksLog, 0);
+          server.log.info(`Truncated oversized hooks.log (${(stats.size / 1024 / 1024).toFixed(1)}MB) at ${hooksLog}`);
+        }
+      } catch {
+        // File doesn't exist or can't be read — fine
+      }
+    }
+  } catch {
+    // DB not ready or other error — skip rotation
+  }
+
   // Recover state from before restart (reconcile PIDs, detect orphan worktrees)
   await recoverOnStartup();
 


### PR DESCRIPTION
Closes #444

## Summary
- **New hooks/run-hook.sh** — universal wrapper logs ENTER layer (proves CC read settings.json and executed the hook command), then execs the real hook script
- **All 12 hooks/on_*.sh files** — HOOK log line at top (proves Bash found and entered the script)
- **hooks/send_event.sh** — SEND log line after curl with ok/fail/missing status (proves event delivery attempt)
- **hooks/settings.json.example** — all hook commands routed through run-hook.sh
- **src/server/index.ts** — log rotation: truncates hooks.log if > 10MB on startup

Three-layer diagnosis: if only ENTER appears, the on_*.sh script was not found. If ENTER+HOOK but no SEND, curl/send_event failed. If all three with curl=ok, everything is working.