### PR TITLE
Issue #433: Fix PowerShell argument quoting for paths with spaces

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,7 +14,7 @@ param(
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 if ($TargetRepo) {
-    & bash "$scriptDir/install.sh" $TargetRepo
+    & bash "$scriptDir/install.sh" "$TargetRepo"
 } else {
     & bash "$scriptDir/install.sh"
 }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -14,7 +14,7 @@ param(
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 if ($TargetRepo) {
-    & bash "$scriptDir/uninstall.sh" $TargetRepo
+    & bash "$scriptDir/uninstall.sh" "$TargetRepo"
 } else {
     & bash "$scriptDir/uninstall.sh"
 }


### PR DESCRIPTION
## Summary
- Fix unquoted `$TargetRepo` in `scripts/install.ps1` and `scripts/uninstall.ps1` that caused paths with spaces to be split into multiple arguments when passed to bash
- Wrap `$TargetRepo` in double quotes on line 17 of both scripts

Closes #433