### PR TITLE
Issue #494: Implement automatic phase tracking based on SubagentStart/Stop events

### DIFF
--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -15,7 +15,7 @@
  *   Non-tool_use events are NEVER throttled.
  */
 
-import type { TeamStatus } from '../../shared/types.js';
+import type { TeamStatus, TeamPhase } from '../../shared/types.js';
 import { TERMINAL_STATUSES } from '../../shared/types.js';
 import type { SSEEventType, SSEEventPayloads } from './sse-broker.js';
 import config from '../config.js';
@@ -144,6 +144,65 @@ export function normalizeAgentName(name: string | null | undefined): string {
 }
 
 // ---------------------------------------------------------------------------
+// Agent role classification for phase transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a normalized agent name into one of three role categories:
+ * planner, dev, or reviewer. Returns null for unknown agent types
+ * (no phase change should occur).
+ *
+ * Uses substring matching to handle variant names across different projects
+ * (e.g., "csharp-dev", "fsharp-dev", "analityk", "weryfikator").
+ */
+export function classifyAgentRole(normalizedName: string): 'planner' | 'dev' | 'reviewer' | null {
+  const name = normalizedName.toLowerCase();
+  if (name.includes('planner') || name.includes('analyst') || name.includes('analityk')) {
+    return 'planner';
+  }
+  if (name.includes('dev') || name.includes('developer') || name.includes('implementer')) {
+    return 'dev';
+  }
+  if (name.includes('reviewer') || name.includes('weryfikator') || name.includes('review')) {
+    return 'reviewer';
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Phase ordering for forward-only transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Numeric ordering for team phases. Higher numbers are later phases.
+ * `blocked` gets -1 because it is set by the poller (CI failures) and
+ * should not prevent forward progression from hook events.
+ */
+export const PHASE_ORDER: Record<TeamPhase, number> = {
+  init: 0,
+  analyzing: 1,
+  implementing: 2,
+  reviewing: 3,
+  pr: 4,
+  done: 5,
+  blocked: -1,
+};
+
+/**
+ * Determine whether the team should advance to the target phase.
+ * Returns true only when the target phase is strictly later in the
+ * forward-only phase sequence than the current phase, and the
+ * current phase is not terminal ('done').
+ */
+export function shouldAdvancePhase(currentPhase: string, targetPhase: TeamPhase): boolean {
+  if (currentPhase === 'done') return false;
+  const currentOrder = PHASE_ORDER[currentPhase as TeamPhase];
+  const targetOrder = PHASE_ORDER[targetPhase];
+  if (currentOrder === undefined || targetOrder === undefined) return false;
+  return targetOrder > currentOrder;
+}
+
+// ---------------------------------------------------------------------------
 // Event type normalization
 // ---------------------------------------------------------------------------
 
@@ -264,6 +323,48 @@ export function processEvent(
     }
   }
 
+  // ── Phase transition: SubagentStart/SubagentStop -> phase update ──
+  // Compute phase transitions for non-terminal teams based on agent role.
+  // Forward-only: a later phase is never replaced by an earlier one.
+  let phaseUpdateData: { phase: TeamPhase; previousPhase: string } | undefined;
+
+  if (!isTerminal) {
+    const evtForPhase = payload.event.toLowerCase();
+    if (evtForPhase === 'subagent_start' || evtForPhase === 'subagent_stop') {
+      const rawAgentName = payload.teammate_name || payload.agent_type;
+      if (rawAgentName) {
+        const normalized = normalizeAgentName(rawAgentName);
+        const role = classifyAgentRole(normalized);
+        if (role) {
+          let targetPhase: TeamPhase | undefined;
+
+          if (evtForPhase === 'subagent_start') {
+            // Agent starting: transition to the phase the agent represents
+            if (role === 'planner') targetPhase = 'analyzing';
+            else if (role === 'dev') targetPhase = 'implementing';
+            else if (role === 'reviewer') targetPhase = 'reviewing';
+          } else {
+            // Agent stopping: transition to the NEXT expected phase
+            if (role === 'planner') targetPhase = 'implementing';
+            else if (role === 'dev') targetPhase = 'reviewing';
+            else if (role === 'reviewer') targetPhase = 'pr';
+          }
+
+          if (targetPhase && shouldAdvancePhase(team.phase, targetPhase)) {
+            phaseUpdateData = { phase: targetPhase, previousPhase: team.phase };
+
+            // Merge phase into existing statusUpdate or create new one
+            if (statusUpdateData) {
+              statusUpdateData.fields.phase = targetPhase;
+            } else {
+              statusUpdateData = { teamId, fields: { phase: targetPhase } };
+            }
+          }
+        }
+      }
+    }
+  }
+
   // ── Throttle tool_use events ─────────────────────────────────────
   // Throttled events still need a heartbeat update and any transition
   // that was determined above. For throttled events, execute the
@@ -360,11 +461,29 @@ export function processEvent(
   }
 
   // ── Broadcast via SSE (after transaction commits) ────────────────
-  if (previousStatus !== undefined) {
+  // Emit a single team_status_changed event carrying both status and
+  // phase info when both change simultaneously (avoids double-broadcast).
+  if (previousStatus !== undefined && phaseUpdateData) {
     sse.broadcast('team_status_changed', {
       team_id: teamId,
       status: 'running',
       previous_status: previousStatus,
+      phase: phaseUpdateData.phase,
+      previous_phase: phaseUpdateData.previousPhase,
+    }, teamId);
+  } else if (previousStatus !== undefined) {
+    sse.broadcast('team_status_changed', {
+      team_id: teamId,
+      status: 'running',
+      previous_status: previousStatus,
+    }, teamId);
+  } else if (phaseUpdateData) {
+    sse.broadcast('team_status_changed', {
+      team_id: teamId,
+      status: team.status,
+      previous_status: team.status,
+      phase: phaseUpdateData.phase,
+      previous_phase: phaseUpdateData.previousPhase,
     }, teamId);
   }
 

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -722,7 +722,27 @@ class GitHubPoller {
 
     if (prs.length > 0 && prs[0]!.number) {
       const db = getDatabase();
-      db.updateTeam(teamId, { prNumber: prs[0]!.number });
+      const team = db.getTeam(teamId);
+      const prevPhase = team?.phase;
+
+      // Update team with PR number and advance phase to 'pr' if appropriate
+      const updateFields: Record<string, unknown> = { prNumber: prs[0]!.number };
+      if (prevPhase && prevPhase !== 'pr' && prevPhase !== 'done') {
+        updateFields.phase = 'pr';
+      }
+      db.updateTeam(teamId, updateFields);
+
+      // Broadcast phase change if it advanced
+      if (team && prevPhase && prevPhase !== 'pr' && prevPhase !== 'done') {
+        sseBroker.broadcast('team_status_changed', {
+          team_id: teamId,
+          status: team.status,
+          previous_status: team.status,
+          phase: 'pr',
+          previous_phase: prevPhase,
+        }, teamId);
+      }
+
       console.log(
         `[GitHubPoller] Detected PR #${prs[0]!.number} for branch "${branchName}" (team ${teamId}, repo: ${githubRepo})`
       );

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -24,6 +24,8 @@ import { getUsageZone } from './usage-tracker.js';
 import { resolveMessage } from '../utils/resolve-message.js';
 import { CircularBuffer } from '../utils/circular-buffer.js';
 import { getHookFiles as getManifestHookFiles, getAgentFiles as getManifestAgentFiles, getGuideFiles as getManifestGuideFiles, getWorkflowFile } from '../utils/fc-manifest.js';
+import { classifyAgentRole, shouldAdvancePhase } from './event-collector.js';
+import type { TeamPhase } from '../../shared/types.js';
 
 const execAsync = promisify(execCallback);
 
@@ -2108,6 +2110,41 @@ export class TeamManager {
                 }
               } catch (err) {
                 console.error(`[TeamManager] Stdout fallback transition failed for team ${teamId}:`, err);
+              }
+
+              // Phase fallback: advance phase from task_notification/task_progress
+              // when the resolved agent is not team-lead. This supplements hook-based
+              // phase tracking for cases where hooks don't fire.
+              if (event.type === 'system' && resolvedAgentName !== 'team-lead') {
+                try {
+                  const role = classifyAgentRole(resolvedAgentName);
+                  if (role) {
+                    const db = getDatabase();
+                    const currentTeam = db.getTeam(teamId);
+                    if (currentTeam) {
+                      let targetPhase: TeamPhase | undefined;
+                      if (role === 'planner') targetPhase = 'analyzing';
+                      else if (role === 'dev') targetPhase = 'implementing';
+                      else if (role === 'reviewer') targetPhase = 'reviewing';
+
+                      if (targetPhase && shouldAdvancePhase(currentTeam.phase, targetPhase)) {
+                        const prevPhase = currentTeam.phase;
+                        db.updateTeam(teamId, { phase: targetPhase });
+                        sseBroker.broadcast('team_status_changed', {
+                          team_id: teamId,
+                          status: currentTeam.status,
+                          previous_status: currentTeam.status,
+                          phase: targetPhase,
+                          previous_phase: prevPhase,
+                        }, teamId);
+                        console.log(`[TeamManager] Team ${teamId} phase ${prevPhase}→${targetPhase} via stdout fallback (agent: ${resolvedAgentName})`);
+                      }
+                    }
+                  }
+                } catch (err) {
+                  // Non-fatal — phase fallback is best-effort
+                  console.error(`[TeamManager] Phase fallback failed for team ${teamId}:`, err);
+                }
               }
             }
           } catch {

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -6,7 +6,7 @@
 // about state transitions — message templates live in message-templates.ts.
 // =============================================================================
 
-import type { TeamStatus } from './types.js';
+import type { TeamStatus, TeamPhase } from './types.js';
 
 export type TriggerType = 'hook' | 'timer' | 'poller' | 'pm_action' | 'system';
 
@@ -329,6 +329,72 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     triggerLabel: 'Branch up-to-date',
     description: 'PR branch is no longer behind main',
     condition: 'Merge status changes from behind to another state (not dirty)',
+    hookEvent: null,
+  },
+];
+
+// =============================================================================
+// Phase Transitions (informational — documents automatic phase tracking)
+// =============================================================================
+// Phase transitions are driven by SubagentStart/SubagentStop hook events
+// and GitHub poller PR detection. The logic lives in event-collector.ts;
+// these entries document the transitions for the /lifecycle UI view.
+// =============================================================================
+
+export interface PhaseTransition {
+  id: string;
+  fromPhase: TeamPhase;
+  toPhase: TeamPhase;
+  trigger: TriggerType;
+  triggerLabel: string;
+  description: string;
+  hookEvent?: string | null;
+}
+
+export const PHASE_TRANSITIONS: PhaseTransition[] = [
+  {
+    id: 'phase-init-analyzing',
+    fromPhase: 'init',
+    toPhase: 'analyzing',
+    trigger: 'hook',
+    triggerLabel: 'Planner subagent starts',
+    description: 'SubagentStart event received for an agent classified as planner role',
+    hookEvent: 'subagent_start',
+  },
+  {
+    id: 'phase-analyzing-implementing',
+    fromPhase: 'analyzing',
+    toPhase: 'implementing',
+    trigger: 'hook',
+    triggerLabel: 'Planner subagent stops',
+    description: 'SubagentStop event received for planner role, indicating analysis complete and development expected',
+    hookEvent: 'subagent_stop',
+  },
+  {
+    id: 'phase-implementing-reviewing',
+    fromPhase: 'implementing',
+    toPhase: 'reviewing',
+    trigger: 'hook',
+    triggerLabel: 'Dev subagent stops',
+    description: 'SubagentStop event received for dev role, indicating implementation complete and review expected',
+    hookEvent: 'subagent_stop',
+  },
+  {
+    id: 'phase-reviewing-pr',
+    fromPhase: 'reviewing',
+    toPhase: 'pr',
+    trigger: 'hook',
+    triggerLabel: 'Reviewer subagent stops',
+    description: 'SubagentStop event received for reviewer role, indicating review complete and PR expected',
+    hookEvent: 'subagent_stop',
+  },
+  {
+    id: 'phase-pr-detected',
+    fromPhase: 'pr',
+    toPhase: 'pr',
+    trigger: 'poller',
+    triggerLabel: 'PR detected by poller',
+    description: 'GitHub poller detects a PR for the team branch. Phase advances to pr from any earlier phase.',
     hookEvent: null,
   },
 ];

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -8,6 +8,9 @@ import {
   resetThrottleState,
   resetSubagentTrackers,
   normalizeAgentName,
+  classifyAgentRole,
+  shouldAdvancePhase,
+  PHASE_ORDER,
   EventCollectorError,
   type EventPayload,
   type EventCollectorDb,
@@ -2130,5 +2133,267 @@ describe('Agent messages in transaction', () => {
     expect(db.processEventTransaction).toHaveBeenCalledTimes(1);
     const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(ops.agentMessages).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Phase transitions (Issue #494)
+// =============================================================================
+
+describe('Phase transitions (Issue #494)', () => {
+  it('should advance init -> analyzing on SubagentStart with planner agent', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'init' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+      db,
+      sse,
+    );
+
+    // statusUpdate should include phase: 'analyzing'
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('analyzing');
+
+    // SSE should broadcast phase change
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({
+        team_id: 1,
+        phase: 'analyzing',
+        previous_phase: 'init',
+      }),
+      1,
+    );
+  });
+
+  it('should advance analyzing -> implementing on SubagentStop with planner agent', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'analyzing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-planner' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('implementing');
+  });
+
+  it('should advance implementing -> reviewing on SubagentStop with dev agent', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-dev' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('reviewing');
+  });
+
+  it('should advance reviewing -> pr on SubagentStop with reviewer agent', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'reviewing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_stop', teammate_name: 'fleet-reviewer' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('pr');
+  });
+
+  it('should NOT regress phase (implementing -> analyzing on planner SubagentStart)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+      db,
+      sse,
+    );
+
+    // No statusUpdate for phase should be created (no status transition either)
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeUndefined();
+
+    // SSE should NOT broadcast a phase change
+    const statusBroadcasts = (sse.broadcast as ReturnType<typeof vi.fn>).mock.calls
+      .filter((call: unknown[]) => call[0] === 'team_status_changed');
+    expect(statusBroadcasts.length).toBe(0);
+  });
+
+  it('should NOT update phase on terminal team (done)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'done' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeUndefined();
+  });
+
+  it('should handle variant agent names (csharp-dev maps to dev role)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'analyzing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'csharp-dev' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('implementing');
+  });
+
+  it('should handle variant agent names (weryfikator maps to reviewer role)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'weryfikator' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.phase).toBe('reviewing');
+  });
+
+  it('should handle unknown agent name (no phase change)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'init' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'pr-watcher' }),
+      db,
+      sse,
+    );
+
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // No statusUpdate should exist (no status or phase change)
+    expect(ops.statusUpdate).toBeUndefined();
+  });
+
+  it('should combine status transition and phase transition in single broadcast', () => {
+    // Team is idle, SubagentStart from planner arrives => idle->running + init->analyzing
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'init' }),
+    });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+      db,
+      sse,
+    );
+
+    // Both status and phase should be in the same statusUpdate
+    const ops = (db.processEventTransaction as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate.fields.status).toBe('running');
+    expect(ops.statusUpdate.fields.phase).toBe('analyzing');
+
+    // Should emit exactly ONE team_status_changed broadcast with both fields
+    const statusBroadcasts = (sse.broadcast as ReturnType<typeof vi.fn>).mock.calls
+      .filter((call: unknown[]) => call[0] === 'team_status_changed');
+    expect(statusBroadcasts.length).toBe(1);
+    expect(statusBroadcasts[0][1]).toEqual(expect.objectContaining({
+      team_id: 1,
+      status: 'running',
+      previous_status: 'idle',
+      phase: 'analyzing',
+      previous_phase: 'init',
+    }));
+  });
+
+  describe('classifyAgentRole', () => {
+    it('should return planner for planner variants', () => {
+      expect(classifyAgentRole('planner')).toBe('planner');
+      expect(classifyAgentRole('analyst')).toBe('planner');
+      expect(classifyAgentRole('analityk')).toBe('planner');
+    });
+
+    it('should return dev for dev variants', () => {
+      expect(classifyAgentRole('dev')).toBe('dev');
+      expect(classifyAgentRole('csharp-dev')).toBe('dev');
+      expect(classifyAgentRole('fsharp-dev')).toBe('dev');
+      expect(classifyAgentRole('developer')).toBe('dev');
+      expect(classifyAgentRole('implementer')).toBe('dev');
+    });
+
+    it('should return reviewer for reviewer variants', () => {
+      expect(classifyAgentRole('reviewer')).toBe('reviewer');
+      expect(classifyAgentRole('weryfikator')).toBe('reviewer');
+      expect(classifyAgentRole('code-review')).toBe('reviewer');
+    });
+
+    it('should return null for unknown agents', () => {
+      expect(classifyAgentRole('team-lead')).toBeNull();
+      expect(classifyAgentRole('pr-watcher')).toBeNull();
+      expect(classifyAgentRole('coordinator')).toBeNull();
+    });
+  });
+
+  describe('shouldAdvancePhase', () => {
+    it('should return true for forward transitions', () => {
+      expect(shouldAdvancePhase('init', 'analyzing')).toBe(true);
+      expect(shouldAdvancePhase('analyzing', 'implementing')).toBe(true);
+      expect(shouldAdvancePhase('implementing', 'reviewing')).toBe(true);
+      expect(shouldAdvancePhase('reviewing', 'pr')).toBe(true);
+      expect(shouldAdvancePhase('pr', 'done')).toBe(true);
+    });
+
+    it('should return false for backward transitions', () => {
+      expect(shouldAdvancePhase('implementing', 'analyzing')).toBe(false);
+      expect(shouldAdvancePhase('reviewing', 'implementing')).toBe(false);
+      expect(shouldAdvancePhase('pr', 'reviewing')).toBe(false);
+    });
+
+    it('should return false when current phase is done', () => {
+      expect(shouldAdvancePhase('done', 'analyzing')).toBe(false);
+      expect(shouldAdvancePhase('done', 'implementing')).toBe(false);
+    });
+
+    it('should allow forward progression from blocked', () => {
+      expect(shouldAdvancePhase('blocked', 'analyzing')).toBe(true);
+      expect(shouldAdvancePhase('blocked', 'implementing')).toBe(true);
+      expect(shouldAdvancePhase('blocked', 'pr')).toBe(true);
+    });
   });
 });

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -558,9 +558,10 @@ describe('CI failure counting', () => {
 describe('PR detection by branch', () => {
   it('detects PR for a team without prNumber', async () => {
     const project = makeProject();
-    const team = makeTeam({ prNumber: null, branchName: 'feat/10-test' });
+    const team = makeTeam({ prNumber: null, branchName: 'feat/10-test', phase: 'implementing' });
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getTeam.mockReturnValue(team);
 
     // detectWorktreeBranch uses execGitAsync
     mockExecGitAsync.mockResolvedValue('feat/10-test');
@@ -569,7 +570,13 @@ describe('PR detection by branch', () => {
 
     await githubPoller.poll();
 
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { prNumber: 55 });
+    // detectPR now also advances phase to 'pr' when the current phase allows it
+    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { prNumber: 55, phase: 'pr' });
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({ team_id: 1, phase: 'pr', previous_phase: 'implementing' }),
+      1,
+    );
   });
 
   it('does nothing when no PR found for branch', async () => {


### PR DESCRIPTION
Closes #494

## Summary
- Wire automatic phase tracking into event-collector based on SubagentStart/SubagentStop hook events
- Add `classifyAgentRole()` to map agent names (including variants like `csharp-dev`, `weryfikator`, `analityk`) to planner/dev/reviewer roles
- Implement forward-only phase transitions (`init → analyzing → implementing → reviewing → pr → done`) that prevent regression/flapping
- Add phase `pr` advancement in GitHub poller when PR is first detected
- Add stdout fallback in team-manager for phase detection when hooks don't fire
- Document phase transitions in `state-machine.ts` for the lifecycle UI view
- Broadcast phase changes via existing `team_status_changed` SSE event with `phase` and `previous_phase` fields
- Add 15 new tests covering all phase transitions, edge cases, variant names, and forward-only enforcement

## Test plan
- [x] All 15 new phase transition tests pass
- [x] Existing event-collector tests unaffected
- [x] GitHub poller PR detection test updated and passing
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] `npm run test:server` passes