### PR TITLE
Issue #441: Add project group collapsible level to Issue Tree

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -29,9 +29,21 @@ const STATUS_FILTERS = [
 interface ProjectIssueGroup {
   projectId: number;
   projectName: string;
+  groupId: number | null;
+  groupName: string | null;
   tree: IssueNode[];
   cachedAt: string | null;
   count: number;
+}
+
+/** A top-level group of projects (for the project group collapsible level) */
+interface ProjectGroupBucket {
+  /** Unique key for collapse state — `group-{id}` or `group-ungrouped` */
+  key: string;
+  /** Display name for the group header */
+  name: string;
+  /** Projects within this group */
+  projects: ProjectIssueGroup[];
 }
 
 interface IssueTreeResponse {
@@ -380,14 +392,53 @@ export function IssueTreeView() {
       .filter((g) => g.tree.length > 0);
   }, [groups, search, statusFilter]);
 
+  // Group filtered project groups into top-level buckets by groupId
+  // Only creates buckets when there are multiple distinct groups (at least one project has a groupId)
+  const groupedBuckets = useMemo((): ProjectGroupBucket[] => {
+    if (filteredGroups.length === 0) return [];
+
+    // Check if any project has a groupId — if not, skip the grouping level entirely
+    const hasAnyGroupId = filteredGroups.some((g) => g.groupId != null);
+    if (!hasAnyGroupId) return [];
+
+    const bucketMap = new Map<string, ProjectGroupBucket>();
+    for (const pg of filteredGroups) {
+      const key = pg.groupId != null ? `group-${pg.groupId}` : 'group-ungrouped';
+      const name = pg.groupName ?? 'Ungrouped';
+      let bucket = bucketMap.get(key);
+      if (!bucket) {
+        bucket = { key, name, projects: [] };
+        bucketMap.set(key, bucket);
+      }
+      bucket.projects.push(pg);
+    }
+
+    // Sort alphabetically, with "Ungrouped" last
+    const buckets = [...bucketMap.values()].sort((a, b) => {
+      if (a.key === 'group-ungrouped') return 1;
+      if (b.key === 'group-ungrouped') return -1;
+      return a.name.localeCompare(b.name);
+    });
+
+    return buckets;
+  }, [filteredGroups]);
+
   // Collect all node IDs from the full (unfiltered) tree for Collapse All
-  // Includes project group IDs (project-{id}) so Collapse All covers project groups too
+  // Includes group bucket IDs (group-{id}), project group IDs (project-{id}),
+  // and individual issue node IDs
   const allNodeIds = useMemo(() => {
     if (groups.length > 0) {
-      return groups.flatMap((g) => [
-        `project-${g.projectId}`,
-        ...collectAllNodeIds(g.tree),
-      ]);
+      const hasAnyGroupId = groups.some((g) => g.groupId != null);
+      const groupKeys = hasAnyGroupId
+        ? [...new Set(groups.map((g) => g.groupId != null ? `group-${g.groupId}` : 'group-ungrouped'))]
+        : [];
+      return [
+        ...groupKeys,
+        ...groups.flatMap((g) => [
+          `project-${g.projectId}`,
+          ...collectAllNodeIds(g.tree),
+        ]),
+      ];
     }
     return collectAllNodeIds(tree);
   }, [tree, groups]);
@@ -573,8 +624,25 @@ export function IssueTreeView() {
               Clear filters
             </button>
           </div>
+        ) : groupedBuckets.length > 0 ? (
+          /* Grouped view with project groups — group bucket > project > issues */
+          <div className="space-y-2">
+            {groupedBuckets.map((bucket) => (
+              <ProjectGroupSection
+                key={bucket.key}
+                bucket={bucket}
+                onLaunch={handleLaunch}
+                launchingIssues={launchingIssues}
+                launchErrors={launchErrors}
+                forceExpand={!!search || statusFilter !== 'all'}
+                fetchTree={fetchTree}
+                collapsedNodes={collapseState.collapsedNodes}
+                onToggleCollapse={collapseState.toggleCollapse}
+              />
+            ))}
+          </div>
         ) : filteredGroups.length > 0 ? (
-          /* Grouped view — each ProjectGroup has its own prioritization */
+          /* Multi-project view without group assignments — flat project groups */
           <div className="space-y-1">
             {filteredGroups.map((group) => (
               <ProjectGroup
@@ -927,6 +995,78 @@ function PrioritizationActionBar({ prioritization, projectId, api, fetchTree }: 
         <span className="text-xs text-dark-muted ml-auto">
           ${prioritization.costUsd.toFixed(4)} &middot; {((prioritization.durationMs ?? 0) / 1000).toFixed(1)}s
         </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ProjectGroupSection — top-level collapsible group of projects
+// ---------------------------------------------------------------------------
+
+interface ProjectGroupSectionProps {
+  bucket: ProjectGroupBucket;
+  onLaunch: (issueNumber: number, title: string, projectId?: number) => Promise<void>;
+  launchingIssues: Set<number>;
+  launchErrors: Map<number, string>;
+  forceExpand: boolean;
+  fetchTree: () => Promise<void>;
+  collapsedNodes: Set<string>;
+  onToggleCollapse: (nodeId: string) => void;
+}
+
+function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: ProjectGroupSectionProps) {
+  const expanded = !collapsedNodes.has(bucket.key);
+  const totalIssueCount = bucket.projects.reduce((sum, p) => sum + countNodes(p.tree), 0);
+
+  return (
+    <div>
+      {/* Group section header */}
+      <div className="flex items-center gap-2 py-2 px-2 rounded hover:bg-dark-surface/60 transition-colors">
+        <button
+          onClick={() => onToggleCollapse(bucket.key)}
+          className="flex items-center gap-2 flex-1 text-left min-w-0"
+        >
+          {/* Expand/collapse arrow */}
+          <span className={`w-4 h-4 flex items-center justify-center text-dark-muted shrink-0 transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}>
+            <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+          </span>
+          {/* Folder icon for group */}
+          <svg className="w-4 h-4 text-dark-accent/70 shrink-0" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z" />
+          </svg>
+          <span className="text-sm font-semibold text-dark-text truncate">
+            {bucket.name}
+          </span>
+          <span className="text-xs text-dark-muted shrink-0">
+            {bucket.projects.length} project{bucket.projects.length !== 1 ? 's' : ''}
+            {' \u00B7 '}
+            {totalIssueCount} issue{totalIssueCount !== 1 ? 's' : ''}
+          </span>
+        </button>
+      </div>
+
+      {/* Nested project groups */}
+      {expanded && (
+        <div className="ml-2 border-l border-dark-accent/20 pl-1">
+          <div className="space-y-1">
+            {bucket.projects.map((group) => (
+              <ProjectGroup
+                key={group.projectId}
+                group={group}
+                onLaunch={onLaunch}
+                launchingIssues={launchingIssues}
+                launchErrors={launchErrors}
+                forceExpand={forceExpand}
+                fetchTree={fetchTree}
+                collapsedNodes={collapsedNodes}
+                onToggleCollapse={onToggleCollapse}
+              />
+            ))}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/server/services/issue-service.ts
+++ b/src/server/services/issue-service.ts
@@ -79,6 +79,8 @@ export class IssueService {
     groups: Array<{
       projectId: number;
       projectName: string;
+      groupId: number | null;
+      groupName: string | null;
       tree: IssueNode[];
       cachedAt: string | null;
       count: number;
@@ -93,9 +95,13 @@ export class IssueService {
     const groups = await Promise.all(projectCaches.map(async (entry) => {
       const project = db.getProject(entry.projectId);
       const enriched = fetcher.enrichWithTeamInfo(entry.tree, entry.projectId);
+      const groupId = project?.groupId ?? null;
+      const group = groupId != null ? db.getProjectGroup(groupId) : undefined;
       return {
         projectId: entry.projectId,
         projectName: project?.name ?? `Project #${entry.projectId}`,
+        groupId,
+        groupName: group?.name ?? null,
         tree: enriched,
         cachedAt: entry.cachedAt,
         count: countIssues(enriched),

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -534,4 +534,257 @@ describe('IssueTreeView', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Project group collapsible sections (Issue #441)
+  // -------------------------------------------------------------------------
+
+  it('renders project group headers when projects have groupId', async () => {
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 20, title: 'Issue B', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueC = { number: 30, title: 'Issue C', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB, issueC],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'frontend-app',
+              groupId: 100,
+              groupName: 'Frontend',
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 2,
+              projectName: 'backend-api',
+              groupId: 200,
+              groupName: 'Backend',
+              tree: [issueB],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 3,
+              projectName: 'misc-scripts',
+              groupId: null,
+              groupName: null,
+              tree: [issueC],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-25T10:00:00Z',
+          count: 3,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      // Group headers should be rendered
+      expect(screen.getByText('Frontend')).toBeInTheDocument();
+      expect(screen.getByText('Backend')).toBeInTheDocument();
+      expect(screen.getByText('Ungrouped')).toBeInTheDocument();
+    });
+
+    // Project names should still be visible under their groups
+    expect(screen.getByText('frontend-app')).toBeInTheDocument();
+    expect(screen.getByText('backend-api')).toBeInTheDocument();
+    expect(screen.getByText('misc-scripts')).toBeInTheDocument();
+  });
+
+  it('does not render group headers when no projects have groupId', async () => {
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 20, title: 'Issue B', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'project-alpha',
+              groupId: null,
+              groupName: null,
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 2,
+              projectName: 'project-beta',
+              groupId: null,
+              groupName: null,
+              tree: [issueB],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-25T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      // No "Ungrouped" header since no project has a groupId
+      expect(screen.queryByText('Ungrouped')).not.toBeInTheDocument();
+      // Projects should still be directly visible as project-level groups
+      expect(screen.getByText('project-alpha')).toBeInTheDocument();
+      expect(screen.getByText('project-beta')).toBeInTheDocument();
+    });
+  });
+
+  it('collapsing a project group hides its projects', async () => {
+    // Set up collapse state so group-100 is collapsed
+    const collapsedSet = new Set(['group-100']);
+    vi.mocked(mockToggleCollapse);
+
+    // Override useCollapseState to have group-100 collapsed
+    const useCollapseStateMod = await import('../../src/client/hooks/useCollapseState');
+    vi.spyOn(useCollapseStateMod, 'useCollapseState').mockReturnValue({
+      collapsedNodes: collapsedSet,
+      toggleCollapse: mockToggleCollapse,
+      expandAll: mockExpandAll,
+      collapseAll: mockCollapseAll,
+      isCollapsed: (id: string) => collapsedSet.has(id),
+    });
+
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 20, title: 'Issue B', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'hidden-project',
+              groupId: 100,
+              groupName: 'Collapsed Group',
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 2,
+              projectName: 'visible-project',
+              groupId: 200,
+              groupName: 'Open Group',
+              tree: [issueB],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-25T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      // Both group headers should be visible
+      expect(screen.getByText('Collapsed Group')).toBeInTheDocument();
+      expect(screen.getByText('Open Group')).toBeInTheDocument();
+    });
+
+    // The collapsed group's project should NOT be visible
+    expect(screen.queryByText('hidden-project')).not.toBeInTheDocument();
+    // The open group's project SHOULD be visible
+    expect(screen.getByText('visible-project')).toBeInTheDocument();
+  });
+
+  it('collapseAll includes group bucket IDs when project groups are present', async () => {
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 20, title: 'Issue B', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'frontend',
+              groupId: 100,
+              groupName: 'Frontend',
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+            {
+              projectId: 2,
+              projectName: 'backend',
+              groupId: null,
+              groupName: null,
+              tree: [issueB],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-25T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Collapse All')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Collapse All'));
+
+    // collapseAll should include group bucket IDs (group-100, group-ungrouped),
+    // project IDs (project-1, project-2), and issue IDs (10, 20)
+    expect(mockCollapseAll).toHaveBeenCalledWith(
+      expect.arrayContaining(['group-100', 'group-ungrouped', 'project-1', 'project-2', '10', '20']),
+    );
+  });
+
+  it('clicking a group header toggles the group collapse state', async () => {
+    const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'test-project',
+              groupId: 100,
+              groupName: 'My Group',
+              tree: [issueA],
+              cachedAt: null,
+              count: 1,
+            },
+          ],
+          cachedAt: '2026-03-25T10:00:00Z',
+          count: 1,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('My Group')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('My Group'));
+    expect(mockToggleCollapse).toHaveBeenCalledWith('group-100');
+  });
 });


### PR DESCRIPTION
Closes #441

## Summary
- Enriched `IssueService.getAllIssues()` with `groupId` and `groupName` per project entry, resolved via existing `db.getProjectGroup()`
- Added `ProjectGroupSection` collapsible component in `IssueTreeView` that groups projects by their assigned project group
- Projects without a group render under an "Ungrouped" section (sorted last)
- Collapse state persists via existing `useCollapseState` hook with `group-{id}` keys
- When no projects have groups assigned, the existing flat project-level view is preserved unchanged
- Added 5 new tests covering group headers, backward compatibility, collapse behavior, Collapse All integration, and toggle interaction

## Test plan
- [x] 26 client tests pass (including 5 new ones for group rendering)
- [x] TypeScript compiles cleanly
- [ ] Manual: assign projects to groups, verify Issue Tree shows group-level headers
- [ ] Manual: verify "Ungrouped" section appears for projects without a group
- [ ] Manual: collapse/expand group headers, verify state persists across page refresh