### PR TITLE
Issue #418: Parallelize TeamDetail API fetches with caching hook

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelection, useConnection, useThinking } from '../context/FleetContext';
 import { useApi } from '../hooks/useApi';
+import { useTeamDetailData } from '../hooks/useTeamDetailData';
 import { StatusBadge } from './StatusBadge';
 import { CIChecks } from './CIChecks';
 import { UnifiedTimeline } from './UnifiedTimeline';
 import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
-import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember, MessageEdge } from '../../shared/types';
 import { STATUS_COLORS } from '../utils/constants';
 
 // ---------------------------------------------------------------------------
@@ -32,22 +32,19 @@ export function TeamDetail() {
   const { lastEvent, lastEventTeamId } = useConnection();
   const { isThinking } = useThinking();
   const api = useApi();
-  const [detail, setDetail] = useState<TeamDetailType | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+
+  // Parallelized data fetching with caching (extracted hook)
+  const { detail, transitions, roster, messageEdges, loading, error, refreshDetail } =
+    useTeamDetailData(selectedTeamId, lastEvent, lastEventTeamId);
+
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [quickActionLoading, setQuickActionLoading] = useState<string | null>(null);
   const [quickActionSent, setQuickActionSent] = useState<string | null>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
-  const [transitions, setTransitions] = useState<TeamTransition[]>([]);
-  const [roster, setRoster] = useState<TeamMember[]>([]);
   const [activeTab, setActiveTab] = useState<'session-log' | 'team'>('session-log');
-  const [messageEdges, setMessageEdges] = useState<MessageEdge[]>([]);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const [agentFilters, setAgentFilters] = useState<Set<string>>(new Set());
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedTeamIdRef = useRef(selectedTeamId);
 
   const isOpen = selectedTeamId !== null;
@@ -56,87 +53,6 @@ export function TeamDetail() {
   useEffect(() => {
     selectedTeamIdRef.current = selectedTeamId;
   }, [selectedTeamId]);
-
-  // Fetch transitions when selectedTeamId changes or detail refreshes
-  useEffect(() => {
-    if (selectedTeamId == null) {
-      setTransitions([]);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchTransitions() {
-      try {
-        const data = await api.get<TeamTransition[]>(`teams/${selectedTeamId}/transitions`);
-        if (!cancelled) {
-          setTransitions(data);
-        }
-      } catch {
-        // Non-critical — transitions are informational
-      }
-    }
-
-    fetchTransitions();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTeamId, refreshKey, api]);
-
-  // Fetch roster when selectedTeamId changes or detail refreshes
-  useEffect(() => {
-    if (selectedTeamId == null) {
-      setRoster([]);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchRoster() {
-      try {
-        const data = await api.get<TeamMember[]>(`teams/${selectedTeamId}/roster`);
-        if (!cancelled) {
-          setRoster(data);
-        }
-      } catch {
-        // Non-critical — roster is informational
-      }
-    }
-
-    fetchRoster();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTeamId, refreshKey, api]);
-
-  // Fetch message edges when selectedTeamId changes or detail refreshes
-  useEffect(() => {
-    if (selectedTeamId == null) {
-      setMessageEdges([]);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchEdges() {
-      try {
-        const data = await api.get<MessageEdge[]>(`teams/${selectedTeamId}/messages/summary`);
-        if (!cancelled) {
-          setMessageEdges(data);
-        }
-      } catch {
-        // Non-critical — comm graph is informational
-      }
-    }
-
-    fetchEdges();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTeamId, refreshKey, api]);
 
   // Reset active tab, metadata collapse state, and agent filters when team changes
   useEffect(() => {
@@ -153,81 +69,6 @@ export function TeamDetail() {
       setMetadataCollapsed(true);
     }
   }, [detail?.status]);
-
-  // Fetch team detail when selectedTeamId changes
-  useEffect(() => {
-    if (selectedTeamId == null) {
-      setDetail(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchDetail() {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await api.get<TeamDetailType>(`teams/${selectedTeamId}`);
-        if (!cancelled) {
-          setDetail(data);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load team detail');
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-
-    fetchDetail();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTeamId, api]);
-
-  // Refresh detail on SSE updates (when lastEvent changes and panel is open)
-  // Debounced to 2 seconds to avoid hammering the REST API on rapid SSE events.
-  // Only refresh when the SSE event pertains to the selected team — events from
-  // other teams (or non-team events like usage_updated, project_*) are skipped.
-  useEffect(() => {
-    if (selectedTeamId == null || !lastEvent) return;
-
-    // Skip refresh when the SSE event is for a different team.
-    // lastEventTeamId === null means a non-team event (e.g. usage_updated,
-    // project_*, snapshot) which does not affect team detail — skip those too.
-    if (lastEventTeamId !== selectedTeamId) return;
-
-    // Clear any pending debounce timer
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-    }
-
-    const teamIdAtSchedule = selectedTeamId;
-
-    refreshTimerRef.current = setTimeout(async () => {
-      try {
-        const data = await api.get<TeamDetailType>(`teams/${teamIdAtSchedule}`);
-        // Guard against stale response if panel switched teams
-        if (selectedTeamIdRef.current === teamIdAtSchedule) {
-          setDetail(data);
-          setRefreshKey((k) => k + 1);
-        }
-      } catch {
-        // Silently ignore refresh errors — stale data is acceptable
-      }
-    }, 2000);
-
-    return () => {
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
-    };
-  }, [lastEvent, lastEventTeamId, selectedTeamId, api]);
 
   // Close panel handler
   const handleClose = useCallback(() => {
@@ -259,23 +100,18 @@ export function TeamDetail() {
   const handleAction = useCallback(
     async (action: 'stop' | 'resume' | 'restart') => {
       if (!selectedTeamId || actionLoading) return;
-      const teamId = selectedTeamId;
       setActionLoading(action);
       try {
-        await api.post(`teams/${teamId}/${action}`);
-        if (selectedTeamIdRef.current !== teamId) return;
-        // Refresh detail after action
-        const data = await api.get<TeamDetailType>(`teams/${teamId}`);
-        if (selectedTeamIdRef.current !== teamId) return;
-        setDetail(data);
-        setRefreshKey((k) => k + 1);
+        await api.post(`teams/${selectedTeamId}/${action}`);
+        // Refresh detail (and stale caches) after action
+        refreshDetail();
       } catch {
         // Action errors are transient; SSE will update the real state
       } finally {
         setActionLoading(null);
       }
     },
-    [selectedTeamId, actionLoading, api],
+    [selectedTeamId, actionLoading, api, refreshDetail],
   );
 
   // Quick action handler — send a pre-defined message template to the team

--- a/src/client/hooks/useTeamDetailData.ts
+++ b/src/client/hooks/useTeamDetailData.ts
@@ -1,0 +1,258 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useApi } from './useApi';
+import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember, MessageEdge } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CacheEntry<T> {
+  data: T;
+  fetchedAt: number;
+}
+
+interface UseTeamDetailDataResult {
+  detail: TeamDetailType | null;
+  transitions: TeamTransition[];
+  roster: TeamMember[];
+  messageEdges: MessageEdge[];
+  loading: boolean;
+  error: string | null;
+  refreshDetail: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cache TTL for non-critical data (roster, transitions, message edges) */
+const CACHE_TTL = 30_000;
+
+/** Debounce delay for SSE-triggered refreshes */
+const SSE_DEBOUNCE_MS = 2_000;
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom hook that encapsulates all data fetching for the TeamDetail panel.
+ *
+ * On team selection, fires all 4 fetches in parallel via Promise.allSettled:
+ * - teams/{id} (required — failure sets error state)
+ * - teams/{id}/transitions (non-critical)
+ * - teams/{id}/roster (non-critical)
+ * - teams/{id}/messages/summary (non-critical)
+ *
+ * On SSE events for the selected team, only re-fetches the detail endpoint
+ * (debounced at 2s). Roster, transitions, and message edges are only
+ * re-fetched if their cache is stale (> 30s).
+ */
+export function useTeamDetailData(
+  selectedTeamId: number | null,
+  lastEvent: Date | null,
+  lastEventTeamId: number | null,
+): UseTeamDetailDataResult {
+  const api = useApi();
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+  const [detail, setDetail] = useState<TeamDetailType | null>(null);
+  const [transitions, setTransitions] = useState<TeamTransition[]>([]);
+  const [roster, setRoster] = useState<TeamMember[]>([]);
+  const [messageEdges, setMessageEdges] = useState<MessageEdge[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Refs
+  // ---------------------------------------------------------------------------
+  const selectedTeamIdRef = useRef(selectedTeamId);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const transitionsCacheRef = useRef<CacheEntry<TeamTransition[]> | null>(null);
+  const rosterCacheRef = useRef<CacheEntry<TeamMember[]> | null>(null);
+  const edgesCacheRef = useRef<CacheEntry<MessageEdge[]> | null>(null);
+
+  // Keep ref in sync for use in async callbacks
+  useEffect(() => {
+    selectedTeamIdRef.current = selectedTeamId;
+  }, [selectedTeamId]);
+
+  // ---------------------------------------------------------------------------
+  // Primary fetch — fires all 4 calls in parallel on team selection
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (selectedTeamId == null) {
+      setDetail(null);
+      setTransitions([]);
+      setRoster([]);
+      setMessageEdges([]);
+      transitionsCacheRef.current = null;
+      rosterCacheRef.current = null;
+      edgesCacheRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchAll() {
+      setLoading(true);
+      setError(null);
+
+      const [detailResult, transResult, rosterResult, edgesResult] =
+        await Promise.allSettled([
+          api.get<TeamDetailType>(`teams/${selectedTeamId}`),
+          api.get<TeamTransition[]>(`teams/${selectedTeamId}/transitions`),
+          api.get<TeamMember[]>(`teams/${selectedTeamId}/roster`),
+          api.get<MessageEdge[]>(`teams/${selectedTeamId}/messages/summary`),
+        ]);
+
+      if (cancelled) return;
+
+      // Detail is required — if it fails, set error state
+      if (detailResult.status === 'fulfilled') {
+        setDetail(detailResult.value);
+      } else {
+        const err = detailResult.reason;
+        setError(err instanceof Error ? err.message : 'Failed to load team detail');
+        setDetail(null);
+      }
+
+      // Transitions — non-critical
+      if (transResult.status === 'fulfilled') {
+        setTransitions(transResult.value);
+        transitionsCacheRef.current = { data: transResult.value, fetchedAt: Date.now() };
+      } else {
+        setTransitions([]);
+      }
+
+      // Roster — non-critical
+      if (rosterResult.status === 'fulfilled') {
+        setRoster(rosterResult.value);
+        rosterCacheRef.current = { data: rosterResult.value, fetchedAt: Date.now() };
+      } else {
+        setRoster([]);
+      }
+
+      // Message edges — non-critical
+      if (edgesResult.status === 'fulfilled') {
+        setMessageEdges(edgesResult.value);
+        edgesCacheRef.current = { data: edgesResult.value, fetchedAt: Date.now() };
+      } else {
+        setMessageEdges([]);
+      }
+
+      setLoading(false);
+    }
+
+    fetchAll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTeamId, api]);
+
+  // ---------------------------------------------------------------------------
+  // refreshDetail — re-fetches detail, plus stale caches in parallel
+  // ---------------------------------------------------------------------------
+  const refreshDetail = useCallback(() => {
+    const teamId = selectedTeamIdRef.current;
+    if (teamId == null) return;
+
+    const now = Date.now();
+    const staleCalls: Array<Promise<unknown>> = [];
+
+    // Always fetch detail
+    const detailPromise = api.get<TeamDetailType>(`teams/${teamId}`);
+    staleCalls.push(detailPromise);
+
+    // Check cache staleness for non-critical data
+    const transStale = !transitionsCacheRef.current ||
+      now - transitionsCacheRef.current.fetchedAt >= CACHE_TTL;
+    const rosterStale = !rosterCacheRef.current ||
+      now - rosterCacheRef.current.fetchedAt >= CACHE_TTL;
+    const edgesStale = !edgesCacheRef.current ||
+      now - edgesCacheRef.current.fetchedAt >= CACHE_TTL;
+
+    if (transStale) {
+      staleCalls.push(api.get<TeamTransition[]>(`teams/${teamId}/transitions`));
+    }
+    if (rosterStale) {
+      staleCalls.push(api.get<TeamMember[]>(`teams/${teamId}/roster`));
+    }
+    if (edgesStale) {
+      staleCalls.push(api.get<MessageEdge[]>(`teams/${teamId}/messages/summary`));
+    }
+
+    Promise.allSettled(staleCalls).then((results) => {
+      if (selectedTeamIdRef.current !== teamId) return;
+
+      let idx = 0;
+
+      // Detail — always at index 0
+      const detailResult = results[idx++];
+      if (detailResult && detailResult.status === 'fulfilled') {
+        setDetail(detailResult.value as TeamDetailType);
+      }
+
+      // Transitions
+      if (transStale) {
+        const r = results[idx++];
+        if (r && r.status === 'fulfilled') {
+          const data = r.value as TeamTransition[];
+          setTransitions(data);
+          transitionsCacheRef.current = { data, fetchedAt: Date.now() };
+        }
+      }
+
+      // Roster
+      if (rosterStale) {
+        const r = results[idx++];
+        if (r && r.status === 'fulfilled') {
+          const data = r.value as TeamMember[];
+          setRoster(data);
+          rosterCacheRef.current = { data, fetchedAt: Date.now() };
+        }
+      }
+
+      // Message edges
+      if (edgesStale) {
+        const r = results[idx++];
+        if (r && r.status === 'fulfilled') {
+          const data = r.value as MessageEdge[];
+          setMessageEdges(data);
+          edgesCacheRef.current = { data, fetchedAt: Date.now() };
+        }
+      }
+    });
+  }, [api]);
+
+  // ---------------------------------------------------------------------------
+  // SSE-driven update — debounced, detail-only (plus stale caches)
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (selectedTeamId == null || !lastEvent) return;
+
+    // Skip when the SSE event is for a different team or non-team event
+    if (lastEventTeamId !== selectedTeamId) return;
+
+    // Clear any pending debounce timer
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+
+    refreshTimerRef.current = setTimeout(() => {
+      refreshDetail();
+    }, SSE_DEBOUNCE_MS);
+
+    return () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
+  }, [lastEvent, lastEventTeamId, selectedTeamId, refreshDetail]);
+
+  return { detail, transitions, roster, messageEdges, loading, error, refreshDetail };
+}

--- a/tests/client/useTeamDetailData.test.ts
+++ b/tests/client/useTeamDetailData.test.ts
@@ -1,0 +1,297 @@
+// =============================================================================
+// Fleet Commander — useTeamDetailData Hook Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+
+// Stable API object reference — the hook uses `api` as a useEffect dependency,
+// so returning a new object each render would cause an infinite re-render loop.
+const mockApi = {
+  get: mockGet,
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+};
+
+vi.mock('../../src/client/hooks/useApi', () => ({
+  useApi: () => mockApi,
+}));
+
+// Import after mocks
+import { useTeamDetailData } from '../../src/client/hooks/useTeamDetailData';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    issueNumber: 100,
+    issueTitle: 'Fix rendering bug',
+    status: 'running',
+    phase: 'implementing',
+    worktreeName: 'kea-100',
+    branchName: 'feat/kea-100',
+    model: 'claude-sonnet',
+    prNumber: null,
+    pr: null,
+    launchedAt: '2026-03-21T10:00:00Z',
+    lastEventAt: '2026-03-21T10:05:00Z',
+    durationMin: 5,
+    idleMin: 0,
+    totalInputTokens: 10000,
+    totalOutputTokens: 5000,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCostUsd: 0.50,
+    githubRepo: 'user/repo',
+    recentEvents: [],
+    outputTail: null,
+    ...overrides,
+  };
+}
+
+function makeTransitions() {
+  return [
+    { id: 1, teamId: 1, fromStatus: 'queued', toStatus: 'launching', trigger: 'system', reason: 'slot available', createdAt: '2026-03-21T10:00:00Z' },
+  ];
+}
+
+function makeRoster() {
+  return [
+    { name: 'team-lead', role: 'lead', isActive: true, firstSeen: '2026-03-21T10:00:00Z', lastSeen: '2026-03-21T10:05:00Z', toolUseCount: 10, errorCount: 0 },
+  ];
+}
+
+function makeEdges() {
+  return [
+    { sender: 'team-lead', recipient: 'dev', count: 3, lastSummary: 'Implement feature X' },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTeamDetailData', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null/empty state when selectedTeamId is null', () => {
+    const { result } = renderHook(() => useTeamDetailData(null, null, null));
+
+    expect(result.current.detail).toBeNull();
+    expect(result.current.transitions).toEqual([]);
+    expect(result.current.roster).toEqual([]);
+    expect(result.current.messageEdges).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fires all 4 fetches in parallel when selectedTeamId is set', async () => {
+    const detail = makeDetail();
+    const transitions = makeTransitions();
+    const rosterData = makeRoster();
+    const edges = makeEdges();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/transitions') return Promise.resolve(transitions);
+      if (path === 'teams/1/roster') return Promise.resolve(rosterData);
+      if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(4);
+    expect(mockGet).toHaveBeenCalledWith('teams/1');
+    expect(mockGet).toHaveBeenCalledWith('teams/1/transitions');
+    expect(mockGet).toHaveBeenCalledWith('teams/1/roster');
+    expect(mockGet).toHaveBeenCalledWith('teams/1/messages/summary');
+
+    expect(result.current.detail).toEqual(detail);
+    expect(result.current.transitions).toEqual(transitions);
+    expect(result.current.roster).toEqual(rosterData);
+    expect(result.current.messageEdges).toEqual(edges);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error when detail fetch fails but keeps non-critical data', async () => {
+    const transitions = makeTransitions();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.reject(new Error('Network error'));
+      if (path === 'teams/1/transitions') return Promise.resolve(transitions);
+      if (path === 'teams/1/roster') return Promise.resolve([]);
+      if (path === 'teams/1/messages/summary') return Promise.resolve([]);
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.detail).toBeNull();
+    expect(result.current.transitions).toEqual(transitions);
+  });
+
+  it('degrades gracefully when non-critical fetches fail', async () => {
+    const detail = makeDetail();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      return Promise.reject(new Error('Non-critical failure'));
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toEqual(detail);
+    expect(result.current.transitions).toEqual([]);
+    expect(result.current.roster).toEqual([]);
+    expect(result.current.messageEdges).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('clears all data when selectedTeamId changes to null', async () => {
+    const detail = makeDetail();
+    mockGet.mockResolvedValue(detail);
+
+    const { result, rerender } = renderHook(
+      ({ teamId }: { teamId: number | null }) => useTeamDetailData(teamId, null, null),
+      { initialProps: { teamId: 1 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.detail).not.toBeNull();
+    });
+
+    rerender({ teamId: null });
+
+    expect(result.current.detail).toBeNull();
+    expect(result.current.transitions).toEqual([]);
+    expect(result.current.roster).toEqual([]);
+    expect(result.current.messageEdges).toEqual([]);
+  });
+
+  it('refreshDetail re-fetches only detail when caches are fresh', async () => {
+    const detail = makeDetail();
+    const transitions = makeTransitions();
+    const rosterData = makeRoster();
+    const edges = makeEdges();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/transitions') return Promise.resolve(transitions);
+      if (path === 'teams/1/roster') return Promise.resolve(rosterData);
+      if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    mockGet.mockClear();
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/transitions') return Promise.resolve(transitions);
+      if (path === 'teams/1/roster') return Promise.resolve(rosterData);
+      if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    // Call refreshDetail immediately — caches are fresh (< 30s)
+    act(() => {
+      result.current.refreshDetail();
+    });
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('teams/1');
+    });
+    // Only detail is re-fetched, not the cached endpoints
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger SSE refresh for a different team', async () => {
+    const detail = makeDetail();
+    mockGet.mockResolvedValue(detail);
+
+    const { result, rerender } = renderHook(
+      ({ teamId, lastEvent, lastEventTeamId }: {
+        teamId: number | null;
+        lastEvent: Date | null;
+        lastEventTeamId: number | null;
+      }) => useTeamDetailData(teamId, lastEvent, lastEventTeamId),
+      { initialProps: { teamId: 1, lastEvent: null as Date | null, lastEventTeamId: null as number | null } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const callCountAfterInit = mockGet.mock.calls.length;
+
+    // SSE event for a different team (id=2) — should NOT trigger refresh
+    rerender({ teamId: 1, lastEvent: new Date(), lastEventTeamId: 2 });
+
+    // Wait a bit for any potential debounced call
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // No additional calls
+    expect(mockGet.mock.calls.length).toBe(callCountAfterInit);
+  });
+
+  it('exposes refreshDetail as a stable function', async () => {
+    const detail = makeDetail();
+    mockGet.mockResolvedValue(detail);
+
+    const { result, rerender } = renderHook(
+      ({ teamId }: { teamId: number | null }) => useTeamDetailData(teamId, null, null),
+      { initialProps: { teamId: 1 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const fn1 = result.current.refreshDetail;
+
+    // Re-render with same teamId
+    rerender({ teamId: 1 });
+
+    const fn2 = result.current.refreshDetail;
+
+    // refreshDetail should be a function
+    expect(typeof fn1).toBe('function');
+    expect(typeof fn2).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #418

## Summary
- Extract data fetching from TeamDetail into a new `useTeamDetailData` hook
- Parallelize 4 independent API calls via `Promise.allSettled` (was 5 sequential useEffect waterfalls)
- Add 30s cache TTL for roster, transitions, and message edges (non-critical data)
- SSE-triggered refreshes now only re-fetch `teams/{id}` unless caches are stale
- Remove `refreshKey` cascading mechanism entirely

## Test plan
- [x] 24/24 tests pass (16 existing TeamDetail + 8 new hook tests)
- [x] TypeScript build passes with no errors
- [x] Production build succeeds
- [ ] Verify in dashboard: opening TeamDetail fires 4 parallel requests (not sequential)
- [ ] Verify SSE updates only trigger 1 detail refetch when caches are fresh