### PR TITLE
Issue #421: Replace polling with SSE-driven incremental updates in UnifiedTimeline

### DIFF
--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, useReducer } from 'react';
 import { useApi } from '../hooks/useApi';
+import { useSSE } from '../hooks/useSSE';
 import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry, TeamMember, TeamStatus } from '../../shared/types';
 import { TERMINAL_STATUSES } from '../../shared/types';
 import { agentColor } from '../utils/constants';
@@ -226,6 +227,167 @@ function getToolDetail(entry: StreamTimelineEntry): string | null {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// SSE event → timeline entry converters
+// ---------------------------------------------------------------------------
+
+/** Shape of an SSE StreamEvent payload (from team_output events) */
+interface SSEStreamEvent {
+  type: string;
+  timestamp?: string;
+  subtype?: string;
+  message?: { content?: Array<{ type: string; text?: string; id?: string; name?: string; input?: unknown }> };
+  tool?: { name?: string; input?: unknown };
+  agentName?: string;
+  description?: string;
+  lastToolName?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Convert an SSE team_output StreamEvent into one or more StreamTimelineEntry objects.
+ * Also extracts tool_use content blocks from assistant events (mirrors build-timeline.ts logic).
+ */
+function streamEventToEntries(
+  teamId: number,
+  event: SSEStreamEvent,
+  seqId: number,
+): StreamTimelineEntry[] {
+  const timestamp = event.timestamp ?? new Date().toISOString();
+  const base: StreamTimelineEntry = {
+    id: `sse-stream-${seqId}`,
+    source: 'stream',
+    timestamp,
+    teamId,
+    streamType: event.type,
+    subtype: event.subtype,
+    message: event.message,
+    tool: event.tool,
+    ...(event.agentName ? { agentName: event.agentName } : {}),
+    ...(event.description ? { description: event.description } : {}),
+    ...(event.lastToolName ? { lastToolName: event.lastToolName } : {}),
+  };
+
+  const entries: StreamTimelineEntry[] = [base];
+
+  // Extract tool_use content blocks from assistant events
+  if (event.type === 'assistant' && event.message?.content) {
+    for (let j = 0; j < event.message.content.length; j++) {
+      const block = event.message.content[j];
+      if (block.type === 'tool_use' && block.name) {
+        entries.push({
+          id: `sse-stream-${seqId}-tool-${j}`,
+          source: 'stream',
+          timestamp,
+          teamId,
+          streamType: 'tool_use',
+          tool: { name: block.name, input: block.input },
+          ...(event.agentName ? { agentName: event.agentName } : {}),
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+/** Shape of an SSE team_event payload */
+interface SSEHookPayload {
+  team_id: number;
+  event_type: string;
+  event_id: number;
+  session_id?: string | null;
+  agent_name?: string | null;
+  tool_name?: string | null;
+  timestamp?: string;
+}
+
+/**
+ * Convert an SSE team_event payload into a HookTimelineEntry.
+ */
+function hookPayloadToEntry(teamId: number, payload: SSEHookPayload): HookTimelineEntry {
+  return {
+    id: `event-${payload.event_id}`,
+    source: 'hook',
+    timestamp: payload.timestamp ?? new Date().toISOString(),
+    teamId,
+    eventType: payload.event_type,
+    toolName: payload.tool_name ?? undefined,
+    agentName: payload.agent_name ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeline state reducer
+// ---------------------------------------------------------------------------
+
+/** High-frequency noise types that should be filtered from SSE events */
+const NOISE_STREAM_TYPES = new Set([
+  'stream_event',
+  'content_block_start',
+  'content_block_delta',
+  'content_block_stop',
+]);
+
+/** Maximum number of entries before trimming oldest */
+const MAX_ENTRIES = 600;
+/** Number of entries to trim when cap is exceeded */
+const TRIM_COUNT = 100;
+
+interface TimelineState {
+  entries: TimelineEntry[];
+  idSet: Set<string>;
+}
+
+type TimelineAction =
+  | { type: 'INIT'; entries: TimelineEntry[] }
+  | { type: 'APPEND_STREAM'; entries: StreamTimelineEntry[] }
+  | { type: 'APPEND_HOOK'; entry: HookTimelineEntry }
+  | { type: 'SYNC'; entries: TimelineEntry[] };
+
+function timelineReducer(state: TimelineState, action: TimelineAction): TimelineState {
+  switch (action.type) {
+    case 'INIT': {
+      const idSet = new Set(action.entries.map((e) => e.id));
+      return { entries: action.entries, idSet };
+    }
+    case 'APPEND_STREAM': {
+      const newEntries = action.entries.filter((e) => !state.idSet.has(e.id));
+      if (newEntries.length === 0) return state;
+      const idSet = new Set(state.idSet);
+      for (const e of newEntries) idSet.add(e.id);
+      let entries = [...state.entries, ...newEntries];
+      // Memory cap: trim oldest entries if over limit
+      if (entries.length > MAX_ENTRIES) {
+        const trimmed = entries.slice(TRIM_COUNT);
+        const trimmedIdSet = new Set(trimmed.map((e) => e.id));
+        return { entries: trimmed, idSet: trimmedIdSet };
+      }
+      return { entries, idSet };
+    }
+    case 'APPEND_HOOK': {
+      if (state.idSet.has(action.entry.id)) return state;
+      const idSet = new Set(state.idSet);
+      idSet.add(action.entry.id);
+      let entries = [...state.entries, action.entry];
+      // Memory cap: trim oldest entries if over limit
+      if (entries.length > MAX_ENTRIES) {
+        const trimmed = entries.slice(TRIM_COUNT);
+        const trimmedIdSet = new Set(trimmed.map((e) => e.id));
+        return { entries: trimmed, idSet: trimmedIdSet };
+      }
+      return { entries, idSet };
+    }
+    case 'SYNC': {
+      // Full replacement on sync (fallback poll) — like INIT but called periodically
+      const idSet = new Set(action.entries.map((e) => e.id));
+      return { entries: action.entries, idSet };
+    }
+  }
+}
+
+const INITIAL_TIMELINE_STATE: TimelineState = { entries: [], idSet: new Set() };
 
 // ---------------------------------------------------------------------------
 // Sub-components for each entry type
@@ -482,6 +644,9 @@ function getEntryAgentName(entry: TimelineEntry): string | undefined {
   return entry.agentName;
 }
 
+/** Fallback poll interval (60 seconds) — only used as safety net alongside SSE */
+const FALLBACK_POLL_MS = 60_000;
+
 export function UnifiedTimeline({
   teamId,
   teamStatus,
@@ -491,13 +656,17 @@ export function UnifiedTimeline({
   onAgentFiltersChange,
 }: UnifiedTimelineProps) {
   const api = useApi();
-  const [entries, setEntries] = useState<TimelineEntry[]>([]);
+  const [state, dispatch] = useReducer(timelineReducer, INITIAL_TIMELINE_STATE);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
-  const pollDelayRef = useRef(2000);
+
+  // Refs to avoid stale closures in SSE callback
+  const teamIdRef = useRef(teamId);
+  teamIdRef.current = teamId;
+  const sseSeqRef = useRef(0);
 
   // Detect if user has scrolled up — disable auto-scroll in that case
   const handleScroll = useCallback(() => {
@@ -508,39 +677,61 @@ export function UnifiedTimeline({
     stickToBottomRef.current = atBottom;
   }, []);
 
-  // Poll for timeline data with exponential backoff (2s -> 4s -> 8s -> 16s -> 30s max)
+  // Initial fetch + 60-second fallback poll for non-terminal teams
   useEffect(() => {
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
+    let timer: ReturnType<typeof setInterval> | null = null;
 
-    // Reset backoff whenever the effect re-runs (e.g. teamStatus change)
-    pollDelayRef.current = 2000;
+    // Reset SSE sequence counter on teamId change
+    sseSeqRef.current = 0;
 
-    async function poll() {
+    async function fetchTimeline(isInit: boolean) {
       if (cancelled) return;
       try {
         const data = await api.get<TimelineEntry[]>(`teams/${teamId}/timeline?limit=500`);
         if (!cancelled) {
-          setEntries(data);
+          dispatch({ type: isInit ? 'INIT' : 'SYNC', entries: data });
         }
       } catch {
-        // Ignore polling errors
-      }
-      // Schedule next poll only if not cancelled and not terminal
-      if (!cancelled && !TERMINAL_STATUSES.has(teamStatus as TeamStatus)) {
-        timer = setTimeout(poll, pollDelayRef.current);
-        pollDelayRef.current = Math.min(pollDelayRef.current * 2, 30000);
+        // Ignore fetch errors
       }
     }
 
     // Initial fetch
-    poll();
+    fetchTimeline(true);
+
+    // 60-second fallback poll for non-terminal teams
+    if (!TERMINAL_STATUSES.has(teamStatus as TeamStatus)) {
+      timer = setInterval(() => fetchTimeline(false), FALLBACK_POLL_MS);
+    }
 
     return () => {
       cancelled = true;
-      if (timer !== null) clearTimeout(timer);
+      if (timer !== null) clearInterval(timer);
     };
   }, [api, teamId, teamStatus]);
+
+  // Subscribe to SSE for real-time updates
+  const handleSSEEvent = useCallback((type: string, data: unknown) => {
+    if (type === 'team_output') {
+      const payload = data as { team_id: number; event: SSEStreamEvent };
+      if (payload.team_id !== teamIdRef.current) return;
+      // Skip noise types
+      if (NOISE_STREAM_TYPES.has(payload.event.type)) return;
+      const seq = sseSeqRef.current++;
+      const entries = streamEventToEntries(teamIdRef.current, payload.event, seq);
+      dispatch({ type: 'APPEND_STREAM', entries });
+    } else if (type === 'team_event') {
+      const payload = data as SSEHookPayload;
+      if (payload.team_id !== teamIdRef.current) return;
+      const entry = hookPayloadToEntry(teamIdRef.current, payload);
+      dispatch({ type: 'APPEND_HOOK', entry });
+    }
+  }, []);
+
+  useSSE({ onEvent: handleSSEEvent });
+
+  const { entries } = state;
 
   // Filter entries by active agent filters
   const filteredEntries = useMemo(() => {

--- a/tests/client/UnifiedTimeline.test.tsx
+++ b/tests/client/UnifiedTimeline.test.tsx
@@ -1,9 +1,12 @@
 // =============================================================================
-// Fleet Commander — UnifiedTimeline Expand/Collapse Tests
+// Fleet Commander — UnifiedTimeline Tests
+// =============================================================================
+// Tests for expand/collapse, error entries, polling behavior (60s fallback),
+// and SSE-driven real-time appending of stream and hook events.
 // =============================================================================
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry } from '../../src/shared/types';
 
@@ -29,6 +32,19 @@ const mockApi = {
 
 vi.mock('../../src/client/hooks/useApi', () => ({
   useApi: () => mockApi,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useSSE — capture the onEvent callback for simulating SSE events
+// ---------------------------------------------------------------------------
+
+let capturedOnEvent: ((type: string, data: unknown) => void) | undefined;
+
+vi.mock('../../src/client/hooks/useSSE', () => ({
+  useSSE: (options: { onEvent?: (type: string, data: unknown) => void }) => {
+    capturedOnEvent = options.onEvent;
+    return { connected: true, lastEvent: null, lastEventTeamId: null };
+  },
 }));
 
 // Import after mocks are set up
@@ -69,6 +85,20 @@ function makeToolUseEntryNoInput(
   };
 }
 
+function makeStreamEntry(
+  streamType: string,
+  overrides: Partial<StreamTimelineEntry> = {},
+): StreamTimelineEntry {
+  return {
+    id: `stream-${Math.random().toString(36).slice(2)}`,
+    source: 'stream',
+    timestamp: '2026-03-20T10:00:00.000Z',
+    teamId: 1,
+    streamType,
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Helper to find the expandable badge (role="button" with aria-expanded)
 // ---------------------------------------------------------------------------
@@ -84,7 +114,7 @@ function getExpandedBadge() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — tool detail expand/collapse
 // ---------------------------------------------------------------------------
 
 describe('UnifiedTimeline — tool detail expand/collapse', () => {
@@ -419,7 +449,7 @@ describe('UnifiedTimeline — error entry collapse/expand', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Polling behavior tests — terminal state + exponential backoff
+// Polling behavior tests — terminal state + 60-second fixed interval
 // ---------------------------------------------------------------------------
 
 describe('UnifiedTimeline — polling behavior', () => {
@@ -445,7 +475,7 @@ describe('UnifiedTimeline — polling behavior', () => {
     expect(initialCalls).toBe(1); // Just the initial fetch
 
     // Advance time well past any polling interval
-    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(120000);
 
     // No additional calls should have been made
     expect(mockGet.mock.calls.length).toBe(initialCalls);
@@ -461,57 +491,232 @@ describe('UnifiedTimeline — polling behavior', () => {
     expect(initialCalls).toBe(1); // Just the initial fetch
 
     // Advance time well past any polling interval
-    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(120000);
 
     // No additional calls should have been made
     expect(mockGet.mock.calls.length).toBe(initialCalls);
   });
 
-  it('polls with increasing delay (exponential backoff)', async () => {
+  it('polls at fixed 60-second intervals for running teams', async () => {
     render(<UnifiedTimeline teamId={1} teamStatus="running" />);
 
     // Initial fetch fires immediately
     await vi.advanceTimersByTimeAsync(0);
     expect(mockGet.mock.calls.length).toBe(1);
 
-    // After 2s: first backoff poll
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(mockGet.mock.calls.length).toBe(2);
-
-    // After another 4s: second backoff poll (delay doubled to 4s)
-    await vi.advanceTimersByTimeAsync(4000);
-    expect(mockGet.mock.calls.length).toBe(3);
-
-    // After another 8s: third backoff poll (delay doubled to 8s)
-    await vi.advanceTimersByTimeAsync(8000);
-    expect(mockGet.mock.calls.length).toBe(4);
-  });
-
-  it('caps backoff delay at 30 seconds', async () => {
-    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
-
-    // Initial fetch
-    await vi.advanceTimersByTimeAsync(0);
+    // Before 60s — no additional poll
+    await vi.advanceTimersByTimeAsync(59999);
     expect(mockGet.mock.calls.length).toBe(1);
 
-    // Run through backoff stages: 2s, 4s, 8s, 16s = 30s total, 4 polls
-    await vi.advanceTimersByTimeAsync(2000); // 2s delay
+    // At 60s — fallback poll fires
+    await vi.advanceTimersByTimeAsync(1);
     expect(mockGet.mock.calls.length).toBe(2);
 
-    await vi.advanceTimersByTimeAsync(4000); // 4s delay
+    // At 120s — another fallback poll fires (fixed interval, not backoff)
+    await vi.advanceTimersByTimeAsync(60000);
     expect(mockGet.mock.calls.length).toBe(3);
+  });
+});
 
-    await vi.advanceTimersByTimeAsync(8000); // 8s delay
-    expect(mockGet.mock.calls.length).toBe(4);
+// ---------------------------------------------------------------------------
+// SSE-driven real-time updates
+// ---------------------------------------------------------------------------
 
-    await vi.advanceTimersByTimeAsync(16000); // 16s delay
-    expect(mockGet.mock.calls.length).toBe(5);
+describe('UnifiedTimeline — SSE-driven updates', () => {
+  beforeEach(() => {
+    mockEntries = [];
+    capturedOnEvent = undefined;
+    mockGet.mockReset();
+    mockGet.mockImplementation(() => Promise.resolve(mockEntries));
+  });
 
-    // Next should be capped at 30s (not 32s)
-    await vi.advanceTimersByTimeAsync(29999); // Just under 30s — should not fire
-    expect(mockGet.mock.calls.length).toBe(5);
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    await vi.advanceTimersByTimeAsync(1); // Completes 30s — should fire
-    expect(mockGet.mock.calls.length).toBe(6);
+  it('appends a stream entry via team_output SSE event', async () => {
+    // Start with one initial entry so the timeline renders
+    mockEntries = [
+      makeStreamEntry('assistant', {
+        id: 'stream-0',
+        message: { content: [{ type: 'text', text: 'Hello from TL' }] },
+      }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    // Wait for initial fetch to render
+    await waitFor(() => {
+      expect(screen.getByText('Hello from TL')).toBeInTheDocument();
+    });
+
+    // Simulate an SSE team_output event with a tool_use payload
+    expect(capturedOnEvent).toBeDefined();
+    act(() => {
+      capturedOnEvent!('team_output', {
+        team_id: 1,
+        event: {
+          type: 'tool_use',
+          timestamp: '2026-03-20T10:01:00.000Z',
+          tool: { name: 'Bash', input: { command: 'echo hello' } },
+        },
+      });
+    });
+
+    // The new entry should appear in the timeline
+    await waitFor(() => {
+      expect(screen.getByText('Bash')).toBeInTheDocument();
+    });
+  });
+
+  it('appends a hook entry via team_event SSE event', async () => {
+    // Start with one initial entry so the timeline renders
+    mockEntries = [
+      makeStreamEntry('assistant', {
+        id: 'stream-0',
+        message: { content: [{ type: 'text', text: 'Hello from TL' }] },
+      }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    // Wait for initial fetch to render
+    await waitFor(() => {
+      expect(screen.getByText('Hello from TL')).toBeInTheDocument();
+    });
+
+    // Simulate an SSE team_event (hook event)
+    expect(capturedOnEvent).toBeDefined();
+    act(() => {
+      capturedOnEvent!('team_event', {
+        team_id: 1,
+        event_type: 'SessionStart',
+        event_id: 42,
+        timestamp: '2026-03-20T10:01:00.000Z',
+        agent_name: 'team-lead',
+      });
+    });
+
+    // The hook entry should appear
+    await waitFor(() => {
+      expect(screen.getByText('SessionStart')).toBeInTheDocument();
+    });
+  });
+
+  it('ignores SSE events for different team_id', async () => {
+    mockEntries = [
+      makeStreamEntry('assistant', {
+        id: 'stream-0',
+        message: { content: [{ type: 'text', text: 'Hello from TL' }] },
+      }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello from TL')).toBeInTheDocument();
+    });
+
+    // Send SSE event for a DIFFERENT team
+    act(() => {
+      capturedOnEvent!('team_output', {
+        team_id: 999,
+        event: {
+          type: 'tool_use',
+          timestamp: '2026-03-20T10:01:00.000Z',
+          tool: { name: 'Bash', input: { command: 'echo wrong team' } },
+        },
+      });
+    });
+
+    // Bash entry should NOT appear
+    expect(screen.queryByText('Bash')).not.toBeInTheDocument();
+  });
+
+  it('deduplicates entries with same ID via APPEND_HOOK', async () => {
+    // Initial fetch returns one hook entry
+    const hookEntry = makeErrorHookEntry('ToolUse', undefined, { id: 'event-100', eventType: 'ToolUse', toolName: 'Bash' });
+    mockEntries = [hookEntry];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ToolUse')).toBeInTheDocument();
+    });
+
+    // Simulate an SSE team_event with the SAME event_id (so id='event-100')
+    act(() => {
+      capturedOnEvent!('team_event', {
+        team_id: 1,
+        event_type: 'ToolUse',
+        event_id: 100,
+        timestamp: '2026-03-20T10:01:00.000Z',
+        tool_name: 'Bash',
+      });
+    });
+
+    // Should still show exactly one ToolUse entry (deduped by ID)
+    const toolUseElements = screen.getAllByText('ToolUse');
+    expect(toolUseElements.length).toBe(1);
+  });
+
+  it('filters out noise stream types from SSE events', async () => {
+    mockEntries = [
+      makeStreamEntry('assistant', {
+        id: 'stream-0',
+        message: { content: [{ type: 'text', text: 'Hello from TL' }] },
+      }),
+    ];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello from TL')).toBeInTheDocument();
+    });
+
+    // Send noise stream types — these should be silently dropped
+    act(() => {
+      capturedOnEvent!('team_output', {
+        team_id: 1,
+        event: { type: 'content_block_delta', timestamp: '2026-03-20T10:01:00.000Z' },
+      });
+      capturedOnEvent!('team_output', {
+        team_id: 1,
+        event: { type: 'stream_event', timestamp: '2026-03-20T10:01:01.000Z' },
+      });
+    });
+
+    // The noise types should not produce any visible new entries
+    // Component should still render cleanly with only the initial entry
+    expect(screen.getByText('Hello from TL')).toBeInTheDocument();
+  });
+
+  it('extracts tool_use blocks from assistant SSE events', async () => {
+    mockEntries = [];
+    render(<UnifiedTimeline teamId={1} teamStatus="running" />);
+
+    await waitFor(() => {
+      // Component should show empty state initially
+      expect(screen.getByText(/No events yet/)).toBeInTheDocument();
+    });
+
+    // Send an assistant event that contains a tool_use content block
+    act(() => {
+      capturedOnEvent!('team_output', {
+        team_id: 1,
+        event: {
+          type: 'assistant',
+          timestamp: '2026-03-20T10:01:00.000Z',
+          message: {
+            content: [
+              { type: 'text', text: 'Let me check that file.' },
+              { type: 'tool_use', name: 'Read', input: { file_path: '/src/main.ts' } },
+            ],
+          },
+          agentName: 'team-lead',
+        },
+      });
+    });
+
+    // Should render both the text content and the extracted tool_use entry
+    await waitFor(() => {
+      expect(screen.getByText('Let me check that file.')).toBeInTheDocument();
+      expect(screen.getByText('Read')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #421

## Summary
- Replaced exponential-backoff polling (2s→30s) in `UnifiedTimeline` with SSE-driven incremental appending via `useReducer`
- New stream entries from `team_output` and hook entries from `team_event` SSE events appear in real-time without full re-fetch
- Scroll position is preserved — no more unmount/remount on every update
- 60-second fallback poll as safety net for non-terminal teams
- Memory cap (600 entries) prevents unbounded growth
- Noise filtering for non-meaningful stream types

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 27 client tests pass (`npm run test:client`)
- [x] 6 new SSE-driven update tests (stream append, hook append, team_id filtering, dedup, noise filtering, tool_use extraction)
- [x] Polling tests updated for 60s fixed interval
- [ ] Manual verification: open team detail panel, confirm timeline updates in real-time without scroll jumps