### PR TITLE
Issue #427: Add server-side test coverage for routes and critical services

### DIFF
--- a/tests/server/routes/projects-routes.test.ts
+++ b/tests/server/routes/projects-routes.test.ts
@@ -1,0 +1,489 @@
+// =============================================================================
+// Fleet Commander -- Projects Routes: HTTP contract tests
+// =============================================================================
+// Tests the projects route plugin for correct HTTP status codes, response shapes,
+// parameter validation, and ServiceError-to-HTTP mapping. Uses mocked services
+// with a real temp SQLite database.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Service mocks -- must be set up BEFORE importing the route plugin
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/services/team-manager.js', () => ({
+  getTeamManager: vi.fn(() => ({
+    sendMessage: vi.fn(),
+    getOutput: vi.fn().mockReturnValue([]),
+    getParsedEvents: vi.fn().mockReturnValue([]),
+    launch: vi.fn().mockResolvedValue({ id: 1, status: 'launching' }),
+    stop: vi.fn().mockResolvedValue({ id: 1, status: 'done' }),
+    stopAll: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('../../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: vi.fn(() => ({
+    fetch: vi.fn().mockResolvedValue([]),
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue(null),
+    enrichWithTeamInfo: vi.fn().mockReturnValue([]),
+    getIssues: vi.fn().mockResolvedValue([]),
+    getIssuesByProject: vi.fn().mockReturnValue([]),
+    getCachedAt: vi.fn().mockReturnValue(null),
+    getAvailableIssues: vi.fn().mockReturnValue([]),
+    getIssue: vi.fn().mockReturnValue(null),
+    clearProject: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    getRecentPRs: vi.fn().mockReturnValue([]),
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+// Mock exec-gh to prevent real CLI calls in ProjectService
+vi.mock('../../../src/server/utils/exec-gh.js', () => ({
+  execGitAsync: vi.fn().mockResolvedValue('true'),
+  execGHAsync: vi.fn().mockResolvedValue(null),
+  execGHResult: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 }),
+  isValidGithubRepo: vi.fn().mockReturnValue(true),
+}));
+
+// Mock hook-installer to prevent filesystem side effects
+vi.mock('../../../src/server/utils/hook-installer.js', () => ({
+  installHooks: vi.fn(),
+  uninstallHooks: vi.fn(),
+}));
+
+// Mock child_process to prevent real exec calls
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockReturnValue(Buffer.from('')),
+}));
+
+// Import routes AFTER mocks
+import projectsRoutes from '../../../src/server/routes/projects.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let server: FastifyInstance;
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-proj-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  server = Fastify({ logger: false });
+  await server.register(projectsRoutes);
+  await server.ready();
+});
+
+afterAll(async () => {
+  sseBroker.stop();
+  await server.close();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let projectCounter = 0;
+
+function seedProject(overrides: {
+  name?: string;
+  repoPath?: string;
+  githubRepo?: string | null;
+  status?: string;
+} = {}) {
+  projectCounter++;
+  const db = getDatabase();
+  return db.insertProject({
+    name: overrides.name ?? `test-project-${Date.now()}-${projectCounter}`,
+    repoPath: overrides.repoPath ?? `C:/fake/repo-${Date.now()}-${projectCounter}`,
+    githubRepo: overrides.githubRepo ?? null,
+  });
+}
+
+function seedTeam(overrides: {
+  issueNumber?: number;
+  worktreeName?: string;
+  projectId?: number;
+  status?: string;
+} = {}) {
+  const db = getDatabase();
+  return db.insertTeam({
+    issueNumber: overrides.issueNumber ?? 100,
+    worktreeName: overrides.worktreeName ?? `proj-team-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    status: (overrides.status as 'running') ?? 'running',
+    phase: 'implementing' as 'implementing',
+    projectId: overrides.projectId ?? null,
+  });
+}
+
+// =============================================================================
+// Tests: GET /api/projects
+// =============================================================================
+
+describe('GET /api/projects', () => {
+  it('should return array of projects with 200', async () => {
+    seedProject();
+
+    const res = await server.inject({ method: 'GET', url: '/api/projects' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it('should filter by status=active', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/projects?status=active' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/projects/:id
+// =============================================================================
+
+describe('GET /api/projects/:id', () => {
+  it('should return project detail with 200', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({ method: 'GET', url: `/api/projects/${project.id}` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe(project.id);
+    expect(body.name).toBe(project.name);
+  });
+
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/projects/99999' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/projects/abc' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for negative ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/projects/-1' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/projects
+// =============================================================================
+
+describe('POST /api/projects', () => {
+  it('should return 400 for missing name', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/projects',
+      payload: { repoPath: 'C:/some/path' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for missing repoPath', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/projects',
+      payload: { name: 'test-project' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for empty name', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/projects',
+      payload: { name: '', repoPath: 'C:/some/path' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: PUT /api/projects/:id
+// =============================================================================
+
+describe('PUT /api/projects/:id', () => {
+  it('should return 200 on success', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { name: 'updated-name' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.name).toBe('updated-name');
+  });
+
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'PUT',
+      url: '/api/projects/99999',
+      payload: { name: 'updated-name' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'PUT',
+      url: '/api/projects/abc',
+      payload: { name: 'updated-name' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: DELETE /api/projects/:id
+// =============================================================================
+
+describe('DELETE /api/projects/:id', () => {
+  it('should return 200 on success', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `/api/projects/${project.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().success).toBe(true);
+  });
+
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/projects/99999',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/projects/abc',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/projects/:id/install
+// =============================================================================
+
+describe('POST /api/projects/:id/install', () => {
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/projects/99999/install',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/projects/abc/install',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/projects/:id/teams
+// =============================================================================
+
+describe('GET /api/projects/:id/teams', () => {
+  it('should return teams for project', async () => {
+    const project = seedProject();
+    seedTeam({ projectId: project.id, issueNumber: 500, worktreeName: `proj-teams-${Date.now()}` });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/projects/${project.id}/teams`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/99999/teams',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/abc/teams',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/projects/:id/prompt
+// =============================================================================
+
+describe('GET /api/projects/:id/prompt', () => {
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/99999/prompt',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/abc/prompt',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: PUT /api/projects/:id/prompt
+// =============================================================================
+
+describe('PUT /api/projects/:id/prompt', () => {
+  it('should return 400 for missing content', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}/prompt`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('content');
+  });
+
+  it('should return 400 for non-string content', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}/prompt`,
+      payload: { content: 123 },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'PUT',
+      url: '/api/projects/99999/prompt',
+      payload: { content: 'new prompt content' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'PUT',
+      url: '/api/projects/abc/prompt',
+      payload: { content: 'new prompt content' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/projects/:id/cleanup-preview
+// =============================================================================
+
+describe('GET /api/projects/:id/cleanup-preview', () => {
+  it('should return 404 for unknown project', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/99999/cleanup-preview',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/projects/abc/cleanup-preview',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/tests/server/routes/teams-routes.test.ts
+++ b/tests/server/routes/teams-routes.test.ts
@@ -1,0 +1,718 @@
+// =============================================================================
+// Fleet Commander -- Teams Routes: HTTP contract tests
+// =============================================================================
+// Tests the teams route plugin for correct HTTP status codes, response shapes,
+// parameter validation, and ServiceError-to-HTTP mapping. Uses mocked services
+// with a real temp SQLite database.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Service mocks -- must be set up BEFORE importing the route plugin
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/services/team-manager.js', () => {
+  const mockSendMessage = vi.fn();
+  const mockGetOutput = vi.fn().mockReturnValue([]);
+  const mockGetParsedEvents = vi.fn().mockReturnValue([]);
+  const mockLaunch = vi.fn().mockResolvedValue({ id: 99, status: 'launching' });
+  const mockStop = vi.fn().mockResolvedValue({ id: 1, status: 'done' });
+  const mockStopAll = vi.fn().mockResolvedValue([]);
+  const mockForceLaunch = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
+  const mockResume = vi.fn().mockResolvedValue({ id: 1, status: 'running' });
+  const mockRestart = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
+  const mockLaunchBatch = vi.fn().mockResolvedValue([]);
+  const mockQueueTeamWithBlockers = vi.fn().mockResolvedValue({ id: 1, status: 'queued' });
+
+  return {
+    getTeamManager: vi.fn(() => ({
+      sendMessage: mockSendMessage,
+      getOutput: mockGetOutput,
+      getParsedEvents: mockGetParsedEvents,
+      launch: mockLaunch,
+      stop: mockStop,
+      stopAll: mockStopAll,
+      forceLaunch: mockForceLaunch,
+      resume: mockResume,
+      restart: mockRestart,
+      launchBatch: mockLaunchBatch,
+      queueTeamWithBlockers: mockQueueTeamWithBlockers,
+    })),
+  };
+});
+
+vi.mock('../../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: vi.fn(() => ({
+    fetch: vi.fn().mockResolvedValue([]),
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue(null),
+    enrichWithTeamInfo: vi.fn().mockReturnValue([]),
+    getNextIssue: vi.fn().mockReturnValue(null),
+    getIssues: vi.fn().mockResolvedValue([]),
+    getIssuesByProject: vi.fn().mockReturnValue([]),
+    getCachedAt: vi.fn().mockReturnValue(null),
+    getAvailableIssues: vi.fn().mockReturnValue([]),
+    getIssue: vi.fn().mockReturnValue(null),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    getRecentPRs: vi.fn().mockReturnValue([]),
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+// Import routes AFTER mocks
+import teamsRoutes from '../../../src/server/routes/teams.js';
+import { getTeamManager } from '../../../src/server/services/team-manager.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let server: FastifyInstance;
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-teams-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  server = Fastify({ logger: false });
+  await server.register(teamsRoutes);
+  await server.ready();
+});
+
+afterAll(async () => {
+  sseBroker.stop();
+  await server.close();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let teamCounter = 0;
+
+function seedTeam(overrides: {
+  issueNumber?: number;
+  worktreeName?: string;
+  status?: string;
+  phase?: string;
+  projectId?: number;
+  prNumber?: number | null;
+} = {}) {
+  teamCounter++;
+  const db = getDatabase();
+  return db.insertTeam({
+    issueNumber: overrides.issueNumber ?? 1000 + teamCounter,
+    worktreeName: overrides.worktreeName ?? `teams-test-${Date.now()}-${teamCounter}`,
+    status: (overrides.status as 'running') ?? 'running',
+    phase: (overrides.phase as 'implementing') ?? 'implementing',
+    projectId: overrides.projectId ?? null,
+    prNumber: overrides.prNumber ?? null,
+  });
+}
+
+function seedProject(overrides: {
+  name?: string;
+  repoPath?: string;
+} = {}) {
+  const db = getDatabase();
+  return db.insertProject({
+    name: overrides.name ?? `test-project-${Date.now()}`,
+    repoPath: overrides.repoPath ?? `C:/fake/repo-${Date.now()}`,
+  });
+}
+
+// =============================================================================
+// Tests: GET /api/teams
+// =============================================================================
+
+describe('GET /api/teams', () => {
+  it('should return paginated dashboard data with 200', async () => {
+    seedTeam();
+
+    const res = await server.inject({ method: 'GET', url: '/api/teams' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('data');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('limit');
+    expect(body).toHaveProperty('offset');
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+  });
+
+  it('should respect limit and offset params', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams?limit=2&offset=0' });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.limit).toBe(2);
+    expect(body.offset).toBe(0);
+    expect(body.data.length).toBeLessThanOrEqual(2);
+  });
+
+  it('should return 400 for invalid limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams?limit=-1' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for non-numeric limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams?limit=abc' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for negative offset', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams?offset=-1' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id
+// =============================================================================
+
+describe('GET /api/teams/:id', () => {
+  it('should return team detail for valid ID with 200', async () => {
+    const manager = getTeamManager();
+    (manager.getOutput as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (manager.getParsedEvents as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+    const team = seedTeam();
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe(team.id);
+    expect(body.issueNumber).toBe(team.issueNumber);
+    expect(body.status).toBe('running');
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/abc' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for negative ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/-5' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/status
+// =============================================================================
+
+describe('GET /api/teams/:id/status', () => {
+  it('should return compact status with pending commands', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/status` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.id).toBe(team.id);
+    expect(body.status).toBe('running');
+    expect(body).toHaveProperty('pending_commands');
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999/status' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/output
+// =============================================================================
+
+describe('GET /api/teams/:id/output', () => {
+  it('should return output buffer for valid team', async () => {
+    const manager = getTeamManager();
+    (manager.getOutput as ReturnType<typeof vi.fn>).mockReturnValue(['line1', 'line2']);
+
+    const team = seedTeam();
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/output` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.teamId).toBe(team.id);
+    expect(body.lines).toEqual(['line1', 'line2']);
+    expect(body.count).toBe(2);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999/output' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/events
+// =============================================================================
+
+describe('GET /api/teams/:id/events', () => {
+  it('should return paginated events for valid team', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/events` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('data');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('limit');
+    expect(body).toHaveProperty('offset');
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999/events' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for invalid limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/events?limit=-1` });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/timeline
+// =============================================================================
+
+describe('GET /api/teams/:id/timeline', () => {
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/abc/timeline' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999/timeline' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/export
+// =============================================================================
+
+describe('GET /api/teams/:id/export', () => {
+  it('should return JSON export with correct headers', async () => {
+    const manager = getTeamManager();
+    (manager.getParsedEvents as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (manager.getOutput as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+    const team = seedTeam({ worktreeName: `export-json-${Date.now()}` });
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/export` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.headers['content-disposition']).toContain('attachment');
+    expect(res.headers['content-disposition']).toContain('.json');
+  });
+
+  it('should return text export when format=txt', async () => {
+    const manager = getTeamManager();
+    (manager.getParsedEvents as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (manager.getOutput as ReturnType<typeof vi.fn>).mockReturnValue(['line1']);
+
+    const team = seedTeam({ worktreeName: `export-txt-${Date.now()}` });
+
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/export?format=txt` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.headers['content-disposition']).toContain('.txt');
+  });
+
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/abc/export' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/teams/99999/export' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/launch
+// =============================================================================
+
+describe('POST /api/teams/launch', () => {
+  it('should return 400 for missing projectId', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/launch',
+      payload: { issueNumber: 1 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for missing issueNumber', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/launch',
+      payload: { projectId: 1 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/:id/stop
+// =============================================================================
+
+describe('POST /api/teams/:id/stop', () => {
+  it('should return 200 on success', async () => {
+    const team = seedTeam();
+    const manager = getTeamManager();
+    (manager.stop as ReturnType<typeof vi.fn>).mockResolvedValue({ id: team.id, status: 'done' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/stop`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('done');
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const manager = getTeamManager();
+    (manager.stop as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Team 99999 not found'));
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/99999/stop',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/stop-all
+// =============================================================================
+
+describe('POST /api/teams/stop-all', () => {
+  it('should return 200', async () => {
+    const manager = getTeamManager();
+    (manager.stopAll as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/stop-all',
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/:id/send-message
+// =============================================================================
+
+describe('POST /api/teams/:id/send-message', () => {
+  it('should return 201 when delivered', async () => {
+    const team = seedTeam();
+    const manager = getTeamManager();
+    (manager.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: 'Hello team' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.status).toBe('delivered');
+    expect(body.deliveredAt).toBeDefined();
+  });
+
+  it('should return 400 for empty message', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: '' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/99999/send-message',
+      payload: { message: 'Hello' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 422 when message is not delivered', async () => {
+    const team = seedTeam();
+    const manager = getTeamManager();
+    (manager.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/send-message`,
+      payload: { message: 'Hello team' },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.error).toBe('Unprocessable Entity');
+  });
+
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/abc/send-message',
+      payload: { message: 'Hello' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/:id/set-phase
+// =============================================================================
+
+describe('POST /api/teams/:id/set-phase', () => {
+  it('should return 200 for valid phase', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/set-phase`,
+      payload: { phase: 'reviewing' },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should return 400 for invalid phase', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/set-phase`,
+      payload: { phase: 'nonexistent_phase' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/abc/set-phase',
+      payload: { phase: 'reviewing' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/99999/set-phase',
+      payload: { phase: 'reviewing' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 409 when team is in terminal status', async () => {
+    const team = seedTeam({ status: 'done' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/set-phase`,
+      payload: { phase: 'reviewing' },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/:id/acknowledge
+// =============================================================================
+
+describe('POST /api/teams/:id/acknowledge', () => {
+  it('should return 200 for stuck team', async () => {
+    const team = seedTeam({ status: 'stuck' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/acknowledge`,
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should return 200 for failed team', async () => {
+    const team = seedTeam({ status: 'failed' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/acknowledge`,
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should return 400 for non-stuck/non-failed team', async () => {
+    const team = seedTeam({ status: 'running' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/acknowledge`,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/abc/acknowledge',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/99999/acknowledge',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/:id/restart
+// =============================================================================
+
+describe('POST /api/teams/:id/restart', () => {
+  it('should return 200 on success', async () => {
+    const team = seedTeam({ status: 'running' });
+    const manager = getTeamManager();
+    (manager.restart as ReturnType<typeof vi.fn>).mockResolvedValue({ id: team.id, status: 'launching' });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/teams/${team.id}/restart`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const manager = getTeamManager();
+    (manager.restart as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Team 99999 not found'));
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/99999/restart',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// =============================================================================
+// Tests: POST /api/teams/launch-batch
+// =============================================================================
+
+describe('POST /api/teams/launch-batch', () => {
+  it('should return 400 for missing issues array', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/launch-batch',
+      payload: { projectId: 1 },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for empty issues array', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/launch-batch',
+      payload: { projectId: 1, issues: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 for missing projectId', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/teams/launch-batch',
+      payload: { issues: [{ number: 1 }] },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/tests/server/services/issue-service.test.ts
+++ b/tests/server/services/issue-service.test.ts
@@ -1,0 +1,440 @@
+// =============================================================================
+// Fleet Commander -- IssueService: business logic tests
+// =============================================================================
+// Tests IssueService methods by mocking the IssueFetcher singleton and using
+// a real temp SQLite database for project queries.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockIssueTree = [
+  {
+    number: 10,
+    title: 'Epic issue',
+    state: 'open',
+    labels: ['epic'],
+    children: [
+      {
+        number: 11,
+        title: 'Sub-issue 1',
+        state: 'open',
+        labels: ['ready'],
+        children: [],
+      },
+      {
+        number: 12,
+        title: 'Sub-issue 2',
+        state: 'closed',
+        labels: [],
+        children: [],
+      },
+    ],
+  },
+];
+
+const mockFlatIssues = [
+  { number: 11, title: 'Sub-issue 1', state: 'open', labels: ['ready'], children: [] },
+  { number: 13, title: 'Available issue', state: 'open', labels: ['ready'], children: [] },
+];
+
+// ---------------------------------------------------------------------------
+// Service mocks
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn().mockResolvedValue([]);
+const mockFetchDependenciesForIssue = vi.fn().mockResolvedValue(null);
+const mockEnrichWithTeamInfo = vi.fn().mockImplementation((issues: unknown[]) => issues);
+const mockGetNextIssue = vi.fn().mockReturnValue(null);
+const mockGetIssues = vi.fn().mockResolvedValue(mockIssueTree);
+const mockGetIssuesByProject = vi.fn().mockReturnValue([]);
+const mockGetCachedAt = vi.fn().mockReturnValue('2026-03-25T12:00:00Z');
+const mockGetAvailableIssues = vi.fn().mockReturnValue(mockFlatIssues);
+const mockGetIssue = vi.fn().mockReturnValue(null);
+const mockRefresh = vi.fn().mockResolvedValue(mockIssueTree);
+const mockStart = vi.fn();
+const mockStop = vi.fn();
+
+vi.mock('../../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: vi.fn(() => ({
+    fetch: mockFetch,
+    fetchDependenciesForIssue: mockFetchDependenciesForIssue,
+    enrichWithTeamInfo: mockEnrichWithTeamInfo,
+    getNextIssue: mockGetNextIssue,
+    getIssues: mockGetIssues,
+    getIssuesByProject: mockGetIssuesByProject,
+    getCachedAt: mockGetCachedAt,
+    getAvailableIssues: mockGetAvailableIssues,
+    getIssue: mockGetIssue,
+    start: mockStart,
+    stop: mockStop,
+    refresh: mockRefresh,
+  })),
+}));
+
+// Import AFTER mocks
+import { IssueService } from '../../../src/server/services/issue-service.js';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+let service: IssueService;
+
+// ---------------------------------------------------------------------------
+// DB lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-issue-svc-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  service = new IssueService();
+});
+
+afterAll(() => {
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Restore default mock implementations
+  mockEnrichWithTeamInfo.mockImplementation((issues: unknown[]) => issues);
+  mockGetIssues.mockResolvedValue(mockIssueTree);
+  mockGetIssuesByProject.mockReturnValue([]);
+  mockGetCachedAt.mockReturnValue('2026-03-25T12:00:00Z');
+  mockGetAvailableIssues.mockReturnValue(mockFlatIssues);
+  mockGetIssue.mockReturnValue(null);
+  mockGetNextIssue.mockReturnValue(null);
+  mockRefresh.mockResolvedValue(mockIssueTree);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedProject(overrides: {
+  name?: string;
+  repoPath?: string;
+  githubRepo?: string | null;
+} = {}) {
+  const db = getDatabase();
+  return db.insertProject({
+    name: overrides.name ?? `issue-svc-project-${Date.now()}`,
+    repoPath: overrides.repoPath ?? `C:/fake/issue-svc-repo-${Date.now()}`,
+    githubRepo: 'githubRepo' in overrides ? overrides.githubRepo : 'owner/repo',
+  });
+}
+
+// =============================================================================
+// Tests: getAllIssues
+// =============================================================================
+
+describe('IssueService.getAllIssues', () => {
+  it('should return tree, groups, cachedAt, and count', async () => {
+    const project = seedProject();
+    mockGetIssuesByProject.mockReturnValue([
+      { projectId: project.id, tree: mockIssueTree, cachedAt: '2026-03-25T12:00:00Z' },
+    ]);
+
+    const result = await service.getAllIssues();
+
+    expect(result).toHaveProperty('tree');
+    expect(result).toHaveProperty('groups');
+    expect(result).toHaveProperty('cachedAt');
+    expect(result).toHaveProperty('count');
+    expect(Array.isArray(result.tree)).toBe(true);
+    expect(Array.isArray(result.groups)).toBe(true);
+  });
+
+  it('should return empty tree when no projects have issues', async () => {
+    mockGetIssuesByProject.mockReturnValue([]);
+
+    const result = await service.getAllIssues();
+
+    expect(result.tree).toHaveLength(0);
+    expect(result.groups).toHaveLength(0);
+    expect(result.count).toBe(0);
+  });
+});
+
+// =============================================================================
+// Tests: getProjectIssues
+// =============================================================================
+
+describe('IssueService.getProjectIssues', () => {
+  it('should return issue tree for existing project', async () => {
+    const project = seedProject();
+
+    const result = await service.getProjectIssues(project.id);
+
+    expect(result.projectId).toBe(project.id);
+    expect(result.projectName).toBe(project.name);
+    expect(Array.isArray(result.tree)).toBe(true);
+    expect(result).toHaveProperty('cachedAt');
+    expect(result).toHaveProperty('count');
+  });
+
+  it('should throw VALIDATION for invalid projectId', async () => {
+    try {
+      await service.getProjectIssues(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown project', async () => {
+    try {
+      await service.getProjectIssues(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: getNextIssue
+// =============================================================================
+
+describe('IssueService.getNextIssue', () => {
+  it('should return null issue when no ready issues exist', () => {
+    mockGetNextIssue.mockReturnValue(null);
+
+    const result = service.getNextIssue();
+
+    expect(result.issue).toBeNull();
+    expect(result.reason).toContain('No available');
+  });
+
+  it('should return the highest priority issue when available', () => {
+    const mockIssue = {
+      number: 42,
+      title: 'High priority issue',
+      state: 'open',
+      labels: ['ready'],
+      children: [],
+    };
+    mockGetNextIssue.mockReturnValue(mockIssue);
+    mockEnrichWithTeamInfo.mockReturnValue([mockIssue]);
+
+    const result = service.getNextIssue();
+
+    expect(result.issue).toBeDefined();
+    expect(result.issue?.number).toBe(42);
+    expect(result.reason).toContain('Highest priority');
+  });
+});
+
+// =============================================================================
+// Tests: getAvailableIssues
+// =============================================================================
+
+describe('IssueService.getAvailableIssues', () => {
+  it('should return available issues with count', () => {
+    const result = service.getAvailableIssues();
+
+    expect(result).toHaveProperty('issues');
+    expect(result).toHaveProperty('count');
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(result.count).toBe(mockFlatIssues.length);
+  });
+
+  it('should return empty list when no issues available', () => {
+    mockGetAvailableIssues.mockReturnValue([]);
+    mockEnrichWithTeamInfo.mockReturnValue([]);
+
+    const result = service.getAvailableIssues();
+
+    expect(result.issues).toHaveLength(0);
+    expect(result.count).toBe(0);
+  });
+});
+
+// =============================================================================
+// Tests: getIssue
+// =============================================================================
+
+describe('IssueService.getIssue', () => {
+  it('should throw VALIDATION for invalid issue number', () => {
+    try {
+      service.getIssue(0);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for negative issue number', () => {
+    try {
+      service.getIssue(-5);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND when issue not in cache', () => {
+    mockGetIssue.mockReturnValue(null);
+
+    try {
+      service.getIssue(999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+      expect((err as ServiceError).message).toContain('999');
+    }
+  });
+
+  it('should return enriched issue when found', () => {
+    const mockIssue = {
+      number: 42,
+      title: 'Test issue',
+      state: 'open',
+      labels: [],
+      children: [],
+    };
+    mockGetIssue.mockReturnValue(mockIssue);
+    mockEnrichWithTeamInfo.mockReturnValue([mockIssue]);
+
+    const result = service.getIssue(42);
+
+    expect(result.number).toBe(42);
+    expect(result.title).toBe('Test issue');
+  });
+});
+
+// =============================================================================
+// Tests: getProjectDependencies
+// =============================================================================
+
+describe('IssueService.getProjectDependencies', () => {
+  it('should throw VALIDATION for invalid projectId', async () => {
+    try {
+      await service.getProjectDependencies(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown project', async () => {
+    try {
+      await service.getProjectDependencies(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should throw VALIDATION when project has no GitHub repo', async () => {
+    const project = seedProject({ githubRepo: null });
+
+    try {
+      await service.getProjectDependencies(project.id);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+      expect((err as ServiceError).message).toContain('no GitHub repo');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: getIssueDependencies
+// =============================================================================
+
+describe('IssueService.getIssueDependencies', () => {
+  it('should throw VALIDATION for invalid issue number', async () => {
+    try {
+      await service.getIssueDependencies(0, 1);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for invalid projectId', async () => {
+    try {
+      await service.getIssueDependencies(1, 0);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown project', async () => {
+    try {
+      await service.getIssueDependencies(1, 99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should return resolved when no deps found', async () => {
+    const project = seedProject();
+    mockFetchDependenciesForIssue.mockResolvedValue(null);
+
+    const result = await service.getIssueDependencies(42, project.id) as Record<string, unknown>;
+
+    expect(result.resolved).toBe(true);
+    expect(result.openCount).toBe(0);
+  });
+});
+
+// =============================================================================
+// Tests: refresh
+// =============================================================================
+
+describe('IssueService.refresh', () => {
+  it('should return refreshed tree with metadata', async () => {
+    const result = await service.refresh();
+
+    expect(result).toHaveProperty('refreshedAt');
+    expect(result).toHaveProperty('issueCount');
+    expect(result).toHaveProperty('tree');
+    expect(Array.isArray(result.tree)).toBe(true);
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/tests/server/services/team-service.test.ts
+++ b/tests/server/services/team-service.test.ts
@@ -1,0 +1,668 @@
+// =============================================================================
+// Fleet Commander -- TeamService: business logic tests
+// =============================================================================
+// Tests TeamService methods directly with a real temp SQLite database.
+// Service dependencies (team-manager, issue-fetcher, github-poller, sse-broker)
+// are mocked to isolate business logic from child processes and CLI calls.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Service mocks -- must be set up BEFORE importing TeamService
+// ---------------------------------------------------------------------------
+
+const mockSendMessage = vi.fn();
+const mockGetOutput = vi.fn().mockReturnValue([]);
+const mockGetParsedEvents = vi.fn().mockReturnValue([]);
+const mockLaunch = vi.fn().mockResolvedValue({ id: 99, status: 'launching' });
+const mockStop = vi.fn().mockResolvedValue({ id: 1, status: 'done' });
+const mockStopAll = vi.fn().mockResolvedValue([]);
+const mockForceLaunch = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
+const mockResume = vi.fn().mockResolvedValue({ id: 1, status: 'running' });
+const mockRestart = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
+const mockLaunchBatch = vi.fn().mockResolvedValue([]);
+const mockQueueTeamWithBlockers = vi.fn().mockResolvedValue({ id: 1, status: 'queued' });
+
+vi.mock('../../../src/server/services/team-manager.js', () => ({
+  getTeamManager: vi.fn(() => ({
+    sendMessage: mockSendMessage,
+    getOutput: mockGetOutput,
+    getParsedEvents: mockGetParsedEvents,
+    launch: mockLaunch,
+    stop: mockStop,
+    stopAll: mockStopAll,
+    forceLaunch: mockForceLaunch,
+    resume: mockResume,
+    restart: mockRestart,
+    launchBatch: mockLaunchBatch,
+    queueTeamWithBlockers: mockQueueTeamWithBlockers,
+  })),
+}));
+
+vi.mock('../../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: vi.fn(() => ({
+    fetch: vi.fn().mockResolvedValue([]),
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue(null),
+    enrichWithTeamInfo: vi.fn().mockReturnValue([]),
+    getIssues: vi.fn().mockResolvedValue([]),
+    getIssuesByProject: vi.fn().mockReturnValue([]),
+    getCachedAt: vi.fn().mockReturnValue(null),
+    getAvailableIssues: vi.fn().mockReturnValue([]),
+    getIssue: vi.fn().mockReturnValue(null),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    getRecentPRs: vi.fn().mockReturnValue([]),
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+// Mock project-service to control readiness checks
+const mockGetProjectReadiness = vi.fn().mockReturnValue({ ready: true, errors: [] });
+
+vi.mock('../../../src/server/services/project-service.js', () => ({
+  getProjectService: vi.fn(() => ({
+    getProjectReadiness: mockGetProjectReadiness,
+  })),
+}));
+
+// Import AFTER mocks
+import { TeamService } from '../../../src/server/services/team-service.js';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+let service: TeamService;
+
+// ---------------------------------------------------------------------------
+// DB lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-team-svc-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  service = new TeamService();
+});
+
+afterAll(() => {
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProjectReadiness.mockReturnValue({ ready: true, errors: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let teamCounter = 0;
+
+function seedTeam(overrides: {
+  issueNumber?: number;
+  worktreeName?: string;
+  status?: string;
+  phase?: string;
+  projectId?: number;
+  launchedAt?: string;
+  prNumber?: number | null;
+} = {}) {
+  teamCounter++;
+  const db = getDatabase();
+  return db.insertTeam({
+    issueNumber: overrides.issueNumber ?? 2000 + teamCounter,
+    worktreeName: overrides.worktreeName ?? `svc-test-${Date.now()}-${teamCounter}`,
+    status: (overrides.status as 'running') ?? 'running',
+    phase: (overrides.phase as 'implementing') ?? 'implementing',
+    projectId: overrides.projectId ?? null,
+    launchedAt: overrides.launchedAt ?? new Date().toISOString(),
+    prNumber: overrides.prNumber ?? null,
+  });
+}
+
+function seedProject(overrides: {
+  name?: string;
+  repoPath?: string;
+} = {}) {
+  const db = getDatabase();
+  return db.insertProject({
+    name: overrides.name ?? `svc-project-${Date.now()}`,
+    repoPath: overrides.repoPath ?? `C:/fake/svc-repo-${Date.now()}`,
+  });
+}
+
+// =============================================================================
+// Tests: launchTeam
+// =============================================================================
+
+describe('TeamService.launchTeam', () => {
+  it('should throw VALIDATION for missing projectId', async () => {
+    await expect(
+      service.launchTeam({ projectId: 0, issueNumber: 1 }),
+    ).rejects.toThrow(ServiceError);
+
+    try {
+      await service.launchTeam({ projectId: 0, issueNumber: 1 });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for missing issueNumber', async () => {
+    await expect(
+      service.launchTeam({ projectId: 1, issueNumber: 0 }),
+    ).rejects.toThrow(ServiceError);
+
+    try {
+      await service.launchTeam({ projectId: 1, issueNumber: 0 });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw PROJECT_NOT_READY when project is not ready', async () => {
+    mockGetProjectReadiness.mockReturnValue({
+      ready: false,
+      errors: ['Hooks not installed'],
+    });
+
+    try {
+      await service.launchTeam({ projectId: 1, issueNumber: 1 });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('PROJECT_NOT_READY');
+    }
+  });
+
+  it('should bypass readiness check when force=true', async () => {
+    mockGetProjectReadiness.mockReturnValue({
+      ready: false,
+      errors: ['Hooks not installed'],
+    });
+
+    const result = await service.launchTeam({
+      projectId: 1,
+      issueNumber: 1,
+      force: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(mockLaunch).toHaveBeenCalled();
+  });
+
+  it('should delegate to manager.launch on success', async () => {
+    const result = await service.launchTeam({ projectId: 1, issueNumber: 42 });
+
+    expect(result).toEqual({ id: 99, status: 'launching' });
+    expect(mockLaunch).toHaveBeenCalledWith(1, 42, undefined, undefined, undefined, undefined);
+  });
+});
+
+// =============================================================================
+// Tests: launchBatch
+// =============================================================================
+
+describe('TeamService.launchBatch', () => {
+  it('should throw VALIDATION for missing projectId', async () => {
+    try {
+      await service.launchBatch({ projectId: 0, issues: [{ number: 1 }] });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for empty issues array', async () => {
+    try {
+      await service.launchBatch({ projectId: 1, issues: [] });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for invalid issue number', async () => {
+    try {
+      await service.launchBatch({ projectId: 1, issues: [{ number: -1 }] });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw PROJECT_NOT_READY when project is not ready', async () => {
+    mockGetProjectReadiness.mockReturnValue({
+      ready: false,
+      errors: ['Hooks not installed'],
+    });
+
+    try {
+      await service.launchBatch({ projectId: 1, issues: [{ number: 1 }] });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('PROJECT_NOT_READY');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: getTeamDetail
+// =============================================================================
+
+describe('TeamService.getTeamDetail', () => {
+  it('should return enriched detail for existing team', () => {
+    const team = seedTeam();
+    mockGetOutput.mockReturnValue(['line1']);
+    mockGetParsedEvents.mockReturnValue([]);
+
+    const detail = service.getTeamDetail(team.id) as Record<string, unknown>;
+
+    expect(detail.id).toBe(team.id);
+    expect(detail.issueNumber).toBe(team.issueNumber);
+    expect(detail.status).toBe('running');
+    expect(detail.durationMin).toBeDefined();
+    expect(typeof detail.durationMin).toBe('number');
+    expect(detail.outputTail).toBe('line1');
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.getTeamDetail(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should compute duration correctly', () => {
+    const launched = new Date();
+    launched.setMinutes(launched.getMinutes() - 30);
+    const team = seedTeam({ launchedAt: launched.toISOString() });
+    mockGetOutput.mockReturnValue([]);
+
+    const detail = service.getTeamDetail(team.id) as Record<string, unknown>;
+    const durationMin = detail.durationMin as number;
+
+    // Should be approximately 30 minutes (allow a margin)
+    expect(durationMin).toBeGreaterThanOrEqual(29);
+    expect(durationMin).toBeLessThanOrEqual(31);
+  });
+});
+
+// =============================================================================
+// Tests: sendMessage
+// =============================================================================
+
+describe('TeamService.sendMessage', () => {
+  it('should throw VALIDATION for empty message', () => {
+    try {
+      service.sendMessage(1, '');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for whitespace-only message', () => {
+    try {
+      service.sendMessage(1, '   ');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.sendMessage(99999, 'hello');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should return delivered=true when stdin delivery succeeds', () => {
+    const team = seedTeam();
+    mockSendMessage.mockReturnValue(true);
+
+    const result = service.sendMessage(team.id, 'hello');
+
+    expect(result.delivered).toBe(true);
+    expect(result.command).toBeDefined();
+    expect(mockSendMessage).toHaveBeenCalledWith(team.id, 'hello', 'user');
+  });
+
+  it('should return delivered=false when stdin delivery fails', () => {
+    const team = seedTeam();
+    mockSendMessage.mockReturnValue(false);
+
+    const result = service.sendMessage(team.id, 'hello');
+
+    expect(result.delivered).toBe(false);
+    expect(result.command).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Tests: setPhase
+// =============================================================================
+
+describe('TeamService.setPhase', () => {
+  it('should update phase for valid input', () => {
+    const team = seedTeam();
+
+    const updated = service.setPhase(team.id, 'reviewing') as Record<string, unknown>;
+
+    expect(updated).toBeDefined();
+    // Verify the DB was updated
+    const db = getDatabase();
+    const refreshed = db.getTeam(team.id);
+    expect(refreshed?.phase).toBe('reviewing');
+  });
+
+  it('should throw VALIDATION for invalid phase', () => {
+    const team = seedTeam();
+
+    try {
+      service.setPhase(team.id, 'invalid_phase' as 'init');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.setPhase(99999, 'reviewing');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should throw CONFLICT for terminal status (done)', () => {
+    const team = seedTeam({ status: 'done' });
+
+    try {
+      service.setPhase(team.id, 'reviewing');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('CONFLICT');
+    }
+  });
+
+  it('should throw CONFLICT for terminal status (failed)', () => {
+    const team = seedTeam({ status: 'failed' });
+
+    try {
+      service.setPhase(team.id, 'reviewing');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('CONFLICT');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: acknowledgeAlert
+// =============================================================================
+
+describe('TeamService.acknowledgeAlert', () => {
+  it('should transition stuck team to idle', () => {
+    const team = seedTeam({ status: 'stuck' });
+
+    const updated = service.acknowledgeAlert(team.id) as Record<string, unknown>;
+
+    expect(updated).toBeDefined();
+    const db = getDatabase();
+    const refreshed = db.getTeam(team.id);
+    expect(refreshed?.status).toBe('idle');
+  });
+
+  it('should transition failed team to done', () => {
+    const team = seedTeam({ status: 'failed' });
+
+    const updated = service.acknowledgeAlert(team.id) as Record<string, unknown>;
+
+    expect(updated).toBeDefined();
+    const db = getDatabase();
+    const refreshed = db.getTeam(team.id);
+    expect(refreshed?.status).toBe('done');
+  });
+
+  it('should throw VALIDATION for running team', () => {
+    const team = seedTeam({ status: 'running' });
+
+    try {
+      service.acknowledgeAlert(team.id);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.acknowledgeAlert(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: listTeams
+// =============================================================================
+
+describe('TeamService.listTeams', () => {
+  it('should return paginated response with limit/offset', () => {
+    seedTeam();
+
+    const result = service.listTeams({ limit: 10, offset: 0 });
+
+    expect(result).toHaveProperty('data');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('limit');
+    expect(result).toHaveProperty('offset');
+  });
+
+  it('should return bare array when called without pagination', () => {
+    seedTeam();
+
+    const result = service.listTeams();
+
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+// =============================================================================
+// Tests: getOutput
+// =============================================================================
+
+describe('TeamService.getOutput', () => {
+  it('should throw VALIDATION for invalid team ID', () => {
+    try {
+      service.getOutput(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.getOutput(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should return output for existing team', () => {
+    const team = seedTeam();
+    mockGetOutput.mockReturnValue(['line1', 'line2']);
+
+    const result = service.getOutput(team.id);
+
+    expect(result.teamId).toBe(team.id);
+    expect(result.lines).toEqual(['line1', 'line2']);
+    expect(result.count).toBe(2);
+  });
+});
+
+// =============================================================================
+// Tests: getEvents
+// =============================================================================
+
+describe('TeamService.getEvents', () => {
+  it('should throw VALIDATION for invalid team ID', () => {
+    try {
+      service.getEvents(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.getEvents(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should return paginated events for existing team', () => {
+    const team = seedTeam();
+
+    const result = service.getEvents(team.id);
+
+    expect(result).toHaveProperty('data');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('limit');
+    expect(result).toHaveProperty('offset');
+  });
+});
+
+// =============================================================================
+// Tests: stopTeam
+// =============================================================================
+
+describe('TeamService.stopTeam', () => {
+  it('should throw VALIDATION for invalid team ID', async () => {
+    try {
+      await service.stopTeam(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should delegate to manager.stop', async () => {
+    const team = seedTeam();
+    mockStop.mockResolvedValue({ id: team.id, status: 'done' });
+
+    const result = await service.stopTeam(team.id);
+
+    expect(result).toEqual({ id: team.id, status: 'done' });
+    expect(mockStop).toHaveBeenCalledWith(team.id);
+  });
+});
+
+// =============================================================================
+// Tests: exportTeam
+// =============================================================================
+
+describe('TeamService.exportTeam', () => {
+  it('should return JSON export by default', () => {
+    const team = seedTeam({ worktreeName: `export-test-${Date.now()}` });
+    mockGetParsedEvents.mockReturnValue([]);
+    mockGetOutput.mockReturnValue([]);
+
+    const result = service.exportTeam(team.id);
+
+    expect(result.contentType).toBe('application/json');
+    expect(result.filename).toContain('.json');
+    expect(result.data).toBeDefined();
+  });
+
+  it('should return text export for format=txt', () => {
+    const team = seedTeam({ worktreeName: `export-txt-test-${Date.now()}` });
+    mockGetParsedEvents.mockReturnValue([]);
+    mockGetOutput.mockReturnValue(['output line']);
+
+    const result = service.exportTeam(team.id, 'txt');
+
+    expect(result.contentType).toBe('text/plain');
+    expect(result.filename).toContain('.txt');
+    expect(typeof result.data).toBe('string');
+    expect((result.data as string)).toContain('output line');
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.exportTeam(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+});


### PR DESCRIPTION
Closes #427

## Summary
- Added 4 new test files with 135 test cases (2315 lines) covering previously untested server modules
- `tests/server/routes/teams-routes.test.ts` — 47 tests for 15 team API endpoints (GET list/detail/status/output/events/timeline/export, POST launch/stop/stop-all/send-message/set-phase/acknowledge/restart/launch-batch)
- `tests/server/routes/projects-routes.test.ts` — 28 tests for 10 project API endpoints (GET list/detail/teams/prompt/cleanup-preview, POST create/install, PUT update/prompt, DELETE)
- `tests/server/services/team-service.test.ts` — 39 tests for TeamService business logic (launchTeam, launchBatch, getTeamDetail, sendMessage, setPhase, acknowledgeAlert, listTeams, getOutput, getEvents, stopTeam, exportTeam)
- `tests/server/services/issue-service.test.ts` — 21 tests for IssueService business logic (getAllIssues, getProjectIssues, getNextIssue, getAvailableIssues, getIssue, getProjectDependencies, getIssueDependencies, refresh)

## Test plan
- [x] All 135 tests pass with `npm run test:server`
- [x] No network access, `gh` CLI, or filesystem access outside temp directories
- [x] Proper cleanup of temp DB files and SSE broker heartbeat in `afterAll`
- [x] Mocking patterns consistent with existing tests (send-message-route, event-collector, issue-fetcher-orphan)