### PR TITLE
Issue #420: Virtualize IssueTree for large issue lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/cors": "^10.0.3",
         "@fastify/static": "^9.0.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@tanstack/react-virtual": "^3.13.23",
         "better-sqlite3": "^12.0.0",
         "execa": "^9.6.1",
         "fastify": "^5.3.3",
@@ -1824,6 +1825,33 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,11 @@
     "prepublishOnly": "echo 'Tests already run in CI — skipping'"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@fastify/cors": "^10.0.3",
     "@fastify/static": "^9.0.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@dagrejs/dagre": "^3.0.0",
+    "@tanstack/react-virtual": "^3.13.23",
     "better-sqlite3": "^12.0.0",
     "execa": "^9.6.1",
     "fastify": "^5.3.3",

--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { StatusBadge } from './StatusBadge';
 import { PRBadge } from './PRBadge';
 import { PlayIcon, LockIcon } from './Icons';
@@ -155,7 +155,6 @@ interface TreeNodeProps {
   onLaunch: (issueNumber: number, title: string, projectId?: number) => Promise<void>;
   launchingIssues: Set<number>;
   launchErrors: Map<number, string>;
-  forceExpand?: boolean;
   /** When set, the play button uses this project instead of requiring the user to select one. */
   projectId?: number;
   /** Map of issue number -> priority data from AI prioritization */
@@ -170,16 +169,13 @@ interface TreeNodeProps {
   prioritizing?: boolean;
   /** Controlled collapse state: set of collapsed node IDs */
   collapsedNodes?: Set<string>;
-  /** Callback when a node's collapse state is toggled (controlled mode) */
+  /** Callback when a node's collapse state is toggled */
   onToggleCollapse?: (nodeId: string) => void;
 }
 
-export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, forceExpand, projectId, priorityMap, checkedIssues, onCheckChange, onPrioritizeSubtree, prioritizing, collapsedNodes, onToggleCollapse }: TreeNodeProps) {
+export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, launchingIssues, launchErrors, projectId, priorityMap, checkedIssues, onCheckChange, onPrioritizeSubtree, prioritizing, collapsedNodes, onToggleCollapse }: TreeNodeProps) {
   const nodeId = node.number.toString();
-  const isControlled = collapsedNodes != null && onToggleCollapse != null;
-  const [localExpanded, setLocalExpanded] = useState(depth < 2);
-  const controlledExpanded = isControlled ? !collapsedNodes.has(nodeId) : localExpanded;
-  const isExpanded = forceExpand || controlledExpanded;
+  const isExpanded = collapsedNodes ? !collapsedNodes.has(nodeId) : true;
   const hasChildren = node.children.length > 0;
   const hasActiveTeam = node.activeTeam != null;
   const isBlocked = !!(node.dependencies && !node.dependencies.resolved && node.dependencies.openCount > 0);
@@ -202,16 +198,14 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
         className={`flex items-center gap-2 py-1.5 px-2 rounded hover:bg-dark-surface/80 group transition-colors ${
           isBlocked ? 'opacity-60 border-l-2 border-[#F85149]' : ''
         }`}
-        style={{ paddingLeft: `${depth * 20 + 8}px` }}
+        style={{ paddingLeft: `${Math.min(depth * 20, 200) + 8}px` }}
       >
         {/* Expand/collapse arrow */}
         <button
           disabled={!hasChildren}
           onClick={() => {
-            if (isControlled) {
+            if (onToggleCollapse) {
               onToggleCollapse(nodeId);
-            } else {
-              setLocalExpanded(!isExpanded);
             }
           }}
           className={`w-4 h-4 flex items-center justify-center text-dark-muted shrink-0 transition-transform duration-150 ${
@@ -362,37 +356,12 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
       {launchError && (
         <div
           className="flex items-center gap-1.5 py-1 text-xs text-[#F85149]"
-          style={{ paddingLeft: `${depth * 20 + 32}px` }}
+          style={{ paddingLeft: `${Math.min(depth * 20, 200) + 32}px` }}
         >
           <svg className="w-3 h-3 shrink-0" viewBox="0 0 16 16" fill="currentColor">
             <path d="M2.343 13.657A8 8 0 1 1 13.657 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042L6.94 8 4.97 9.97a.749.749 0 0 0 .326 1.275.749.749 0 0 0 .734-.215L8 9.06l1.97 1.97a.749.749 0 0 0 1.275-.326.749.749 0 0 0-.215-.734L9.06 8l1.97-1.97a.749.749 0 0 0-.326-1.275.749.749 0 0 0-.734.215L8 6.94Z" />
           </svg>
           <span>{launchError}</span>
-        </div>
-      )}
-
-      {/* Children (recursive) */}
-      {hasChildren && isExpanded && (
-        <div>
-          {node.children.map((child) => (
-            <TreeNode
-              key={child.number}
-              node={child}
-              depth={depth + 1}
-              onLaunch={onLaunch}
-              launchingIssues={launchingIssues}
-              launchErrors={launchErrors}
-              forceExpand={forceExpand}
-              projectId={projectId}
-              priorityMap={priorityMap}
-              checkedIssues={checkedIssues}
-              onCheckChange={onCheckChange}
-              onPrioritizeSubtree={onPrioritizeSubtree}
-              prioritizing={prioritizing}
-              collapsedNodes={collapsedNodes}
-              onToggleCollapse={onToggleCollapse}
-            />
-          ))}
         </div>
       )}
     </div>

--- a/src/client/components/VirtualizedTreeList.tsx
+++ b/src/client/components/VirtualizedTreeList.tsx
@@ -1,0 +1,120 @@
+import React, { useRef, useCallback } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { TreeNode, type IssueNode } from './TreeNode';
+import type { FlatTreeRow } from '../hooks/useVirtualizedTree';
+import type { PrioritizedIssue } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface VirtualizedTreeListProps {
+  rows: FlatTreeRow[];
+  onLaunch: (issueNumber: number, title: string, projectId?: number) => Promise<void>;
+  launchingIssues: Set<number>;
+  launchErrors: Map<number, string>;
+  projectId?: number;
+  priorityMap?: Map<number, PrioritizedIssue>;
+  checkedIssues?: Set<number>;
+  onCheckChange?: (issueNumber: number, checked: boolean) => void;
+  onPrioritizeSubtree?: (subtreeChildren: IssueNode[]) => Promise<void>;
+  prioritizing?: boolean;
+  collapsedNodes: Set<string>;
+  onToggleCollapse: (nodeId: string) => void;
+  /** Additional CSS class for the scrollable container */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const ESTIMATED_ROW_HEIGHT = 32;
+const OVERSCAN = 15;
+
+export const VirtualizedTreeList = React.memo(function VirtualizedTreeList({
+  rows,
+  onLaunch,
+  launchingIssues,
+  launchErrors,
+  projectId,
+  priorityMap,
+  checkedIssues,
+  onCheckChange,
+  onPrioritizeSubtree,
+  prioritizing,
+  collapsedNodes,
+  onToggleCollapse,
+  className,
+}: VirtualizedTreeListProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: OVERSCAN,
+    getItemKey: (index) => rows[index].key,
+  });
+
+  const measureElement = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (el) {
+        virtualizer.measureElement(el);
+      }
+    },
+    [virtualizer],
+  );
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={parentRef}
+      className={`overflow-auto ${className ?? ''}`}
+      style={{ contain: 'strict' }}
+    >
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          return (
+            <div
+              key={row.key}
+              ref={measureElement}
+              data-index={virtualRow.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              <TreeNode
+                node={row.node}
+                depth={row.depth}
+                onLaunch={onLaunch}
+                launchingIssues={launchingIssues}
+                launchErrors={launchErrors}
+                projectId={projectId}
+                priorityMap={priorityMap}
+                checkedIssues={checkedIssues}
+                onCheckChange={onCheckChange}
+                onPrioritizeSubtree={onPrioritizeSubtree}
+                prioritizing={prioritizing}
+                collapsedNodes={collapsedNodes}
+                onToggleCollapse={onToggleCollapse}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/src/client/hooks/useCollapseState.ts
+++ b/src/client/hooks/useCollapseState.ts
@@ -13,6 +13,21 @@ interface UseCollapseStateReturn {
   collapseAll: (allNodeIds: string[]) => void;
   /** Check if a specific node is collapsed */
   isCollapsed: (nodeId: string) => boolean;
+  /**
+   * Seed default collapsed nodes on first load (when localStorage is empty).
+   * Call this after the tree data is available. Only applies if no prior
+   * collapse state was persisted.
+   */
+  seedDefaults: (nodeIds: string[]) => void;
+}
+
+/** Check if localStorage has a persisted collapse state */
+function hasStoredState(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
 }
 
 /** Read collapsed node IDs from localStorage */
@@ -50,6 +65,12 @@ export function useCollapseState(): UseCollapseStateReturn {
   // so we don't write back to storage on mount.
   const initialized = useRef(false);
 
+  // Track whether default seeding has already been attempted to avoid repeated calls
+  const seeded = useRef(false);
+
+  // Track whether localStorage had prior state (used by seedDefaults)
+  const hadStoredState = useRef(hasStoredState());
+
   useEffect(() => {
     if (!initialized.current) {
       initialized.current = true;
@@ -83,11 +104,21 @@ export function useCollapseState(): UseCollapseStateReturn {
     [collapsedNodes],
   );
 
+  const seedDefaults = useCallback((nodeIds: string[]) => {
+    // Only seed on first load when localStorage was empty
+    if (seeded.current || hadStoredState.current) return;
+    seeded.current = true;
+    if (nodeIds.length > 0) {
+      setCollapsedNodes(new Set(nodeIds));
+    }
+  }, []);
+
   return {
     collapsedNodes,
     toggleCollapse,
     expandAll,
     collapseAll,
     isCollapsed,
+    seedDefaults,
   };
 }

--- a/src/client/hooks/useVirtualizedTree.ts
+++ b/src/client/hooks/useVirtualizedTree.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import type { IssueNode } from '../components/TreeNode';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FlatTreeRow {
+  /** The issue node for this row */
+  node: IssueNode;
+  /** Tree depth (0 = root level) */
+  depth: number;
+  /** Unique key for React rendering — the issue number as a string */
+  key: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure flattening function (testable without hooks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten a tree of IssueNode into a flat list suitable for virtualization.
+ * Only includes children that are currently expanded (not in collapsedNodes).
+ * When forceExpand is true, all nodes are expanded regardless of collapsedNodes.
+ */
+export function flattenTree(
+  nodes: IssueNode[],
+  collapsedNodes: Set<string>,
+  forceExpand: boolean,
+  depth: number = 0,
+): FlatTreeRow[] {
+  const rows: FlatTreeRow[] = [];
+  for (const node of nodes) {
+    const key = node.number.toString();
+    rows.push({ node, depth, key });
+
+    if (node.children.length > 0) {
+      const isExpanded = forceExpand || !collapsedNodes.has(key);
+      if (isExpanded) {
+        const childRows = flattenTree(node.children, collapsedNodes, forceExpand, depth + 1);
+        for (const row of childRows) {
+          rows.push(row);
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// React hook wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Memoized hook wrapping flattenTree. Re-computes only when inputs change.
+ */
+export function useFlattenedTree(
+  nodes: IssueNode[],
+  collapsedNodes: Set<string>,
+  forceExpand: boolean,
+): FlatTreeRow[] {
+  return useMemo(
+    () => flattenTree(nodes, collapsedNodes, forceExpand),
+    [nodes, collapsedNodes, forceExpand],
+  );
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -3,7 +3,9 @@ import { useApi } from '../hooks/useApi';
 import { useSSE } from '../hooks/useSSE';
 import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritization';
 import { useCollapseState } from '../hooks/useCollapseState';
-import { TreeNode, type IssueNode } from '../components/TreeNode';
+import { useFlattenedTree } from '../hooks/useVirtualizedTree';
+import { VirtualizedTreeList } from '../components/VirtualizedTreeList';
+import type { IssueNode } from '../components/TreeNode';
 import type { ProjectSummary } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -442,6 +444,21 @@ export function IssueTreeView() {
     }
     return collectAllNodeIds(tree);
   }, [tree, groups]);
+
+  // Seed default collapse state: collapse parent nodes at depth >= 2
+  // This only fires once on first load when localStorage is empty.
+  const deepNodeIds = useMemo(() => {
+    if (groups.length > 0) {
+      return groups.flatMap((g) => collectDeepParentNodeIds(g.tree, 0, 2));
+    }
+    return collectDeepParentNodeIds(tree, 0, 2);
+  }, [tree, groups]);
+
+  useEffect(() => {
+    if (deepNodeIds.length > 0) {
+      collapseState.seedDefaults(deepNodeIds);
+    }
+  }, [deepNodeIds, collapseState.seedDefaults]);
 
   // -------------------------------------------------------------------------
   // Loading state
@@ -1101,6 +1118,8 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
 
   const launchableInfo = useMemo(() => collectLaunchableIssues(group.tree), [group.tree]);
 
+  const flatRows = useFlattenedTree(displayTree, collapsedNodes, forceExpand);
+
   return (
     <div>
       {/* Project section header */}
@@ -1161,28 +1180,24 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
         fetchTree={fetchTree}
       />
 
-      {/* Issue tree within this project group */}
+      {/* Issue tree within this project group (virtualized) */}
       {expanded && (
         <div className="ml-2 border-l border-dark-border/40 pl-1">
-          {displayTree.map((node) => (
-            <TreeNode
-              key={node.number}
-              node={node}
-              depth={0}
-              onLaunch={onLaunch}
-              launchingIssues={launchingIssues}
-              launchErrors={launchErrors}
-              forceExpand={forceExpand}
-              projectId={group.projectId}
-              priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
-              checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
-              onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
-              onPrioritizeSubtree={prioritization.prioritizeSubtree}
-              prioritizing={prioritization.loading}
-              collapsedNodes={collapsedNodes}
-              onToggleCollapse={onToggleCollapse}
-            />
-          ))}
+          <VirtualizedTreeList
+            rows={flatRows}
+            onLaunch={onLaunch}
+            launchingIssues={launchingIssues}
+            launchErrors={launchErrors}
+            projectId={group.projectId}
+            priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
+            checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
+            onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
+            onPrioritizeSubtree={prioritization.prioritizeSubtree}
+            prioritizing={prioritization.loading}
+            collapsedNodes={collapsedNodes}
+            onToggleCollapse={onToggleCollapse}
+            className="max-h-[70vh]"
+          />
         </div>
       )}
 
@@ -1230,10 +1245,12 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
 
   const launchableInfo = useMemo(() => collectLaunchableIssues(tree), [tree]);
 
+  const flatRows = useFlattenedTree(displayTree, collapsedNodes, forceExpand);
+
   return (
-    <div>
+    <div className="flex flex-col h-full">
       {/* Prioritize controls */}
-      <div className="flex items-center gap-2 px-2 pb-2">
+      <div className="flex items-center gap-2 px-2 pb-2 shrink-0">
         <PrioritizeButtons
           prioritization={prioritization}
           tree={tree}
@@ -1244,14 +1261,14 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
 
       {/* Prioritization error banner */}
       {prioritization.error && (
-        <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#F85149]/30 bg-[#F85149]/10 text-xs text-[#F85149]">
+        <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#F85149]/30 bg-[#F85149]/10 text-xs text-[#F85149] shrink-0">
           Prioritization failed: {prioritization.error}
         </div>
       )}
 
       {/* Prioritization loading banner */}
       {prioritization.loading && (
-        <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#A371F7]/30 bg-[#A371F7]/10 flex items-center gap-2">
+        <div className="mx-2 mb-2 px-3 py-2 rounded border border-[#A371F7]/30 bg-[#A371F7]/10 flex items-center gap-2 shrink-0">
           <svg className="w-4 h-4 text-[#A371F7] animate-spin shrink-0" viewBox="0 0 24 24" fill="none">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
@@ -1270,26 +1287,21 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
         />
       )}
 
-      <div className="space-y-0">
-        {displayTree.map((node) => (
-          <TreeNode
-            key={node.number}
-            node={node}
-            depth={0}
-            onLaunch={onLaunch}
-            launchingIssues={launchingIssues}
-            launchErrors={launchErrors}
-            forceExpand={forceExpand}
-            priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
-            checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
-            onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
-            onPrioritizeSubtree={prioritization.prioritizeSubtree}
-            prioritizing={prioritization.loading}
-            collapsedNodes={collapsedNodes}
-            onToggleCollapse={onToggleCollapse}
-          />
-        ))}
-      </div>
+      <VirtualizedTreeList
+        rows={flatRows}
+        onLaunch={onLaunch}
+        launchingIssues={launchingIssues}
+        launchErrors={launchErrors}
+        projectId={projectId ?? undefined}
+        priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
+        checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
+        onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
+        onPrioritizeSubtree={prioritization.prioritizeSubtree}
+        prioritizing={prioritization.loading}
+        collapsedNodes={collapsedNodes}
+        onToggleCollapse={onToggleCollapse}
+        className="flex-1"
+      />
 
       {/* Run All confirmation dialog */}
       {showRunAllDialog && projectId && (
@@ -1403,6 +1415,23 @@ function collectLaunchableIssues(nodes: IssueNode[]): {
 
   walk(nodes);
   return { launchable, skippedActive, skippedBlocked };
+}
+
+/**
+ * Collect IDs of parent nodes (nodes with children) at depth >= minDepth.
+ * Used to pre-collapse deep branches on first load.
+ */
+function collectDeepParentNodeIds(nodes: IssueNode[], currentDepth: number, minDepth: number): string[] {
+  const ids: string[] = [];
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      if (currentDepth >= minDepth) {
+        ids.push(node.number.toString());
+      }
+      ids.push(...collectDeepParentNodeIds(node.children, currentDepth + 1, minDepth));
+    }
+  }
+  return ids;
 }
 
 /** Format a timestamp as HH:MM local time */

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../../src/client/hooks/usePrioritization', () => ({
 const mockExpandAll = vi.fn();
 const mockCollapseAll = vi.fn();
 const mockToggleCollapse = vi.fn();
+const mockSeedDefaults = vi.fn();
 
 vi.mock('../../src/client/hooks/useCollapseState', () => ({
   useCollapseState: () => ({
@@ -64,6 +65,7 @@ vi.mock('../../src/client/hooks/useCollapseState', () => ({
     expandAll: mockExpandAll,
     collapseAll: mockCollapseAll,
     isCollapsed: () => false,
+    seedDefaults: mockSeedDefaults,
   }),
 }));
 
@@ -72,6 +74,19 @@ vi.mock('../../src/client/components/TreeNode', () => ({
   TreeNode: (props: { node: { number: number; title: string } }) => (
     <div data-testid={`tree-node-${props.node.number}`}>
       #{props.node.number} {props.node.title}
+    </div>
+  ),
+}));
+
+// Mock VirtualizedTreeList to render rows without virtualization
+vi.mock('../../src/client/components/VirtualizedTreeList', () => ({
+  VirtualizedTreeList: (props: { rows: Array<{ node: { number: number; title: string }; key: string }> }) => (
+    <div data-testid="virtualized-tree-list">
+      {props.rows.map((row) => (
+        <div key={row.key} data-testid={`tree-node-${row.node.number}`}>
+          #{row.node.number} {row.node.title}
+        </div>
+      ))}
     </div>
   ),
 }));
@@ -656,6 +671,7 @@ describe('IssueTreeView', () => {
       expandAll: mockExpandAll,
       collapseAll: mockCollapseAll,
       isCollapsed: (id: string) => collapsedSet.has(id),
+      seedDefaults: mockSeedDefaults,
     });
 
     const issueA = { number: 10, title: 'Issue A', state: 'open', labels: [], children: [], activeTeam: null };

--- a/tests/client/TreeNode.test.tsx
+++ b/tests/client/TreeNode.test.tsx
@@ -68,28 +68,14 @@ describe('TreeNode', () => {
     expect(arrowBtn).toBeDefined();
   });
 
-  it('shows children when expanded (depth < 2 is default expanded)', () => {
+  it('does not render children (flat row renderer)', () => {
     const parent = makeNode({
       number: 1,
       title: 'Parent',
       children: [makeNode({ number: 2, title: 'Child issue' })],
     });
-    render(<TreeNode node={parent} {...defaultProps} depth={0} />);
-    expect(screen.getByText('Child issue')).toBeInTheDocument();
-  });
-
-  it('collapses children when arrow is clicked', () => {
-    const parent = makeNode({
-      number: 1,
-      title: 'Parent',
-      children: [makeNode({ number: 2, title: 'Child issue' })],
-    });
-    render(<TreeNode node={parent} {...defaultProps} depth={0} />);
-    expect(screen.getByText('Child issue')).toBeInTheDocument();
-
-    // Click the first (parent) Collapse button — child also has one but it's invisible
-    const collapseButtons = screen.getAllByLabelText('Collapse');
-    fireEvent.click(collapseButtons[0]);
+    render(<TreeNode node={parent} {...defaultProps} depth={0} collapsedNodes={new Set()} onToggleCollapse={vi.fn()} />);
+    // TreeNode no longer renders children — only the parent row
     expect(screen.queryByText('Child issue')).not.toBeInTheDocument();
   });
 
@@ -178,22 +164,6 @@ describe('TreeNode', () => {
     expect(screen.getByText('7/10')).toBeInTheDocument();
   });
 
-  it('force expands all children when forceExpand is true', () => {
-    const parent = makeNode({
-      number: 1,
-      title: 'Parent',
-      children: [
-        makeNode({
-          number: 2,
-          title: 'Child',
-          children: [makeNode({ number: 3, title: 'Grandchild' })],
-        }),
-      ],
-    });
-    render(<TreeNode node={parent} {...defaultProps} depth={0} forceExpand />);
-    expect(screen.getByText('Grandchild')).toBeInTheDocument();
-  });
-
   it('renders blocked badge for issues with unresolved dependencies', () => {
     render(
       <TreeNode
@@ -212,36 +182,34 @@ describe('TreeNode', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Closed parent with open children (Issue #348 fix)
+  // Closed parent styling (Issue #348 fix)
   // -------------------------------------------------------------------------
 
-  it('renders closed parent with open children correctly', () => {
+  it('renders closed parent with correct styling', () => {
     const closedParent = makeNode({
       number: 5,
       title: 'Closed epic',
       state: 'closed',
       children: [
         makeNode({ number: 10, title: 'Open sub-issue A', state: 'open' }),
-        makeNode({ number: 11, title: 'Open sub-issue B', state: 'open' }),
       ],
     });
-    render(<TreeNode node={closedParent} {...defaultProps} depth={0} />);
+    render(
+      <TreeNode
+        node={closedParent}
+        {...defaultProps}
+        depth={0}
+        collapsedNodes={new Set()}
+        onToggleCollapse={vi.fn()}
+      />,
+    );
 
     // Parent should have closed styling
     const parentTitle = screen.getByText('Closed epic');
     expect(parentTitle.className).toContain('line-through');
 
-    // Children should be visible (expanded by default at depth 0)
-    expect(screen.getByText('Open sub-issue A')).toBeInTheDocument();
-    expect(screen.getByText('Open sub-issue B')).toBeInTheDocument();
-
-    // Children should NOT have line-through styling
-    const childA = screen.getByText('Open sub-issue A');
-    expect(childA.className).not.toContain('line-through');
-
-    // Play button should be available for open leaf children
-    expect(screen.getByTitle('Launch team for #10')).toBeInTheDocument();
-    expect(screen.getByTitle('Launch team for #11')).toBeInTheDocument();
+    // TreeNode no longer renders children — only the parent row
+    expect(screen.queryByText('Open sub-issue A')).not.toBeInTheDocument();
 
     // No Play button for the closed parent (it also has children)
     expect(screen.queryByTitle('Launch team for #5')).not.toBeInTheDocument();
@@ -256,7 +224,7 @@ describe('TreeNode', () => {
   // Controlled collapse state (Issue #349)
   // -------------------------------------------------------------------------
 
-  it('uses controlled collapse state when collapsedNodes and onToggleCollapse are provided', () => {
+  it('shows expand arrow when node is not in collapsedNodes (expanded)', () => {
     const collapsedNodes = new Set<string>();
     const onToggleCollapse = vi.fn();
     const parent = makeNode({
@@ -265,7 +233,6 @@ describe('TreeNode', () => {
       children: [makeNode({ number: 2, title: 'Child issue' })],
     });
 
-    // Not in collapsed set = expanded
     render(
       <TreeNode
         node={parent}
@@ -275,10 +242,11 @@ describe('TreeNode', () => {
         onToggleCollapse={onToggleCollapse}
       />,
     );
-    expect(screen.getByText('Child issue')).toBeInTheDocument();
+    // Arrow should show Collapse label since node is expanded
+    expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
   });
 
-  it('hides children when node is in collapsedNodes set', () => {
+  it('shows collapse arrow when node is in collapsedNodes set', () => {
     const collapsedNodes = new Set<string>(['1']);
     const onToggleCollapse = vi.fn();
     const parent = makeNode({
@@ -296,10 +264,11 @@ describe('TreeNode', () => {
         onToggleCollapse={onToggleCollapse}
       />,
     );
-    expect(screen.queryByText('Child issue')).not.toBeInTheDocument();
+    // Arrow should show Expand label since node is collapsed
+    expect(screen.getByLabelText('Expand')).toBeInTheDocument();
   });
 
-  it('calls onToggleCollapse with nodeId when arrow is clicked in controlled mode', () => {
+  it('calls onToggleCollapse with nodeId when arrow is clicked', () => {
     const collapsedNodes = new Set<string>();
     const onToggleCollapse = vi.fn();
     const parent = makeNode({
@@ -318,61 +287,24 @@ describe('TreeNode', () => {
       />,
     );
 
-    const collapseBtn = screen.getAllByLabelText('Collapse')[0];
+    const collapseBtn = screen.getByLabelText('Collapse');
     fireEvent.click(collapseBtn);
     expect(onToggleCollapse).toHaveBeenCalledWith('42');
   });
 
-  it('forceExpand overrides controlled collapse state', () => {
-    const collapsedNodes = new Set<string>(['1']);
-    const onToggleCollapse = vi.fn();
-    const parent = makeNode({
-      number: 1,
-      title: 'Parent',
-      children: [makeNode({ number: 2, title: 'Child issue' })],
-    });
-
-    render(
+  it('caps paddingLeft for deeply nested rows', () => {
+    const deepNode = makeNode({ number: 99, title: 'Deep node' });
+    const { container } = render(
       <TreeNode
-        node={parent}
+        node={deepNode}
         {...defaultProps}
-        depth={0}
-        forceExpand
-        collapsedNodes={collapsedNodes}
-        onToggleCollapse={onToggleCollapse}
+        depth={15}
+        collapsedNodes={new Set()}
+        onToggleCollapse={vi.fn()}
       />,
     );
-    // Child should be visible because forceExpand overrides collapse
-    expect(screen.getByText('Child issue')).toBeInTheDocument();
-  });
-
-  it('passes collapsedNodes and onToggleCollapse to child TreeNodes', () => {
-    const collapsedNodes = new Set<string>(['2']);
-    const onToggleCollapse = vi.fn();
-    const parent = makeNode({
-      number: 1,
-      title: 'Parent',
-      children: [
-        makeNode({
-          number: 2,
-          title: 'Child',
-          children: [makeNode({ number: 3, title: 'Grandchild' })],
-        }),
-      ],
-    });
-
-    render(
-      <TreeNode
-        node={parent}
-        {...defaultProps}
-        depth={0}
-        collapsedNodes={collapsedNodes}
-        onToggleCollapse={onToggleCollapse}
-      />,
-    );
-
-    // Parent is expanded (not in collapsed set), Child (2) is collapsed
-    expect(screen.getByText('Child')).toBeInTheDocument();
-    expect(screen.queryByText('Grandchild')).not.toBeInTheDocument();
+    // depth 15 * 20 = 300, capped at 200, plus 8 = 208px
+    const row = container.querySelector('.flex.items-center.gap-2') as HTMLElement;
+    expect(row.style.paddingLeft).toBe('208px');
   });
 });

--- a/tests/client/useVirtualizedTree.test.ts
+++ b/tests/client/useVirtualizedTree.test.ts
@@ -1,0 +1,182 @@
+// =============================================================================
+// Fleet Commander — useVirtualizedTree / flattenTree Tests
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { flattenTree } from '../../src/client/hooks/useVirtualizedTree';
+import type { IssueNode } from '../../src/client/components/TreeNode';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(overrides: Partial<IssueNode> = {}): IssueNode {
+  return {
+    number: 1,
+    title: 'Test issue',
+    state: 'open',
+    labels: [],
+    url: 'https://github.com/user/repo/issues/1',
+    children: [],
+    activeTeam: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('flattenTree', () => {
+  it('should flatten a flat list (no children)', () => {
+    const nodes = [
+      makeNode({ number: 1, title: 'A' }),
+      makeNode({ number: 2, title: 'B' }),
+      makeNode({ number: 3, title: 'C' }),
+    ];
+    const rows = flattenTree(nodes, new Set(), false);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.node.number)).toEqual([1, 2, 3]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0, 0]);
+    expect(rows.map((r) => r.key)).toEqual(['1', '2', '3']);
+  });
+
+  it('should flatten a nested list with expanded children', () => {
+    const tree = [
+      makeNode({
+        number: 1,
+        title: 'Parent',
+        children: [
+          makeNode({ number: 2, title: 'Child A' }),
+          makeNode({ number: 3, title: 'Child B' }),
+        ],
+      }),
+    ];
+    const rows = flattenTree(tree, new Set(), false);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({ key: '1', depth: 0 });
+    expect(rows[1]).toMatchObject({ key: '2', depth: 1 });
+    expect(rows[2]).toMatchObject({ key: '3', depth: 1 });
+  });
+
+  it('should exclude children of collapsed nodes', () => {
+    const tree = [
+      makeNode({
+        number: 1,
+        children: [
+          makeNode({ number: 2, title: 'Hidden child' }),
+        ],
+      }),
+    ];
+    const collapsed = new Set(['1']);
+    const rows = flattenTree(tree, collapsed, false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe('1');
+  });
+
+  it('should force expand all nodes when forceExpand is true', () => {
+    const tree = [
+      makeNode({
+        number: 1,
+        children: [
+          makeNode({
+            number: 2,
+            children: [
+              makeNode({ number: 3, title: 'Grandchild' }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const collapsed = new Set(['1', '2']);
+    const rows = flattenTree(tree, collapsed, true);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.key)).toEqual(['1', '2', '3']);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 2]);
+  });
+
+  it('should return empty array for empty tree', () => {
+    const rows = flattenTree([], new Set(), false);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('should handle deeply nested tree with correct depths', () => {
+    const tree = [
+      makeNode({
+        number: 1,
+        children: [
+          makeNode({
+            number: 2,
+            children: [
+              makeNode({
+                number: 3,
+                children: [
+                  makeNode({
+                    number: 4,
+                    children: [
+                      makeNode({ number: 5 }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const rows = flattenTree(tree, new Set(), false);
+    expect(rows).toHaveLength(5);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('should collapse only the specified node and its subtree', () => {
+    const tree = [
+      makeNode({
+        number: 1,
+        children: [
+          makeNode({
+            number: 2,
+            children: [
+              makeNode({ number: 3, title: 'Grandchild of 2' }),
+            ],
+          }),
+          makeNode({ number: 4, title: 'Sibling of 2' }),
+        ],
+      }),
+    ];
+    // Collapse node 2 only — node 4 (sibling) should still be visible
+    const collapsed = new Set(['2']);
+    const rows = flattenTree(tree, collapsed, false);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.key)).toEqual(['1', '2', '4']);
+  });
+
+  it('should handle leaf nodes that are in collapsedNodes set (no-op)', () => {
+    const tree = [
+      makeNode({ number: 1 }),
+      makeNode({ number: 2 }),
+    ];
+    // Marking a leaf as collapsed should not affect rendering
+    const collapsed = new Set(['1']);
+    const rows = flattenTree(tree, collapsed, false);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('should process multiple root-level parents independently', () => {
+    const tree = [
+      makeNode({
+        number: 10,
+        children: [makeNode({ number: 11 })],
+      }),
+      makeNode({
+        number: 20,
+        children: [makeNode({ number: 21 })],
+      }),
+    ];
+    // Collapse only first parent
+    const collapsed = new Set(['10']);
+    const rows = flattenTree(tree, collapsed, false);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.key)).toEqual(['10', '20', '21']);
+  });
+});


### PR DESCRIPTION
Closes #420

## Summary
- Add `@tanstack/react-virtual` for tree virtualization (only render visible nodes + 15-row overscan buffer)
- Create `flattenTree` utility + `useFlattenedTree` hook to convert recursive tree into flat list for virtualization
- Create `VirtualizedTreeList` component with `useVirtualizer`, dynamic row measurement, and absolute positioning
- Refactor `TreeNode` from recursive renderer to flat single-row renderer
- Add default deep collapse (depth >= 2) on first visit via `seedDefaults` in `useCollapseState`
- Cap indentation padding at 200px for deeply nested rows

## Test plan
- [x] 9 new unit tests for `flattenTree` (empty, flat, nested, collapsed, forceExpand, deep nesting)
- [x] 22 existing TreeNode tests updated for flat row renderer model
- [x] 26 existing IssueTreeView tests updated with VirtualizedTreeList mock
- [x] TypeScript typecheck passes
- [x] All 57 client tests pass
- [x] Production build succeeds