### PR TITLE
Issue #426: Show connection/fetch errors in FleetContext instead of silently using stale data

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -11,6 +11,7 @@ import { UsageViewPage } from './views/UsageViewPage';
 import { ProjectsPage } from './views/ProjectsPage';
 import { SettingsPage } from './views/SettingsPage';
 import { StateMachinePage } from './views/StateMachinePage';
+import { FetchErrorBanner } from './components/FetchErrorBanner';
 
 export function App() {
   return (
@@ -28,6 +29,7 @@ export function App() {
 
               {/* Main content area — fills remaining space */}
               <main className="flex-1 min-w-0 overflow-auto">
+                <FetchErrorBanner />
                 <Routes>
                   <Route path="/" element={<FleetGridView />} />
                   <Route path="/issues" element={<IssueTreeView />} />

--- a/src/client/components/FetchErrorBanner.tsx
+++ b/src/client/components/FetchErrorBanner.tsx
@@ -1,0 +1,16 @@
+import { useTeams } from '../context/FleetContext';
+
+export function FetchErrorBanner() {
+  const { fetchError } = useTeams();
+  if (!fetchError) return null;
+  return (
+    <div
+      role="alert"
+      style={{ backgroundColor: '#3B2607', borderBottom: '1px solid #6B4C1E', color: '#F0C674', padding: '6px 16px', fontSize: '0.75rem' }}
+      className="flex items-center gap-2 shrink-0"
+    >
+      <span style={{ color: '#F0C674' }}>&#9888;</span>
+      <span>Data may be stale — {fetchError}</span>
+    </div>
+  );
+}

--- a/src/client/components/StatusBar.tsx
+++ b/src/client/components/StatusBar.tsx
@@ -1,8 +1,9 @@
-import { useConnection } from '../context/FleetContext';
+import { useConnection, useTeams } from '../context/FleetContext';
 import { useEffect, useState } from 'react';
 
 export function StatusBar() {
   const { connected, lastEvent } = useConnection();
+  const { fetchError } = useTeams();
   const [secondsAgo, setSecondsAgo] = useState<number | null>(null);
   const [version, setVersion] = useState<string | null>(null);
 
@@ -40,6 +41,11 @@ export function StatusBar() {
         }`}
       />
       <span>{connected ? 'Connected' : 'Disconnected'}</span>
+      {fetchError && (
+        <span className="ml-3" style={{ color: '#F0C674' }}>
+          Stale
+        </span>
+      )}
       {secondsAgo !== null && (
         <span className="ml-4">
           Last update: {secondsAgo}s ago

--- a/src/client/context/FleetContext.tsx
+++ b/src/client/context/FleetContext.tsx
@@ -8,6 +8,7 @@ import type { TeamDashboardRow } from '../../shared/types';
 
 interface TeamsContextValue {
   teams: TeamDashboardRow[];
+  fetchError: string | null;
 }
 
 interface SelectionContextValue {
@@ -43,8 +44,10 @@ const FALLBACK_REFRESH_MS = 45_000;
 
 export function FleetProvider({ children }: { children: ReactNode }) {
   const [teams, setTeams] = useState<TeamDashboardRow[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
   const fetchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchFailCountRef = useRef(0);
   const thinkingTeamIdsRef = useRef<Set<number>>(new Set());
   const [thinkingVersion, forceThinkingUpdate] = useState(0);
 
@@ -54,14 +57,24 @@ export function FleetProvider({ children }: { children: ReactNode }) {
   const fetchTeams = useCallback(async () => {
     try {
       const res = await fetch('/api/teams');
-      if (res.ok) {
-        const json = await res.json();
-        // Handle paginated response envelope { data, total, limit, offset }
-        const rows = (Array.isArray(json) ? json : json.data) as TeamDashboardRow[];
-        setTeams(rows);
+      if (!res.ok) {
+        fetchFailCountRef.current += 1;
+        if (fetchFailCountRef.current >= 2) {
+          setFetchError(`Server error: ${res.status} ${res.statusText}`);
+        }
+        return;
       }
-    } catch {
-      // Network error — will be retried on next event or periodic refresh
+      const json = await res.json();
+      // Handle paginated response envelope { data, total, limit, offset }
+      const rows = (Array.isArray(json) ? json : json.data) as TeamDashboardRow[];
+      setTeams(rows);
+      fetchFailCountRef.current = 0;
+      setFetchError(null);
+    } catch (err: unknown) {
+      fetchFailCountRef.current += 1;
+      if (fetchFailCountRef.current >= 2) {
+        setFetchError(err instanceof Error ? err.message : 'Network error');
+      }
     }
   }, []);
 
@@ -82,6 +95,8 @@ export function FleetProvider({ children }: { children: ReactNode }) {
       const payload = data as { teams?: TeamDashboardRow[] };
       if (Array.isArray(payload.teams)) {
         setTeams(payload.teams);
+        fetchFailCountRef.current = 0;
+        setFetchError(null);
       }
     } else if (type === 'team_status_changed') {
       // C7: Incremental update — parse payload and update the single affected team locally
@@ -196,7 +211,8 @@ export function FleetProvider({ children }: { children: ReactNode }) {
   // when their specific slice changes.
   const teamsValue = useMemo<TeamsContextValue>(() => ({
     teams,
-  }), [teams]);
+    fetchError,
+  }), [teams, fetchError]);
 
   const selectionValue = useMemo<SelectionContextValue>(() => ({
     selectedTeamId,

--- a/tests/client/FetchErrorBanner.test.tsx
+++ b/tests/client/FetchErrorBanner.test.tsx
@@ -1,0 +1,64 @@
+// =============================================================================
+// Fleet Commander — FetchErrorBanner Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ---------------------------------------------------------------------------
+// Mock FleetContext — control fetchError value
+// ---------------------------------------------------------------------------
+
+let mockFetchError: string | null = null;
+
+vi.mock('../../src/client/context/FleetContext', () => ({
+  useTeams: () => ({
+    teams: [],
+    fetchError: mockFetchError,
+  }),
+}));
+
+// Import after mocks
+import { FetchErrorBanner } from '../../src/client/components/FetchErrorBanner';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FetchErrorBanner', () => {
+  beforeEach(() => {
+    mockFetchError = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when fetchError is null', () => {
+    const { container } = render(<FetchErrorBanner />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders warning banner when fetchError is set', () => {
+    mockFetchError = 'Server error: 500 Internal Server Error';
+    render(<FetchErrorBanner />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('displays the specific error message', () => {
+    mockFetchError = 'Failed to fetch';
+    render(<FetchErrorBanner />);
+    expect(screen.getByText(/Data may be stale/)).toBeInTheDocument();
+    expect(screen.getByText(/Failed to fetch/)).toBeInTheDocument();
+  });
+
+  it('displays the warning icon', () => {
+    mockFetchError = 'Network error';
+    render(<FetchErrorBanner />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    // The warning icon is ⚠ (&#9888;)
+    expect(alert.textContent).toContain('\u26A0');
+  });
+});

--- a/tests/client/FleetGridView.test.tsx
+++ b/tests/client/FleetGridView.test.tsx
@@ -17,6 +17,7 @@ const mockSetSelectedTeamId = vi.fn();
 vi.mock('../../src/client/context/FleetContext', () => ({
   useTeams: () => ({
     teams: mockTeams,
+    fetchError: null,
   }),
   useSelection: () => ({
     selectedTeamId: mockSelectedTeamId,

--- a/tests/client/StatusBar.test.tsx
+++ b/tests/client/StatusBar.test.tsx
@@ -12,11 +12,16 @@ import '@testing-library/jest-dom';
 
 let mockConnected = true;
 let mockLastEvent: Date | null = null;
+let mockFetchError: string | null = null;
 
 vi.mock('../../src/client/context/FleetContext', () => ({
   useConnection: () => ({
     connected: mockConnected,
     lastEvent: mockLastEvent,
+  }),
+  useTeams: () => ({
+    teams: [],
+    fetchError: mockFetchError,
   }),
 }));
 
@@ -31,6 +36,7 @@ describe('StatusBar', () => {
   beforeEach(() => {
     mockConnected = true;
     mockLastEvent = null;
+    mockFetchError = null;
   });
 
   afterEach(() => {
@@ -71,5 +77,16 @@ describe('StatusBar', () => {
     mockLastEvent = new Date('2026-03-21T10:00:00Z');
     render(<StatusBar />);
     expect(screen.getByText('Last update: 10s ago')).toBeInTheDocument();
+  });
+
+  it('does not show "Stale" when fetchError is null', () => {
+    render(<StatusBar />);
+    expect(screen.queryByText('Stale')).not.toBeInTheDocument();
+  });
+
+  it('shows "Stale" when fetchError is set', () => {
+    mockFetchError = 'Server error: 500 Internal Server Error';
+    render(<StatusBar />);
+    expect(screen.getByText('Stale')).toBeInTheDocument();
   });
 });

--- a/tests/client/TopBar.test.tsx
+++ b/tests/client/TopBar.test.tsx
@@ -17,6 +17,7 @@ let mockTeams: TeamDashboardRow[] = [];
 vi.mock('../../src/client/context/FleetContext', () => ({
   useTeams: () => ({
     teams: mockTeams,
+    fetchError: null,
   }),
 }));
 


### PR DESCRIPTION
Closes #426

## Summary
- Add `fetchError` state to `FleetContext` with 2-consecutive-failure threshold to avoid flashing on transient errors
- Create `FetchErrorBanner` component — dark-amber warning bar with `role="alert"` at top of main content area
- Add "Stale" indicator to `StatusBar` when fetch errors are present
- Reset error state on successful REST fetch or SSE snapshot
- Update all existing test mocks and add new tests for banner and stale indicator

## Test plan
- [x] `npm run test:client` passes with no regressions
- [x] New tests: FetchErrorBanner (4 tests), StatusBar stale indicator (2 tests)
- [x] Existing mock updates: FleetGridView, TopBar