### PR TITLE
Issue #432: Read PORT env var in launcher scripts instead of hardcoding 4680

### DIFF
--- a/fleet-commander.ps1
+++ b/fleet-commander.ps1
@@ -2,6 +2,8 @@
 $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 
+$port = if ($env:PORT) { $env:PORT } else { "4680" }
+
 Write-Host "Fleet Commander" -ForegroundColor Cyan
 Write-Host ""
 
@@ -15,11 +17,11 @@ if (-not (Test-Path "dist/server/index.js")) {
     npm run build
 }
 
-Write-Host "Starting on http://localhost:4680" -ForegroundColor Green
+Write-Host "Starting on http://localhost:$port" -ForegroundColor Green
 Write-Host ""
 
 # Open browser after delay
-Start-Job -ScriptBlock { Start-Sleep 2; Start-Process "http://localhost:4680" } | Out-Null
+Start-Job -ScriptBlock { param($p) Start-Sleep 2; Start-Process "http://localhost:$p" } -ArgumentList $port | Out-Null
 
 # Run server
 node dist/server/index.js

--- a/scripts/launch.js
+++ b/scripts/launch.js
@@ -8,6 +8,8 @@ const root = path.resolve(__dirname, '..');
 
 process.chdir(root);
 
+const port = process.env.PORT || '4680';
+
 // Auto-install if needed
 if (!existsSync('node_modules')) {
   console.log('Installing dependencies...');
@@ -20,7 +22,7 @@ if (!existsSync('dist/server/index.js')) {
   execSync('npm run build', { stdio: 'inherit' });
 }
 
-console.log('\n  Fleet Commander → http://localhost:4680\n');
+console.log(`\n  Fleet Commander → http://localhost:${port}\n`);
 
 // Start server first, then wait for it to be ready
 const server = spawn('node', ['dist/server/index.js'], {
@@ -41,12 +43,12 @@ async function waitForServer(url, maxWaitMs = 10000) {
   return false;
 }
 
-waitForServer('http://localhost:4680/api/health').then((ok) => {
+waitForServer(`http://localhost:${port}/api/health`).then((ok) => {
   if (ok) {
     const cmd = process.platform === 'win32' ? 'start' :
                 process.platform === 'darwin' ? 'open' : 'xdg-open';
     try {
-      execSync(`${cmd} http://localhost:4680`, { stdio: 'ignore', shell: true });
+      execSync(`${cmd} http://localhost:${port}`, { stdio: 'ignore', shell: true });
     } catch { /* ignore */ }
   }
 });


### PR DESCRIPTION
Closes #432

## Summary
- Read `PORT` env var in `scripts/launch.js` and `fleet-commander.ps1` instead of hardcoding `4680`
- Both files default to `4680` when `PORT` is not set, preserving existing behavior
- Fixes dev clone on port 4681 opening the wrong URL

## Changes
- **`scripts/launch.js`**: Added `const port = process.env.PORT || '4680'` and replaced 3 hardcoded URL references with template literals
- **`fleet-commander.ps1`**: Added `$port = if ($env:PORT) { $env:PORT } else { "4680" }` and replaced 2 hardcoded URL references with interpolation

## Test plan
- [ ] `PORT=4681 node scripts/launch.js` prints `http://localhost:4681` and polls/opens correct port
- [ ] `node scripts/launch.js` without PORT defaults to 4680
- [ ] `$env:PORT="4681"; .\fleet-commander.ps1` displays and opens port 4681
- [ ] `.\fleet-commander.ps1` without PORT defaults to 4680