### PR TITLE
Issue #424: Fix silent error swallowing across server services

### DIFF
--- a/src/server/services/cleanup.ts
+++ b/src/server/services/cleanup.ts
@@ -211,7 +211,8 @@ export function executeCleanup(
             `git -C "${project.repoPath}" worktree remove --force "${config.worktreeDir}/${item.name}"`,
             { encoding: 'utf-8', stdio: 'pipe', timeout: 15000 },
           );
-        } catch {
+        } catch (e) {
+          console.error(`[Cleanup] worktree remove failed for ${item.name}:`, e instanceof Error ? e.message : e);
           // Fallback: rm -rf the directory
           fs.rmSync(item.path, { recursive: true, force: true });
         }
@@ -221,8 +222,9 @@ export function executeCleanup(
             stdio: 'pipe',
             timeout: 5000,
           });
-        } catch {
-          // non-fatal
+        } catch (e) {
+          // non-fatal — log and continue
+          console.error(`[Cleanup] worktree prune failed:`, e instanceof Error ? e.message : e);
         }
         removed.push(item.name);
       } else if (item.type === 'signal_file') {

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -124,7 +124,9 @@ class GitHubPoller {
   /** Trigger an immediate extra poll (e.g. after a PR is detected) */
   triggerPoll(): void {
     // Run poll in background, don't wait
-    this.poll().catch(() => {});
+    this.poll().catch((err) => {
+      console.error('[GitHubPoller] triggerPoll error:', err instanceof Error ? err.message : err);
+    });
   }
 
   /**

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -2102,6 +2102,10 @@ export class TeamManager {
         }
       });
 
+      child.stdout.on('error', (err: Error) => {
+        console.error(`[TeamManager] stdout stream error for team ${teamId}:`, err.message);
+      });
+
       child.stdout.on('end', () => {
         if (stdoutPartial.trim()) {
           const trimmed = stdoutPartial.trim();
@@ -2162,6 +2166,10 @@ export class TeamManager {
           if (line === '' && idx === newLines.length - 1) continue;
           buffer.push(line);
         }
+      });
+
+      child.stderr.on('error', (err: Error) => {
+        console.error(`[TeamManager] stderr stream error for team ${teamId}:`, err.message);
       });
     }
   }

--- a/src/server/utils/exec-gh.ts
+++ b/src/server/utils/exec-gh.ts
@@ -20,10 +20,43 @@ const execAsync = promisify(exec);
 // Types
 // ---------------------------------------------------------------------------
 
+/** Classification of CLI execution errors for caller-side recovery logic */
+export type ExecErrorType = 'auth' | 'network' | 'rate_limit' | 'not_found' | 'timeout' | 'unknown';
+
 export interface ExecResult {
   ok: boolean;
   stdout?: string;
   error?: string;
+  /** Error classification — only present when ok is false */
+  errorType?: ExecErrorType;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a CLI error string into a typed error category.
+ * Inspects stderr / error message content for known patterns.
+ */
+function classifyError(errorText: string): ExecErrorType {
+  const lower = errorText.toLowerCase();
+  if (lower.includes('rate limit') || lower.includes('api rate limit')) {
+    return 'rate_limit';
+  }
+  if (lower.includes('http 401') || lower.includes('authentication') || lower.includes('auth token') || lower.includes('not logged in')) {
+    return 'auth';
+  }
+  if (lower.includes('http 404') || lower.includes('not found') || lower.includes('could not resolve to a repository')) {
+    return 'not_found';
+  }
+  if (lower.includes('could not resolve host') || lower.includes('network') || lower.includes('econnrefused') || lower.includes('enotfound') || lower.includes('etimedout')) {
+    return 'network';
+  }
+  if (lower.includes('timed out') || lower.includes('timeout') || lower.includes('timedout')) {
+    return 'timeout';
+  }
+  return 'unknown';
 }
 
 // ---------------------------------------------------------------------------
@@ -56,7 +89,8 @@ export async function execGHAsync(
     const message = err instanceof Error ? err.message : String(err);
     // Only log if it's not a benign "no PRs found" type error
     if (!message.includes('no pull requests match')) {
-      console.error(`[execGHAsync] CLI error: ${message.slice(0, 200)}`);
+      const errorType = classifyError(message);
+      console.error(`[execGHAsync] CLI error (${errorType}): ${message.slice(0, 200)}`);
     }
     return null;
   }
@@ -89,7 +123,8 @@ export async function execGHResult(
       const rawStderr = (err as { stderr: string | Buffer }).stderr;
       stderr = typeof rawStderr === 'string' ? rawStderr : rawStderr.toString('utf-8');
     }
-    return { ok: false, error: stderr.trim() || message };
+    const errorText = stderr.trim() || message;
+    return { ok: false, error: errorText, errorType: classifyError(errorText) };
   }
 }
 


### PR DESCRIPTION
Closes #424

## Summary
- **E1:** Replace `.catch(() => {})` with error logging in `github-poller.ts` `triggerPoll()`
- **E2:** Add `.on('error')` handlers to child process stdout/stderr streams in `team-manager.ts`
- **E4:** Add `ExecErrorType` classification and `errorType` field to `ExecResult` in `exec-gh.ts`
- **E5:** Add error logging to empty catch blocks in `cleanup.ts` worktree/prune operations

## Test plan
- [x] All 94 server tests pass
- [x] Build and type-check pass
- [x] Backward-compatible: `execGHAsync` still returns `string | null`