### PR TITLE
Issue #416: Convert SSE teamFilter from Array to Set for O(1) lookup

### DIFF
--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -62,7 +62,7 @@ export interface SSEEventPayloads {
 interface SSEClient {
   id: string;
   reply: FastifyReply;
-  teamFilter: number[] | null; // null = all teams
+  teamFilter: Set<number> | null; // null = all teams
 }
 
 // ---------------------------------------------------------------------------
@@ -125,7 +125,7 @@ class SSEBroker {
     const client: SSEClient = {
       id,
       reply,
-      teamFilter: teamFilter && teamFilter.length > 0 ? teamFilter : null,
+      teamFilter: teamFilter && teamFilter.length > 0 ? new Set(teamFilter) : null,
     };
     this.clients.set(id, client);
     return id;
@@ -158,7 +158,7 @@ class SSEBroker {
     for (const [id, client] of this.clients) {
       // If the event is scoped to a team, check the client's filter
       if (teamId !== undefined && client.teamFilter !== null) {
-        if (!client.teamFilter.includes(teamId)) {
+        if (!client.teamFilter.has(teamId)) {
           continue;
         }
       }


### PR DESCRIPTION
Closes #416

## Summary
- Convert `SSEClient.teamFilter` from `number[]` to `Set<number>` for O(1) membership checks during SSE broadcast
- Replace `.includes(teamId)` with `.has(teamId)` in the `broadcast` method
- Keep `addClient` public API signature unchanged — conversion happens internally

## Changes
Single file: `src/server/services/sse-broker.ts` (3 lines changed)

## Test plan
- [x] `tsc --noEmit` passes with no type errors
- [x] All 23 SSE broker tests pass without modification
- [x] All 29 integration tests pass
- [x] Public API signature unchanged — no caller changes needed