### PR TITLE
Issue #408: Validate repoPath on project creation to prevent path traversal

### DIFF
--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -35,6 +35,45 @@ function normalizePath(p: string): string {
 }
 
 /**
+ * Validate a raw repo path for safety and existence.
+ *
+ * Checks:
+ * 1. Input must be a non-empty string.
+ * 2. Rejects path traversal sequences (`..` as a standalone path segment).
+ * 3. Resolved path must exist and be a directory.
+ *
+ * @param rawPath - The raw user-supplied repoPath string
+ * @returns The resolved, forward-slash-normalized absolute path
+ * @throws ServiceError (VALIDATION / 400) on any check failure
+ */
+export function validateRepoPath(rawPath: string): string {
+  if (!rawPath || typeof rawPath !== 'string' || rawPath.trim().length === 0) {
+    throw validationError('repoPath is required and must be a non-empty string');
+  }
+
+  // Reject path traversal: `..` as a standalone path segment
+  // Matches `..` at start, end, or between path separators (/ or \)
+  // Does NOT match `..` embedded in names like `my..project`
+  if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(rawPath)) {
+    throw validationError('repoPath must not contain path traversal sequences (..)');
+  }
+
+  const resolved = normalizePath(rawPath);
+
+  try {
+    const stat = fs.statSync(resolved);
+    if (!stat.isDirectory()) {
+      throw validationError(`Path is not a directory: ${resolved}`);
+    }
+  } catch (err: unknown) {
+    if (err instanceof ServiceError) throw err;
+    throw validationError(`Path does not exist: ${resolved}`);
+  }
+
+  return resolved;
+}
+
+/**
  * Check if a directory is a git repository (async to avoid blocking event loop).
  */
 async function isGitRepo(dirPath: string): Promise<boolean> {
@@ -728,16 +767,8 @@ export class ProjectService {
       throw validationError('name is required and must be a non-empty string');
     }
 
-    // Validate repoPath
-    if (!repoPath || typeof repoPath !== 'string' || repoPath.trim().length === 0) {
-      throw validationError('repoPath is required and must be a non-empty string');
-    }
-
-    const normalizedPath = normalizePath(repoPath);
-
-    if (!fs.existsSync(normalizedPath)) {
-      throw validationError(`Path does not exist: ${normalizedPath}`);
-    }
+    // Validate repoPath (traversal, existence, directory check)
+    const normalizedPath = validateRepoPath(repoPath);
 
     if (!(await isGitRepo(normalizedPath))) {
       throw validationError(`Path is not a git repository: ${normalizedPath}`);

--- a/tests/server/services/validate-repo-path.test.ts
+++ b/tests/server/services/validate-repo-path.test.ts
@@ -1,0 +1,108 @@
+// =============================================================================
+// Fleet Commander — validateRepoPath Tests
+// =============================================================================
+// Tests the path validation function that prevents path traversal attacks
+// and ensures the provided repo path is a valid, existing directory.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { validateRepoPath } from '../../../src/server/services/project-service.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('validateRepoPath', () => {
+  // -------------------------------------------------------------------------
+  // Empty / missing input
+  // -------------------------------------------------------------------------
+
+  it('should throw for empty string', () => {
+    expect(() => validateRepoPath('')).toThrow('repoPath is required and must be a non-empty string');
+  });
+
+  it('should throw for whitespace-only string', () => {
+    expect(() => validateRepoPath('   ')).toThrow('repoPath is required and must be a non-empty string');
+  });
+
+  it('should throw for non-string input', () => {
+    expect(() => validateRepoPath(undefined as unknown as string)).toThrow(
+      'repoPath is required and must be a non-empty string',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Path traversal detection
+  // -------------------------------------------------------------------------
+
+  it('should throw for path with forward-slash traversal segments', () => {
+    expect(() => validateRepoPath('C:/Git/legit/../../../Windows/System32')).toThrow(
+      'path traversal',
+    );
+  });
+
+  it('should throw for path with backslash traversal segments', () => {
+    expect(() => validateRepoPath('C:\\Git\\legit\\..\\..\\Windows\\System32')).toThrow(
+      'path traversal',
+    );
+  });
+
+  it('should throw for path that is just relative traversal', () => {
+    expect(() => validateRepoPath('../..')).toThrow('path traversal');
+  });
+
+  it('should throw for path starting with .. segment', () => {
+    expect(() => validateRepoPath('../some/path')).toThrow('path traversal');
+  });
+
+  it('should throw for path ending with .. segment', () => {
+    expect(() => validateRepoPath('/some/path/..')).toThrow('path traversal');
+  });
+
+  // -------------------------------------------------------------------------
+  // Legitimate paths with ".." in names (NOT traversal)
+  // -------------------------------------------------------------------------
+
+  it('should not reject paths with .. embedded in directory names', () => {
+    // A directory literally named "my..project" is NOT a traversal.
+    // The function will throw for non-existence, but NOT for traversal.
+    expect(() => validateRepoPath('C:/Git/my..project')).toThrow('does not exist');
+    expect(() => validateRepoPath('C:/Git/my..project')).not.toThrow('path traversal');
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-existent path
+  // -------------------------------------------------------------------------
+
+  it('should throw for path that does not exist', () => {
+    expect(() => validateRepoPath('/nonexistent/path/xyz/does-not-exist')).toThrow(
+      'does not exist',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Path is a file, not a directory
+  // -------------------------------------------------------------------------
+
+  it('should throw for path that is a file, not a directory', () => {
+    // Use the test file itself as a known file path
+    expect(() => validateRepoPath(__filename)).toThrow('not a directory');
+  });
+
+  // -------------------------------------------------------------------------
+  // Valid directory
+  // -------------------------------------------------------------------------
+
+  it('should return normalized path for a valid directory', () => {
+    // Use the test directory — guaranteed to exist
+    const result = validateRepoPath(__dirname);
+    // Should be an absolute path with forward slashes
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).not.toContain('\\');
+  });
+});


### PR DESCRIPTION
Closes #408

## Summary
- Add `validateRepoPath()` function in `project-service.ts` that rejects path traversal sequences (`..`), non-existent paths, and non-directory paths before they reach the database
- Replace inline validation in `createProject` with the new function — all entry points (REST API + MCP tool) are protected
- Add 12 dedicated unit tests covering traversal detection, edge cases (e.g., `..` in directory names), and invalid path types

## Test plan
- [x] Unit tests pass: `validateRepoPath` rejects traversal, missing paths, files; accepts valid directories
- [x] Paths with `..` in directory names (e.g., `my..project`) are NOT false-positived
- [x] MCP `fleet_add_project` inherits validation (calls `createProject`)
- [x] All existing tests pass (`npm test`)