### PR TITLE
Issue #431: Add set -euo pipefail and dependency validation to install/uninstall scripts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Fleet Commander Installer
 # Installs hook scripts, merges settings.json, deploys workflow prompt,
 # and copies agent templates into a target repo's .claude directory.
@@ -9,6 +10,11 @@
 # Ensure standard Unix tools are on PATH — when Git Bash's usr/bin/bash.exe
 # is invoked directly (not via git-bash.exe), /usr/bin may be missing.
 export PATH="/usr/bin:/bin:$PATH"
+
+# ── Validate required dependencies ────────────────────────────────
+for cmd in git node sed; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd not found. Please install $cmd and ensure it is on your PATH." >&2; exit 1; }
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Fleet Commander Uninstaller
 # Removes hook scripts, cleans settings.json, removes workflow prompt,
 # and removes Fleet Commander agent templates from a target repo's .claude directory.
@@ -11,6 +12,11 @@
 # Ensure standard Unix tools are on PATH — when Git Bash's usr/bin/bash.exe
 # is invoked directly (not via git-bash.exe), /usr/bin may be missing.
 export PATH="/usr/bin:/bin:$PATH"
+
+# ── Validate required dependencies ────────────────────────────────
+for cmd in git node; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd not found. Please install $cmd and ensure it is on your PATH." >&2; exit 1; }
+done
 
 TARGET="${1:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
 if [ -z "$TARGET" ]; then


### PR DESCRIPTION
Closes #431

## Summary
- Add `set -euo pipefail` to `scripts/install.sh` and `scripts/uninstall.sh` for strict error handling
- Add early dependency validation (`git`, `node`, `sed` for install; `git`, `node` for uninstall) using `command -v` pattern
- Error messages go to stderr with clear indication of which tool is missing
- Hook scripts (`hooks/send_event.sh` etc.) intentionally left unchanged — they are fire-and-forget by design

## Test plan
- [ ] Run `scripts/install.sh` against a test repo — completes successfully
- [ ] Run `scripts/uninstall.sh` against a test repo — completes successfully
- [ ] Temporarily remove `node` from PATH, run install.sh — aborts with clear error naming `node`
- [ ] Verify `hooks/send_event.sh` has no changes