### PR TITLE
Issue #467: Fix git commit status showing red instead of amber for version upgrades

### DIFF
--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -377,16 +377,33 @@ export function checkGitCommitStatus(repoPath: string): GitCommitStatus | undefi
     let health: GitCommitHealth;
     let message: string;
 
-    if (!allCommitted) {
+    if (!allCommitted && !anyOutdated) {
+      // Files genuinely not committed (not a version upgrade scenario)
       health = 'red';
       const missingCount = fileStatuses.filter((f) => !f.committed).length + missingHooks.length;
       message = `${missingCount} .claude/ file${missingCount === 1 ? '' : 's'} not committed to ${shortBranch}`;
-    } else if (anyOutdated) {
+    } else if (!allCommitted && anyOutdated) {
+      // Some files missing + some outdated = likely a version upgrade
+      // Missing files are new in this FC version, not user error
       health = 'amber';
+      const outdatedVersion = fileStatuses.find(
+        (f) => f.committed && f.committedVersion && f.committedVersion !== currentVersion,
+      )?.committedVersion;
+      message = outdatedVersion
+        ? `Outdated (v${outdatedVersion} → v${currentVersion}) — reinstall and commit to update`
+        : `Committed to ${shortBranch} but some files outdated — reinstall and commit to update`;
+    } else if (anyOutdated) {
+      // All files committed but some have older version stamps
+      health = 'amber';
+      const outdatedVersion = fileStatuses.find(
+        (f) => f.committed && f.committedVersion && f.committedVersion !== currentVersion,
+      )?.committedVersion;
       const outdatedCount = fileStatuses.filter(
         (f) => f.committed && f.committedVersion && f.committedVersion !== currentVersion,
       ).length;
-      message = `Committed to ${shortBranch} but ${outdatedCount} file${outdatedCount === 1 ? '' : 's'} outdated`;
+      message = outdatedVersion
+        ? `Outdated (v${outdatedVersion} → v${currentVersion}) — reinstall and commit to update`
+        : `Committed to ${shortBranch} but ${outdatedCount} file${outdatedCount === 1 ? '' : 's'} outdated`;
     } else {
       health = 'green';
       message = `All .claude/ files committed to ${shortBranch}`;


### PR DESCRIPTION
Closes #467

## Summary
- Fix `checkGitCommitStatus()` in `project-service.ts` to distinguish between genuinely uncommitted files (RED) and files missing due to a FC version upgrade (AMBER)
- When committed files have an older version stamp and some new files are missing from the default branch, health is now AMBER ("Outdated v0.0.8 → v0.0.9 — reinstall and commit to update") instead of RED ("not committed")
- No client-side changes needed — `ProjectsPage.tsx` already handles amber correctly with "Update & Commit" button and no "hooks won't work" suffix

## Test plan
- [ ] Verify fresh install (no files committed) still shows RED with "Fix" button
- [ ] Verify upgraded FC (committed v0.0.8, running v0.0.9) shows AMBER with "Update & Commit" button
- [ ] Verify all files committed with current version shows GREEN