### PR TITLE
Issue #516: Report merge conflicts on dirty PRs at first detection

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -339,11 +339,19 @@ class GitHubPoller {
             let msg: string | null = null;
             let ciSubtype: string | undefined;
             if (ciStatus === 'passing') {
-              msg = resolveMessage('ci_green', {
-                PR_NUMBER: String(prNumber),
-                AUTO_MERGE_STATUS: autoMerge ? 'enabled' : 'not enabled',
-              });
-              ciSubtype = 'ci_green';
+              if (mergeState === 'dirty') {
+                msg = resolveMessage('ci_green_but_dirty', {
+                  PR_NUMBER: String(prNumber),
+                  AUTO_MERGE_STATUS: autoMerge ? 'enabled' : 'not enabled',
+                });
+                ciSubtype = 'ci_green_but_dirty';
+              } else {
+                msg = resolveMessage('ci_green', {
+                  PR_NUMBER: String(prNumber),
+                  AUTO_MERGE_STATUS: autoMerge ? 'enabled' : 'not enabled',
+                });
+                ciSubtype = 'ci_green';
+              }
             } else if (ciStatus === 'failing') {
               const failedCheckNames = checks
                 .filter((c) => isFailureConclusion(c.conclusion))
@@ -420,8 +428,22 @@ class GitHubPoller {
         teamId
       );
       console.log(
-        `[GitHubPoller] PR #${prNumber} discovered — state=${state} ci=${ciStatus} (repo: ${githubRepo})`
+        `[GitHubPoller] PR #${prNumber} discovered — state=${state} ci=${ciStatus} merge=${mergeState} (repo: ${githubRepo})`
       );
+
+      // Notify team if the PR was born with merge conflicts
+      if (mergeState === 'dirty') {
+        try {
+          const { getTeamManager } = await import('./team-manager.js');
+          const manager = getTeamManager();
+          const msg = resolveMessage('merge_conflict', {
+            PR_NUMBER: String(prNumber),
+          });
+          if (msg) manager.sendMessage(teamId, msg, 'fc', 'merge_conflict');
+        } catch (err) {
+          console.error(`[GitHubPoller] Failed to send initial merge_conflict to team ${teamId}:`, err);
+        }
+      }
     }
 
     // If the PR was merged, update the team status to 'done'

--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -22,6 +22,14 @@ export const DEFAULT_MESSAGE_TEMPLATES: DefaultMessageTemplate[] = [
     placeholders: ['PR_NUMBER', 'AUTO_MERGE_STATUS'],
   },
   {
+    id: 'ci_green_but_dirty',
+    template:
+      'CI passed on PR #{{PR_NUMBER}}, all checks green. However, the PR has merge conflicts. Rebase or merge the base branch to resolve conflicts before merging. Auto-merge is {{AUTO_MERGE_STATUS}}.',
+    description:
+      'Sent to TL when CI passes but PR has merge conflicts (dirty merge state)',
+    placeholders: ['PR_NUMBER', 'AUTO_MERGE_STATUS'],
+  },
+  {
     id: 'ci_red',
     template:
       'CI failed on PR #{{PR_NUMBER}}. Failing checks: {{FAILED_CHECKS}}. Fix count: {{FAIL_COUNT}}/{{MAX_FAILURES}}. What went wrong?',

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -260,6 +260,17 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     hookEvent: null,
   },
   {
+    id: 'ci_green_but_dirty',
+    from: 'running',
+    to: 'running',
+    trigger: 'poller',
+    triggerLabel: 'CI green but merge conflicts',
+    description:
+      'All CI checks pass but PR has merge conflicts — TL needs to rebase before merge is possible',
+    condition: 'CI status changes to success AND merge status is dirty',
+    hookEvent: null,
+  },
+  {
     id: 'ci_red',
     from: 'running',
     to: 'running',

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -1041,6 +1041,147 @@ describe('Branch behind notifications', () => {
 });
 
 // =============================================================================
+// First PR detection — dirty merge state notification
+// =============================================================================
+
+describe('First PR detection — dirty merge state', () => {
+  it('sends merge_conflict message when PR is first detected as dirty', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue(undefined);
+
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockImplementation(
+      (id: string) => (id === 'merge_conflict' ? 'PR has merge conflicts' : null),
+    );
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({ mergeStateStatus: 'DIRTY' }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.insertPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        teamId: 1,
+        mergeStatus: 'dirty',
+      }),
+    );
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'PR has merge conflicts',
+      'fc',
+      'merge_conflict',
+    );
+  });
+
+  it('does not send merge_conflict when PR is first detected as clean', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue(undefined);
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({ mergeStateStatus: 'CLEAN' }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.insertPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        teamId: 1,
+        mergeStatus: 'clean',
+      }),
+    );
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// CI green with dirty merge state
+// =============================================================================
+
+describe('CI green with dirty merge state', () => {
+  it('sends ci_green_but_dirty when CI passes and PR is dirty', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'dirty',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockImplementation(
+      (id: string) => (id === 'ci_green_but_dirty' ? 'CI green but dirty' : null),
+    );
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'DIRTY',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'CI green but dirty',
+      'fc',
+      'ci_green_but_dirty',
+    );
+  });
+
+  it('sends regular ci_green when CI passes and PR is clean', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockImplementation(
+      (id: string) => (id === 'ci_green' ? 'CI passed' : null),
+    );
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'CI passed',
+      'fc',
+      'ci_green',
+    );
+  });
+});
+
+// =============================================================================
 // Input validation guards (injection prevention)
 // =============================================================================
 


### PR DESCRIPTION
Closes #516

## Summary
- Send `merge_conflict` message to TL when a PR is first detected by the poller with dirty merge state (previously only fired on clean→dirty transitions, missing born-dirty PRs)
- Send `ci_green_but_dirty` instead of `ci_green` when CI passes but PR has merge conflicts, so TL knows to rebase before merge
- Add `ci_green_but_dirty` message template and state machine transition

## Changes
- `src/server/services/github-poller.ts` — two new code paths for initial dirty detection and CI green + dirty
- `src/shared/message-templates.ts` — new `ci_green_but_dirty` template
- `src/shared/state-machine.ts` — new `ci_green_but_dirty` transition entry
- `tests/server/github-poller.test.ts` — 4 new test cases (all 40 tests pass)

## Test plan
- [x] `npm run test:server` passes (40/40 tests)
- [ ] Manual: create a PR with merge conflicts, verify `merge_conflict` message sent on first poll
- [ ] Manual: CI passes on a PR with conflicts, verify `ci_green_but_dirty` message instead of `ci_green`