### PR TITLE
Issue #512: Add WorktreeCreate/WorktreeRemove hooks to collect worktree lifecycle events

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,6 +116,26 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_create on_worktree_create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_remove on_worktree_remove.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/on_worktree_create.sh
+++ b/hooks/on_worktree_create.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# fleet-commander v0.0.10
+# Fleet Commander hook: WorktreeCreate
+# Fires when CC creates a worktree for an isolated subagent.
+# stdin JSON example: {"session_id":"abc123","worktree_path":"/path/to/worktree","teammate_name":"dev"}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | worktree_create | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "worktree_create"

--- a/hooks/on_worktree_remove.sh
+++ b/hooks/on_worktree_remove.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# fleet-commander v0.0.10
+# Fleet Commander hook: WorktreeRemove
+# Fires when CC removes a worktree after an isolated subagent finishes.
+# stdin JSON example: {"session_id":"abc123","worktree_path":"/path/to/worktree","teammate_name":"dev"}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | worktree_remove | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "worktree_remove"

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -115,6 +115,26 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_create on_worktree_create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_remove on_worktree_remove.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -74,6 +74,10 @@ function buildPayloadFromCcStdin(body: Record<string, unknown>): EventPayload {
     payload.msg_summary = str(toolInput.summary);
   }
 
+  // Worktree fields
+  payload.worktree_root = str(cc.worktree_root);
+  payload.worktree_path = str(cc.worktree_path);
+
   // New fields that CC provides but were previously dropped by shell regex
   payload.model = str(cc.model);
   payload.source = str(cc.source);
@@ -104,6 +108,7 @@ function buildPayloadFromLegacy(body: Record<string, unknown>): EventPayload {
     error_details: str(body.error_details),
     last_assistant_message: str(body.last_assistant_message),
     worktree_root: str(body.worktree_root),
+    worktree_path: str(body.worktree_path),
     msg_to: str(body.msg_to),
     msg_summary: str(body.msg_summary),
   };

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -40,6 +40,7 @@ export interface EventPayload {
   error_details?: string;       // StopFailure: reason for the failure (e.g. "rate_limit")
   last_assistant_message?: string; // StopFailure: last thing the agent said before failure
   worktree_root?: string;
+  worktree_path?: string;
   msg_to?: string;
   msg_summary?: string;
   // Raw CC stdin JSON forwarded from send_event.sh (new format)
@@ -224,6 +225,8 @@ function normalizeEventType(raw: string): string {
     'tool_error': 'ToolError',
     'pre_compact': 'PreCompact',
     'teammate_idle': 'TeammateIdle',
+    'worktree_create': 'WorktreeCreate',
+    'worktree_remove': 'WorktreeRemove',
   };
   return map[raw.toLowerCase()] || raw;
 }

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -124,6 +124,8 @@ describe('Valid payload processing', () => {
     'teammate_idle',
     'tool_error',
     'pre_compact',
+    'worktree_create',
+    'worktree_remove',
   ];
 
   const normalizedTypes: Record<string, string> = {
@@ -138,6 +140,8 @@ describe('Valid payload processing', () => {
     teammate_idle: 'TeammateIdle',
     tool_error: 'ToolError',
     pre_compact: 'PreCompact',
+    worktree_create: 'WorktreeCreate',
+    worktree_remove: 'WorktreeRemove',
   };
 
   for (const eventType of eventTypes) {
@@ -724,6 +728,8 @@ describe('Non-tool_use events never throttled', () => {
     'notification',
     'teammate_idle',
     'tool_error',
+    'worktree_create',
+    'worktree_remove',
   ];
 
   for (const eventType of nonToolUseEvents) {
@@ -2395,5 +2401,205 @@ describe('Phase transitions (Issue #494)', () => {
       expect(shouldAdvancePhase('blocked', 'implementing')).toBe(true);
       expect(shouldAdvancePhase('blocked', 'pr')).toBe(true);
     });
+  });
+});
+
+// =============================================================================
+// Worktree lifecycle events (Issue #512)
+// =============================================================================
+
+describe('Worktree lifecycle events (Issue #512)', () => {
+  it('worktree_create does NOT transition launching -> running', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'launching', phase: 'init' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'worktree_create' });
+
+    processEvent(payload, db, sse);
+
+    // Should NOT have inserted a transition or changed status
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('worktree_remove does NOT transition launching -> running', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'launching', phase: 'init' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'worktree_remove' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
+  it('worktree_create DOES wake idle team to running', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'worktree_create' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'idle',
+        toStatus: 'running',
+        trigger: 'hook',
+      }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'running' }),
+    );
+  });
+
+  it('worktree_remove DOES wake idle team to running', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'worktree_remove' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'idle',
+        toStatus: 'running',
+        trigger: 'hook',
+      }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'running' }),
+    );
+  });
+
+  it('worktree_create DOES wake stuck team to running', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'worktree_create' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'stuck',
+        toStatus: 'running',
+        trigger: 'hook',
+      }),
+    );
+  });
+
+  it('worktree_create stores worktree_path in payload JSON', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'worktree_create',
+      worktree_path: '/path/to/worktree',
+    });
+
+    processEvent(payload, db, sse);
+
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.worktree_path).toBe('/path/to/worktree');
+  });
+
+  it('worktree_create is never throttled', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const r1 = processEvent(makePayload({ event: 'worktree_create' }), db, sse);
+    const r2 = processEvent(makePayload({ event: 'worktree_create' }), db, sse);
+    const r3 = processEvent(makePayload({ event: 'worktree_create' }), db, sse);
+
+    expect(r1.processed).toBe(true);
+    expect(r2.processed).toBe(true);
+    expect(r3.processed).toBe(true);
+  });
+
+  it('worktree_remove is never throttled', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const r1 = processEvent(makePayload({ event: 'worktree_remove' }), db, sse);
+    const r2 = processEvent(makePayload({ event: 'worktree_remove' }), db, sse);
+    const r3 = processEvent(makePayload({ event: 'worktree_remove' }), db, sse);
+
+    expect(r1.processed).toBe(true);
+    expect(r2.processed).toBe(true);
+    expect(r3.processed).toBe(true);
+  });
+});
+
+// =============================================================================
+// Worktree payload parsing (Issue #512)
+// =============================================================================
+
+describe('Worktree payload parsing (Issue #512)', () => {
+  it('buildPayloadFromCcStdin extracts worktree_path', () => {
+    const ccData = {
+      session_id: 'sess-1',
+      worktree_path: '/home/user/project/.worktrees/feat-123',
+      teammate_name: 'dev',
+    };
+    const body = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify(ccData),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.worktree_path).toBe('/home/user/project/.worktrees/feat-123');
+    expect(payload.session_id).toBe('sess-1');
+    expect(payload.teammate_name).toBe('dev');
+  });
+
+  it('buildPayloadFromCcStdin extracts worktree_root', () => {
+    const ccData = {
+      session_id: 'sess-1',
+      worktree_root: '/home/user/project',
+    };
+    const body = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify(ccData),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.worktree_root).toBe('/home/user/project');
+  });
+
+  it('buildPayloadFromLegacy extracts worktree_path', () => {
+    const body = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      worktree_path: '/path/to/worktree',
+      worktree_root: '/path/to/root',
+    };
+
+    const payload = buildPayloadFromLegacy(body);
+
+    expect(payload.worktree_path).toBe('/path/to/worktree');
+    expect(payload.worktree_root).toBe('/path/to/root');
   });
 });


### PR DESCRIPTION
Closes #512

## Summary
- Add `hooks/on_worktree_create.sh` and `hooks/on_worktree_remove.sh` hook scripts following existing SubagentStart/SubagentStop patterns
- Register `WorktreeCreate` and `WorktreeRemove` in `hooks/settings.json.example` and `.claude/settings.json`
- Add `normalizeEventType` mappings for `worktree_create`/`worktree_remove` in event-collector
- Add `worktree_path` field to `EventPayload` interface
- Extract `worktree_path` and `worktree_root` in both `buildPayloadFromCcStdin` and `buildPayloadFromLegacy`
- Add 11 new tests: parameterized coverage, launching guard, idle/stuck wake, throttle, and payload parsing

## Test plan
- [x] `npm run test:server` passes (148 event-collector tests green)
- [x] New hooks follow exact structure of existing `on_subagent_start.sh`/`on_subagent_stop.sh`
- [x] `worktree_create` does NOT transition `launching -> running`
- [x] `worktree_create` DOES wake idle/stuck teams to `running`
- [x] Manifest auto-discovers new hook files without code changes