### PR TITLE
Issue #522: Fix gracefulShutdown flood after merge and perpetual fast-poll for open PRs

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -205,7 +205,7 @@ class GitHubPoller {
           if (team.prNumber) {
             const pr = await this.pollPR(team.prNumber, team.id, githubRepo);
             // Fast-poll when CI is pending
-            if (pr && (pr.ciStatus === 'pending' || pr.state === 'open')) {
+            if (pr && pr.ciStatus === 'pending') {
               wantFast = true;
             }
           } else if (team.branchName) {
@@ -471,20 +471,20 @@ class GitHubPoller {
         console.log(
           `[GitHubPoller] Team ${teamId} marked done — PR #${prNumber} merged`
         );
-      }
 
-      // Record merged_at timestamp on the PR
-      db.updatePullRequest(prNumber, {
-        mergedAt: new Date().toISOString(),
-      });
+        // Record merged_at timestamp on the PR (once, during the done transition)
+        db.updatePullRequest(prNumber, {
+          mergedAt: new Date().toISOString(),
+        });
 
-      // Initiate graceful shutdown: notify TL, wait grace period, then kill
-      try {
-        const { getTeamManager } = await import('./team-manager.js');
-        const manager = getTeamManager();
-        manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
-      } catch (err) {
-        console.error(`[GitHubPoller] Failed to initiate graceful shutdown for team ${teamId}:`, err);
+        // Initiate graceful shutdown: notify TL, wait grace period, then kill
+        try {
+          const { getTeamManager } = await import('./team-manager.js');
+          const manager = getTeamManager();
+          manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
+        } catch (err) {
+          console.error(`[GitHubPoller] Failed to initiate graceful shutdown for team ${teamId}:`, err);
+        }
       }
     }
 

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -216,6 +216,40 @@ describe('PR state transitions', () => {
     expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
   });
 
+  it('does not call gracefulShutdown again when team is already done', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'done' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'merged',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    // Team is already done
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'done' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // gracefulShutdown should NOT be called since team is already done
+    expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
+    // mergedAt should NOT be written again either
+    expect(mockDb.updatePullRequest).not.toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergedAt: expect.any(String) }),
+    );
+  });
+
   it('detects new PR state (no existing PR record) and inserts it', async () => {
     const project = makeProject();
     const team = makeTeam({ prNumber: 42 });
@@ -1184,6 +1218,64 @@ describe('CI green with dirty merge state', () => {
 // =============================================================================
 // Input validation guards (injection prevention)
 // =============================================================================
+
+describe('Adaptive polling interval', () => {
+  it('sets fast poll when CI is pending', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: null, status: 'IN_PROGRESS' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // needsFastPoll should be true (accessed via bracket notation)
+    expect((githubPoller as unknown as Record<string, unknown>)['needsFastPoll']).toBe(true);
+  });
+
+  it('does not set fast poll for open PR with passing CI', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // needsFastPoll should be false — open PRs with passing CI do NOT trigger fast poll
+    expect((githubPoller as unknown as Record<string, unknown>)['needsFastPoll']).toBe(false);
+  });
+});
 
 describe('Input validation guards', () => {
   it('pollPR skips gh CLI call when githubRepo is invalid', async () => {


### PR DESCRIPTION
Closes #522

## Summary
- **Shutdown flood fix**: Moved `gracefulShutdown()` and `mergedAt` DB write inside the `if (team && team.status !== 'done')` guard in `github-poller.ts`, so they fire exactly once during the done transition instead of on every 10s poll cycle after merge
- **Fast-poll fix**: Narrowed the fast-poll condition from `pr.ciStatus === 'pending' || pr.state === 'open'` to just `pr.ciStatus === 'pending'`, so open PRs with stable CI no longer trigger perpetual 10s polling

## Test plan
- [x] New test: "does not call gracefulShutdown again when team is already done"
- [x] New test: "sets fast poll when CI is pending"
- [x] New test: "does not set fast poll for open PR with passing CI"
- [x] All 43 existing tests pass
- [x] `tsc --noEmit` clean