### PR TITLE
Issue #407: Quote all variables in gh CLI shell commands to prevent command injection

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -18,7 +18,7 @@ import { getDatabase } from '../db.js';
 import config from '../config.js';
 import { sseBroker } from './sse-broker.js';
 import { resolveMessage } from '../utils/resolve-message.js';
-import { execGHAsync, execGitAsync } from '../utils/exec-gh.js';
+import { execGHAsync, execGitAsync, isValidGithubRepo, isValidBranchName } from '../utils/exec-gh.js';
 import type { PRState, CIStatus, MergeStatus } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -236,9 +236,14 @@ class GitHubPoller {
   // -------------------------------------------------------------------------
 
   private async pollPR(prNumber: number, teamId: number, githubRepo: string): Promise<{ ciStatus: CIStatus; state: PRState } | null> {
+    if (!isValidGithubRepo(githubRepo)) {
+      console.warn(`[GitHubPoller] Skipping pollPR for team ${teamId} — invalid githubRepo: ${githubRepo}`);
+      return null;
+    }
+
     // Use gh pr view to get PR status, CI checks, merge state, and auto-merge
     const result = await execGHAsync(
-      `gh pr view ${prNumber} --repo ${githubRepo} ` +
+      `gh pr view ${prNumber} --repo "${githubRepo}" ` +
         `--json number,title,state,mergeStateStatus,statusCheckRollup,autoMergeRequest,headRefName,mergedAt`
     );
     if (!result) return null; // gh CLI failed — skip this cycle
@@ -708,8 +713,17 @@ class GitHubPoller {
   // -------------------------------------------------------------------------
 
   private async detectPR(branchName: string, teamId: number, githubRepo: string): Promise<void> {
+    if (!isValidBranchName(branchName)) {
+      console.warn(`[GitHubPoller] Skipping detectPR for team ${teamId} — invalid branchName: ${branchName}`);
+      return;
+    }
+    if (!isValidGithubRepo(githubRepo)) {
+      console.warn(`[GitHubPoller] Skipping detectPR for team ${teamId} — invalid githubRepo: ${githubRepo}`);
+      return;
+    }
+
     const result = await execGHAsync(
-      `gh pr list --head ${branchName} --repo ${githubRepo} --state all --json number --limit 1`
+      `gh pr list --head "${branchName}" --repo "${githubRepo}" --state all --json number --limit 1`
     );
     if (!result) return; // gh CLI failed — skip
 

--- a/src/server/services/pr-service.ts
+++ b/src/server/services/pr-service.ts
@@ -8,19 +8,12 @@
 import { getDatabase } from '../db.js';
 import { sseBroker } from './sse-broker.js';
 import { githubPoller } from './github-poller.js';
-import { execGHResult } from '../utils/exec-gh.js';
+import { execGHResult, isValidGithubRepo } from '../utils/exec-gh.js';
 import { ServiceError, notFoundError, validationError, externalError } from './service-error.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Validate a GitHub repo slug (owner/repo) to prevent injection */
-const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
-
-function validateGithubRepo(repo: string): boolean {
-  return GITHUB_REPO_RE.test(repo);
-}
 
 /**
  * Resolve the github_repo for a PR by looking up the team's project.
@@ -49,7 +42,7 @@ function resolveGithubRepoForPR(prNumber: number): { githubRepo: string; teamId:
     );
   }
 
-  if (!validateGithubRepo(project.githubRepo)) {
+  if (!isValidGithubRepo(project.githubRepo)) {
     throw validationError(`Invalid GitHub repo slug: ${project.githubRepo}`);
   }
 
@@ -73,7 +66,7 @@ export class PRService {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
     const result = await execGHResult(
-      `gh pr merge ${prNumber} --auto --squash --repo ${githubRepo}`,
+      `gh pr merge ${prNumber} --auto --squash --repo "${githubRepo}"`,
     );
 
     if (!result.ok) {
@@ -121,7 +114,7 @@ export class PRService {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
     const result = await execGHResult(
-      `gh pr merge ${prNumber} --disable-auto --repo ${githubRepo}`,
+      `gh pr merge ${prNumber} --disable-auto --repo "${githubRepo}"`,
     );
 
     if (!result.ok) {
@@ -169,7 +162,7 @@ export class PRService {
     const { githubRepo, teamId } = resolveGithubRepoForPR(prNumber);
 
     const result = await execGHResult(
-      `gh api repos/${githubRepo}/pulls/${prNumber}/update-branch -X PUT`,
+      `gh api "repos/${githubRepo}/pulls/${prNumber}/update-branch" -X PUT`,
     );
 
     if (!result.ok) {

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -14,7 +14,7 @@ import { getIssueFetcher } from './issue-fetcher.js';
 import { sseBroker } from './sse-broker.js';
 import { installHooks, uninstallHooks } from '../utils/hook-installer.js';
 import config from '../config.js';
-import { execGitAsync, execGHAsync, execGHResult } from '../utils/exec-gh.js';
+import { execGitAsync, execGHAsync, execGHResult, isValidGithubRepo } from '../utils/exec-gh.js';
 import { execSync } from 'child_process';
 import type { ProjectStatus, InstallStatus, InstallFileStatus, RepoSettings, GitCommitStatus, GitCommitFileStatus, GitCommitHealth, ProjectReadiness } from '../../shared/types.js';
 import { ServiceError, validationError, notFoundError, conflictError } from './service-error.js';
@@ -118,10 +118,11 @@ function fileHasCrlf(filePath: string): boolean {
  */
 export async function checkRepoSettings(githubRepo: string | null | undefined): Promise<RepoSettings | undefined> {
   if (!githubRepo) return undefined;
+  if (!isValidGithubRepo(githubRepo)) return undefined;
 
   try {
     const repoJson = await execGHAsync(
-      `gh api repos/${githubRepo} --jq "{allow_auto_merge, default_branch}"`,
+      `gh api "repos/${githubRepo}" --jq "{allow_auto_merge, default_branch}"`,
       { timeout: 10_000 },
     );
 
@@ -140,7 +141,7 @@ export async function checkRepoSettings(githubRepo: string | null | undefined): 
 
     // Branch protection may not be configured — 404 is expected
     const protectionJson = await execGHAsync(
-      `gh api repos/${githubRepo}/branches/${defaultBranch}/protection --jq "{required_status_checks}"`,
+      `gh api "repos/${githubRepo}/branches/${defaultBranch}/protection" --jq "{required_status_checks}"`,
       { timeout: 10_000 },
     );
 

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -26,6 +26,7 @@ import { CircularBuffer } from '../utils/circular-buffer.js';
 import { getHookFiles as getManifestHookFiles, getAgentFiles as getManifestAgentFiles, getGuideFiles as getManifestGuideFiles, getWorkflowFile } from '../utils/fc-manifest.js';
 import { classifyAgentRole, shouldAdvancePhase } from './event-collector.js';
 import type { TeamPhase } from '../../shared/types.js';
+import { isValidGithubRepo } from '../utils/exec-gh.js';
 
 const execAsync = promisify(execCallback);
 
@@ -221,10 +222,10 @@ export class TeamManager {
     }
 
     // If no title provided, fetch from GitHub
-    if (!issueTitle && project.githubRepo) {
+    if (!issueTitle && project.githubRepo && isValidGithubRepo(project.githubRepo)) {
       try {
         const { stdout } = await execAsync(
-          `gh issue view ${issueNumber} --repo ${project.githubRepo} --json title --jq .title`,
+          `gh issue view ${issueNumber} --repo "${project.githubRepo}" --json title --jq .title`,
           { timeout: 10000 },
         );
         const result = stdout.trim();
@@ -717,10 +718,10 @@ export class TeamManager {
     prompt?: string,
   ): Promise<Team> {
     // Fetch title from GitHub if needed
-    if (!issueTitle && project.githubRepo) {
+    if (!issueTitle && project.githubRepo && isValidGithubRepo(project.githubRepo)) {
       try {
         const { stdout } = await execAsync(
-          `gh issue view ${issueNumber} --repo ${project.githubRepo} --json title --jq .title`,
+          `gh issue view ${issueNumber} --repo "${project.githubRepo}" --json title --jq .title`,
           { timeout: 10000 },
         );
         const result = stdout.trim();
@@ -826,10 +827,10 @@ export class TeamManager {
     }
 
     // Fetch title from GitHub if needed
-    if (!issueTitle && project.githubRepo) {
+    if (!issueTitle && project.githubRepo && isValidGithubRepo(project.githubRepo)) {
       try {
         const { stdout } = await execAsync(
-          `gh issue view ${issueNumber} --repo ${project.githubRepo} --json title --jq .title`,
+          `gh issue view ${issueNumber} --repo "${project.githubRepo}" --json title --jq .title`,
           { timeout: 10000 },
         );
         const result = stdout.trim();

--- a/src/server/utils/exec-gh.ts
+++ b/src/server/utils/exec-gh.ts
@@ -17,6 +17,40 @@ import type { ExecOptions } from 'child_process';
 const execAsync = promisify(exec);
 
 // ---------------------------------------------------------------------------
+// Input validation — defence-in-depth guards against shell injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Allowed characters in a GitHub repo slug: alphanumeric, `.`, `_`, `-`, plus
+ * exactly one `/` separating owner and repo.
+ */
+const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
+/**
+ * Validate a GitHub repo slug (e.g. "owner/repo").
+ * Rejects strings containing shell metacharacters (`$`, backticks, `;`, spaces, etc.).
+ */
+export function isValidGithubRepo(repo: string): boolean {
+  return GITHUB_REPO_RE.test(repo);
+}
+
+/**
+ * Allowed characters in a git branch name: alphanumeric, `.`, `_`, `-`, `/`.
+ * This covers the vast majority of real-world branch names (e.g. `feat/my-feature`,
+ * `release-1.0`, `fix/123-bug`) while rejecting shell metacharacters (`$`, backticks,
+ * `;`, spaces, parentheses, etc.).
+ */
+const BRANCH_NAME_RE = /^[a-zA-Z0-9._/\-]+$/;
+
+/**
+ * Validate a git branch name.
+ * Rejects strings containing shell metacharacters that could enable command injection.
+ */
+export function isValidBranchName(branch: string): boolean {
+  return BRANCH_NAME_RE.test(branch);
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 

--- a/tests/server/exec-gh.test.ts
+++ b/tests/server/exec-gh.test.ts
@@ -28,7 +28,7 @@ vi.mock('util', async (importOriginal) => {
 });
 
 // Import after mocks
-const { execGHAsync, execGHResult, execGitAsync } = await import(
+const { execGHAsync, execGHResult, execGitAsync, isValidGithubRepo, isValidBranchName } = await import(
   '../../src/server/utils/exec-gh.js'
 );
 
@@ -194,5 +194,63 @@ describe('execGitAsync', () => {
       encoding: 'utf-8',
       timeout: 30_000,
     });
+  });
+});
+
+// =============================================================================
+// isValidGithubRepo
+// =============================================================================
+
+describe('isValidGithubRepo', () => {
+  it('accepts valid repo slugs', () => {
+    expect(isValidGithubRepo('owner/repo')).toBe(true);
+    expect(isValidGithubRepo('my-org/my-repo.ts')).toBe(true);
+    expect(isValidGithubRepo('org123/repo_name')).toBe(true);
+    expect(isValidGithubRepo('Owner/Repo-Name')).toBe(true);
+    expect(isValidGithubRepo('a.b/c.d')).toBe(true);
+  });
+
+  it('rejects slugs with shell injection payloads', () => {
+    expect(isValidGithubRepo('owner/repo; rm -rf /')).toBe(false);
+    expect(isValidGithubRepo('$(whoami)/repo')).toBe(false);
+    expect(isValidGithubRepo('`id`/repo')).toBe(false);
+    expect(isValidGithubRepo('owner/repo && echo pwned')).toBe(false);
+  });
+
+  it('rejects empty string, no slash, and double slash', () => {
+    expect(isValidGithubRepo('')).toBe(false);
+    expect(isValidGithubRepo('ownerrepo')).toBe(false);
+    expect(isValidGithubRepo('owner//repo')).toBe(false);
+    expect(isValidGithubRepo('/repo')).toBe(false);
+    expect(isValidGithubRepo('owner/')).toBe(false);
+  });
+});
+
+// =============================================================================
+// isValidBranchName
+// =============================================================================
+
+describe('isValidBranchName', () => {
+  it('accepts valid branch names', () => {
+    expect(isValidBranchName('main')).toBe(true);
+    expect(isValidBranchName('feat/my-feature')).toBe(true);
+    expect(isValidBranchName('fix/123-bug')).toBe(true);
+    expect(isValidBranchName('release-1.0')).toBe(true);
+    expect(isValidBranchName('user/feature/sub-task')).toBe(true);
+  });
+
+  it('rejects names with shell injection payloads', () => {
+    expect(isValidBranchName(';rm -rf /')).toBe(false);
+    expect(isValidBranchName('$(pwd)')).toBe(false);
+    expect(isValidBranchName('`id`')).toBe(false);
+    expect(isValidBranchName('branch && echo pwned')).toBe(false);
+  });
+
+  it('rejects names with spaces', () => {
+    expect(isValidBranchName('branch name with spaces')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidBranchName('')).toBe(false);
   });
 });

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -72,9 +72,17 @@ vi.mock('../../src/server/services/issue-fetcher.js', () => ({
 // Mock the shared async exec utilities (replaces the old child_process mock)
 const mockExecGHAsync = vi.fn().mockResolvedValue(null);
 const mockExecGitAsync = vi.fn().mockResolvedValue(null);
+
+// Import the real validators — they are pure functions with no side effects
+const { isValidGithubRepo, isValidBranchName } = await import(
+  '../../src/server/utils/exec-gh.js'
+);
+
 vi.mock('../../src/server/utils/exec-gh.js', () => ({
   execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
   execGitAsync: (...args: unknown[]) => mockExecGitAsync(...args),
+  isValidGithubRepo: (repo: string) => /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(repo),
+  isValidBranchName: (branch: string) => /^[a-zA-Z0-9._/\-]+$/.test(branch),
 }));
 
 // Import after mocks
@@ -1029,5 +1037,66 @@ describe('Branch behind notifications', () => {
 
     // No change detected (behind -> behind), so no message should be sent
     expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Input validation guards (injection prevention)
+// =============================================================================
+
+describe('Input validation guards', () => {
+  it('pollPR skips gh CLI call when githubRepo is invalid', async () => {
+    const project = makeProject({ githubRepo: 'owner/repo; rm -rf /' });
+    const team = makeTeam({ prNumber: 42, projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await githubPoller.poll();
+
+    // gh CLI should never be called for an invalid repo slug
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('detectPR skips gh CLI call when branchName contains injection payload', async () => {
+    const project = makeProject();
+    const team = makeTeam({
+      prNumber: null,
+      branchName: "'; rm -rf /",
+      worktreeName: 'proj-10',
+    });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    // detectWorktreeBranch returns the same malicious branch name
+    mockExecGitAsync.mockResolvedValue("'; rm -rf /");
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await githubPoller.poll();
+
+    // execGHAsync should not be called for the detectPR step
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('detectPR skips gh CLI call when githubRepo is invalid', async () => {
+    const project = makeProject({ githubRepo: '$(whoami)/repo' });
+    const team = makeTeam({
+      prNumber: null,
+      branchName: 'feat/10-test',
+      worktreeName: 'proj-10',
+    });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    mockExecGitAsync.mockResolvedValue('feat/10-test');
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await githubPoller.poll();
+
+    // gh CLI should never be called for an invalid repo slug
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #407

## Summary
- Add shared `isValidGithubRepo()` and `isValidBranchName()` validators in `exec-gh.ts` with regex guards that reject shell metacharacters
- Quote all `${variables}` in `gh` CLI shell strings across `github-poller.ts`, `team-manager.ts`, `pr-service.ts`, and `project-service.ts`
- Add pre-execution validation guards that return early without shelling out when inputs are invalid
- Deduplicate private `GITHUB_REPO_RE` from `pr-service.ts` into the shared module
- Add unit tests for both validators and integration tests for guard behavior in `github-poller.ts`

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm test` passes (3 pre-existing failures in cc-spawn.test.ts unrelated)
- [x] New validator tests cover valid inputs and injection payloads
- [x] Guard behavior tests verify early return without shell execution