### PR TITLE
Issue #520: Prevent unbounded growth of subagentTrackers map

### DIFF
--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -131,6 +131,9 @@ const subagentTrackers = new Map<string, SubagentTracker>();
 /** Throttle window: tool_use events from the same team within this period are deduplicated */
 const TOOL_USE_THROTTLE_MS = 5000; // 5 seconds
 
+/** TTL for subagent trackers: entries older than this are pruned to prevent unbounded growth */
+const SUBAGENT_TRACKER_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
 // ---------------------------------------------------------------------------
 // Agent name normalization
 // ---------------------------------------------------------------------------
@@ -289,6 +292,13 @@ export function processEvent(
   // by hook events. The event data is still recorded (below) for
   // debugging, but all transition logic is skipped.
   const isTerminal = TERMINAL_STATUSES.has(team.status);
+
+  // ── Clean up subagent trackers for teams in terminal states ───────
+  // If a team has reached done/failed, any orphaned tracker entries for
+  // that team's subagents are removed on the next event for that team.
+  if (isTerminal) {
+    cleanSubagentTrackersForTeam(payload.team);
+  }
 
   // ── Collect transition data (without writing to DB yet) ──────────
   // The actual DB writes happen inside a single transaction below.
@@ -559,6 +569,11 @@ export function processEvent(
     const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
     const trackerKey = `${payload.team}:${subagentName}`;
     subagentTrackers.set(trackerKey, { startTime: now, eventCount: 0 });
+
+    // Prune stale subagent trackers to prevent unbounded growth
+    for (const [k, tracker] of subagentTrackers) {
+      if (now - tracker.startTime > SUBAGENT_TRACKER_TTL_MS) subagentTrackers.delete(k);
+    }
   }
 
   // Increment event count for any tracked subagent on this team
@@ -625,4 +640,17 @@ export function resetThrottleState(): void {
 /** Reset subagent tracking state. Intended for use in tests only. */
 export function resetSubagentTrackers(): void {
   subagentTrackers.clear();
+}
+
+/** Return current size of subagent tracker map. Intended for use in tests only. */
+export function getSubagentTrackerSize(): number {
+  return subagentTrackers.size;
+}
+
+/** Remove all subagent tracker entries for a given team (worktree name). */
+export function cleanSubagentTrackersForTeam(worktreeName: string): void {
+  const prefix = worktreeName + ':';
+  for (const key of subagentTrackers.keys()) {
+    if (key.startsWith(prefix)) subagentTrackers.delete(key);
+  }
 }

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -7,6 +7,8 @@ import {
   processEvent,
   resetThrottleState,
   resetSubagentTrackers,
+  getSubagentTrackerSize,
+  cleanSubagentTrackersForTeam,
   normalizeAgentName,
   classifyAgentRole,
   shouldAdvancePhase,
@@ -1420,6 +1422,184 @@ describe('Subagent crash detection', () => {
     expect(msg).toContain('s after start');
     expect(msg).toContain('events');
     expect(msg).toContain('Consider respawning');
+  });
+});
+
+// =============================================================================
+// Subagent tracker TTL sweep (Issue #520)
+// =============================================================================
+
+describe('Subagent tracker TTL sweep', () => {
+  it('should prune subagent trackers older than 30 minutes on subagent_start', () => {
+    vi.useFakeTimers();
+    try {
+      const baseTime = new Date('2026-03-20T12:00:00Z').getTime();
+      vi.setSystemTime(baseTime);
+
+      const db = createMockDb();
+      const sse = createMockSse();
+
+      // Start a subagent at time T
+      processEvent(
+        makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+        db,
+        sse,
+      );
+      expect(getSubagentTrackerSize()).toBe(1);
+
+      // Advance time by 31 minutes
+      vi.setSystemTime(baseTime + 31 * 60 * 1000);
+
+      // Start another subagent — should trigger TTL sweep and prune the old one
+      processEvent(
+        makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+        db,
+        sse,
+      );
+
+      // Only the new tracker should remain
+      expect(getSubagentTrackerSize()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should NOT prune recent subagent trackers', () => {
+    vi.useFakeTimers();
+    try {
+      const baseTime = new Date('2026-03-20T12:00:00Z').getTime();
+      vi.setSystemTime(baseTime);
+
+      const db = createMockDb();
+      const sse = createMockSse();
+
+      // Start two subagents at time T (different names)
+      processEvent(
+        makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev' }),
+        db,
+        sse,
+      );
+      processEvent(
+        makePayload({ event: 'subagent_start', teammate_name: 'fleet-reviewer' }),
+        db,
+        sse,
+      );
+      expect(getSubagentTrackerSize()).toBe(2);
+
+      // Advance time by only 5 minutes
+      vi.setSystemTime(baseTime + 5 * 60 * 1000);
+
+      // Start a third subagent
+      processEvent(
+        makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner' }),
+        db,
+        sse,
+      );
+
+      // All three trackers should still be present
+      expect(getSubagentTrackerSize()).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// =============================================================================
+// Subagent tracker terminal-state cleanup (Issue #520)
+// =============================================================================
+
+describe('Subagent tracker terminal-state cleanup', () => {
+  it('should clean subagent trackers when team is in terminal state (done)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    // Start a subagent for the team
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', team: 'kea-100' }),
+      db,
+      sse,
+    );
+    expect(getSubagentTrackerSize()).toBe(1);
+
+    // Now simulate the team being in terminal state 'done'
+    const terminalDb = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'pr' }),
+    });
+
+    // Any event for the terminal team should clean up its trackers
+    processEvent(
+      makePayload({ event: 'tool_use', team: 'kea-100' }),
+      terminalDb,
+      sse,
+    );
+
+    expect(getSubagentTrackerSize()).toBe(0);
+  });
+
+  it('should clean subagent trackers when team is in terminal state (failed)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    // Start subagents for the team
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', team: 'kea-100' }),
+      db,
+      sse,
+    );
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-planner', team: 'kea-100' }),
+      db,
+      sse,
+    );
+    expect(getSubagentTrackerSize()).toBe(2);
+
+    // Simulate the team being in terminal state 'failed'
+    const terminalDb = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'failed', phase: 'implementing' }),
+    });
+
+    processEvent(
+      makePayload({ event: 'tool_use', team: 'kea-100' }),
+      terminalDb,
+      sse,
+    );
+
+    expect(getSubagentTrackerSize()).toBe(0);
+  });
+
+  it('should NOT clean trackers for other teams when one team reaches terminal state', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    // Start subagents on two different teams
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', team: 'kea-100' }),
+      db,
+      sse,
+    );
+    processEvent(
+      makePayload({ event: 'subagent_start', teammate_name: 'fleet-dev', team: 'kea-200' }),
+      db,
+      sse,
+    );
+    expect(getSubagentTrackerSize()).toBe(2);
+
+    // Only kea-100 reaches terminal state
+    const terminalDb = createMockDb({
+      getTeamByWorktree: vi.fn().mockImplementation((worktree: string) => {
+        if (worktree === 'kea-100') return { id: 1, status: 'done', phase: 'pr' };
+        return { id: 2, status: 'running', phase: 'implementing' };
+      }),
+    });
+
+    processEvent(
+      makePayload({ event: 'tool_use', team: 'kea-100' }),
+      terminalDb,
+      sse,
+    );
+
+    // Only kea-100 trackers should be cleaned; kea-200 should remain
+    expect(getSubagentTrackerSize()).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #520

## Summary
- Add 30-minute TTL sweep on `subagent_start` events to prune stale tracker entries
- Add terminal-state cleanup that removes all tracker entries when a team reaches `done` or `failed`
- Export `getSubagentTrackerSize()` and `cleanSubagentTrackersForTeam()` for test observability

## Test plan
- [x] TTL sweep prunes entries older than 30 minutes
- [x] Recent trackers (< 30 min) are not pruned
- [x] Terminal cleanup removes trackers for `done` teams
- [x] Terminal cleanup removes trackers for `failed` teams
- [x] Cross-team isolation: cleanup for one team doesn't affect others
- [x] All 157 existing event-collector tests pass unchanged
- [x] `npm run test:server` passes with no regressions