### PR TITLE
Issue #419: Stop polling in UnifiedTimeline and LaunchDialog on terminal state

### DIFF
--- a/src/client/components/LaunchDialog.tsx
+++ b/src/client/components/LaunchDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useApi } from '../hooks/useApi';
 import type { ProjectSummary, Team, TeamStatus } from '../../shared/types';
+import { TERMINAL_STATUSES } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Flattened issue item used in the issue picker
@@ -148,19 +149,23 @@ function LaunchLog({ teamId, issueNumber, onClose }: LaunchLogProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const outputEndRef = useRef<HTMLDivElement>(null);
   const autoCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const statusRef = useRef<TeamStatus>('queued');
 
-  // Poll team status, output, and stream events every 2 seconds
+  // Poll team status, output, and stream events with setTimeout chaining
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     async function poll() {
       if (cancelled) return;
+      if (TERMINAL_STATUSES.has(statusRef.current)) return;
 
       try {
         // Fetch team status
         const team = await api.get<Team>(`teams/${teamId}`);
         if (cancelled) return;
         setTeamStatus(team.status);
+        statusRef.current = team.status;
 
         if (team.status === 'failed') {
           setErrorMessage(`Team failed${team.stoppedAt ? ` at ${new Date(team.stoppedAt).toLocaleTimeString()}` : ''}`);
@@ -178,19 +183,21 @@ function LaunchLog({ teamId, issueNumber, onClose }: LaunchLogProps) {
       } catch {
         // Ignore polling errors — will retry
       }
+
+      // Schedule next poll only if not cancelled and not terminal
+      if (!cancelled && !TERMINAL_STATUSES.has(statusRef.current)) {
+        timer = setTimeout(poll, 2000);
+      }
     }
 
     // Initial poll immediately
     poll();
 
-    // Then every 2 seconds
-    const interval = setInterval(poll, 2000);
-
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (timer !== null) clearTimeout(timer);
     };
-  }, [api, teamId]);
+  }, [api, teamId, teamStatus]);
 
   // Auto-scroll output to bottom
   useEffect(() => {

--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useApi } from '../hooks/useApi';
-import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry, TeamMember } from '../../shared/types';
+import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry, TeamMember, TeamStatus } from '../../shared/types';
+import { TERMINAL_STATUSES } from '../../shared/types';
 import { agentColor } from '../utils/constants';
 import { AgentFilterBar } from './AgentFilterBar';
 import { SettingsIcon } from './Icons';
@@ -496,6 +497,7 @@ export function UnifiedTimeline({
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
+  const pollDelayRef = useRef(2000);
 
   // Detect if user has scrolled up — disable auto-scroll in that case
   const handleScroll = useCallback(() => {
@@ -506,9 +508,13 @@ export function UnifiedTimeline({
     stickToBottomRef.current = atBottom;
   }, []);
 
-  // Poll for timeline data every 2 seconds
+  // Poll for timeline data with exponential backoff (2s -> 4s -> 8s -> 16s -> 30s max)
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    // Reset backoff whenever the effect re-runs (e.g. teamStatus change)
+    pollDelayRef.current = 2000;
 
     async function poll() {
       if (cancelled) return;
@@ -520,20 +526,19 @@ export function UnifiedTimeline({
       } catch {
         // Ignore polling errors
       }
+      // Schedule next poll only if not cancelled and not terminal
+      if (!cancelled && !TERMINAL_STATUSES.has(teamStatus as TeamStatus)) {
+        timer = setTimeout(poll, pollDelayRef.current);
+        pollDelayRef.current = Math.min(pollDelayRef.current * 2, 30000);
+      }
     }
 
     // Initial fetch
     poll();
 
-    // Stop polling when team is in a terminal state
-    if (teamStatus === 'done' || teamStatus === 'failed') {
-      return () => { cancelled = true; };
-    }
-
-    const interval = setInterval(poll, 2000);
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (timer !== null) clearTimeout(timer);
     };
   }, [api, teamId, teamStatus]);
 
@@ -606,7 +611,7 @@ export function UnifiedTimeline({
   );
 
   if (entries.length === 0) {
-    const isTerminal = teamStatus === 'done' || teamStatus === 'failed';
+    const isTerminal = TERMINAL_STATUSES.has(teamStatus as TeamStatus);
     return (
       <div className="text-[11px] text-dark-muted italic py-2">
         {isTerminal

--- a/tests/client/LaunchDialog.test.tsx
+++ b/tests/client/LaunchDialog.test.tsx
@@ -171,3 +171,97 @@ describe('LaunchDialog', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// LaunchLog polling behavior tests
+//
+// The LaunchLog is an internal component rendered after a team is launched.
+// We simulate the launch flow, then verify polling stops on terminal status.
+// We use real timers and a short wait to verify polling ceases.
+// ---------------------------------------------------------------------------
+
+describe('LaunchDialog — LaunchLog polling', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Simulate a launch to get into the LaunchLog view, returns team poll count getter */
+  async function launchAndGetToLog(terminalStatus: 'done' | 'failed') {
+    let teamGetCount = 0;
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'projects') return Promise.resolve(makeProjects());
+      if (path.match(/^projects\/\d+\/issues/)) return Promise.resolve(makeIssuesResponse());
+      if (path === 'usage') return Promise.resolve(makeUsage());
+      if (path === 'teams/42') {
+        teamGetCount++;
+        return Promise.resolve({
+          id: 42, issueNumber: 10, status: terminalStatus,
+          stoppedAt: '2026-03-20T10:00:00.000Z',
+        });
+      }
+      if (path === 'teams/42/output?lines=50') return Promise.resolve({ lines: [] });
+      if (path === 'teams/42/stream-events') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    mockPost.mockResolvedValue({ id: 42, issueNumber: 10, status: 'queued' });
+
+    render(<LaunchDialog open onClose={vi.fn()} />);
+
+    // Wait for issues to load
+    await waitFor(() => {
+      expect(screen.getByText('Fix login')).toBeInTheDocument();
+    });
+
+    // Select issue and launch
+    fireEvent.click(screen.getByText('Fix login'));
+    const launchBtn = screen.getByRole('button', { name: /launch/i });
+    fireEvent.click(launchBtn);
+
+    // Wait for LaunchLog to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Team #42/)).toBeInTheDocument();
+    });
+
+    return () => teamGetCount;
+  }
+
+  it('stops polling when team status becomes done', async () => {
+    const getTeamGetCount = await launchAndGetToLog('done');
+
+    // Wait for the initial poll cycle to complete
+    await waitFor(() => {
+      expect(getTeamGetCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    const countAfterInitial = getTeamGetCount();
+
+    // Wait long enough for a second poll cycle to have fired if polling continued (>2s)
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Polling should have stopped — no additional team polls
+    expect(getTeamGetCount()).toBe(countAfterInitial);
+  }, 10000);
+
+  it('stops polling when team status becomes failed', async () => {
+    const getTeamGetCount = await launchAndGetToLog('failed');
+
+    // Wait for the initial poll cycle to complete
+    await waitFor(() => {
+      expect(getTeamGetCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    const countAfterInitial = getTeamGetCount();
+
+    // Wait long enough for a second poll cycle to have fired if polling continued (>2s)
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Polling should have stopped — no additional team polls
+    expect(getTeamGetCount()).toBe(countAfterInitial);
+  }, 10000);
+});

--- a/tests/client/UnifiedTimeline.test.tsx
+++ b/tests/client/UnifiedTimeline.test.tsx
@@ -14,18 +14,21 @@ import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry } from '../.
 Element.prototype.scrollIntoView = vi.fn();
 
 // ---------------------------------------------------------------------------
-// Mock useApi — return controlled timeline data
+// Mock useApi — return controlled timeline data (stable reference)
 // ---------------------------------------------------------------------------
 
 let mockEntries: TimelineEntry[] = [];
+const mockGet = vi.fn().mockImplementation(() => Promise.resolve(mockEntries));
+
+const mockApi = {
+  get: mockGet,
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+};
 
 vi.mock('../../src/client/hooks/useApi', () => ({
-  useApi: () => ({
-    get: vi.fn().mockImplementation(() => Promise.resolve(mockEntries)),
-    post: vi.fn(),
-    put: vi.fn(),
-    del: vi.fn(),
-  }),
+  useApi: () => mockApi,
 }));
 
 // Import after mocks are set up
@@ -87,6 +90,7 @@ function getExpandedBadge() {
 describe('UnifiedTimeline — tool detail expand/collapse', () => {
   beforeEach(() => {
     mockEntries = [];
+    mockGet.mockImplementation(() => Promise.resolve(mockEntries));
   });
 
   afterEach(() => {
@@ -313,6 +317,7 @@ function makeErrorHookEntry(
 describe('UnifiedTimeline — error entry collapse/expand', () => {
   beforeEach(() => {
     mockEntries = [];
+    mockGet.mockImplementation(() => Promise.resolve(mockEntries));
   });
 
   afterEach(() => {
@@ -410,5 +415,103 @@ describe('UnifiedTimeline — error entry collapse/expand', () => {
     await waitFor(() => {
       expect(screen.getByText('Something broke')).toBeInTheDocument();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Polling behavior tests — terminal state + exponential backoff
+// ---------------------------------------------------------------------------
+
+describe('UnifiedTimeline — polling behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockEntries = [];
+    mockGet.mockReset();
+    mockGet.mockImplementation(() => Promise.resolve(mockEntries));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not set up polling interval when teamStatus is done', async () => {
+    render(<UnifiedTimeline teamId={1} teamStatus="done" />);
+
+    // Let the initial fetch resolve
+    await vi.advanceTimersByTimeAsync(0);
+
+    const initialCalls = mockGet.mock.calls.length;
+    expect(initialCalls).toBe(1); // Just the initial fetch
+
+    // Advance time well past any polling interval
+    await vi.advanceTimersByTimeAsync(10000);
+
+    // No additional calls should have been made
+    expect(mockGet.mock.calls.length).toBe(initialCalls);
+  });
+
+  it('does not set up polling interval when teamStatus is failed', async () => {
+    render(<UnifiedTimeline teamId={1} teamStatus="failed" />);
+
+    // Let the initial fetch resolve
+    await vi.advanceTimersByTimeAsync(0);
+
+    const initialCalls = mockGet.mock.calls.length;
+    expect(initialCalls).toBe(1); // Just the initial fetch
+
+    // Advance time well past any polling interval
+    await vi.advanceTimersByTimeAsync(10000);
+
+    // No additional calls should have been made
+    expect(mockGet.mock.calls.length).toBe(initialCalls);
+  });
+
+  it('polls with increasing delay (exponential backoff)', async () => {
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    // Initial fetch fires immediately
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGet.mock.calls.length).toBe(1);
+
+    // After 2s: first backoff poll
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockGet.mock.calls.length).toBe(2);
+
+    // After another 4s: second backoff poll (delay doubled to 4s)
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(mockGet.mock.calls.length).toBe(3);
+
+    // After another 8s: third backoff poll (delay doubled to 8s)
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(mockGet.mock.calls.length).toBe(4);
+  });
+
+  it('caps backoff delay at 30 seconds', async () => {
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    // Initial fetch
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockGet.mock.calls.length).toBe(1);
+
+    // Run through backoff stages: 2s, 4s, 8s, 16s = 30s total, 4 polls
+    await vi.advanceTimersByTimeAsync(2000); // 2s delay
+    expect(mockGet.mock.calls.length).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(4000); // 4s delay
+    expect(mockGet.mock.calls.length).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(8000); // 8s delay
+    expect(mockGet.mock.calls.length).toBe(4);
+
+    await vi.advanceTimersByTimeAsync(16000); // 16s delay
+    expect(mockGet.mock.calls.length).toBe(5);
+
+    // Next should be capped at 30s (not 32s)
+    await vi.advanceTimersByTimeAsync(29999); // Just under 30s — should not fire
+    expect(mockGet.mock.calls.length).toBe(5);
+
+    await vi.advanceTimersByTimeAsync(1); // Completes 30s — should fire
+    expect(mockGet.mock.calls.length).toBe(6);
   });
 });


### PR DESCRIPTION
Closes #419

## Summary
- Replace fixed 2s `setInterval` polling with exponential backoff `setTimeout` chaining (2s → 4s → 8s → 16s → 30s max) in `UnifiedTimeline`
- Stop polling entirely when `teamStatus` reaches terminal state (`done`/`failed`) in both `UnifiedTimeline` and `LaunchDialog`
- Use shared `TERMINAL_STATUSES` constant instead of inline string checks
- Add `statusRef` in `LaunchDialog` to prevent stale closure issues and add `teamStatus` to useEffect dependency array

## Test plan
- [x] 4 new tests in `UnifiedTimeline.test.tsx` (terminal stop for done/failed, exponential backoff, 30s cap)
- [x] 2 new tests in `LaunchDialog.test.tsx` (polling stops on done/failed)
- [x] All 32 tests pass, `tsc --noEmit` clean