### PR TITLE
Issue #511: Add Tasks tab in TeamDetail with TaskCreated hook support

### DIFF
--- a/hooks/on_task_created.sh
+++ b/hooks/on_task_created.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# fleet-commander v0.0.10
+# Fleet Commander hook: TaskCreated
+# Fires when an agent creates or updates a task via TaskCreate/TodoWrite.
+# stdin JSON example: {"session_id":"abc123","task_id":"task_1","subject":"Implement feature","status":"in_progress"}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | task_created | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "task_created"

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -106,6 +106,16 @@
         ]
       }
     ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh task_created on_task_created.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUseFailure": [
       {
         "hooks": [

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -8,6 +8,7 @@ import { UnifiedTimeline } from './UnifiedTimeline';
 import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
 import { STATUS_COLORS } from '../utils/constants';
+import type { TeamTask } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -40,7 +41,9 @@ export function TeamDetail() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [quickActionLoading, setQuickActionLoading] = useState<string | null>(null);
   const [quickActionSent, setQuickActionSent] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'session-log' | 'team'>('session-log');
+  const [activeTab, setActiveTab] = useState<'session-log' | 'tasks' | 'team'>('session-log');
+  const [tasks, setTasks] = useState<TeamTask[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(false);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const [agentFilters, setAgentFilters] = useState<Set<string>>(new Set());
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
@@ -69,6 +72,40 @@ export function TeamDetail() {
       setMetadataCollapsed(true);
     }
   }, [detail?.status]);
+
+  // Fetch tasks when the Tasks tab is selected
+  useEffect(() => {
+    if (activeTab !== 'tasks' || !selectedTeamId) return;
+    let cancelled = false;
+    setTasksLoading(true);
+    api.get<TeamTask[]>(`teams/${selectedTeamId}/tasks`)
+      .then((data) => {
+        if (!cancelled) setTasks(data);
+      })
+      .catch(() => {
+        if (!cancelled) setTasks([]);
+      })
+      .finally(() => {
+        if (!cancelled) setTasksLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [activeTab, selectedTeamId, api]);
+
+  // Refresh tasks on SSE task_updated events
+  useEffect(() => {
+    if (activeTab !== 'tasks' || !selectedTeamId) return;
+    if (!lastEvent || lastEventTeamId !== selectedTeamId) return;
+    try {
+      const parsed = typeof lastEvent === 'string' ? JSON.parse(lastEvent) : lastEvent;
+      if (parsed?.type === 'task_updated') {
+        api.get<TeamTask[]>(`teams/${selectedTeamId}/tasks`)
+          .then((data) => setTasks(data))
+          .catch(() => { /* SSE refresh is best-effort */ });
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, [activeTab, selectedTeamId, lastEvent, lastEventTeamId, api]);
 
   // Close panel handler
   const handleClose = useCallback(() => {
@@ -461,6 +498,21 @@ export function TeamDetail() {
                     Session Log
                   </button>
                   <button
+                    onClick={() => setActiveTab('tasks')}
+                    className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab === 'tasks'
+                        ? 'border-dark-accent text-dark-text'
+                        : 'border-transparent text-dark-muted hover:text-dark-text'
+                    }`}
+                  >
+                    Tasks
+                    {tasks.length > 0 && (
+                      <span className="ml-1.5 text-xs text-dark-muted">
+                        ({tasks.filter(t => t.status === 'completed').length}/{tasks.length})
+                      </span>
+                    )}
+                  </button>
+                  <button
                     onClick={() => setActiveTab('team')}
                     className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
                       activeTab === 'team'
@@ -485,6 +537,80 @@ export function TeamDetail() {
                         onAgentFiltersChange={setAgentFilters}
                       />
                     </div>
+                  </div>
+                )}
+
+                {activeTab === 'tasks' && (
+                  <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-5 py-3">
+                    {tasksLoading && tasks.length === 0 && (
+                      <div className="flex items-center justify-center py-8">
+                        <span className="text-dark-muted">Loading tasks...</span>
+                      </div>
+                    )}
+
+                    {!tasksLoading && tasks.length === 0 && (
+                      <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <svg className="w-10 h-10 text-dark-muted/40 mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                        <p className="text-sm text-dark-muted">No tasks yet.</p>
+                        <p className="text-xs text-dark-muted/60 mt-1">Tasks appear when the TL creates a task list.</p>
+                      </div>
+                    )}
+
+                    {tasks.length > 0 && (
+                      <div className="space-y-1">
+                        {tasks.map((task) => (
+                          <div
+                            key={task.id}
+                            className={`flex items-start gap-2.5 px-3 py-2 rounded border transition-colors ${
+                              task.status === 'completed'
+                                ? 'border-dark-border/30 bg-dark-border/5'
+                                : task.status === 'in_progress'
+                                  ? 'border-[#58A6FF]/30 bg-[#58A6FF]/5'
+                                  : 'border-dark-border/50 bg-transparent'
+                            }`}
+                          >
+                            {/* Status icon */}
+                            <div className="shrink-0 mt-0.5">
+                              {task.status === 'completed' && (
+                                <svg className="w-4 h-4 text-[#3FB950]" viewBox="0 0 16 16" fill="currentColor">
+                                  <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+                                </svg>
+                              )}
+                              {task.status === 'in_progress' && (
+                                <svg className="w-4 h-4 text-[#58A6FF] animate-spin" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <circle cx="8" cy="8" r="6" strokeOpacity="0.3" />
+                                  <path d="M8 2a6 6 0 014.9 9.4" />
+                                </svg>
+                              )}
+                              {task.status === 'pending' && (
+                                <svg className="w-4 h-4 text-dark-muted" viewBox="0 0 16 16" fill="currentColor">
+                                  <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                                </svg>
+                              )}
+                            </div>
+
+                            {/* Task content */}
+                            <div className="flex-1 min-w-0">
+                              <p className={`text-sm leading-snug ${
+                                task.status === 'completed' ? 'text-dark-muted line-through' : 'text-dark-text'
+                              }`}>
+                                {task.subject}
+                              </p>
+                              {task.description && (
+                                <p className="text-xs text-dark-muted mt-0.5 truncate">{task.description}</p>
+                              )}
+                            </div>
+
+                            {/* Owner badge */}
+                            <span className="shrink-0 text-[10px] text-dark-muted px-1.5 py-0.5 rounded bg-dark-border/20">
+                              {task.owner}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 )}
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -27,6 +27,7 @@ import type {
   TeamMember,
   AgentMessage,
   MessageEdge,
+  TeamTask,
 } from '../shared/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -329,6 +330,9 @@ export class FleetDatabase {
 
     // Add UNIQUE constraint on teams(project_id, issue_number) (v8 migration)
     this.addTeamProjectIssueUniqueIndex();
+
+    // Add team_tasks table if missing (v9 migration — TaskCreated hook)
+    this.addTeamTasksTable();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -703,6 +707,32 @@ export class FleetDatabase {
       console.log('[DB] v8 migration: added UNIQUE index on teams(project_id, issue_number)');
     } catch {
       // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
+   * Add team_tasks table if it doesn't exist.
+   * v9 migration — stores task items from TaskCreated hook / TodoWrite.
+   */
+  private addTeamTasksTable(): void {
+    try {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS team_tasks (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          team_id         INTEGER NOT NULL REFERENCES teams(id),
+          task_id         TEXT NOT NULL,
+          subject         TEXT NOT NULL,
+          description     TEXT,
+          status          TEXT NOT NULL DEFAULT 'pending',
+          owner           TEXT NOT NULL DEFAULT 'team-lead',
+          created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_team_tasks_team_task ON team_tasks(team_id, task_id);
+        CREATE INDEX IF NOT EXISTS idx_team_tasks_team ON team_tasks(team_id);
+      `);
+    } catch {
+      // Table may already exist — safe to ignore
     }
   }
 
@@ -2341,6 +2371,74 @@ export class FleetDatabase {
       content: (row.content as string | null) ?? null,
       sessionId: (row.session_id as string | null) ?? null,
       createdAt: utcify(row.created_at as string),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Team Tasks
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Upsert a task for a team. Uses ON CONFLICT to update existing tasks
+   * (keyed on team_id + task_id) or insert new ones.
+   */
+  upsertTeamTask(data: {
+    teamId: number;
+    taskId: string;
+    subject: string;
+    description?: string | null;
+    status: string;
+    owner: string;
+  }): TeamTask {
+    const stmt = this.db.prepare(`
+      INSERT INTO team_tasks (team_id, task_id, subject, description, status, owner)
+      VALUES (@teamId, @taskId, @subject, @description, @status, @owner)
+      ON CONFLICT(team_id, task_id) DO UPDATE SET
+        subject = excluded.subject,
+        description = excluded.description,
+        status = excluded.status,
+        owner = excluded.owner,
+        updated_at = datetime('now')
+    `);
+
+    stmt.run({
+      teamId: data.teamId,
+      taskId: data.taskId,
+      subject: data.subject,
+      description: data.description ?? null,
+      status: data.status,
+      owner: data.owner,
+    });
+
+    const row = this.db.prepare(
+      'SELECT * FROM team_tasks WHERE team_id = ? AND task_id = ?'
+    ).get(data.teamId, data.taskId) as Record<string, unknown>;
+
+    return this.mapTeamTaskRow(row);
+  }
+
+  /**
+   * Get all tasks for a team, ordered by id ascending.
+   */
+  getTeamTasks(teamId: number): TeamTask[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM team_tasks WHERE team_id = ? ORDER BY id ASC'
+    ).all(teamId) as Record<string, unknown>[];
+
+    return rows.map((r) => this.mapTeamTaskRow(r));
+  }
+
+  private mapTeamTaskRow(row: Record<string, unknown>): TeamTask {
+    return {
+      id: row.id as number,
+      teamId: row.team_id as number,
+      taskId: row.task_id as string,
+      subject: row.subject as string,
+      description: (row.description as string | null) ?? null,
+      status: row.status as 'pending' | 'in_progress' | 'completed',
+      owner: row.owner as string,
+      createdAt: utcify(row.created_at as string),
+      updatedAt: utcify(row.updated_at as string),
     };
   }
 }

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -769,6 +769,40 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // GET /api/teams/:id/tasks — task list for this team
+  // -------------------------------------------------------------------------
+  fastify.get(
+    '/api/teams/:id/tasks',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseInt(request.params.id, 10);
+        if (isNaN(teamId) || teamId < 1) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Invalid team ID',
+          });
+        }
+
+        const service = getTeamService();
+        const tasks = service.getTasks(teamId);
+        return reply.code(200).send(tasks);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to get team tasks');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // GET /api/teams/:id/messages — agent messages for this team
   // -------------------------------------------------------------------------
   fastify.get(

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -270,5 +270,23 @@ CREATE TABLE IF NOT EXISTS stream_events (
 
 CREATE INDEX IF NOT EXISTS idx_stream_events_team ON stream_events(team_id);
 
--- Insert schema version 8 (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (8);
+-- ---------------------------------------------------------------------------
+-- TEAM TASKS — task items from TL's task list (TaskCreated hook / TodoWrite)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS team_tasks (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  team_id         INTEGER NOT NULL REFERENCES teams(id),
+  task_id         TEXT NOT NULL,
+  subject         TEXT NOT NULL,
+  description     TEXT,
+  status          TEXT NOT NULL DEFAULT 'pending',
+  owner           TEXT NOT NULL DEFAULT 'team-lead',
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_tasks_team_task ON team_tasks(team_id, task_id);
+CREATE INDEX IF NOT EXISTS idx_team_tasks_team ON team_tasks(team_id);
+
+-- Insert schema version 9 (or upgrade from earlier versions)
+INSERT OR IGNORE INTO schema_version (version) VALUES (9);

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -89,6 +89,14 @@ export interface EventCollectorDb {
     eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string };
     agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
   }): { eventId: number };
+  upsertTeamTask?(data: {
+    teamId: number;
+    taskId: string;
+    subject: string;
+    description?: string | null;
+    status: string;
+    owner: string;
+  }): { id: number; teamId: number; taskId: string; subject: string; status: string; owner: string };
 }
 
 /** SSE broker interface for broadcasting events */
@@ -227,6 +235,7 @@ function normalizeEventType(raw: string): string {
     'teammate_idle': 'TeammateIdle',
     'worktree_create': 'WorktreeCreate',
     'worktree_remove': 'WorktreeRemove',
+    'task_created': 'TaskCreated',
   };
   return map[raw.toLowerCase()] || raw;
 }
@@ -499,6 +508,48 @@ export function processEvent(
     tool_name: payload.tool_name || null,
     timestamp: payload.timestamp || nowIso,
   });
+
+  // ── Task extraction from TaskCreated events ─────────────────────
+  // Parse TaskCreated hook events and upsert task data into team_tasks.
+  if (eventType === 'TaskCreated' && db.upsertTeamTask) {
+    try {
+      // Parse cc_stdin for task fields (hook sends raw CC stdin JSON)
+      let ccData: Record<string, unknown> = {};
+      if (payload.cc_stdin) {
+        try {
+          ccData = JSON.parse(payload.cc_stdin) as Record<string, unknown>;
+        } catch {
+          // Malformed cc_stdin — fall through to direct payload fields
+        }
+      }
+
+      // Cascading fallback: cc_stdin fields -> direct payload fields -> defaults
+      const taskId = (ccData.task_id ?? payload.tool_use_id ?? `task-${eventId}`) as string;
+      const subject = (ccData.subject ?? ccData.title ?? payload.message ?? 'Untitled task') as string;
+      const description = (ccData.description ?? null) as string | null;
+      const status = (ccData.status ?? 'pending') as string;
+      const owner = normalizeAgentName(payload.agent_type);
+
+      const task = db.upsertTeamTask({
+        teamId,
+        taskId,
+        subject,
+        description,
+        status,
+        owner,
+      });
+
+      sse.broadcast('task_updated', {
+        team_id: teamId,
+        task_id: task.taskId,
+        subject: task.subject,
+        status: task.status,
+        owner: task.owner,
+      }, teamId);
+    } catch {
+      // Non-critical — task extraction failure should not break event processing
+    }
+  }
 
   // ── Subagent crash detection (advisory) ───────────────────────
   // Track SubagentStart/SubagentStop pairs. If a subagent stops very

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -33,7 +33,8 @@ export type SSEEventType =
   | 'heartbeat'
   | 'dependency_resolved'
   | 'team_thinking_start'
-  | 'team_thinking_stop';
+  | 'team_thinking_stop'
+  | 'task_updated';
 
 /** Payload shapes for each event type */
 export interface SSEEventPayloads {
@@ -53,6 +54,7 @@ export interface SSEEventPayloads {
   dependency_resolved: { issue_number: number; project_id: number; previously_blocked_by: number[] };
   team_thinking_start: { team_id: number };
   team_thinking_stop: { team_id: number; duration_ms: number };
+  task_updated: { team_id: number; task_id: string; subject: string; status: string; owner: string };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -2010,6 +2010,42 @@ export class TeamManager {
                       const agentName = (input?.agent_name ?? input?.name ?? 'subagent') as string;
                       agentMap.set(toolId, agentName.toLowerCase());
                     }
+
+                    // Stdout fallback: extract tasks from TodoWrite tool_use blocks
+                    if (toolName === 'TodoWrite') {
+                      try {
+                        const input = toolBlock.input as Record<string, unknown> | undefined;
+                        const todos = input?.todos as Array<Record<string, unknown>> | undefined;
+                        if (Array.isArray(todos)) {
+                          const db = getDatabase();
+                          for (const todo of todos) {
+                            const taskId = (todo.id ?? `stdout-${toolId}-${todos.indexOf(todo)}`) as string;
+                            const subject = (todo.content ?? todo.title ?? todo.subject ?? 'Untitled task') as string;
+                            const status = (todo.status ?? 'pending') as string;
+                            // Derive owner from parent_tool_use_id if available
+                            const parentId = (ev.parent_tool_use_id as string | null | undefined) ?? null;
+                            const owner = parentId ? (agentMap.get(parentId) ?? 'team-lead') : 'team-lead';
+
+                            const task = db.upsertTeamTask({
+                              teamId,
+                              taskId,
+                              subject,
+                              status,
+                              owner,
+                            });
+                            sseBroker.broadcast('task_updated', {
+                              team_id: teamId,
+                              task_id: task.taskId,
+                              subject: task.subject,
+                              status: task.status,
+                              owner: task.owner,
+                            }, teamId);
+                          }
+                        }
+                      } catch {
+                        // Non-critical — task extraction failure should not break stream parsing
+                      }
+                    }
                   }
                 }
               }

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -861,6 +861,28 @@ export class TeamService {
 
     return db.getAgentMessageSummary(teamId);
   }
+
+  /**
+   * Get tasks for a team.
+   *
+   * @param teamId - The team ID
+   * @returns Array of team tasks
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getTasks(teamId: number): unknown[] {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    return db.getTeamTasks(teamId);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -371,6 +371,19 @@ export interface AgentMessage {
   createdAt: string;
 }
 
+/** A task item from the TL's task list (TodoWrite/TaskCreate) */
+export interface TeamTask {
+  id: number;
+  teamId: number;
+  taskId: string;
+  subject: string;
+  description: string | null;
+  status: 'pending' | 'in_progress' | 'completed';
+  owner: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** Aggregated edge for the communication graph (sender -> recipient) */
 export interface MessageEdge {
   sender: string;

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -2603,3 +2603,112 @@ describe('Worktree payload parsing (Issue #512)', () => {
     expect(payload.worktree_root).toBe('/path/to/root');
   });
 });
+
+// =============================================================================
+// TaskCreated event processing
+// =============================================================================
+
+describe('TaskCreated event processing', () => {
+  it('should upsert task and broadcast task_updated SSE event', () => {
+    const upsertTeamTask = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      taskId: 'task-1',
+      subject: 'Implement feature',
+      status: 'in_progress',
+      owner: 'team-lead',
+    });
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'task_created',
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'Implement feature',
+        status: 'in_progress',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        taskId: 'task-1',
+        subject: 'Implement feature',
+        status: 'in_progress',
+      }),
+    );
+
+    // Verify task_updated SSE broadcast
+    const taskBroadcasts = (sse.broadcast as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => call[0] === 'task_updated',
+    );
+    expect(taskBroadcasts.length).toBe(1);
+    expect(taskBroadcasts[0][1]).toMatchObject({
+      team_id: 1,
+      task_id: 'task-1',
+      subject: 'Implement feature',
+      status: 'in_progress',
+    });
+  });
+
+  it('should handle malformed cc_stdin gracefully and use fallback fields', () => {
+    const upsertTeamTask = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      taskId: expect.any(String),
+      subject: 'Some message',
+      status: 'pending',
+      owner: 'team-lead',
+    });
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'task_created',
+      cc_stdin: 'not valid json{{{',
+      message: 'Some message',
+    });
+
+    // Should not throw
+    const result = processEvent(payload, db, sse);
+    expect(result.processed).toBe(true);
+
+    // Should still call upsertTeamTask with fallback values
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        subject: 'Some message',
+        status: 'pending',
+      }),
+    );
+  });
+
+  it('should not throw when upsertTeamTask is not available on db', () => {
+    // Simulates an older db that doesn't have the method
+    const db = createMockDb();
+    // Ensure upsertTeamTask is not set
+    delete (db as Record<string, unknown>).upsertTeamTask;
+    const sse = createMockSse();
+
+    const payload = makePayload({ event: 'task_created' });
+
+    // Should not throw
+    const result = processEvent(payload, db, sse);
+    expect(result.processed).toBe(true);
+  });
+
+  it('should normalize task_created event type to TaskCreated', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const payload = makePayload({ event: 'task_created' });
+    processEvent(payload, db, sse);
+
+    // The event should be stored with normalized type
+    const insertCall = db.processEventTransaction.mock.calls[0][0];
+    expect(insertCall.eventInsert.eventType).toBe('TaskCreated');
+  });
+});

--- a/tests/server/fc-manifest.test.ts
+++ b/tests/server/fc-manifest.test.ts
@@ -32,6 +32,7 @@ describe('getHookFiles', () => {
     expect(hooks).toContain('on_session_start.sh');
     expect(hooks).toContain('on_session_end.sh');
     expect(hooks).toContain('on_stop.sh');
+    expect(hooks).toContain('on_task_created.sh');
   });
 
   it('returns filenames sorted alphabetically', () => {
@@ -112,6 +113,7 @@ describe('getHookEventTypes', () => {
     expect(types).toContain('SessionStart');
     expect(types).toContain('SessionEnd');
     expect(types).toContain('Stop');
+    expect(types).toContain('TaskCreated');
   });
 
   it('returns event types sorted alphabetically', () => {

--- a/tests/server/routes/teams-routes.test.ts
+++ b/tests/server/routes/teams-routes.test.ts
@@ -716,3 +716,75 @@ describe('POST /api/teams/launch-batch', () => {
     expect(res.statusCode).toBe(400);
   });
 });
+
+// =============================================================================
+// Tests: GET /api/teams/:id/tasks
+// =============================================================================
+
+describe('GET /api/teams/:id/tasks', () => {
+  it('should return 200 with empty task list for team with no tasks', async () => {
+    const team = seedTeam();
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${team.id}/tasks`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  it('should return 200 with task list after upserting tasks', async () => {
+    const team = seedTeam();
+    const db = getDatabase();
+
+    db.upsertTeamTask({
+      teamId: team.id,
+      taskId: 'task-1',
+      subject: 'Implement feature A',
+      status: 'in_progress',
+      owner: 'dev',
+    });
+    db.upsertTeamTask({
+      teamId: team.id,
+      taskId: 'task-2',
+      subject: 'Write tests',
+      status: 'pending',
+      owner: 'team-lead',
+    });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${team.id}/tasks`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.length).toBe(2);
+    expect(body[0].taskId).toBe('task-1');
+    expect(body[0].subject).toBe('Implement feature A');
+    expect(body[0].status).toBe('in_progress');
+    expect(body[0].owner).toBe('dev');
+    expect(body[1].taskId).toBe('task-2');
+  });
+
+  it('should return 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/teams/99999/tasks',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for invalid team ID', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/teams/abc/tasks',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new **Tasks** tab in the TeamDetail slide-over panel (between Session Log and Team) showing the TL's task list in real-time
- Implements hook-based task ingestion via new `TaskCreated` hook (`on_task_created.sh`) with stdout fallback parsing `TodoWrite` tool_use events
- New `team_tasks` DB table with upsert semantics, `GET /api/teams/:id/tasks` endpoint, and `task_updated` SSE event for live refresh

Closes #511

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` passes (new tests for event-collector, routes, fc-manifest)
- [ ] Open TeamDetail panel → verify Tasks tab appears between Session Log and Team
- [ ] Launch a team → verify tasks appear in real-time as TL creates them
- [ ] Verify completed tasks show line-through styling
- [ ] Verify empty state when no tasks exist