### PR TITLE
Issue #459: Use configured absolute path for hooks.log

### DIFF
--- a/hooks/on_notification.sh
+++ b/hooks/on_notification.sh
@@ -6,7 +6,7 @@
 # stdin JSON example: {"session_id":"abc123","message":"Permission requested..."}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | notification | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "notification"

--- a/hooks/on_post_tool_use.sh
+++ b/hooks/on_post_tool_use.sh
@@ -6,7 +6,7 @@
 # stdin JSON example: {"session_id":"abc123","tool_name":"Bash","agent_type":"main"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | tool_use | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "tool_use"

--- a/hooks/on_pre_compact.sh
+++ b/hooks/on_pre_compact.sh
@@ -7,7 +7,7 @@
 # stdin JSON example: {"session_id":"abc123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | pre_compact | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "pre_compact"

--- a/hooks/on_session_end.sh
+++ b/hooks/on_session_end.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | session_end | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "session_end"

--- a/hooks/on_session_start.sh
+++ b/hooks/on_session_start.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","agent_type":"main"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | session_start | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "session_start"

--- a/hooks/on_stop.sh
+++ b/hooks/on_stop.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","stop_reason":"end_turn"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | stop | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "stop"

--- a/hooks/on_stop_failure.sh
+++ b/hooks/on_stop_failure.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","error_details":"rate_limit","last_assistant_message":"..."}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | stop_failure | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "stop_failure"

--- a/hooks/on_subagent_start.sh
+++ b/hooks/on_subagent_start.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | subagent_start | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "subagent_start"

--- a/hooks/on_subagent_stop.sh
+++ b/hooks/on_subagent_stop.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev","agent_type":"kea-csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | subagent_stop | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "subagent_stop"

--- a/hooks/on_teammate_idle.sh
+++ b/hooks/on_teammate_idle.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","teammate_name":"csharp-dev"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | teammate_idle | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "teammate_idle"

--- a/hooks/on_tool_error.sh
+++ b/hooks/on_tool_error.sh
@@ -5,7 +5,7 @@
 # stdin JSON example: {"session_id":"abc123","tool_name":"Bash","error":"exit code 1","tool_use_id":"toolu_123"}
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-_LOG="${HOOK_DIR}/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | tool_error | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "tool_error"

--- a/hooks/run-hook.sh
+++ b/hooks/run-hook.sh
@@ -7,7 +7,7 @@
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 EVENT_TYPE="${1:-unknown}"
 SCRIPT="${2:-}"
-LOG="${HOOK_DIR}/../../../../hooks.log"
+LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | ENTER | $EVENT_TYPE | ${FLEET_TEAM_ID:-?} | pid=$$" >> "$LOG" 2>/dev/null || true
 

--- a/hooks/send_event.sh
+++ b/hooks/send_event.sh
@@ -108,7 +108,7 @@ PAYLOAD="${PAYLOAD}}"
 # ── Fire and forget ───────────────────────────────────────────────
 # curl with 2-second timeout. Errors are silenced completely.
 # The hook MUST NOT block Claude Code or cause visible failures.
-_LOG="$(cd "$(dirname "$0")" && pwd)/../../../../hooks.log"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 if command -v curl >/dev/null 2>&1; then
     curl -s -S --max-time 2 --connect-timeout 1 \
         -X POST \

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -5,6 +5,30 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 /**
+ * Return the platform-appropriate default directory for Fleet Commander data files.
+ *
+ * - Windows:  %APPDATA%\fleet-commander
+ * - macOS:    ~/Library/Application Support/fleet-commander
+ * - Linux:    $XDG_DATA_HOME/fleet-commander  (default ~/.local/share)
+ */
+function defaultDataDir(): string {
+  const APP_DIR = 'fleet-commander';
+
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
+    return path.join(appData, APP_DIR);
+  }
+
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', APP_DIR);
+  }
+
+  // Linux / other
+  const dataHome = process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share');
+  return path.join(dataHome, APP_DIR);
+}
+
+/**
  * Return the platform-appropriate default path for the Fleet Commander database.
  *
  * - Windows:  %APPDATA%\fleet-commander\fleet.db
@@ -12,21 +36,19 @@ import { fileURLToPath } from 'url';
  * - Linux:    $XDG_DATA_HOME/fleet-commander/fleet.db  (default ~/.local/share)
  */
 export function defaultDbPath(): string {
-  const DB_NAME = 'fleet.db';
-  const APP_DIR = 'fleet-commander';
+  return path.join(defaultDataDir(), 'fleet.db');
+}
 
-  if (process.platform === 'win32') {
-    const appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
-    return path.join(appData, APP_DIR, DB_NAME);
-  }
-
-  if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Application Support', APP_DIR, DB_NAME);
-  }
-
-  // Linux / other
-  const dataHome = process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share');
-  return path.join(dataHome, APP_DIR, DB_NAME);
+/**
+ * Return the platform-appropriate default path for the hook execution log.
+ *
+ * Lives in the same directory as the database file:
+ * - Windows:  %APPDATA%\fleet-commander\hooks.log
+ * - macOS:    ~/Library/Application Support/fleet-commander/hooks.log
+ * - Linux:    $XDG_DATA_HOME/fleet-commander/hooks.log  (default ~/.local/share)
+ */
+export function defaultHookLogPath(): string {
+  return path.join(defaultDataDir(), 'hooks.log');
 }
 
 /**
@@ -117,6 +139,7 @@ const config = Object.freeze({
   enableAgentTeams: process.env['FLEET_ENABLE_AGENT_TEAMS'] !== 'false',
 
   dbPath: process.env['FLEET_DB_PATH'] || defaultDbPath(),
+  hookLogPath: process.env['FLEET_HOOK_LOG'] || defaultHookLogPath(),
 
   logLevel: process.env['LOG_LEVEL'] || 'info',
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -84,23 +84,14 @@ async function main() {
   );
 
   // Rotate hooks.log if > 10MB (prevents unbounded growth)
-  // Check all registered project paths for hooks.log files
   try {
-    const projects = db.getProjects();
-    for (const project of projects) {
-      const hooksLog = path.join(project.repoPath, 'hooks.log');
-      try {
-        const stats = fs.statSync(hooksLog);
-        if (stats.size > 10 * 1024 * 1024) {
-          fs.truncateSync(hooksLog, 0);
-          server.log.info(`Truncated oversized hooks.log (${(stats.size / 1024 / 1024).toFixed(1)}MB) at ${hooksLog}`);
-        }
-      } catch {
-        // File doesn't exist or can't be read — fine
-      }
+    const stats = fs.statSync(config.hookLogPath);
+    if (stats.size > 10 * 1024 * 1024) {
+      fs.truncateSync(config.hookLogPath, 0);
+      server.log.info(`Truncated oversized hooks.log (${(stats.size / 1024 / 1024).toFixed(1)}MB) at ${config.hookLogPath}`);
     }
   } catch {
-    // DB not ready or other error — skip rotation
+    // File doesn't exist yet — fine
   }
 
   // Recover state from before restart (reconcile PIDs, detect orphan worktrees)

--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -85,6 +85,10 @@ export function buildEnv(fleetContext?: FleetEnvContext): SpawnEnv {
     env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = undefined;
   }
 
+  // Absolute path to the shared hooks.log file. Hook scripts read this env
+  // var instead of computing a fragile relative path from their own location.
+  env['FLEET_HOOK_LOG'] = config.hookLogPath;
+
   // Windows: CC requires git-bash for hook execution. Auto-detect the path
   // so CC can find bash.exe even when Fleet Commander is started from a
   // non-Git-Bash terminal (e.g. cmd.exe or PowerShell).


### PR DESCRIPTION
Closes #459

## Summary
- Added `hookLogPath` config property in `src/server/config.ts` with `FLEET_HOOK_LOG` env var override, defaulting to platform data dir (same directory as the database)
- Injected `FLEET_HOOK_LOG` into all CC spawn environments via `buildEnv()` in `cc-spawn.ts`
- Replaced fragile relative path (`../../../../hooks.log`) with `${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}` in all 13 hook scripts
- Simplified hooks.log rotation in `index.ts` to use single `config.hookLogPath` instead of iterating project paths

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Verify hooks.log is created at platform data dir when FC starts and spawns a team
- [ ] Verify `FLEET_HOOK_LOG` env var override works
- [ ] Verify fallback to `/tmp/fleet-hooks.log` when run outside FC