### PR TITLE
Issue #425: Add React Error Boundary to prevent blank screen on component crash

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { FleetProvider } from './context/FleetContext';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { TopBar } from './components/TopBar';
 import { SideNav } from './components/SideNav';
 import { StatusBar } from './components/StatusBar';
@@ -14,36 +15,38 @@ import { StateMachinePage } from './views/StateMachinePage';
 export function App() {
   return (
     <BrowserRouter>
-      <FleetProvider>
-        <div className="h-screen w-screen flex flex-col bg-dark-base text-dark-text overflow-hidden">
-          {/* Top bar — fixed 48px */}
-          <TopBar />
+      <ErrorBoundary>
+        <FleetProvider>
+          <div className="h-screen w-screen flex flex-col bg-dark-base text-dark-text overflow-hidden">
+            {/* Top bar — fixed 48px */}
+            <TopBar />
 
-          {/* Middle section: SideNav + main content */}
-          <div className="flex flex-1 min-h-0">
-            {/* Side navigation — fixed 56px wide */}
-            <SideNav />
+            {/* Middle section: SideNav + main content */}
+            <div className="flex flex-1 min-h-0">
+              {/* Side navigation — fixed 56px wide */}
+              <SideNav />
 
-            {/* Main content area — fills remaining space */}
-            <main className="flex-1 min-w-0 overflow-auto">
-              <Routes>
-                <Route path="/" element={<FleetGridView />} />
-                <Route path="/issues" element={<IssueTreeView />} />
-                <Route path="/usage" element={<UsageViewPage />} />
-                <Route path="/projects" element={<ProjectsPage />} />
-                <Route path="/lifecycle" element={<StateMachinePage />} />
-                <Route path="/settings" element={<SettingsPage />} />
-              </Routes>
-            </main>
+              {/* Main content area — fills remaining space */}
+              <main className="flex-1 min-w-0 overflow-auto">
+                <Routes>
+                  <Route path="/" element={<FleetGridView />} />
+                  <Route path="/issues" element={<IssueTreeView />} />
+                  <Route path="/usage" element={<UsageViewPage />} />
+                  <Route path="/projects" element={<ProjectsPage />} />
+                  <Route path="/lifecycle" element={<StateMachinePage />} />
+                  <Route path="/settings" element={<SettingsPage />} />
+                </Routes>
+              </main>
+            </div>
+
+            {/* Status bar — fixed 24px */}
+            <StatusBar />
           </div>
 
-          {/* Status bar — fixed 24px */}
-          <StatusBar />
-        </div>
-
-        {/* Team detail slide-over panel — rendered as overlay outside the main layout */}
-        <TeamDetail />
-      </FleetProvider>
+          {/* Team detail slide-over panel — rendered as overlay outside the main layout */}
+          <TeamDetail />
+        </FleetProvider>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -1,0 +1,105 @@
+// =============================================================================
+// Fleet Commander -- ErrorBoundary
+// React Error Boundaries require class components (no functional equivalent).
+// =============================================================================
+
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Top-level error boundary that catches unhandled React render errors and
+ * displays a dark-themed fallback UI instead of a blank white screen.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('[ErrorBoundary] Uncaught error:', error, errorInfo);
+  }
+
+  private handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100vh',
+            width: '100vw',
+            backgroundColor: '#0d1117',
+            color: '#e6edf3',
+            fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+            padding: '2rem',
+            textAlign: 'center',
+          }}
+        >
+          <h1
+            style={{
+              fontSize: '1.5rem',
+              fontWeight: 600,
+              color: '#F85149',
+              marginBottom: '1rem',
+            }}
+          >
+            Something went wrong
+          </h1>
+
+          {this.state.error && (
+            <p
+              style={{
+                fontSize: '0.875rem',
+                color: '#8b949e',
+                maxWidth: '36rem',
+                marginBottom: '1.5rem',
+                wordBreak: 'break-word',
+              }}
+            >
+              {this.state.error.message}
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={this.handleReload}
+            style={{
+              padding: '0.5rem 1rem',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              color: '#e6edf3',
+              backgroundColor: 'transparent',
+              border: '1px solid #30363d',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/tests/client/ErrorBoundary.test.tsx
+++ b/tests/client/ErrorBoundary.test.tsx
@@ -1,0 +1,109 @@
+// =============================================================================
+// Fleet Commander -- ErrorBoundary Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ErrorBoundary } from '../../src/client/components/ErrorBoundary';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A component that throws on render, used to trigger the error boundary. */
+function ThrowingComponent({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+/** A harmless child component for the happy-path test. */
+function GoodChild() {
+  return <p>All systems nominal</p>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Suppress noisy console.error output from React and componentDidCatch
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <GoodChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('All systems nominal')).toBeInTheDocument();
+  });
+
+  it('renders fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="kaboom" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('displays the error message in the fallback', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="flux capacitor overload" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('flux capacitor overload')).toBeInTheDocument();
+  });
+
+  it('renders a Reload button in the fallback', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="oops" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when the Reload button is clicked', () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="oops" />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+  });
+
+  it('logs the error via console.error', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="log-test" />
+      </ErrorBoundary>,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const callArgs = consoleErrorSpy.mock.calls.flat().map(String);
+    expect(callArgs.some((arg) => arg.includes('log-test'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #425

## Summary
- Add `ErrorBoundary` class component (`src/client/components/ErrorBoundary.tsx`) that catches render errors and displays a dark-themed fallback UI with error message and reload button
- Wrap the React tree in `App.tsx` with `<ErrorBoundary>` so component crashes show a recovery UI instead of a blank screen
- Add 6 tests covering normal rendering, error fallback, reload behavior, and console logging

## Test plan
- [x] TypeScript type-check passes (zero errors)
- [x] Production build passes
- [x] 6 new ErrorBoundary tests pass
- [x] Full client test suite (30 suites) passes