### PR TITLE
Issue #519: Fix SSE client memory leak with proper error/close handlers and back-pressure eviction

### DIFF
--- a/src/server/routes/stream.ts
+++ b/src/server/routes/stream.ts
@@ -52,7 +52,9 @@ const streamRoutes: FastifyPluginCallback = (
     // Send an initial comment so the client knows the connection is live
     reply.raw.write(`:ok\n\n`);
 
-    // Send initial team dashboard snapshot so the client has data immediately
+    // Send initial team dashboard snapshot so the client has data immediately.
+    // If the write fails (client already disconnected), remove from broker and
+    // destroy the socket to prevent a dangling connection.
     try {
       const db = getDatabase();
       const dashboard = db.getTeamDashboard();
@@ -61,12 +63,13 @@ const streamRoutes: FastifyPluginCallback = (
       reply.raw.write(frame);
     } catch (err) {
       request.log.warn(err, 'Failed to send initial SSE snapshot');
-    }
-
-    // Detect client disconnect
-    request.raw.on('close', () => {
       sseBroker.removeClient(clientId);
-    });
+      try {
+        reply.raw.destroy();
+      } catch {
+        // Socket may already be destroyed — ignore
+      }
+    }
   });
 
   done();

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -65,6 +65,8 @@ interface SSEClient {
   id: string;
   reply: FastifyReply;
   teamFilter: Set<number> | null; // null = all teams
+  backPressureTimer: NodeJS.Timeout | null;
+  cleanupBound: (() => void) | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,9 +105,22 @@ class SSEBroker {
       this.heartbeatInterval = null;
     }
 
-    // Close all client connections — use destroy() for immediate socket
-    // teardown without waiting for a graceful FIN/ACK handshake.
+    // Close all client connections — clear timers, remove listeners, then
+    // destroy socket for immediate teardown.
     for (const [id, client] of this.clients) {
+      if (client.backPressureTimer) {
+        clearTimeout(client.backPressureTimer);
+        client.backPressureTimer = null;
+      }
+      if (client.cleanupBound) {
+        try {
+          client.reply.raw.removeListener('close', client.cleanupBound);
+          client.reply.raw.removeListener('error', client.cleanupBound);
+        } catch {
+          // Client may already be disconnected — ignore
+        }
+        client.cleanupBound = null;
+      }
       try {
         client.reply.raw.destroy();
       } catch {
@@ -118,25 +133,64 @@ class SSEBroker {
   /**
    * Register a new SSE client. Returns the generated client id.
    *
+   * Registers `close` and `error` listeners on `reply.raw` (the underlying
+   * `http.ServerResponse` writable stream) so the client is automatically
+   * removed when the connection drops, regardless of how it was lost.
+   *
    * @param reply   The Fastify reply object (must NOT have been sent yet)
    * @param teamFilter  Optional array of team IDs to subscribe to.
    *                    When omitted or empty, the client receives all events.
    */
   addClient(reply: FastifyReply, teamFilter?: number[]): string {
     const id = randomUUID();
+
+    const cleanup = (): void => {
+      this.removeClient(id);
+    };
+
     const client: SSEClient = {
       id,
       reply,
       teamFilter: teamFilter && teamFilter.length > 0 ? new Set(teamFilter) : null,
+      backPressureTimer: null,
+      cleanupBound: cleanup,
     };
     this.clients.set(id, client);
+
+    // Listen on the response writable stream for disconnect/error
+    reply.raw.on('close', cleanup);
+    reply.raw.on('error', cleanup);
+
     return id;
   }
 
   /**
    * Remove a client by id (e.g. on disconnect).
+   *
+   * Idempotent — safe to call multiple times for the same id (e.g. when
+   * both `close` and `error` fire for the same connection). Clears any
+   * active back-pressure eviction timer and removes event listeners from
+   * `reply.raw` to prevent dangling references.
    */
   removeClient(id: string): void {
+    const client = this.clients.get(id);
+    if (!client) return;
+
+    if (client.backPressureTimer) {
+      clearTimeout(client.backPressureTimer);
+      client.backPressureTimer = null;
+    }
+
+    if (client.cleanupBound) {
+      try {
+        client.reply.raw.removeListener('close', client.cleanupBound);
+        client.reply.raw.removeListener('error', client.cleanupBound);
+      } catch {
+        // Socket may already be destroyed — ignore
+      }
+      client.cleanupBound = null;
+    }
+
     this.clients.delete(id);
   }
 
@@ -167,13 +221,40 @@ class SSEBroker {
 
       try {
         const ok = client.reply.raw.write(frame);
-        if (ok === false) {
-          // Back-pressure — stream buffer full; unlikely for SSE but handle it
-          // We keep the client; the kernel buffer will drain eventually.
+        if (ok === false && !client.backPressureTimer) {
+          // Back-pressure — stream buffer full. Start a 30s eviction timer.
+          // If the buffer drains before timeout, cancel eviction.
+          const drainHandler = (): void => {
+            if (client.backPressureTimer) {
+              clearTimeout(client.backPressureTimer);
+              client.backPressureTimer = null;
+            }
+          };
+          client.reply.raw.once('drain', drainHandler);
+
+          client.backPressureTimer = setTimeout(() => {
+            client.backPressureTimer = null;
+            try {
+              client.reply.raw.removeListener('drain', drainHandler);
+            } catch {
+              // Socket may already be destroyed — ignore
+            }
+            try {
+              client.reply.raw.destroy();
+            } catch {
+              // Socket may already be destroyed — ignore
+            }
+            this.removeClient(id);
+          }, 30_000);
+
+          // Allow the Node.js process to exit even if the timer is active
+          if (client.backPressureTimer.unref) {
+            client.backPressureTimer.unref();
+          }
         }
       } catch {
         // Write failed — client is gone. Clean up.
-        this.clients.delete(id);
+        this.removeClient(id);
       }
     }
   }

--- a/tests/server/sse-broker.test.ts
+++ b/tests/server/sse-broker.test.ts
@@ -16,7 +16,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // Mock FastifyReply
 // ---------------------------------------------------------------------------
 
-interface MockRaw {
+import { EventEmitter } from 'events';
+
+interface MockRaw extends EventEmitter {
   write: ReturnType<typeof vi.fn>;
   end: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
@@ -27,13 +29,13 @@ interface MockReply {
 }
 
 function createMockReply(): MockReply {
-  return {
-    raw: {
-      write: vi.fn().mockReturnValue(true),
-      end: vi.fn(),
-      destroy: vi.fn(),
-    },
-  };
+  const emitter = new EventEmitter();
+  const raw = Object.assign(emitter, {
+    write: vi.fn().mockReturnValue(true),
+    end: vi.fn(),
+    destroy: vi.fn(),
+  }) as MockRaw;
+  return { raw };
 }
 
 // ---------------------------------------------------------------------------
@@ -328,5 +330,219 @@ describe('Client count', () => {
 
     sseBroker.stop();
     expect(sseBroker.getClientCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// Client lifecycle and error handling
+// =============================================================================
+
+describe('Client lifecycle and error handling', () => {
+  it('registers close and error listeners on reply.raw during addClient', () => {
+    const reply = createMockReply();
+    const onSpy = vi.spyOn(reply.raw, 'on');
+
+    sseBroker.addClient(reply as any);
+
+    expect(onSpy).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  it('removes client when reply.raw emits close', () => {
+    const reply = createMockReply();
+    sseBroker.addClient(reply as any);
+
+    expect(sseBroker.getClientCount()).toBe(1);
+
+    reply.raw.emit('close');
+
+    expect(sseBroker.getClientCount()).toBe(0);
+  });
+
+  it('removes client when reply.raw emits error', () => {
+    const reply = createMockReply();
+    sseBroker.addClient(reply as any);
+
+    expect(sseBroker.getClientCount()).toBe(1);
+
+    reply.raw.emit('error', new Error('Connection reset'));
+
+    expect(sseBroker.getClientCount()).toBe(0);
+  });
+
+  it('removes listeners from reply.raw during removeClient', () => {
+    const reply = createMockReply();
+    const id = sseBroker.addClient(reply as any);
+
+    // Before removal, listeners should be registered
+    expect(reply.raw.listenerCount('close')).toBe(1);
+    expect(reply.raw.listenerCount('error')).toBe(1);
+
+    sseBroker.removeClient(id);
+
+    expect(reply.raw.listenerCount('close')).toBe(0);
+    expect(reply.raw.listenerCount('error')).toBe(0);
+  });
+
+  it('double removal is idempotent and does not throw', () => {
+    const reply = createMockReply();
+    const id = sseBroker.addClient(reply as any);
+
+    sseBroker.removeClient(id);
+    expect(sseBroker.getClientCount()).toBe(0);
+
+    // Second removal should be a no-op
+    expect(() => sseBroker.removeClient(id)).not.toThrow();
+    expect(sseBroker.getClientCount()).toBe(0);
+  });
+
+  it('handles both close and error firing for the same client', () => {
+    const reply = createMockReply();
+    sseBroker.addClient(reply as any);
+
+    expect(sseBroker.getClientCount()).toBe(1);
+
+    reply.raw.emit('close');
+    expect(sseBroker.getClientCount()).toBe(0);
+
+    // After removeClient, our cleanup listener is gone. In a real
+    // http.ServerResponse (a Writable), error events are handled internally.
+    // In our bare EventEmitter mock, unhandled error events throw by default.
+    // Add a no-op listener to mimic real ServerResponse behavior.
+    reply.raw.on('error', () => { /* no-op — mimics Writable internals */ });
+    expect(() => reply.raw.emit('error', new Error('late error'))).not.toThrow();
+    expect(sseBroker.getClientCount()).toBe(0);
+  });
+
+  it('stop removes listeners before destroying sockets', () => {
+    const reply = createMockReply();
+    const removeListenerSpy = vi.spyOn(reply.raw, 'removeListener');
+
+    sseBroker.addClient(reply as any);
+    sseBroker.stop();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith('close', expect.any(Function));
+    expect(removeListenerSpy).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(reply.raw.destroy).toHaveBeenCalled();
+  });
+
+  it('broadcast uses removeClient (not direct delete) on write error', () => {
+    const reply = createMockReply();
+    reply.raw.write.mockImplementation(() => {
+      throw new Error('Connection reset');
+    });
+
+    sseBroker.addClient(reply as any);
+    expect(sseBroker.getClientCount()).toBe(1);
+
+    sseBroker.broadcast('heartbeat', { timestamp: new Date().toISOString() });
+    expect(sseBroker.getClientCount()).toBe(0);
+
+    // Listeners should have been cleaned up via removeClient
+    expect(reply.raw.listenerCount('close')).toBe(0);
+    expect(reply.raw.listenerCount('error')).toBe(0);
+  });
+});
+
+// =============================================================================
+// Back-pressure eviction
+// =============================================================================
+
+describe('Back-pressure eviction', () => {
+  it('starts eviction timer when write returns false', () => {
+    vi.useFakeTimers();
+    try {
+      const reply = createMockReply();
+      reply.raw.write.mockReturnValue(false); // simulate back-pressure
+
+      sseBroker.addClient(reply as any);
+      sseBroker.broadcast('heartbeat', { timestamp: new Date().toISOString() });
+
+      // Client should still be present (timer not yet fired)
+      expect(sseBroker.getClientCount()).toBe(1);
+
+      // Advance past the 30s eviction timeout
+      vi.advanceTimersByTime(30_000);
+
+      // Client should now be evicted
+      expect(sseBroker.getClientCount()).toBe(0);
+      expect(reply.raw.destroy).toHaveBeenCalled();
+    } finally {
+      sseBroker.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels eviction timer when drain fires', () => {
+    vi.useFakeTimers();
+    try {
+      const reply = createMockReply();
+      reply.raw.write.mockReturnValue(false);
+
+      sseBroker.addClient(reply as any);
+      sseBroker.broadcast('heartbeat', { timestamp: new Date().toISOString() });
+
+      expect(sseBroker.getClientCount()).toBe(1);
+
+      // Simulate buffer drain before timeout
+      reply.raw.emit('drain');
+
+      // Advance past the 30s eviction timeout
+      vi.advanceTimersByTime(30_000);
+
+      // Client should still be present (drain cancelled eviction)
+      expect(sseBroker.getClientCount()).toBe(1);
+      expect(reply.raw.destroy).not.toHaveBeenCalled();
+    } finally {
+      sseBroker.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not start duplicate timers on repeated back-pressure', () => {
+    vi.useFakeTimers();
+    try {
+      const reply = createMockReply();
+      reply.raw.write.mockReturnValue(false);
+
+      sseBroker.addClient(reply as any);
+
+      // Two broadcasts, both with back-pressure
+      sseBroker.broadcast('heartbeat', { timestamp: '2025-01-01T00:00:00Z' });
+      sseBroker.broadcast('heartbeat', { timestamp: '2025-01-01T00:00:01Z' });
+
+      // Client should still be present
+      expect(sseBroker.getClientCount()).toBe(1);
+
+      // Only one drain listener should be registered (from the first back-pressure)
+      expect(reply.raw.listenerCount('drain')).toBe(1);
+
+      // Advance past eviction timeout
+      vi.advanceTimersByTime(30_000);
+      expect(sseBroker.getClientCount()).toBe(0);
+    } finally {
+      sseBroker.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('stop clears back-pressure timers', () => {
+    vi.useFakeTimers();
+    try {
+      const reply = createMockReply();
+      reply.raw.write.mockReturnValue(false);
+
+      sseBroker.addClient(reply as any);
+      sseBroker.broadcast('heartbeat', { timestamp: new Date().toISOString() });
+
+      // Stop should clear the timer and remove the client
+      sseBroker.stop();
+      expect(sseBroker.getClientCount()).toBe(0);
+
+      // Advancing time should not cause errors
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Closes #519

## Summary
- Register `reply.raw` `close` and `error` listeners in `SSEBroker.addClient()` so dead clients are always evicted from the client map
- Remove redundant `request.raw.on('close', ...)` from `stream.ts` (broker handles lifecycle now)
- Handle initial snapshot write failure by removing the client entry and destroying the socket
- Add 30-second back-pressure eviction timer when `write()` returns `false`; cancelled on `drain`, destroys client on timeout
- Make `removeClient()` idempotent with full cleanup (timers + listeners)
- Update `stop()` to clear all timers and listeners before destroying sockets

## Test plan
- [x] 11 new tests for client lifecycle, error handling, and back-pressure eviction
- [x] All 35 SSE broker tests pass
- [x] `tsc --noEmit` passes clean
- [x] `npm run test:server` passes