### PR TITLE
Issue #422: Implement data retention policy for events and usage_snapshots tables

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -129,6 +129,9 @@ const config = Object.freeze({
   /** Minimum tool-use events for a subagent session to be considered healthy */
   earlyCrashMinTools: safeParseInt(process.env['FLEET_EARLY_CRASH_MIN_TOOLS'] || '5', 'FLEET_EARLY_CRASH_MIN_TOOLS'),
 
+  eventsRetentionDays: safeParseInt(process.env['FLEET_EVENTS_RETENTION_DAYS'] || '90', 'FLEET_EVENTS_RETENTION_DAYS'),
+  usageRetentionDays: safeParseInt(process.env['FLEET_USAGE_RETENTION_DAYS'] || '30', 'FLEET_USAGE_RETENTION_DAYS'),
+
   usageRedDailyPct: safeParseInt(process.env['FLEET_USAGE_RED_DAILY_PCT'] || '85', 'FLEET_USAGE_RED_DAILY_PCT'),
   usageRedWeeklyPct: safeParseInt(process.env['FLEET_USAGE_RED_WEEKLY_PCT'] || '95', 'FLEET_USAGE_RED_WEEKLY_PCT'),
   usageRedSonnetPct: safeParseInt(process.env['FLEET_USAGE_RED_SONNET_PCT'] || '95', 'FLEET_USAGE_RED_SONNET_PCT'),
@@ -193,6 +196,8 @@ export function validateConfig(): void {
     ['earlyCrashThresholdSec', config.earlyCrashThresholdSec],
     ['earlyCrashMinTools', config.earlyCrashMinTools],
     ['ccQueryMaxTurns', config.ccQueryMaxTurns],
+    ['eventsRetentionDays', config.eventsRetentionDays],
+    ['usageRetentionDays', config.usageRetentionDays],
   ];
   for (const [name, value] of positiveIntegers) {
     if (isNaN(value) || value <= 0) {

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1843,6 +1843,127 @@ export class FleetDatabase {
   }
 
   // -------------------------------------------------------------------------
+  // Data retention — batched purge of old records
+  // -------------------------------------------------------------------------
+
+  /**
+   * Delete events older than `retentionDays` in batches of `batchSize`.
+   * Returns total number of rows deleted.
+   */
+  purgeOldEvents(retentionDays: number, batchSize: number = 5000): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM events WHERE id IN (
+        SELECT id FROM events WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
+      )`
+    );
+    let totalDeleted = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = stmt.run({ days: retentionDays, limit: batchSize });
+      totalDeleted += result.changes;
+      if (result.changes < batchSize) break;
+    }
+    return totalDeleted;
+  }
+
+  /**
+   * Delete usage_snapshots older than `retentionDays` in batches of `batchSize`.
+   * Returns total number of rows deleted.
+   */
+  purgeOldUsageSnapshots(retentionDays: number, batchSize: number = 5000): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM usage_snapshots WHERE id IN (
+        SELECT id FROM usage_snapshots WHERE recorded_at < datetime('now', '-' || @days || ' days') LIMIT @limit
+      )`
+    );
+    let totalDeleted = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = stmt.run({ days: retentionDays, limit: batchSize });
+      totalDeleted += result.changes;
+      if (result.changes < batchSize) break;
+    }
+    return totalDeleted;
+  }
+
+  /**
+   * Delete commands older than `retentionDays` in batches of `batchSize`.
+   * Returns total number of rows deleted.
+   */
+  purgeOldCommands(retentionDays: number, batchSize: number = 5000): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM commands WHERE id IN (
+        SELECT id FROM commands WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
+      )`
+    );
+    let totalDeleted = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = stmt.run({ days: retentionDays, limit: batchSize });
+      totalDeleted += result.changes;
+      if (result.changes < batchSize) break;
+    }
+    return totalDeleted;
+  }
+
+  /**
+   * Delete team_transitions older than `retentionDays` in batches of `batchSize`.
+   * Returns total number of rows deleted.
+   */
+  purgeOldTeamTransitions(retentionDays: number, batchSize: number = 5000): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM team_transitions WHERE id IN (
+        SELECT id FROM team_transitions WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
+      )`
+    );
+    let totalDeleted = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = stmt.run({ days: retentionDays, limit: batchSize });
+      totalDeleted += result.changes;
+      if (result.changes < batchSize) break;
+    }
+    return totalDeleted;
+  }
+
+  /**
+   * Delete agent_messages older than `retentionDays` in batches of `batchSize`.
+   * Returns total number of rows deleted.
+   */
+  purgeOldAgentMessages(retentionDays: number, batchSize: number = 5000): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM agent_messages WHERE id IN (
+        SELECT id FROM agent_messages WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
+      )`
+    );
+    let totalDeleted = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = stmt.run({ days: retentionDays, limit: batchSize });
+      totalDeleted += result.changes;
+      if (result.changes < batchSize) break;
+    }
+    return totalDeleted;
+  }
+
+  /**
+   * Delete stream_events for teams that have been stopped for more than
+   * `retentionDays`. stream_events has a UNIQUE constraint on team_id
+   * (one row per team), so batch size is less critical here.
+   * Returns total number of rows deleted.
+   */
+  purgeOldStreamEvents(retentionDays: number): number {
+    const result = this.db.prepare(
+      `DELETE FROM stream_events WHERE team_id IN (
+        SELECT id FROM teams
+        WHERE stopped_at IS NOT NULL
+          AND stopped_at < datetime('now', '-' || @days || ' days')
+      )`
+    ).run({ days: retentionDays });
+    return result.changes;
+  }
+
+  // -------------------------------------------------------------------------
   // Connection management
   // -------------------------------------------------------------------------
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import { errorHandler } from './middleware/error-handler.js';
 import { getDatabase, closeDatabase } from './db.js';
 import { recoverOnStartup } from './services/startup-recovery.js';
 import { usagePoller } from './services/usage-tracker.js';
+import { dataRetention } from './services/data-retention.js';
 import config from './config.js';
 import { resolveClaudePath } from './utils/resolve-claude-path.js';
 import { getTeamManager } from './services/team-manager.js';
@@ -149,10 +150,12 @@ async function main() {
   stuckDetector.start();
   githubPoller.start();
   usagePoller.start();
-  server.log.info('All services started (SSE, issues, stuck detector, GitHub poller, usage poller)');
+  dataRetention.start();
+  server.log.info('All services started (SSE, issues, stuck detector, GitHub poller, usage poller, data retention)');
 
   // Graceful shutdown
   server.addHook('onClose', async () => {
+    dataRetention.stop();
     usagePoller.stop();
     githubPoller.stop();
     stuckDetector.stop();

--- a/src/server/services/data-retention.ts
+++ b/src/server/services/data-retention.ts
@@ -1,0 +1,94 @@
+// =============================================================================
+// Fleet Commander — Data Retention Service
+//
+// Periodically purges old records from high-volume tables (events,
+// usage_snapshots, commands, team_transitions, agent_messages, stream_events)
+// to prevent unbounded database growth.
+//
+// Runs once on startup, then every 24 hours. Uses batched deletes (LIMIT 5000
+// per iteration) to avoid long WAL locks on large tables.
+// =============================================================================
+
+import { getDatabase } from '../db.js';
+import config from '../config.js';
+
+/** 24 hours in milliseconds */
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+class DataRetention {
+  private interval: NodeJS.Timeout | null = null;
+
+  /**
+   * Start the data retention service.
+   * Runs a purge immediately on startup, then schedules every 24 hours.
+   */
+  start(): void {
+    if (this.interval) {
+      return; // already running
+    }
+
+    // Run once immediately
+    this.purge();
+
+    this.interval = setInterval(() => this.purge(), TWENTY_FOUR_HOURS_MS);
+
+    // Allow Node.js to exit even if this timer is still active
+    if (this.interval.unref) {
+      this.interval.unref();
+    }
+  }
+
+  /**
+   * Stop the periodic purge loop.
+   */
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  /**
+   * Run a single retention purge pass.
+   * Can be called manually (e.g. from tests) or is invoked by the timer.
+   */
+  purge(): void {
+    try {
+      const db = getDatabase();
+      const eventsRetention = config.eventsRetentionDays;
+      const usageRetention = config.usageRetentionDays;
+
+      const eventsDeleted = db.purgeOldEvents(eventsRetention);
+      const usageDeleted = db.purgeOldUsageSnapshots(usageRetention);
+      const commandsDeleted = db.purgeOldCommands(eventsRetention);
+      const transitionsDeleted = db.purgeOldTeamTransitions(eventsRetention);
+      const messagesDeleted = db.purgeOldAgentMessages(eventsRetention);
+      const streamEventsDeleted = db.purgeOldStreamEvents(eventsRetention);
+
+      const total = eventsDeleted + usageDeleted + commandsDeleted
+        + transitionsDeleted + messagesDeleted + streamEventsDeleted;
+
+      if (total > 0) {
+        console.log(
+          `[DataRetention] Purged ${total} old records — ` +
+          `events=${eventsDeleted} (>${eventsRetention}d), ` +
+          `usage_snapshots=${usageDeleted} (>${usageRetention}d), ` +
+          `commands=${commandsDeleted}, ` +
+          `team_transitions=${transitionsDeleted}, ` +
+          `agent_messages=${messagesDeleted}, ` +
+          `stream_events=${streamEventsDeleted}`
+        );
+      } else {
+        console.log('[DataRetention] No old records to purge');
+      }
+    } catch (err: unknown) {
+      console.error(
+        '[DataRetention] Purge failed:',
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+}
+
+// Singleton instance — importable from anywhere in the server
+export const dataRetention = new DataRetention();

--- a/tests/server/data-retention.test.ts
+++ b/tests/server/data-retention.test.ts
@@ -1,0 +1,376 @@
+// =============================================================================
+// Fleet Commander — Data Retention Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { FleetDatabase } from '../../src/server/db.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let db: FleetDatabase;
+let dbPath: string;
+
+function createTempDb(): FleetDatabase {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-retention-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+  const database = new FleetDatabase(dbPath);
+  database.initSchema();
+  return database;
+}
+
+function cleanupDb(): void {
+  try {
+    db.close();
+  } catch {
+    // already closed
+  }
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+}
+
+/** Insert a project and team for FK constraints. Returns the team ID. */
+function insertProjectAndTeam(): number {
+  db.raw.prepare(
+    `INSERT INTO projects (name, repo_path, github_repo, status)
+     VALUES ('test-proj', '/tmp/test-proj', 'org/test-proj', 'active')`
+  ).run();
+  const projectId = db.raw.prepare('SELECT id FROM projects ORDER BY id DESC LIMIT 1').get() as { id: number };
+
+  db.raw.prepare(
+    `INSERT INTO teams (issue_number, project_id, worktree_name, status, phase)
+     VALUES (1, @projectId, 'test-proj-1', 'done', 'done')`
+  ).run({ projectId: projectId.id });
+  const teamRow = db.raw.prepare('SELECT id FROM teams ORDER BY id DESC LIMIT 1').get() as { id: number };
+  return teamRow.id;
+}
+
+/** Insert an event with a specific created_at timestamp. */
+function insertEventAt(teamId: number, createdAt: string): void {
+  db.raw.prepare(
+    `INSERT INTO events (team_id, event_type, created_at) VALUES (?, 'tool_use', ?)`
+  ).run(teamId, createdAt);
+}
+
+/** Insert a usage_snapshot with a specific recorded_at timestamp. */
+function insertUsageAt(recordedAt: string): void {
+  db.raw.prepare(
+    `INSERT INTO usage_snapshots (daily_percent, weekly_percent, recorded_at)
+     VALUES (10, 20, ?)`
+  ).run(recordedAt);
+}
+
+/** Insert a command with a specific created_at timestamp. */
+function insertCommandAt(teamId: number, createdAt: string): void {
+  db.raw.prepare(
+    `INSERT INTO commands (team_id, message, created_at) VALUES (?, 'test msg', ?)`
+  ).run(teamId, createdAt);
+}
+
+/** Insert a team_transition with a specific created_at timestamp. */
+function insertTransitionAt(teamId: number, createdAt: string): void {
+  db.raw.prepare(
+    `INSERT INTO team_transitions (team_id, from_status, to_status, created_at)
+     VALUES (?, 'running', 'idle', ?)`
+  ).run(teamId, createdAt);
+}
+
+/** Insert an agent_message with a specific created_at timestamp. */
+function insertAgentMessageAt(teamId: number, createdAt: string): void {
+  db.raw.prepare(
+    `INSERT INTO agent_messages (team_id, sender, recipient, content, created_at)
+     VALUES (?, 'dev', 'tl', 'hello', ?)`
+  ).run(teamId, createdAt);
+}
+
+function daysAgo(days: number): string {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  // Format as SQLite datetime: YYYY-MM-DD HH:MM:SS
+  return d.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+}
+
+function countRows(table: string): number {
+  const row = db.raw.prepare(`SELECT COUNT(*) as cnt FROM ${table}`).get() as { cnt: number };
+  return row.cnt;
+}
+
+beforeEach(() => {
+  db = createTempDb();
+});
+
+afterEach(() => {
+  cleanupDb();
+});
+
+// =============================================================================
+// purgeOldEvents
+// =============================================================================
+
+describe('purgeOldEvents', () => {
+  it('should delete events older than retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Insert old events (100 days ago)
+    insertEventAt(teamId, daysAgo(100));
+    insertEventAt(teamId, daysAgo(95));
+
+    // Insert recent events (10 days ago)
+    insertEventAt(teamId, daysAgo(10));
+    insertEventAt(teamId, daysAgo(5));
+
+    expect(countRows('events')).toBe(4);
+
+    const deleted = db.purgeOldEvents(90);
+
+    expect(deleted).toBe(2);
+    expect(countRows('events')).toBe(2);
+  });
+
+  it('should keep events within retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    insertEventAt(teamId, daysAgo(30));
+    insertEventAt(teamId, daysAgo(10));
+    insertEventAt(teamId, daysAgo(1));
+
+    const deleted = db.purgeOldEvents(90);
+
+    expect(deleted).toBe(0);
+    expect(countRows('events')).toBe(3);
+  });
+
+  it('should handle empty events table gracefully', () => {
+    const deleted = db.purgeOldEvents(90);
+    expect(deleted).toBe(0);
+  });
+
+  it('should use batched deletes', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Insert 12 old events (use small batch size to test batching)
+    for (let i = 0; i < 12; i++) {
+      insertEventAt(teamId, daysAgo(100));
+    }
+
+    const deleted = db.purgeOldEvents(90, 5); // batch size of 5
+
+    expect(deleted).toBe(12);
+    expect(countRows('events')).toBe(0);
+  });
+});
+
+// =============================================================================
+// purgeOldUsageSnapshots
+// =============================================================================
+
+describe('purgeOldUsageSnapshots', () => {
+  it('should delete usage snapshots older than retention period', () => {
+    // Insert old snapshots (40 days ago)
+    insertUsageAt(daysAgo(40));
+    insertUsageAt(daysAgo(35));
+
+    // Insert recent snapshots (10 days ago)
+    insertUsageAt(daysAgo(10));
+
+    expect(countRows('usage_snapshots')).toBe(3);
+
+    const deleted = db.purgeOldUsageSnapshots(30);
+
+    expect(deleted).toBe(2);
+    expect(countRows('usage_snapshots')).toBe(1);
+  });
+
+  it('should keep snapshots within retention period', () => {
+    insertUsageAt(daysAgo(15));
+    insertUsageAt(daysAgo(5));
+
+    const deleted = db.purgeOldUsageSnapshots(30);
+
+    expect(deleted).toBe(0);
+    expect(countRows('usage_snapshots')).toBe(2);
+  });
+
+  it('should handle empty usage_snapshots table gracefully', () => {
+    const deleted = db.purgeOldUsageSnapshots(30);
+    expect(deleted).toBe(0);
+  });
+});
+
+// =============================================================================
+// purgeOldCommands
+// =============================================================================
+
+describe('purgeOldCommands', () => {
+  it('should delete commands older than retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    insertCommandAt(teamId, daysAgo(100));
+    insertCommandAt(teamId, daysAgo(5));
+
+    const deleted = db.purgeOldCommands(90);
+
+    expect(deleted).toBe(1);
+    expect(countRows('commands')).toBe(1);
+  });
+
+  it('should handle empty commands table gracefully', () => {
+    const deleted = db.purgeOldCommands(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// =============================================================================
+// purgeOldTeamTransitions
+// =============================================================================
+
+describe('purgeOldTeamTransitions', () => {
+  it('should delete transitions older than retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    insertTransitionAt(teamId, daysAgo(100));
+    insertTransitionAt(teamId, daysAgo(5));
+
+    const deleted = db.purgeOldTeamTransitions(90);
+
+    expect(deleted).toBe(1);
+    expect(countRows('team_transitions')).toBe(1);
+  });
+
+  it('should handle empty team_transitions table gracefully', () => {
+    const deleted = db.purgeOldTeamTransitions(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// =============================================================================
+// purgeOldAgentMessages
+// =============================================================================
+
+describe('purgeOldAgentMessages', () => {
+  it('should delete agent messages older than retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    insertAgentMessageAt(teamId, daysAgo(100));
+    insertAgentMessageAt(teamId, daysAgo(5));
+
+    const deleted = db.purgeOldAgentMessages(90);
+
+    expect(deleted).toBe(1);
+    expect(countRows('agent_messages')).toBe(1);
+  });
+
+  it('should handle empty agent_messages table gracefully', () => {
+    const deleted = db.purgeOldAgentMessages(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// =============================================================================
+// purgeOldStreamEvents
+// =============================================================================
+
+describe('purgeOldStreamEvents', () => {
+  it('should delete stream_events for teams stopped beyond retention period', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Mark the team as stopped 100 days ago
+    db.raw.prepare(
+      `UPDATE teams SET stopped_at = ? WHERE id = ?`
+    ).run(daysAgo(100), teamId);
+
+    // Insert stream events for that team
+    db.raw.prepare(
+      `INSERT INTO stream_events (team_id, event_data) VALUES (?, '[]')`
+    ).run(teamId);
+
+    expect(countRows('stream_events')).toBe(1);
+
+    const deleted = db.purgeOldStreamEvents(90);
+
+    expect(deleted).toBe(1);
+    expect(countRows('stream_events')).toBe(0);
+  });
+
+  it('should keep stream_events for recently stopped teams', () => {
+    const teamId = insertProjectAndTeam();
+
+    db.raw.prepare(
+      `UPDATE teams SET stopped_at = ? WHERE id = ?`
+    ).run(daysAgo(10), teamId);
+
+    db.raw.prepare(
+      `INSERT INTO stream_events (team_id, event_data) VALUES (?, '[]')`
+    ).run(teamId);
+
+    const deleted = db.purgeOldStreamEvents(90);
+
+    expect(deleted).toBe(0);
+    expect(countRows('stream_events')).toBe(1);
+  });
+
+  it('should keep stream_events for teams that are still running (no stopped_at)', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Team is still running (no stopped_at)
+    db.raw.prepare(
+      `UPDATE teams SET status = 'running', stopped_at = NULL WHERE id = ?`
+    ).run(teamId);
+
+    db.raw.prepare(
+      `INSERT INTO stream_events (team_id, event_data) VALUES (?, '[]')`
+    ).run(teamId);
+
+    const deleted = db.purgeOldStreamEvents(90);
+
+    expect(deleted).toBe(0);
+    expect(countRows('stream_events')).toBe(1);
+  });
+
+  it('should handle empty stream_events table gracefully', () => {
+    const deleted = db.purgeOldStreamEvents(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// =============================================================================
+// Configurable retention periods
+// =============================================================================
+
+describe('Configurable retention periods', () => {
+  it('should respect different retention periods for events vs usage_snapshots', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Insert events and usage at 45 days ago
+    insertEventAt(teamId, daysAgo(45));
+    insertUsageAt(daysAgo(45));
+
+    // With 90-day events retention, the event should survive
+    const eventsDeleted = db.purgeOldEvents(90);
+    expect(eventsDeleted).toBe(0);
+
+    // With 30-day usage retention, the snapshot should be deleted
+    const usageDeleted = db.purgeOldUsageSnapshots(30);
+    expect(usageDeleted).toBe(1);
+  });
+
+  it('should allow very short retention periods (1 day)', () => {
+    const teamId = insertProjectAndTeam();
+
+    // Insert events from 2 days ago
+    insertEventAt(teamId, daysAgo(2));
+
+    const deleted = db.purgeOldEvents(1);
+    expect(deleted).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #422

## Summary
- Add periodic data retention service that prunes old rows from `events` (90 days) and `usage_snapshots` (30 days) tables
- Also prunes related tables: `team_transitions`, `agent_messages`, `commands`, `stream_events` for teams stopped >90 days ago
- Runs on startup + every 24 hours via setInterval
- Configurable via `FLEET_EVENTS_RETENTION_DAYS` and `FLEET_USAGE_RETENTION_DAYS` env vars
- Uses batched deletes (LIMIT 5000) to avoid long WAL locks on large tables
- 19 tests covering all 6 purge methods

## Changes
- **NEW** `src/server/services/data-retention.ts` — DataRetention service class
- **NEW** `tests/server/data-retention.test.ts` — comprehensive test suite
- `src/server/config.ts` — added retention config env vars
- `src/server/db.ts` — added 6 batched purge methods to FleetDatabase
- `src/server/index.ts` — registered service in startup/shutdown

## Test plan
- [x] 19 unit tests pass covering all purge methods
- [x] TypeScript type-check clean
- [x] Build succeeds
- [ ] CI green