### PR TITLE
Issue #474: Block team launches until project passes all install health checks

### DIFF
--- a/src/client/components/LaunchDialog.tsx
+++ b/src/client/components/LaunchDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useApi } from '../hooks/useApi';
-import type { ProjectSummary, Team, TeamStatus } from '../../shared/types';
+import type { ProjectSummary, Team, TeamStatus, InstallStatus } from '../../shared/types';
 import { TERMINAL_STATUSES } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -47,6 +47,61 @@ function flattenIssueTree(nodes: IssueTreeNode[]): IssueItem[] {
   };
   walk(nodes);
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Project readiness check (client-side, mirrors server logic)
+// ---------------------------------------------------------------------------
+
+type ProjectHealth = 'ready' | 'warn' | 'blocked';
+
+interface ClientProjectReadiness {
+  health: ProjectHealth;
+  warnings: string[];
+  errors: string[];
+}
+
+/** Compute readiness from an InstallStatus. Returns 'blocked' if critical
+ *  artifacts are missing, 'warn' if files are outdated, 'ready' otherwise. */
+function computeProjectReadiness(status: InstallStatus | undefined): ClientProjectReadiness {
+  if (!status) {
+    // No install status available — treat as blocked (unknown state)
+    return { health: 'blocked', warnings: [], errors: ['Install status unavailable'] };
+  }
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!status.hooks.installed) {
+    errors.push(`Hooks not installed (${status.hooks.found}/${status.hooks.total})`);
+  }
+  if (!status.prompt.installed) {
+    errors.push('Prompt file not installed');
+  }
+  if (!status.agents.installed) {
+    errors.push('Agent files not installed');
+  }
+  if (status.gitCommitStatus?.gitignored) {
+    errors.push('.claude/ is in .gitignore');
+  }
+  if (
+    status.gitCommitStatus?.health === 'red' &&
+    !status.gitCommitStatus.gitignored
+  ) {
+    errors.push('Files not committed to default branch');
+  }
+
+  if (status.outdatedCount > 0) {
+    warnings.push(`${status.outdatedCount} file(s) outdated`);
+  }
+  if (status.gitCommitStatus?.health === 'amber') {
+    warnings.push('Committed files are outdated');
+  }
+
+  const health: ProjectHealth =
+    errors.length > 0 ? 'blocked' : warnings.length > 0 ? 'warn' : 'ready';
+
+  return { health, warnings, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -520,6 +575,24 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
     );
   }, [issues, issueSearch]);
 
+  // --- Project readiness map (computed from install status) ---
+  const projectReadiness = useMemo(() => {
+    const map = new Map<number, ClientProjectReadiness>();
+    for (const p of projects) {
+      map.set(p.id, computeProjectReadiness(p.installStatus));
+    }
+    return map;
+  }, [projects]);
+
+  // Readiness of the currently selected project
+  const selectedReadiness = useMemo(() => {
+    if (!selectedProjectId) return null;
+    return projectReadiness.get(parseInt(selectedProjectId, 10)) ?? null;
+  }, [selectedProjectId, projectReadiness]);
+
+  // Whether the selected project is blocked (cannot launch)
+  const selectedProjectBlocked = selectedReadiness?.health === 'blocked';
+
   // --- Select an issue from the picker ---
   const handleSelectIssue = useCallback((issue: IssueItem) => {
     setIssueNumber(String(issue.number));
@@ -703,16 +776,50 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
                       disabled={loading}
                     >
                       <option value="">Select a project...</option>
-                      {projects.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
+                      {projects.map((p) => {
+                        const r = projectReadiness.get(p.id);
+                        const blocked = r?.health === 'blocked';
+                        const suffix = blocked
+                          ? ' (not ready \u2014 fix on Projects page)'
+                          : r?.health === 'warn'
+                            ? ' (warnings)'
+                            : '';
+                        return (
+                          <option key={p.id} value={p.id} disabled={blocked}>
+                            {p.name}{suffix}
+                          </option>
+                        );
+                      })}
                     </select>
                   </div>
                 ) : (
                   <div className="px-3 py-2 rounded border border-[#D29922]/30 bg-[#D29922]/10 text-[#D29922] text-sm">
                     Add a project first
+                  </div>
+                )}
+
+                {/* Project health banner — blocked */}
+                {selectedReadiness?.health === 'blocked' && (
+                  <div className="px-3 py-2 rounded border border-[#F85149]/30 bg-[#F85149]/10 text-[#F85149] text-sm">
+                    <p className="font-medium">Project not ready for launch</p>
+                    <ul className="mt-1 list-disc list-inside text-xs">
+                      {selectedReadiness.errors.map((e, i) => (
+                        <li key={i}>{e}</li>
+                      ))}
+                    </ul>
+                    <p className="mt-1 text-xs opacity-80">Fix these issues on the Projects page before launching.</p>
+                  </div>
+                )}
+
+                {/* Project health banner — warnings */}
+                {selectedReadiness?.health === 'warn' && (
+                  <div className="px-3 py-2 rounded border border-[#D29922]/30 bg-[#D29922]/10 text-[#D29922] text-sm">
+                    <p className="font-medium">Project has warnings</p>
+                    <ul className="mt-1 list-disc list-inside text-xs">
+                      {selectedReadiness.warnings.map((w, i) => (
+                        <li key={i}>{w}</li>
+                      ))}
+                    </ul>
                   </div>
                 )}
 
@@ -977,7 +1084,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
                 <>
                   <button
                     onClick={() => batchMode ? handleLaunchBatch() : void handleLaunch()}
-                    disabled={loading || projects.length === 0}
+                    disabled={loading || projects.length === 0 || selectedProjectBlocked}
                     className="px-4 py-1.5 text-sm font-medium rounded border border-dark-accent/40 text-dark-accent bg-dark-accent/10 hover:bg-dark-accent/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     {loading
@@ -989,7 +1096,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
                   {zone === 'red' && !batchMode && (
                     <button
                       onClick={() => void handleLaunch(true)}
-                      disabled={loading || projects.length === 0}
+                      disabled={loading || projects.length === 0 || selectedProjectBlocked}
                       className="px-4 py-1.5 text-sm font-medium rounded border border-[#F85149]/40 text-[#F85149] bg-[#F85149]/10 hover:bg-[#F85149]/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                       title="Force launch ignoring red zone usage limits"
                     >

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -92,6 +92,13 @@ const teamsRoutes: FastifyPluginCallback = (
         return reply.code(201).send(team);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
+          if (err.code === 'PROJECT_NOT_READY') {
+            return reply.code(400).send({
+              error: 'Project Not Ready',
+              message: err.message,
+              hint: 'Fix the project on the Projects page before launching.',
+            });
+          }
           if (err.code === 'BLOCKED_BY_DEPENDENCIES') {
             return reply.code(409).send({
               error: 'Blocked by Dependencies',
@@ -131,6 +138,13 @@ const teamsRoutes: FastifyPluginCallback = (
         return reply.code(201).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
+          if (err.code === 'PROJECT_NOT_READY') {
+            return reply.code(400).send({
+              error: 'Project Not Ready',
+              message: err.message,
+              hint: 'Fix the project on the Projects page before launching.',
+            });
+          }
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
         }
         const message = err instanceof Error ? err.message : String(err);

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -16,7 +16,7 @@ import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
 import { execGitAsync, execGHAsync, execGHResult } from '../utils/exec-gh.js';
 import { execSync } from 'child_process';
-import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings, GitCommitStatus, GitCommitFileStatus, GitCommitHealth } from '../../shared/types.js';
+import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings, GitCommitStatus, GitCommitFileStatus, GitCommitHealth, ProjectReadiness } from '../../shared/types.js';
 import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
 import { getPackageVersion } from '../utils/version.js';
 import { getHookFiles as getManifestHookFiles, getAgentFiles as getManifestAgentFiles, getGuideFiles as getManifestGuideFiles, getWorkflowFile } from '../utils/fc-manifest.js';
@@ -608,6 +608,78 @@ export class ProjectService {
       }
       return { ...p, installStatus };
     });
+  }
+
+  /**
+   * Evaluate a project's readiness for launching teams.
+   * Checks install status (hooks, prompt, agents) and git commit status.
+   *
+   * @param projectId - The project ID
+   * @returns ProjectReadiness with ready flag, warnings, and errors
+   * @throws ServiceError with code NOT_FOUND if project doesn't exist
+   */
+  getProjectReadiness(projectId: number): ProjectReadiness {
+    const db = getDatabase();
+    const project = db.getProject(projectId);
+    if (!project) {
+      throw notFoundError(`Project ${projectId} not found`);
+    }
+
+    const status = checkInstallStatus(project.repoPath);
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // Blocking: hooks not installed
+    if (!status.hooks.installed) {
+      errors.push(
+        `Hooks not installed (${status.hooks.found}/${status.hooks.total} found)`,
+      );
+    }
+
+    // Blocking: prompt file not installed
+    if (!status.prompt.installed) {
+      errors.push('Prompt file not installed');
+    }
+
+    // Blocking: agent files not installed
+    if (!status.agents.installed) {
+      errors.push('Agent files not installed');
+    }
+
+    // Blocking: .claude/ in .gitignore
+    if (status.gitCommitStatus?.gitignored) {
+      errors.push('.claude/ is in .gitignore — files will not be available on branches');
+    }
+
+    // Blocking: git commit health is red (files not committed)
+    if (
+      status.gitCommitStatus?.health === 'red' &&
+      !status.gitCommitStatus.gitignored // already covered above
+    ) {
+      errors.push(
+        `Git commit check failed: ${status.gitCommitStatus.message}`,
+      );
+    }
+
+    // Warning: outdated files
+    if (status.outdatedCount > 0) {
+      warnings.push(
+        `${status.outdatedCount} installed file(s) are outdated — consider reinstalling`,
+      );
+    }
+
+    // Warning: git commit health is amber (outdated on branch)
+    if (status.gitCommitStatus?.health === 'amber') {
+      warnings.push(
+        `Git commit check: ${status.gitCommitStatus.message}`,
+      );
+    }
+
+    return {
+      ready: errors.length === 0,
+      warnings,
+      errors,
+    };
   }
 
   /**

--- a/src/server/services/service-error.ts
+++ b/src/server/services/service-error.ts
@@ -49,6 +49,11 @@ export function conflictError(message: string): ServiceError {
   return new ServiceError(message, 'CONFLICT', 409);
 }
 
+/** 400 Bad Request — project not ready for launch (install health check failed) */
+export function projectNotReadyError(message: string): ServiceError {
+  return new ServiceError(message, 'PROJECT_NOT_READY', 400);
+}
+
 /** 502 Bad Gateway — external tool/CLI failures */
 export function externalError(message: string, details?: string): ServiceError {
   return new ServiceError(message, 'EXTERNAL_ERROR', 502, details);

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -16,7 +16,8 @@ import { sseBroker } from './sse-broker.js';
 import config from '../config.js';
 import type { TeamPhase, IssueDependencyInfo } from '../../shared/types.js';
 import { buildTimeline } from '../utils/build-timeline.js';
-import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
+import { ServiceError, validationError, notFoundError, conflictError, projectNotReadyError } from './service-error.js';
+import { getProjectService } from './project-service.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,6 +82,17 @@ export class TeamService {
       throw validationError('issueNumber is required and must be a positive integer');
     }
 
+    // Project readiness check -- block launch if install health checks fail
+    if (!force) {
+      const projectService = getProjectService();
+      const readiness = projectService.getProjectReadiness(projectId);
+      if (!readiness.ready) {
+        throw projectNotReadyError(
+          `Project is not ready for launch: ${readiness.errors.join('; ')}`,
+        );
+      }
+    }
+
     // Dependency check -- block launch if unresolved dependencies exist
     if (!force) {
       const depInfo = await checkDependencies(projectId, issueNumber);
@@ -143,6 +155,15 @@ export class TeamService {
       if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
         throw validationError(`Invalid issue number: ${JSON.stringify(issue)}`);
       }
+    }
+
+    // Project readiness check -- block batch launch if install health checks fail
+    const projectService = getProjectService();
+    const readiness = projectService.getProjectReadiness(projectId);
+    if (!readiness.ready) {
+      throw projectNotReadyError(
+        `Project is not ready for launch: ${readiness.errors.join('; ')}`,
+      );
     }
 
     // Dependency check for batch launch

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -137,6 +137,16 @@ export interface InstallStatus {
   gitCommitStatus?: GitCommitStatus;
 }
 
+/** Result of a project readiness check for launching teams */
+export interface ProjectReadiness {
+  /** Whether the project is ready for team launches */
+  ready: boolean;
+  /** Non-blocking issues (e.g. outdated files) — launch is allowed */
+  warnings: string[];
+  /** Blocking issues (e.g. hooks not installed) — launch is denied */
+  errors: string[];
+}
+
 /** Project with team count for list view */
 export interface ProjectSummary extends Project {
   teamCount: number;

--- a/tests/client/LaunchDialog.test.tsx
+++ b/tests/client/LaunchDialog.test.tsx
@@ -42,6 +42,21 @@ function makeProjects() {
       maxActiveTeams: 5,
       activeTeamCount: 1,
       queuedTeamCount: 0,
+      installStatus: {
+        hooks: { installed: true, total: 10, found: 10, files: [] },
+        prompt: { installed: true, files: [] },
+        agents: { installed: true, files: [] },
+        settings: { name: 'settings.json', exists: true },
+        outdatedCount: 0,
+        currentVersion: '0.0.9',
+        gitCommitStatus: {
+          health: 'green',
+          gitignored: false,
+          defaultBranch: 'main',
+          files: [],
+          message: 'All files committed',
+        },
+      },
     },
   ];
 }


### PR DESCRIPTION
Closes #474

## Summary
- Adds pre-launch health check validation in `TeamService.launchTeam()` and `launchBatch()` — blocks launches when project has RED install/git-commit status, allows with warning on AMBER
- API returns 400 with `PROJECT_NOT_READY` code and actionable hint message
- LaunchDialog greys out unhealthy projects in the dropdown, shows inline health banners (red/amber), disables Launch button for blocked projects
- MCP `fleet_launch_team` covered automatically via service delegation

## Test plan
- [ ] Verify `POST /api/teams/launch` returns 400 when project has uninstalled hooks
- [ ] Verify `POST /api/teams/launch` returns 400 when `.claude/` is not committed (RED git check)
- [ ] Verify `POST /api/teams/launch` succeeds with warning when project is AMBER (outdated)
- [ ] Verify LaunchDialog greys out RED projects and shows "(not ready)" suffix
- [ ] Verify LaunchDialog shows amber warning banner for outdated projects
- [ ] Verify Launch button is disabled when a blocked project is selected
- [ ] Verify batch launch also checks project readiness
- [ ] Run `npm test` — all tests pass