### PR TITLE
Issue #518: DB performance: cache prepared statements, remove spin-wait, eliminate redundant SELECTs

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -256,6 +256,7 @@ export interface AgentMessageInsert {
 
 export class FleetDatabase {
   private db: Database.Database;
+  private stmtCache = new Map<string, Database.Statement>();
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -266,6 +267,25 @@ export class FleetDatabase {
     // Performance pragmas
     this.db.pragma('foreign_keys = ON');
     this.db.pragma('busy_timeout = 5000');
+  }
+
+  // -------------------------------------------------------------------------
+  // Prepared statement cache
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get a cached prepared statement for a static SQL string.
+   * Avoids re-parsing the same SQL on every call. Only use with constant
+   * SQL strings — dynamic SQL (variable SET clauses) must use db.prepare()
+   * directly.
+   */
+  private stmt(sql: string): Database.Statement {
+    let cached = this.stmtCache.get(sql);
+    if (!cached) {
+      cached = this.db.prepare(sql);
+      this.stmtCache.set(sql, cached);
+    }
+    return cached;
   }
 
   // -------------------------------------------------------------------------
@@ -649,7 +669,6 @@ export class FleetDatabase {
           created_at      TEXT NOT NULL DEFAULT (datetime('now')),
           updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
         );
-        CREATE INDEX IF NOT EXISTS idx_stream_events_team ON stream_events(team_id);
       `);
     } catch {
       // Table may already exist — safe to ignore
@@ -759,7 +778,7 @@ export class FleetDatabase {
 
   insertProject(data: ProjectInsert): Project {
     const now = new Date().toISOString();
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO projects (name, repo_path, github_repo, group_id, max_active_teams, prompt_file, model, created_at, updated_at)
       VALUES (@name, @repoPath, @githubRepo, @groupId, @maxActiveTeams, @promptFile, @model, @createdAt, @updatedAt)
     `);
@@ -780,13 +799,13 @@ export class FleetDatabase {
   }
 
   getProject(id: number): Project | undefined {
-    const stmt = this.db.prepare('SELECT * FROM projects WHERE id = ?');
+    const stmt = this.stmt('SELECT * FROM projects WHERE id = ?');
     const row = stmt.get(id) as Record<string, unknown> | undefined;
     return row ? this.mapProjectRow(row) : undefined;
   }
 
   getProjectByRepoPath(repoPath: string): Project | undefined {
-    const stmt = this.db.prepare('SELECT * FROM projects WHERE repo_path = ?');
+    const stmt = this.stmt('SELECT * FROM projects WHERE repo_path = ?');
     const row = stmt.get(repoPath) as Record<string, unknown> | undefined;
     return row ? this.mapProjectRow(row) : undefined;
   }
@@ -808,7 +827,7 @@ export class FleetDatabase {
   }
 
   getProjectSummaries(): ProjectSummary[] {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       SELECT
         p.*,
         COUNT(t.id) AS team_count,
@@ -877,12 +896,12 @@ export class FleetDatabase {
   }
 
   deleteProject(id: number): boolean {
-    const result = this.db.prepare('DELETE FROM projects WHERE id = ?').run(id);
+    const result = this.stmt('DELETE FROM projects WHERE id = ?').run(id);
     return result.changes > 0;
   }
 
   getProjectTeams(projectId: number): TeamDashboardRow[] {
-    const stmt = this.db.prepare('SELECT * FROM v_team_dashboard WHERE project_id = ?');
+    const stmt = this.stmt('SELECT * FROM v_team_dashboard WHERE project_id = ?');
     const rows = stmt.all(projectId) as Record<string, unknown>[];
     return rows.map((r) => this.mapDashboardRow(r));
   }
@@ -893,7 +912,7 @@ export class FleetDatabase {
 
   insertProjectGroup(data: ProjectGroupInsert): ProjectGroup {
     const now = new Date().toISOString();
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO project_groups (name, description, created_at, updated_at)
       VALUES (@name, @description, @createdAt, @updatedAt)
     `);
@@ -909,13 +928,13 @@ export class FleetDatabase {
   }
 
   getProjectGroup(id: number): ProjectGroup | undefined {
-    const stmt = this.db.prepare('SELECT * FROM project_groups WHERE id = ?');
+    const stmt = this.stmt('SELECT * FROM project_groups WHERE id = ?');
     const row = stmt.get(id) as Record<string, unknown> | undefined;
     return row ? this.mapProjectGroupRow(row) : undefined;
   }
 
   getProjectGroups(): ProjectGroup[] {
-    const stmt = this.db.prepare('SELECT * FROM project_groups ORDER BY name ASC');
+    const stmt = this.stmt('SELECT * FROM project_groups ORDER BY name ASC');
     const rows = stmt.all() as Record<string, unknown>[];
     return rows.map((r) => this.mapProjectGroupRow(r));
   }
@@ -944,8 +963,8 @@ export class FleetDatabase {
 
   deleteProjectGroup(id: number): boolean {
     // Unlink all projects from this group before deleting
-    this.db.prepare('UPDATE projects SET group_id = NULL WHERE group_id = ?').run(id);
-    const result = this.db.prepare('DELETE FROM project_groups WHERE id = ?').run(id);
+    this.stmt('UPDATE projects SET group_id = NULL WHERE group_id = ?').run(id);
+    const result = this.stmt('DELETE FROM project_groups WHERE id = ?').run(id);
     return result.changes > 0;
   }
 
@@ -955,7 +974,7 @@ export class FleetDatabase {
 
   insertTeam(data: TeamInsert): Team {
     const now = new Date().toISOString();
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO teams (issue_number, issue_title, project_id, worktree_name, branch_name, status, phase, pid, session_id, pr_number, custom_prompt, headless, blocked_by_json, launched_at, created_at, updated_at)
       VALUES (@issueNumber, @issueTitle, @projectId, @worktreeName, @branchName, @status, @phase, @pid, @sessionId, @prNumber, @customPrompt, @headless, @blockedByJson, @launchedAt, @createdAt, @updatedAt)
     `);
@@ -992,13 +1011,13 @@ export class FleetDatabase {
   }
 
   getTeam(id: number): Team | undefined {
-    const stmt = this.db.prepare('SELECT * FROM teams WHERE id = ?');
+    const stmt = this.stmt('SELECT * FROM teams WHERE id = ?');
     const row = stmt.get(id) as Record<string, unknown> | undefined;
     return row ? this.mapTeamRow(row) : undefined;
   }
 
   getTeamByWorktree(name: string): Team | undefined {
-    const stmt = this.db.prepare('SELECT * FROM teams WHERE worktree_name = ?');
+    const stmt = this.stmt('SELECT * FROM teams WHERE worktree_name = ?');
     const row = stmt.get(name) as Record<string, unknown> | undefined;
     return row ? this.mapTeamRow(row) : undefined;
   }
@@ -1068,7 +1087,7 @@ export class FleetDatabase {
   }
 
   getActiveTeams(): Team[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT * FROM teams WHERE status IN ('queued', 'launching', 'running', 'idle', 'stuck') ORDER BY created_at DESC"
     );
     const rows = stmt.all() as Record<string, unknown>[];
@@ -1076,7 +1095,7 @@ export class FleetDatabase {
   }
 
   getActiveTeamsByProject(projectId: number): Team[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT * FROM teams WHERE project_id = ? AND status IN ('queued', 'launching', 'running', 'idle', 'stuck') ORDER BY created_at DESC"
     );
     const rows = stmt.all(projectId) as Record<string, unknown>[];
@@ -1089,7 +1108,7 @@ export class FleetDatabase {
    * because they haven't consumed a slot yet.
    */
   getActiveTeamCountByProject(projectId: number): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT COUNT(*) AS cnt FROM teams WHERE project_id = ? AND status IN ('launching', 'running', 'idle', 'stuck')"
     );
     const row = stmt.get(projectId) as { cnt: number };
@@ -1100,7 +1119,7 @@ export class FleetDatabase {
    * Get queued teams for a project, ordered by creation time (FIFO).
    */
   getQueuedTeamsByProject(projectId: number): Team[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT * FROM teams WHERE project_id = ? AND status = 'queued' ORDER BY created_at ASC"
     );
     const rows = stmt.all(projectId) as Record<string, unknown>[];
@@ -1112,14 +1131,19 @@ export class FleetDatabase {
    * Used by the GitHub poller to check DB-persisted blockers for resolution.
    */
   getQueuedBlockedTeams(): Team[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT * FROM teams WHERE status = 'queued' AND blocked_by_json IS NOT NULL ORDER BY created_at ASC"
     );
     const rows = stmt.all() as Record<string, unknown>[];
     return rows.map((r) => this.mapTeamRow(r));
   }
 
-  updateTeam(id: number, fields: TeamUpdate): Team | undefined {
+  /**
+   * Update team fields without returning the updated record.
+   * Use when the caller discards the return value (fire-and-forget updates).
+   * Skips the trailing SELECT that `updateTeam()` performs.
+   */
+  updateTeamSilent(id: number, fields: TeamUpdate): void {
     const setClauses: string[] = [];
     const params: Record<string, unknown> = { id };
 
@@ -1196,13 +1220,17 @@ export class FleetDatabase {
       params.lastEventAt = fields.lastEventAt;
     }
 
-    if (setClauses.length === 0) return this.getTeam(id);
+    if (setClauses.length === 0) return;
 
     // Always update updated_at
     setClauses.push("updated_at = datetime('now')");
 
     const sql = `UPDATE teams SET ${setClauses.join(', ')} WHERE id = @id`;
     this.db.prepare(sql).run(params);
+  }
+
+  updateTeam(id: number, fields: TeamUpdate): Team | undefined {
+    this.updateTeamSilent(id, fields);
     return this.getTeam(id);
   }
 
@@ -1211,7 +1239,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   insertEvent(data: EventInsert): Event {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO events (team_id, session_id, agent_name, event_type, tool_name, payload)
       VALUES (@teamId, @sessionId, @agentName, @eventType, @toolName, @payload)
     `);
@@ -1225,7 +1253,7 @@ export class FleetDatabase {
       payload: data.payload ?? null,
     });
 
-    const row = this.db.prepare('SELECT * FROM events WHERE id = ?').get(
+    const row = this.stmt('SELECT * FROM events WHERE id = ?').get(
       Number(info.lastInsertRowid)
     ) as Record<string, unknown>;
     return this.mapEventRow(row);
@@ -1239,8 +1267,8 @@ export class FleetDatabase {
    * a failure in any write rolls back all of them — preventing partial state
    * (e.g., transition recorded but event lost).
    *
-   * Retries once on SQLITE_BUSY after the configured busy_timeout has
-   * already been exhausted (defense-in-depth).
+   * Logs a warning and re-throws on SQLITE_BUSY (the busy_timeout pragma
+   * is the correct retry mechanism; spin-waiting after it expires wastes CPU).
    */
   processEventTransaction(ops: {
     transition?: { teamId: number; fromStatus: TeamStatus; toStatus: TeamStatus; trigger: string; reason: string };
@@ -1252,7 +1280,7 @@ export class FleetDatabase {
     const runTransaction = this.db.transaction((txOps: typeof ops) => {
       // 1. Insert transition record (if transitioning)
       if (txOps.transition) {
-        this.db.prepare(
+        this.stmt(
           'INSERT INTO team_transitions (team_id, from_status, to_status, trigger, reason) VALUES (?, ?, ?, ?, ?)'
         ).run(
           txOps.transition.teamId,
@@ -1263,16 +1291,16 @@ export class FleetDatabase {
         );
       }
 
-      // 2. Update team status (if transitioning)
+      // 2. Update team status (if transitioning) — skip trailing SELECT
       if (txOps.statusUpdate) {
-        this.updateTeam(txOps.statusUpdate.teamId, txOps.statusUpdate.fields);
+        this.updateTeamSilent(txOps.statusUpdate.teamId, txOps.statusUpdate.fields);
       }
 
-      // 3. Update heartbeat (lastEventAt) — always required
-      this.updateTeam(txOps.heartbeatUpdate.teamId, { lastEventAt: txOps.heartbeatUpdate.lastEventAt });
+      // 3. Update heartbeat (lastEventAt) — always required, skip trailing SELECT
+      this.updateTeamSilent(txOps.heartbeatUpdate.teamId, { lastEventAt: txOps.heartbeatUpdate.lastEventAt });
 
       // 4. Insert event — always required
-      const eventInfo = this.db.prepare(`
+      const eventInfo = this.stmt(`
         INSERT INTO events (team_id, session_id, agent_name, event_type, tool_name, payload)
         VALUES (@teamId, @sessionId, @agentName, @eventType, @toolName, @payload)
       `).run({
@@ -1287,7 +1315,7 @@ export class FleetDatabase {
 
       // 5. Insert agent messages (if any), filling in the eventId
       if (txOps.agentMessages && txOps.agentMessages.length > 0) {
-        const msgStmt = this.db.prepare(`
+        const msgStmt = this.stmt(`
           INSERT INTO agent_messages (team_id, event_id, sender, recipient, summary, content, session_id)
           VALUES (@teamId, @eventId, @sender, @recipient, @summary, @content, @sessionId)
         `);
@@ -1307,18 +1335,12 @@ export class FleetDatabase {
       return { eventId };
     });
 
-    // Execute with single BUSY retry
     try {
       return runTransaction(ops);
     } catch (err: unknown) {
       const sqliteErr = err as { code?: string };
       if (sqliteErr.code === 'SQLITE_BUSY') {
-        // Synchronous spin-wait for 100ms then retry once
-        const start = Date.now();
-        while (Date.now() - start < 100) {
-          // spin
-        }
-        return runTransaction(ops);
+        console.warn('[DB] processEventTransaction: SQLITE_BUSY after busy_timeout exhausted');
       }
       throw err;
     }
@@ -1343,13 +1365,13 @@ export class FleetDatabase {
   }
 
   getEventsByTeamCount(teamId: number): number {
-    const stmt = this.db.prepare('SELECT COUNT(*) AS cnt FROM events WHERE team_id = ?');
+    const stmt = this.stmt('SELECT COUNT(*) AS cnt FROM events WHERE team_id = ?');
     const row = stmt.get(teamId) as { cnt: number };
     return row.cnt;
   }
 
   getLatestEventByTeam(teamId: number): Event | undefined {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       'SELECT * FROM events WHERE team_id = ? ORDER BY id DESC LIMIT 1'
     );
     const row = stmt.get(teamId) as Record<string, unknown> | undefined;
@@ -1447,7 +1469,7 @@ export class FleetDatabase {
       END
       ORDER BY MIN(created_at) ASC
     `;
-    const rows = this.db.prepare(sql).all(teamId) as Record<string, unknown>[];
+    const rows = this.stmt(sql).all(teamId) as Record<string, unknown>[];
     return rows.map((row) => {
       const name = row.name as string;
       const starts = (row.starts as number) ?? 0;
@@ -1469,7 +1491,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   insertAgentMessage(data: AgentMessageInsert): AgentMessage {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO agent_messages (team_id, event_id, sender, recipient, summary, content, session_id)
       VALUES (@teamId, @eventId, @sender, @recipient, @summary, @content, @sessionId)
     `);
@@ -1484,7 +1506,7 @@ export class FleetDatabase {
       sessionId: data.sessionId ?? null,
     });
 
-    const row = this.db.prepare('SELECT * FROM agent_messages WHERE id = ?').get(
+    const row = this.stmt('SELECT * FROM agent_messages WHERE id = ?').get(
       Number(info.lastInsertRowid)
     ) as Record<string, unknown>;
     return this.mapAgentMessageRow(row);
@@ -1532,7 +1554,7 @@ export class FleetDatabase {
       GROUP BY norm_sender, norm_recipient
       ORDER BY count DESC
     `;
-    const rows = this.db.prepare(sql).all(teamId) as Array<{
+    const rows = this.stmt(sql).all(teamId) as Array<{
       sender: string;
       recipient: string;
       count: number;
@@ -1551,7 +1573,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   insertPullRequest(data: PRInsert): PullRequest {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO pull_requests (pr_number, team_id, title, state, ci_status, merge_status, auto_merge, ci_fail_count, checks_json)
       VALUES (@prNumber, @teamId, @title, @state, @ciStatus, @mergeStatus, @autoMerge, @ciFailCount, @checksJson)
     `);
@@ -1572,13 +1594,13 @@ export class FleetDatabase {
   }
 
   getPullRequest(prNumber: number): PullRequest | undefined {
-    const stmt = this.db.prepare('SELECT * FROM pull_requests WHERE pr_number = ?');
+    const stmt = this.stmt('SELECT * FROM pull_requests WHERE pr_number = ?');
     const row = stmt.get(prNumber) as Record<string, unknown> | undefined;
     return row ? this.mapPRRow(row) : undefined;
   }
 
   getAllPullRequests(): PullRequest[] {
-    const stmt = this.db.prepare('SELECT * FROM pull_requests ORDER BY updated_at DESC');
+    const stmt = this.stmt('SELECT * FROM pull_requests ORDER BY updated_at DESC');
     const rows = stmt.all() as Record<string, unknown>[];
     return rows.map((r) => this.mapPRRow(r));
   }
@@ -1639,7 +1661,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   insertCommand(data: CommandInsert): Command {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO commands (team_id, target_agent, message)
       VALUES (@teamId, @targetAgent, @message)
     `);
@@ -1650,14 +1672,14 @@ export class FleetDatabase {
       message: data.message,
     });
 
-    const row = this.db.prepare('SELECT * FROM commands WHERE id = ?').get(
+    const row = this.stmt('SELECT * FROM commands WHERE id = ?').get(
       Number(info.lastInsertRowid)
     ) as Record<string, unknown>;
     return this.mapCommandRow(row);
   }
 
   getPendingCommands(teamId: number): Command[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       "SELECT * FROM commands WHERE team_id = ? AND status = 'pending' ORDER BY created_at ASC"
     );
     const rows = stmt.all(teamId) as Record<string, unknown>[];
@@ -1665,11 +1687,11 @@ export class FleetDatabase {
   }
 
   markCommandDelivered(id: number): Command | undefined {
-    this.db.prepare(
+    this.stmt(
       "UPDATE commands SET status = 'delivered', delivered_at = datetime('now') WHERE id = ?"
     ).run(id);
 
-    const row = this.db.prepare('SELECT * FROM commands WHERE id = ?').get(id) as Record<string, unknown> | undefined;
+    const row = this.stmt('SELECT * FROM commands WHERE id = ?').get(id) as Record<string, unknown> | undefined;
     return row ? this.mapCommandRow(row) : undefined;
   }
 
@@ -1678,7 +1700,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   insertUsageSnapshot(data: UsageInsert): UsageSnapshot {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO usage_snapshots (team_id, project_id, session_id, daily_percent, weekly_percent, sonnet_percent, extra_percent, daily_resets_at, weekly_resets_at, raw_output)
       VALUES (@teamId, @projectId, @sessionId, @dailyPercent, @weeklyPercent, @sonnetPercent, @extraPercent, @dailyResetsAt, @weeklyResetsAt, @rawOutput)
     `);
@@ -1696,14 +1718,14 @@ export class FleetDatabase {
       rawOutput: data.rawOutput ?? null,
     });
 
-    const row = this.db.prepare('SELECT * FROM usage_snapshots WHERE id = ?').get(
+    const row = this.stmt('SELECT * FROM usage_snapshots WHERE id = ?').get(
       Number(info.lastInsertRowid)
     ) as Record<string, unknown>;
     return this.mapUsageRow(row);
   }
 
   getLatestUsage(): UsageSnapshot | undefined {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       'SELECT * FROM usage_snapshots ORDER BY recorded_at DESC, id DESC LIMIT 1'
     );
     const row = stmt.get() as Record<string, unknown> | undefined;
@@ -1711,7 +1733,7 @@ export class FleetDatabase {
   }
 
   getUsageHistory(limit: number = 50): UsageSnapshot[] {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       'SELECT * FROM usage_snapshots ORDER BY recorded_at DESC, id DESC LIMIT ?'
     );
     const rows = stmt.all(limit) as Record<string, unknown>[];
@@ -1720,7 +1742,7 @@ export class FleetDatabase {
 
   getUsageByProject(projectId?: number): UsageSnapshot[] {
     if (projectId !== undefined) {
-      const stmt = this.db.prepare(
+      const stmt = this.stmt(
         'SELECT * FROM usage_snapshots WHERE project_id = ? ORDER BY recorded_at DESC, id DESC LIMIT 1'
       );
       const row = stmt.get(projectId) as Record<string, unknown> | undefined;
@@ -1728,7 +1750,7 @@ export class FleetDatabase {
     }
 
     // Latest snapshot per project_id
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       SELECT u.* FROM usage_snapshots u
       INNER JOIN (
         SELECT project_id, MAX(id) AS max_id
@@ -1750,7 +1772,7 @@ export class FleetDatabase {
    * Get a single message template by ID.
    */
   getMessageTemplate(id: string): { id: string; template: string; enabled: boolean } | undefined {
-    const stmt = this.db.prepare('SELECT id, template, enabled FROM message_templates WHERE id = ?');
+    const stmt = this.stmt('SELECT id, template, enabled FROM message_templates WHERE id = ?');
     const row = stmt.get(id) as { id: string; template: string; enabled: number } | undefined;
     if (!row) return undefined;
     return { id: row.id, template: row.template, enabled: row.enabled === 1 };
@@ -1760,7 +1782,7 @@ export class FleetDatabase {
    * Get all message templates.
    */
   getMessageTemplates(): MessageTemplate[] {
-    const stmt = this.db.prepare('SELECT * FROM message_templates ORDER BY id');
+    const stmt = this.stmt('SELECT * FROM message_templates ORDER BY id');
     const rows = stmt.all() as Array<{ id: string; template: string; enabled: number; updated_at: string }>;
     return rows.map((r) => ({
       id: r.id,
@@ -1804,7 +1826,7 @@ export class FleetDatabase {
     template: string;
     enabled?: boolean;
   }): void {
-    this.db.prepare(
+    this.stmt(
       `INSERT INTO message_templates (id, template, enabled)
        VALUES (@id, @template, @enabled)`
     ).run({
@@ -1819,7 +1841,7 @@ export class FleetDatabase {
    * user-edited templates are preserved across restarts.
    */
   initDefaultTemplates(defaults: { id: string; template: string }[]): void {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       'INSERT OR IGNORE INTO message_templates (id, template) VALUES (@id, @template)'
     );
 
@@ -1855,7 +1877,7 @@ export class FleetDatabase {
    * @param eventData - JSON-serialized array of StreamEvent objects
    */
   upsertStreamEvents(teamId: number, eventData: string): void {
-    this.db.prepare(`
+    this.stmt(`
       INSERT INTO stream_events (team_id, event_data, updated_at)
       VALUES (@teamId, @eventData, datetime('now'))
       ON CONFLICT(team_id) DO UPDATE SET
@@ -1869,7 +1891,7 @@ export class FleetDatabase {
    * Returns the JSON string, or null if no persisted events exist.
    */
   getStreamEvents(teamId: number): string | null {
-    const row = this.db.prepare(
+    const row = this.stmt(
       'SELECT event_data FROM stream_events WHERE team_id = ?'
     ).get(teamId) as { event_data: string } | undefined;
     return row?.event_data ?? null;
@@ -1879,7 +1901,7 @@ export class FleetDatabase {
    * Delete persisted stream events for a specific team.
    */
   deleteStreamEventsByTeam(teamId: number): void {
-    this.db.prepare('DELETE FROM stream_events WHERE team_id = ?').run(teamId);
+    this.stmt('DELETE FROM stream_events WHERE team_id = ?').run(teamId);
   }
 
   // -------------------------------------------------------------------------
@@ -1905,7 +1927,7 @@ export class FleetDatabase {
   }
 
   getTeamDashboardCount(): number {
-    const stmt = this.db.prepare('SELECT COUNT(*) AS cnt FROM v_team_dashboard');
+    const stmt = this.stmt('SELECT COUNT(*) AS cnt FROM v_team_dashboard');
     const row = stmt.get() as { cnt: number };
     return row.cnt;
   }
@@ -1916,7 +1938,7 @@ export class FleetDatabase {
    * @param stuckMinutes - minutes of silence before considered stuck (default: 5)
    */
   getStuckCandidates(idleMinutes: number = 3, stuckMinutes: number = 5): StuckCandidate[] {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       SELECT
         t.id,
         t.issue_number,
@@ -1980,7 +2002,7 @@ export class FleetDatabase {
       );
       return;
     }
-    this.db.prepare(
+    this.stmt(
       'INSERT INTO team_transitions (team_id, from_status, to_status, trigger, reason) VALUES (?, ?, ?, ?, ?)'
     ).run(data.teamId, data.fromStatus, data.toStatus, data.trigger, data.reason);
   }
@@ -1989,7 +2011,7 @@ export class FleetDatabase {
    * Get all transitions for a team, ordered by creation time ascending.
    */
   getTransitions(teamId: number): TeamTransition[] {
-    const rows = this.db.prepare(
+    const rows = this.stmt(
       'SELECT id, team_id, from_status, to_status, trigger, reason, created_at FROM team_transitions WHERE team_id = ? ORDER BY created_at ASC'
     ).all(teamId) as Array<{
       id: number;
@@ -2013,14 +2035,14 @@ export class FleetDatabase {
 
   deleteTeamsByProject(projectId: number): void {
     this.db.transaction((pid: number) => {
-      this.db.prepare('DELETE FROM stream_events WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM agent_messages WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM team_transitions WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM events WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM commands WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM usage_snapshots WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM pull_requests WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
-      this.db.prepare('DELETE FROM teams WHERE project_id = ?').run(pid);
+      this.stmt('DELETE FROM stream_events WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM agent_messages WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM team_transitions WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM events WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM commands WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM usage_snapshots WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM pull_requests WHERE team_id IN (SELECT id FROM teams WHERE project_id = ?)').run(pid);
+      this.stmt('DELETE FROM teams WHERE project_id = ?').run(pid);
     })(projectId);
   }
 
@@ -2034,14 +2056,14 @@ export class FleetDatabase {
    */
   deleteTeamAndRelated(teamId: number): void {
     this.db.transaction((id: number) => {
-      this.db.prepare('DELETE FROM stream_events WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM agent_messages WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM team_transitions WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM events WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM commands WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM usage_snapshots WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM pull_requests WHERE team_id = ?').run(id);
-      this.db.prepare('DELETE FROM teams WHERE id = ?').run(id);
+      this.stmt('DELETE FROM stream_events WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM agent_messages WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM team_transitions WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM events WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM commands WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM usage_snapshots WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM pull_requests WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM teams WHERE id = ?').run(id);
     })(teamId);
   }
 
@@ -2056,16 +2078,16 @@ export class FleetDatabase {
    */
   factoryReset(defaultTemplates: { id: string; template: string }[]): number {
     this.db.transaction(() => {
-      this.db.prepare('DELETE FROM stream_events').run();
-      this.db.prepare('DELETE FROM agent_messages').run();
-      this.db.prepare('DELETE FROM team_transitions').run();
-      this.db.prepare('DELETE FROM events').run();
-      this.db.prepare('DELETE FROM commands').run();
-      this.db.prepare('DELETE FROM usage_snapshots').run();
-      this.db.prepare('DELETE FROM pull_requests').run();
-      this.db.prepare('DELETE FROM teams').run();
-      this.db.prepare('DELETE FROM message_templates').run();
-      this.db.prepare('DELETE FROM projects').run();
+      this.stmt('DELETE FROM stream_events').run();
+      this.stmt('DELETE FROM agent_messages').run();
+      this.stmt('DELETE FROM team_transitions').run();
+      this.stmt('DELETE FROM events').run();
+      this.stmt('DELETE FROM commands').run();
+      this.stmt('DELETE FROM usage_snapshots').run();
+      this.stmt('DELETE FROM pull_requests').run();
+      this.stmt('DELETE FROM teams').run();
+      this.stmt('DELETE FROM message_templates').run();
+      this.stmt('DELETE FROM projects').run();
     })();
 
     // Re-seed default templates outside the transaction (uses its own)
@@ -2083,7 +2105,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldEvents(retentionDays: number, batchSize: number = 5000): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       `DELETE FROM events WHERE id IN (
         SELECT id FROM events WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
       )`
@@ -2103,7 +2125,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldUsageSnapshots(retentionDays: number, batchSize: number = 5000): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       `DELETE FROM usage_snapshots WHERE id IN (
         SELECT id FROM usage_snapshots WHERE recorded_at < datetime('now', '-' || @days || ' days') LIMIT @limit
       )`
@@ -2123,7 +2145,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldCommands(retentionDays: number, batchSize: number = 5000): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       `DELETE FROM commands WHERE id IN (
         SELECT id FROM commands WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
       )`
@@ -2143,7 +2165,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldTeamTransitions(retentionDays: number, batchSize: number = 5000): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       `DELETE FROM team_transitions WHERE id IN (
         SELECT id FROM team_transitions WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
       )`
@@ -2163,7 +2185,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldAgentMessages(retentionDays: number, batchSize: number = 5000): number {
-    const stmt = this.db.prepare(
+    const stmt = this.stmt(
       `DELETE FROM agent_messages WHERE id IN (
         SELECT id FROM agent_messages WHERE created_at < datetime('now', '-' || @days || ' days') LIMIT @limit
       )`
@@ -2185,7 +2207,7 @@ export class FleetDatabase {
    * Returns total number of rows deleted.
    */
   purgeOldStreamEvents(retentionDays: number): number {
-    const result = this.db.prepare(
+    const result = this.stmt(
       `DELETE FROM stream_events WHERE team_id IN (
         SELECT id FROM teams
         WHERE stopped_at IS NOT NULL
@@ -2201,8 +2223,11 @@ export class FleetDatabase {
 
   /**
    * Properly close the database connection.
+   * Clears the statement cache first since prepared statements become
+   * invalid after the database is closed.
    */
   close(): void {
+    this.stmtCache.clear();
     this.db.close();
   }
 
@@ -2390,7 +2415,7 @@ export class FleetDatabase {
     status: string;
     owner: string;
   }): TeamTask {
-    const stmt = this.db.prepare(`
+    const stmt = this.stmt(`
       INSERT INTO team_tasks (team_id, task_id, subject, description, status, owner)
       VALUES (@teamId, @taskId, @subject, @description, @status, @owner)
       ON CONFLICT(team_id, task_id) DO UPDATE SET
@@ -2410,7 +2435,7 @@ export class FleetDatabase {
       owner: data.owner,
     });
 
-    const row = this.db.prepare(
+    const row = this.stmt(
       'SELECT * FROM team_tasks WHERE team_id = ? AND task_id = ?'
     ).get(data.teamId, data.taskId) as Record<string, unknown>;
 
@@ -2421,7 +2446,7 @@ export class FleetDatabase {
    * Get all tasks for a team, ordered by id ascending.
    */
   getTeamTasks(teamId: number): TeamTask[] {
-    const rows = this.db.prepare(
+    const rows = this.stmt(
       'SELECT * FROM team_tasks WHERE team_id = ? ORDER BY id ASC'
     ).all(teamId) as Record<string, unknown>[];
 

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -268,7 +268,7 @@ CREATE TABLE IF NOT EXISTS stream_events (
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_stream_events_team ON stream_events(team_id);
+-- Note: no explicit index on team_id — SQLite auto-creates one for the UNIQUE constraint.
 
 -- ---------------------------------------------------------------------------
 -- TEAM TASKS — task items from TL's task list (TaskCreated hook / TodoWrite)

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -72,6 +72,7 @@ export interface EventCollectorDb {
     payload: string;
   }): { id: number };
   updateTeam(teamId: number, fields: Record<string, unknown>): void;
+  updateTeamSilent(teamId: number, fields: Record<string, unknown>): void;
   insertTransition(data: { teamId: number; fromStatus: TeamStatus; toStatus: TeamStatus; trigger: string; reason: string }): void;
   insertAgentMessage(data: {
     teamId: number;
@@ -402,9 +403,9 @@ export function processEvent(
         db.insertTransition(transitionData);
       }
       if (statusUpdateData) {
-        db.updateTeam(statusUpdateData.teamId, statusUpdateData.fields);
+        db.updateTeamSilent(statusUpdateData.teamId, statusUpdateData.fields);
       }
-      db.updateTeam(teamId, { lastEventAt: nowIso });
+      db.updateTeamSilent(teamId, { lastEventAt: nowIso });
       if (previousStatus !== undefined) {
         sse.broadcast('team_status_changed', {
           team_id: teamId,

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -196,7 +196,7 @@ class GitHubPoller {
                 console.log(
                   `[GitHubPoller] Branch name updated for team ${team.id}: "${team.branchName}" -> "${actualBranch}"`
                 );
-                db.updateTeam(team.id, { branchName: actualBranch });
+                db.updateTeamSilent(team.id, { branchName: actualBranch });
                 team.branchName = actualBranch;
               }
             }
@@ -311,7 +311,7 @@ class GitHubPoller {
 
         // PR status changes count as team activity — update lastEventAt
         // so the stuck-detector knows the team is not truly idle.
-        db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
+        db.updateTeamSilent(teamId, { lastEventAt: new Date().toISOString() });
 
         sseBroker.broadcast(
           'pr_updated',
@@ -458,7 +458,7 @@ class GitHubPoller {
           trigger: 'poller',
           reason: `PR #${prNumber} merged`,
         });
-        db.updateTeam(teamId, { status: 'done', phase: 'done', stoppedAt: new Date().toISOString() });
+        db.updateTeamSilent(teamId, { status: 'done', phase: 'done', stoppedAt: new Date().toISOString() });
         sseBroker.broadcast(
           'team_status_changed',
           {
@@ -503,7 +503,7 @@ class GitHubPoller {
           trigger: 'poller',
           reason: `CI blocked: ${ciFailCount} unique CI failure types on PR #${prNumber}`,
         });
-        db.updateTeam(teamId, { phase: 'blocked', status: 'stuck' });
+        db.updateTeamSilent(teamId, { phase: 'blocked', status: 'stuck' });
 
         sseBroker.broadcast(
           'team_status_changed',
@@ -606,7 +606,7 @@ class GitHubPoller {
           const deps = await fetcher.fetchDependenciesForIssue(team.projectId, team.issueNumber);
           if (deps && deps.resolved) {
             // All blockers resolved — clear blocked_by_json and broadcast
-            db.updateTeam(team.id, { blockedByJson: null });
+            db.updateTeamSilent(team.id, { blockedByJson: null });
 
             sseBroker.broadcast('dependency_resolved', {
               issue_number: team.issueNumber,
@@ -766,7 +766,7 @@ class GitHubPoller {
       if (prevPhase && prevPhase !== 'pr' && prevPhase !== 'done') {
         updateFields.phase = 'pr';
       }
-      db.updateTeam(teamId, updateFields);
+      db.updateTeamSilent(teamId, updateFields);
 
       // Broadcast phase change if it advanced
       if (team && prevPhase && prevPhase !== 'pr' && prevPhase !== 'done') {

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -926,7 +926,7 @@ export class ProjectService {
     // Mark queued teams as failed before deletion
     const queuedTeams = db.getQueuedTeamsByProject(projectId);
     for (const t of queuedTeams) {
-      db.updateTeam(t.id, { status: 'failed' });
+      db.updateTeamSilent(t.id, { status: 'failed' });
     }
 
     // Stop all active teams for this project

--- a/src/server/services/startup-recovery.ts
+++ b/src/server/services/startup-recovery.ts
@@ -46,7 +46,7 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: 'Server restart recovery: no PID recorded',
       });
-      db.updateTeam(team.id, { status: 'idle', lastEventAt: new Date().toISOString() });
+      db.updateTeamSilent(team.id, { status: 'idle', lastEventAt: new Date().toISOString() });
       continue;
     }
 
@@ -58,7 +58,7 @@ export async function recoverOnStartup(): Promise<void> {
       console.log(
         `[recovery] Team ${team.worktreeName} (PID ${team.pid}) still running`
       );
-      db.updateTeam(team.id, { lastEventAt: new Date().toISOString() });
+      db.updateTeamSilent(team.id, { lastEventAt: new Date().toISOString() });
     } else {
       // Process is gone.  If it was still launching when we lost track,
       // treat it as a failure; otherwise just mark idle.
@@ -73,7 +73,7 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: `Server restart recovery: process (PID ${team.pid}) no longer alive`,
       });
-      db.updateTeam(team.id, { status: newStatus, pid: null, lastEventAt: new Date().toISOString() });
+      db.updateTeamSilent(team.id, { status: newStatus, pid: null, lastEventAt: new Date().toISOString() });
     }
   }
 

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -100,7 +100,7 @@ class StuckDetector {
             trigger: 'timer',
             reason: `Launch timeout after ${Math.round(launchMinutes)} minutes`,
           });
-          db.updateTeam(team.id, { status: 'failed' });
+          db.updateTeamSilent(team.id, { status: 'failed' });
 
           sseBroker.broadcast(
             'team_status_changed',
@@ -179,7 +179,7 @@ class StuckDetector {
               ? `No events for ${Math.round(idleMinutes)} minutes`
               : `Idle for ${Math.round(idleMinutes)} minutes (stuck threshold exceeded)`,
           });
-          db.updateTeam(team.id, { status: newStatus as 'idle' | 'stuck' });
+          db.updateTeamSilent(team.id, { status: newStatus as 'idle' | 'stuck' });
 
           sseBroker.broadcast(
             'team_status_changed',

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -270,7 +270,7 @@ export class TeamManager {
       // Relaunch: reset the existing terminal team record
       console.log(`[TeamManager] Relaunching existing team record: id=${relaunchTeamId}, worktree=${worktreeName}`);
       const prevTeam = db.getTeam(relaunchTeamId);
-      db.updateTeam(relaunchTeamId, {
+      db.updateTeamSilent(relaunchTeamId, {
         status: 'queued',
         phase: 'init',
         pid: null,
@@ -331,7 +331,7 @@ export class TeamManager {
       trigger: 'system',
       reason: 'Worktree created, spawning Claude Code process',
     });
-    db.updateTeam(team.id, { status: 'launching' });
+    db.updateTeamSilent(team.id, { status: 'launching' });
     this.broadcastSnapshot();
 
     // ── Step 3: Copy hook scripts and settings into worktree ──
@@ -367,13 +367,13 @@ export class TeamManager {
         trigger: 'system',
         reason: 'Spawn failed: no PID returned',
       });
-      db.updateTeam(team.id, { status: 'failed', stoppedAt: new Date().toISOString() });
+      db.updateTeamSilent(team.id, { status: 'failed', stoppedAt: new Date().toISOString() });
       this.broadcastSnapshot();
       throw new Error('Failed to spawn Claude Code process — no PID returned');
     }
 
     console.log(`[TeamManager] Process spawned: PID ${pid} (headless=${isHeadless})`);
-    db.updateTeam(team.id, { pid });
+    db.updateTeamSilent(team.id, { pid });
     this.broadcastSnapshot();
     this.childProcesses.set(team.id, child);
 
@@ -416,7 +416,7 @@ export class TeamManager {
         trigger: 'pm_action',
         reason: 'PM stopped queued team',
       });
-      db.updateTeam(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
+      db.updateTeamSilent(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
       this.broadcastSnapshot();
       return db.getTeam(teamId)!;
     }
@@ -518,7 +518,7 @@ export class TeamManager {
         trigger: 'pm_action',
         reason: `Resume queued (${activeCount}/${project.maxActiveTeams} active)`,
       });
-      db.updateTeam(teamId, { status: 'queued' });
+      db.updateTeamSilent(teamId, { status: 'queued' });
       console.log(`[TeamManager] Resume queued for team ${teamId} (${activeCount}/${project.maxActiveTeams} active)`);
       this.broadcastSnapshot();
       return db.getTeam(teamId)!;
@@ -540,7 +540,7 @@ export class TeamManager {
       trigger: 'pm_action',
       reason: 'PM resumed team',
     });
-    db.updateTeam(teamId, {
+    db.updateTeamSilent(teamId, {
       status: 'launching',
       launchedAt: new Date().toISOString(),
       stoppedAt: null,
@@ -566,13 +566,13 @@ export class TeamManager {
         trigger: 'system',
         reason: 'Spawn failed: no PID returned',
       });
-      db.updateTeam(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
+      db.updateTeamSilent(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
       this.broadcastSnapshot();
       throw new Error('Failed to spawn Claude Code process — no PID returned');
     }
 
     console.log(`[TeamManager] Resume process spawned: PID ${pid}`);
-    db.updateTeam(teamId, { pid });
+    db.updateTeamSilent(teamId, { pid });
     this.broadcastSnapshot();
     this.childProcesses.set(teamId, child);
 
@@ -743,7 +743,7 @@ export class TeamManager {
       }
       // Terminal state (failed) — reuse the existing team record as queued
       const now = new Date().toISOString();
-      db.updateTeam(existing.id, {
+      db.updateTeamSilent(existing.id, {
         status: 'queued',
         phase: 'init',
         pid: null,
@@ -853,7 +853,7 @@ export class TeamManager {
       }
       // Terminal state (failed) — reuse the existing team record as queued
       const now = new Date().toISOString();
-      db.updateTeam(existing.id, {
+      db.updateTeamSilent(existing.id, {
         status: 'queued',
         phase: 'init',
         pid: null,
@@ -949,7 +949,7 @@ export class TeamManager {
       trigger: 'pm_action',
       reason: 'PM force-launched team',
     });
-    db.updateTeam(teamId, { status: 'launching' });
+    db.updateTeamSilent(teamId, { status: 'launching' });
     this.broadcastSnapshot();
 
     // Delegate to the existing private launch method
@@ -1003,7 +1003,7 @@ export class TeamManager {
           trigger: 'system',
           reason: 'Slot available, dequeuing team',
         });
-        db.updateTeam(team.id, { status: 'launching' });
+        db.updateTeamSilent(team.id, { status: 'launching' });
         try {
           await this.launchQueued(team);
         } catch (err: unknown) {
@@ -1195,7 +1195,7 @@ export class TeamManager {
     console.log(`[TeamManager] Worktree created for dequeued team: ${team.worktreeName}`);
 
     // Clear blocker metadata now that the team is being launched
-    db.updateTeam(team.id, { status: 'launching', blockedByJson: null });
+    db.updateTeamSilent(team.id, { status: 'launching', blockedByJson: null });
     this.broadcastSnapshot();
 
     // ── Step 2: Copy hooks and settings ──
@@ -1231,13 +1231,13 @@ export class TeamManager {
         trigger: 'system',
         reason: 'Spawn failed: no PID returned',
       });
-      db.updateTeam(team.id, { status: 'failed', stoppedAt: new Date().toISOString() });
+      db.updateTeamSilent(team.id, { status: 'failed', stoppedAt: new Date().toISOString() });
       this.broadcastSnapshot();
       return;
     }
 
     console.log(`[TeamManager] Dequeued team ${team.id} spawned: PID ${pid} (headless=${isHeadless})`);
-    db.updateTeam(team.id, { pid });
+    db.updateTeamSilent(team.id, { pid });
     this.broadcastSnapshot();
     this.childProcesses.set(team.id, child);
 
@@ -1317,7 +1317,7 @@ export class TeamManager {
       if (!team || ['done', 'failed'].includes(team.status)) continue;
       const lastEventMs = team.lastEventAt ? new Date(team.lastEventAt).getTime() : 0;
       if (lastTs > lastEventMs) {
-        db.updateTeam(teamId, { lastEventAt: new Date(lastTs).toISOString() });
+        db.updateTeamSilent(teamId, { lastEventAt: new Date(lastTs).toISOString() });
       }
     }
   }
@@ -1460,7 +1460,7 @@ export class TeamManager {
 
         // Set stoppedAt and broadcast
         if (team && !team.stoppedAt) {
-          db.updateTeam(teamId, {
+          db.updateTeamSilent(teamId, {
             pid: null,
             stoppedAt: new Date().toISOString(),
           });
@@ -1611,7 +1611,7 @@ export class TeamManager {
       trigger: 'system',
       reason: 'Interactive terminal window opened',
     });
-    db.updateTeam(team.id, { status: 'running' });
+    db.updateTeamSilent(team.id, { status: 'running' });
     this.broadcastSnapshot();
 
     sseBroker.broadcast(
@@ -1649,7 +1649,7 @@ export class TeamManager {
             ? 'Process exited normally (code 0)'
             : `Process exited with code ${code}${signal ? `, signal ${signal}` : ''}`,
         });
-        db.updateTeam(teamId, {
+        db.updateTeamSilent(teamId, {
           status: exitStatus,
           pid: null,
           stoppedAt: new Date().toISOString(),
@@ -1683,7 +1683,7 @@ export class TeamManager {
           trigger: 'system',
           reason: `Process error: ${err.message.slice(0, 200)}`,
         });
-        db.updateTeam(teamId, {
+        db.updateTeamSilent(teamId, {
           status: 'failed',
           pid: null,
           stoppedAt: new Date().toISOString(),
@@ -1774,7 +1774,7 @@ export class TeamManager {
           trigger: 'system',
           reason: `Worktree creation failed: ${msg.slice(0, 200)}`,
         });
-        db.updateTeam(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
+        db.updateTeamSilent(teamId, { status: 'failed', stoppedAt: new Date().toISOString() });
         this.broadcastSnapshot();
         return false;
       }
@@ -2120,7 +2120,7 @@ export class TeamManager {
                     trigger: 'system',
                     reason: 'Stdout stream event received (hook fallback)',
                   });
-                  db.updateTeam(teamId, { status: 'running', lastEventAt: new Date().toISOString() });
+                  db.updateTeamSilent(teamId, { status: 'running', lastEventAt: new Date().toISOString() });
                   sseBroker.broadcast('team_status_changed', {
                     team_id: teamId,
                     status: 'running',
@@ -2150,7 +2150,7 @@ export class TeamManager {
 
                       if (targetPhase && shouldAdvancePhase(currentTeam.phase, targetPhase)) {
                         const prevPhase = currentTeam.phase;
-                        db.updateTeam(teamId, { phase: targetPhase });
+                        db.updateTeamSilent(teamId, { phase: targetPhase });
                         sseBroker.broadcast('team_status_changed', {
                           team_id: teamId,
                           status: currentTeam.status,
@@ -2298,7 +2298,7 @@ export class TeamManager {
 
     try {
       const db = getDatabase();
-      db.updateTeam(teamId, {
+      db.updateTeamSilent(teamId, {
         totalInputTokens: counter.inputTokens,
         totalOutputTokens: counter.outputTokens,
         totalCacheCreationTokens: counter.cacheCreationTokens,

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -466,7 +466,7 @@ export class TeamService {
     const delivered = manager.sendMessage(teamId, message.trim(), 'user');
     if (delivered) {
       db.markCommandDelivered(command.id);
-      db.updateTeam(teamId, { lastEventAt: new Date().toISOString() });
+      db.updateTeamSilent(teamId, { lastEventAt: new Date().toISOString() });
     }
 
     return { command, delivered };

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -1149,6 +1149,174 @@ describe('Schema includes stream_events', () => {
 
 });
 
+// =============================================================================
+// Statement caching
+// =============================================================================
+
+describe('Statement caching', () => {
+  it('returns the same results on repeated calls (cache hit)', () => {
+    const project = db.insertProject({
+      name: 'cache-test',
+      repoPath: '/tmp/cache-test',
+    });
+
+    // Two sequential calls with the same SQL should both return the project
+    const first = db.getProject(project.id);
+    const second = db.getProject(project.id);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first!.id).toBe(second!.id);
+    expect(first!.name).toBe(second!.name);
+  });
+
+  it('close() clears the statement cache without errors', () => {
+    // Insert data to exercise cached statements
+    db.insertProject({ name: 'close-cache', repoPath: '/tmp/close-cache' });
+    db.getProjects();
+
+    // close() should clear cache and close DB without errors
+    expect(() => db.close()).not.toThrow();
+
+    // After close, operations should fail
+    expect(() => db.getProjects()).toThrow();
+  });
+});
+
+// =============================================================================
+// updateTeamSilent
+// =============================================================================
+
+describe('updateTeamSilent', () => {
+  it('updates team fields without returning a value', () => {
+    const project = db.insertProject({
+      name: 'silent-test',
+      repoPath: '/tmp/silent-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 999,
+      worktreeName: 'silent-test-999',
+      projectId: project.id,
+    });
+
+    // updateTeamSilent returns void
+    const result = db.updateTeamSilent(team.id, { status: 'running', phase: 'implementing' });
+    expect(result).toBeUndefined();
+
+    // Verify the update was persisted
+    const updated = db.getTeam(team.id);
+    expect(updated!.status).toBe('running');
+    expect(updated!.phase).toBe('implementing');
+  });
+
+  it('does nothing when fields are empty', () => {
+    const project = db.insertProject({
+      name: 'silent-empty',
+      repoPath: '/tmp/silent-empty',
+    });
+    const team = db.insertTeam({
+      issueNumber: 998,
+      worktreeName: 'silent-empty-998',
+      projectId: project.id,
+    });
+
+    // Should not throw and should not modify the team
+    const result = db.updateTeamSilent(team.id, {});
+    expect(result).toBeUndefined();
+
+    const unchanged = db.getTeam(team.id);
+    expect(unchanged!.status).toBe('queued');
+  });
+
+  it('updateTeam delegates to updateTeamSilent and returns the team', () => {
+    const project = db.insertProject({
+      name: 'delegate-test',
+      repoPath: '/tmp/delegate-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 997,
+      worktreeName: 'delegate-test-997',
+      projectId: project.id,
+    });
+
+    // updateTeam should return the updated team
+    const updated = db.updateTeam(team.id, { status: 'launching' });
+    expect(updated).toBeDefined();
+    expect(updated!.status).toBe('launching');
+  });
+});
+
+// =============================================================================
+// processEventTransaction — SQLITE_BUSY behavior
+// =============================================================================
+
+describe('processEventTransaction', () => {
+  it('inserts event and transition atomically', () => {
+    const project = db.insertProject({
+      name: 'txn-test',
+      repoPath: '/tmp/txn-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 900,
+      worktreeName: 'txn-test-900',
+      projectId: project.id,
+      status: 'launching',
+    });
+
+    const { eventId } = db.processEventTransaction({
+      transition: {
+        teamId: team.id,
+        fromStatus: 'launching',
+        toStatus: 'running',
+        trigger: 'hook',
+        reason: 'First event received',
+      },
+      statusUpdate: {
+        teamId: team.id,
+        fields: { status: 'running' },
+      },
+      heartbeatUpdate: {
+        teamId: team.id,
+        lastEventAt: new Date().toISOString(),
+      },
+      eventInsert: {
+        teamId: team.id,
+        sessionId: 'sess-1',
+        agentName: 'team-lead',
+        eventType: 'session_start',
+        payload: '{}',
+      },
+    });
+
+    expect(eventId).toBeGreaterThan(0);
+
+    // Verify the team status was updated
+    const updated = db.getTeam(team.id);
+    expect(updated!.status).toBe('running');
+
+    // Verify the transition was recorded
+    const transitions = db.getTransitions(team.id);
+    expect(transitions.length).toBe(1);
+    expect(transitions[0]!.fromStatus).toBe('launching');
+    expect(transitions[0]!.toStatus).toBe('running');
+  });
+});
+
+// =============================================================================
+// Redundant index removal
+// =============================================================================
+
+describe('Schema indexes', () => {
+  it('does not create redundant idx_stream_events_team index', () => {
+    const indexes = db.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_stream_events_team'")
+      .all() as { name: string }[];
+
+    // The explicit index should NOT exist because the UNIQUE constraint
+    // on team_id already creates an automatic unique index.
+    expect(indexes).toHaveLength(0);
+  });
+});
+
 describe('Connection management', () => {
   it('closes the database', () => {
     db.close();

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -69,6 +69,7 @@ function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
     getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
     insertEvent,
     updateTeam,
+    updateTeamSilent: updateTeam,
     insertTransition,
     insertAgentMessage,
     processEventTransaction,

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -23,6 +23,7 @@ const mockDb = {
   getTeams: vi.fn().mockReturnValue([]),
   getPullRequest: vi.fn(),
   updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
   updatePullRequest: vi.fn(),
   insertPullRequest: vi.fn(),
   insertTransition: vi.fn(),
@@ -204,7 +205,7 @@ describe('PR state transitions', () => {
         reason: expect.stringContaining('merged'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({
         status: 'done',
@@ -586,7 +587,7 @@ describe('CI failure counting', () => {
         reason: expect.stringContaining('CI blocked'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ phase: 'blocked', status: 'stuck' }),
     );
@@ -613,7 +614,7 @@ describe('PR detection by branch', () => {
     await githubPoller.poll();
 
     // detectPR now also advances phase to 'pr' when the current phase allows it
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { prNumber: 55, phase: 'pr' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { prNumber: 55, phase: 'pr' });
     expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
       'team_status_changed',
       expect.objectContaining({ team_id: 1, phase: 'pr', previous_phase: 'implementing' }),
@@ -632,7 +633,7 @@ describe('PR detection by branch', () => {
 
     await githubPoller.poll();
 
-    expect(mockDb.updateTeam).not.toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(
       1,
       expect.objectContaining({ prNumber: expect.anything() }),
     );
@@ -976,7 +977,7 @@ describe('Branch detection', () => {
 
     await githubPoller.poll();
 
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { branchName: 'new-branch' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { branchName: 'new-branch' });
   });
 });
 

--- a/tests/server/startup-recovery.test.ts
+++ b/tests/server/startup-recovery.test.ts
@@ -18,6 +18,7 @@ const mockDb = {
   getTeamByWorktree: vi.fn(),
   getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
   updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
   insertTransition: vi.fn(),
 };
 
@@ -140,7 +141,7 @@ describe('Dead PID recovery', () => {
         reason: expect.stringContaining('no longer alive'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, expect.objectContaining({
       status: 'idle',
       pid: null,
     }));
@@ -161,7 +162,7 @@ describe('Dead PID recovery', () => {
         trigger: 'system',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(2, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(2, expect.objectContaining({
       status: 'failed',
       pid: null,
     }));
@@ -182,7 +183,7 @@ describe('Dead PID recovery', () => {
         trigger: 'system',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(3, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(3, expect.objectContaining({
       status: 'idle',
       pid: null,
     }));
@@ -203,7 +204,7 @@ describe('Dead PID recovery', () => {
         trigger: 'system',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(4, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(4, expect.objectContaining({
       status: 'idle',
       pid: null,
     }));
@@ -225,11 +226,11 @@ describe('Alive PID recovery', () => {
     // Should not change status
     expect(mockDb.insertTransition).not.toHaveBeenCalled();
     // Should update lastEventAt
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(5, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(5, expect.objectContaining({
       lastEventAt: expect.any(String),
     }));
     // Should NOT set status or pid
-    const updateCall = mockDb.updateTeam.mock.calls[0]![1];
+    const updateCall = mockDb.updateTeamSilent.mock.calls[0]![1];
     expect(updateCall).not.toHaveProperty('status');
     expect(updateCall).not.toHaveProperty('pid');
   });
@@ -255,7 +256,7 @@ describe('No PID recovery', () => {
         reason: expect.stringContaining('no PID'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(6, expect.objectContaining({
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(6, expect.objectContaining({
       status: 'idle',
     }));
   });
@@ -267,7 +268,7 @@ describe('No PID recovery', () => {
     await recoverOnStartup();
 
     expect(mockDb.insertTransition).not.toHaveBeenCalled();
-    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -12,6 +12,7 @@ import type { Team } from '../../src/shared/types.js';
 const mockDb = {
   getActiveTeams: vi.fn<() => Partial<Team>[]>().mockReturnValue([]),
   updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
   insertTransition: vi.fn(),
   getPullRequest: vi.fn(),
 };
@@ -117,7 +118,7 @@ describe('Launch timeout detection', () => {
         reason: expect.stringContaining('Launch timeout'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'failed' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'failed' });
   });
 
   it('does NOT transition launching team with recent launchedAt', () => {
@@ -131,7 +132,7 @@ describe('Launch timeout detection', () => {
     stuckDetector.check();
 
     expect(mockDb.insertTransition).not.toHaveBeenCalled();
-    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
   });
 
   it('broadcasts SSE on launching -> failed', () => {
@@ -180,7 +181,7 @@ describe('Launch timeout detection', () => {
 
     // Should not throw
     expect(() => stuckDetector.check()).not.toThrow();
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'failed' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'failed' });
   });
 
   it('guards against launchedAt === null', () => {
@@ -195,7 +196,7 @@ describe('Launch timeout detection', () => {
 
     // Should skip this team entirely
     expect(mockDb.insertTransition).not.toHaveBeenCalled();
-    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
   });
 });
 
@@ -250,7 +251,7 @@ describe('Existing idle/stuck detection', () => {
         trigger: 'timer',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'idle' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'idle' });
   });
 
   it('transitions idle -> stuck when lastEventAt exceeds stuck threshold', () => {
@@ -269,7 +270,7 @@ describe('Existing idle/stuck detection', () => {
         trigger: 'timer',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'stuck' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
   });
 });
 
@@ -314,7 +315,7 @@ describe('Idle nudge message', () => {
     stuckDetector.check();
 
     // Transition should still happen
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(1, { status: 'idle' });
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'idle' });
     // But no message sent
     expect(mockManager.sendMessage).not.toHaveBeenCalled();
   });
@@ -358,7 +359,7 @@ describe('Idle nudge message', () => {
     stuckDetector.check();
 
     // Transition should be skipped entirely (CI pending)
-    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
     expect(mockManager.sendMessage).not.toHaveBeenCalled();
 
     // Reset mocks

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -22,6 +22,7 @@ const mockDb = vi.hoisted(() => ({
   getActiveTeamCountByProject: vi.fn().mockReturnValue(0),
   getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
   updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
   insertTransition: vi.fn(),
   getPullRequest: vi.fn(),
   insertEvent: vi.fn(),
@@ -161,7 +162,6 @@ describe('TeamManager.stop', () => {
   it('cancels a queued team by marking it failed', async () => {
     const team = makeTeam({ id: 1, status: 'queued', pid: null });
     mockDb.getTeam.mockReturnValue(team);
-    mockDb.updateTeam.mockReturnValue(team);
 
     await tm.stop(1);
 
@@ -173,7 +173,7 @@ describe('TeamManager.stop', () => {
         trigger: 'pm_action',
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ status: 'failed' }),
     );
@@ -354,7 +354,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
         reason: expect.stringContaining('code 0'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ status: 'done', pid: null }),
     );
@@ -384,7 +384,7 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
         reason: expect.stringContaining('code 1'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ status: 'failed', pid: null }),
     );
@@ -507,7 +507,7 @@ describe('TeamManager.attachProcessHandlers (error)', () => {
         reason: expect.stringContaining('ENOENT'),
       }),
     );
-    expect(mockDb.updateTeam).toHaveBeenCalledWith(
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ status: 'failed', pid: null }),
     );

--- a/tests/server/team-manager-process-queue.test.ts
+++ b/tests/server/team-manager-process-queue.test.ts
@@ -20,6 +20,7 @@ const mockDb = {
   getQueuedTeamsByProject: vi.fn(),
   getTeam: vi.fn(),
   updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
   insertTransition: vi.fn(),
 };
 
@@ -176,7 +177,7 @@ describe('TeamManager.processQueue re-drain', () => {
       .mockReturnValueOnce([team2])  // second processQueue (re-drain): find queued teams
       .mockReturnValueOnce([]);      // second finally: re-drain check
 
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // Run the first processQueue — it should launch team1, then re-drain and launch team2
@@ -204,7 +205,7 @@ describe('TeamManager.processQueue re-drain', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([team1])  // processQueue: 1 queued
       .mockReturnValueOnce([]);      // finally: no more queued
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     await tm.processQueue(1);
@@ -229,7 +230,7 @@ describe('TeamManager.processQueue re-drain', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([interactiveTeam, headlessTeam])  // processQueue: 2 queued
       .mockReturnValueOnce([]);  // finally: no more queued
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     await tm.processQueue(1);
@@ -271,7 +272,7 @@ describe('TeamManager.processQueue re-drain', () => {
       .mockReturnValueOnce([team2])  // first finally: re-drain check
       .mockReturnValueOnce([team2])  // second processQueue (re-drain)
       .mockReturnValueOnce([]);      // second finally
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // Start processQueue — it will start the async filterUnblockedTeams
@@ -350,7 +351,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
       .mockReturnValueOnce([blockedTeam])  // first finally: blocked team still queued
       .mockReturnValueOnce([blockedTeam]); // second processQueue (re-drain)
     // No 4th value needed: re-drain stops when launchedCount=0
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // unblockedTeam has no open deps; blockedTeam has open deps
@@ -395,7 +396,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([team])
       .mockReturnValueOnce([]);
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // Dependencies exist but are all closed
@@ -425,7 +426,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([team])
       .mockReturnValueOnce([]);
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // Dependency fetch fails — returns null
@@ -450,7 +451,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([team])
       .mockReturnValueOnce([]);
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // Dependency fetch throws
@@ -477,7 +478,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([team1, team2, team3])
       .mockReturnValueOnce([team2, team3]);
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     // All teams unblocked
@@ -509,7 +510,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([blockedTeam, unblockedTeam1, unblockedTeam2])
       .mockReturnValueOnce([blockedTeam]); // finally: blocked team still queued
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     mockFetchDependenciesForIssue.mockImplementation(async (_projectId: number, issueNumber: number) => {
@@ -545,7 +546,7 @@ describe('TeamManager.processQueue dependency filtering', () => {
     mockDb.getQueuedTeamsByProject
       .mockReturnValueOnce([blockedTeam])
       .mockReturnValueOnce([blockedTeam]);
-    mockDb.updateTeam.mockReturnValue(undefined);
+    mockDb.updateTeamSilent.mockReturnValue(undefined);
     mockDb.insertTransition.mockReturnValue(undefined);
 
     mockFetchDependenciesForIssue.mockResolvedValue({


### PR DESCRIPTION
Closes #518

## Summary
- **Cache prepared statements**: Added `stmtCache` Map and `stmt()` helper to `FleetDatabase`. All ~63 static-SQL `prepare()` calls now use the cache, avoiding repeated SQL parsing on every event/poll/API cycle. Dynamic UPDATE methods and migration code remain uncached.
- **Remove spin-wait on SQLITE_BUSY**: Replaced the 100ms synchronous busy-loop in `processEventTransaction` with a log warning and immediate re-throw. The `busy_timeout = 5000` pragma already handles BUSY correctly.
- **Add `updateTeamSilent`**: New method performs UPDATE without trailing SELECT. `updateTeam` delegates to it internally. 36 fire-and-forget call sites across 7 service files switched to the silent variant, eliminating ~36 unnecessary SELECT queries per update cycle.
- **Remove redundant index**: Dropped `idx_stream_events_team` from `schema.sql` and migration — the UNIQUE constraint on `team_id` already auto-creates an equivalent index.

## Test plan
- [x] 7 new tests: statement caching, `updateTeamSilent` behavior, `processEventTransaction` happy path, index absence verification
- [x] `npm test` passes (server tests)
- [x] `npx tsc --noEmit` passes with no type errors
- [x] All existing test mocks updated for `updateTeamSilent`