### PR TITLE
Issue #483: Increase prioritization timeout to 5 min and show loading indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ The SSE broker emits 14 event types:
 | `FLEET_MAX_CI_FAILURES` | `3` | Unique CI failures before blocking |
 | `FLEET_EARLY_CRASH_THRESHOLD_SEC` | `120` | Seconds before a SubagentStop is considered an early crash |
 | `FLEET_EARLY_CRASH_MIN_TOOLS` | `5` | Minimum tool-use events for a subagent to be considered healthy |
+| `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` | `300000` | Timeout for AI issue prioritization (ms) |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub poll interval |
 | `FLEET_DB_PATH` | (platform data dir) | Database file location. Defaults to platform user data dir |
 | `FLEET_TERMINAL` | `auto` | Windows terminal preference (`auto`/`wt`/`cmd`) |

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -1142,6 +1142,17 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
         </div>
       )}
 
+      {/* Prioritization loading banner */}
+      {prioritization.loading && (
+        <div className="mx-2 mb-1 px-3 py-2 rounded border border-[#A371F7]/30 bg-[#A371F7]/10 flex items-center gap-2">
+          <svg className="w-4 h-4 text-[#A371F7] animate-spin shrink-0" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+          <span className="text-xs text-[#A371F7]">Prioritizing issues... this may take a few minutes</span>
+        </div>
+      )}
+
       {/* Prioritization action bar */}
       <PrioritizationActionBar
         prioritization={prioritization}
@@ -1235,6 +1246,17 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
       {prioritization.error && (
         <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#F85149]/30 bg-[#F85149]/10 text-xs text-[#F85149]">
           Prioritization failed: {prioritization.error}
+        </div>
+      )}
+
+      {/* Prioritization loading banner */}
+      {prioritization.loading && (
+        <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#A371F7]/30 bg-[#A371F7]/10 flex items-center gap-2">
+          <svg className="w-4 h-4 text-[#A371F7] animate-spin shrink-0" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+          <span className="text-xs text-[#A371F7]">Prioritizing issues... this may take a few minutes</span>
         </div>
       )}
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -160,7 +160,7 @@ const config = Object.freeze({
 
   ccQueryModel: process.env['FLEET_CC_QUERY_MODEL'] || 'sonnet',
   ccQueryTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_TIMEOUT_MS'] || '30000', 'FLEET_CC_QUERY_TIMEOUT_MS'),
-  ccQueryPrioritizeTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'] || '60000', 'FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'),
+  ccQueryPrioritizeTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'] || '300000', 'FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'),
   ccQueryMaxRetries: safeParseInt(process.env['FLEET_CC_QUERY_MAX_RETRIES'] || '2', 'FLEET_CC_QUERY_MAX_RETRIES'),
   ccQueryMaxTurns: safeParseInt(process.env['FLEET_CC_QUERY_MAX_TURNS'] || '4', 'FLEET_CC_QUERY_MAX_TURNS'),
 

--- a/tests/server/cc-query.test.ts
+++ b/tests/server/cc-query.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../src/server/config.js', () => ({
   default: {
     ccQueryModel: 'claude-sonnet-4-20250514',
     ccQueryTimeoutMs: 60000,
-    ccQueryPrioritizeTimeoutMs: 60000,
+    ccQueryPrioritizeTimeoutMs: 300000,
     ccQueryMaxRetries: 2,
     ccQueryMaxTurns: 4,
   },


### PR DESCRIPTION
Closes #483

## Summary
- Increased default prioritization timeout from 60s to 300s (5 min) in `config.ts` — configurable via `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` env var
- Added purple loading banner with animated spinner in both `ProjectGroup` and `SingleProjectTree` components showing "Prioritizing issues... this may take a few minutes"
- Updated mock config in `cc-query.test.ts` to match new default
- Documented `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` in CLAUDE.md env var table

## Test plan
- [x] `tsc --noEmit` passes
- [x] All tests pass (24/24 in cc-query.test.ts)
- [ ] Verify loading banner appears when clicking Prioritize on a project
- [ ] Verify banner disappears on completion/error
- [ ] Verify UI remains navigable during prioritization