### PR TITLE
Issue #521: Eliminate duplicate SSE connections via FleetContext dispatcher

### DIFF
--- a/src/client/components/UnifiedTimeline.tsx
+++ b/src/client/components/UnifiedTimeline.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, useReducer } from 'react';
 import { useApi } from '../hooks/useApi';
-import { useSSE } from '../hooks/useSSE';
+import { useFleetSSE } from '../hooks/useFleetSSE';
 import type { TimelineEntry, StreamTimelineEntry, HookTimelineEntry, TeamMember, TeamStatus } from '../../shared/types';
 import { TERMINAL_STATUSES } from '../../shared/types';
 import { agentColor } from '../utils/constants';
@@ -729,7 +729,7 @@ export function UnifiedTimeline({
     }
   }, []);
 
-  useSSE({ onEvent: handleSSEEvent });
+  useFleetSSE(['team_output', 'team_event'], handleSSEEvent);
 
   const { entries } = state;
 

--- a/src/client/context/FleetContext.tsx
+++ b/src/client/context/FleetContext.tsx
@@ -3,6 +3,19 @@ import { useSSE } from '../hooks/useSSE';
 import type { TeamDashboardRow } from '../../shared/types';
 
 // =============================================================================
+// SSE dispatch context — allows components to subscribe to specific SSE events
+// without opening their own EventSource connections.
+// =============================================================================
+
+type SSESubscriberCallback = (type: string, data: unknown) => void;
+
+interface SSEDispatchContextValue {
+  subscribe: (type: string, cb: SSESubscriberCallback) => () => void;
+}
+
+const SSEDispatchContext = createContext<SSEDispatchContextValue | null>(null);
+
+// =============================================================================
 // Context value interfaces — each context holds a narrow slice of state
 // =============================================================================
 
@@ -50,6 +63,30 @@ export function FleetProvider({ children }: { children: ReactNode }) {
   const fetchFailCountRef = useRef(0);
   const thinkingTeamIdsRef = useRef<Set<number>>(new Set());
   const [thinkingVersion, forceThinkingUpdate] = useState(0);
+
+  // SSE subscriber registry — ref-based to avoid re-renders on subscribe/unsubscribe
+  const subscribersRef = useRef<Map<string, Set<SSESubscriberCallback>>>(new Map());
+
+  const subscribe = useCallback((type: string, cb: SSESubscriberCallback): () => void => {
+    const map = subscribersRef.current;
+    if (!map.has(type)) {
+      map.set(type, new Set());
+    }
+    map.get(type)!.add(cb);
+    return () => {
+      const set = map.get(type);
+      if (set) {
+        set.delete(cb);
+        if (set.size === 0) {
+          map.delete(type);
+        }
+      }
+    };
+  }, []);
+
+  const sseDispatchValue = useMemo<SSEDispatchContextValue>(() => ({
+    subscribe,
+  }), [subscribe]);
 
   // Fetch the full team dashboard from the REST API.
   // Used as a fallback when an SSE event signals a change but
@@ -179,6 +216,18 @@ export function FleetProvider({ children }: { children: ReactNode }) {
       }
     }
     // usage_updated: no longer triggers team list refetch (C7)
+
+    // Dispatch to registered subscribers (other components listening via useFleetSSE)
+    const subscribers = subscribersRef.current.get(type);
+    if (subscribers) {
+      for (const cb of subscribers) {
+        try {
+          cb(type, data);
+        } catch (err) {
+          console.error('[FleetProvider] SSE subscriber error:', err);
+        }
+      }
+    }
   }, [debouncedFetchTeams]);
 
   const { connected, lastEvent, lastEventTeamId } = useSSE({ onEvent: handleSSEEvent });
@@ -231,15 +280,17 @@ export function FleetProvider({ children }: { children: ReactNode }) {
   }), [isThinking, thinkingVersion]);
 
   return (
-    <TeamsContext.Provider value={teamsValue}>
-      <SelectionContext.Provider value={selectionValue}>
-        <ConnectionContext.Provider value={connectionValue}>
-          <ThinkingContext.Provider value={thinkingValue}>
-            {children}
-          </ThinkingContext.Provider>
-        </ConnectionContext.Provider>
-      </SelectionContext.Provider>
-    </TeamsContext.Provider>
+    <SSEDispatchContext.Provider value={sseDispatchValue}>
+      <TeamsContext.Provider value={teamsValue}>
+        <SelectionContext.Provider value={selectionValue}>
+          <ConnectionContext.Provider value={connectionValue}>
+            <ThinkingContext.Provider value={thinkingValue}>
+              {children}
+            </ThinkingContext.Provider>
+          </ConnectionContext.Provider>
+        </SelectionContext.Provider>
+      </TeamsContext.Provider>
+    </SSEDispatchContext.Provider>
   );
 }
 
@@ -279,6 +330,15 @@ export function useThinking(): ThinkingContextValue {
   const ctx = useContext(ThinkingContext);
   if (!ctx) {
     throw new Error('useThinking must be used within a FleetProvider');
+  }
+  return ctx;
+}
+
+/** Access the SSE dispatch context for subscribing to specific SSE event types */
+export function useSSEDispatch(): SSEDispatchContextValue {
+  const ctx = useContext(SSEDispatchContext);
+  if (!ctx) {
+    throw new Error('useSSEDispatch must be used within a FleetProvider');
   }
   return ctx;
 }

--- a/src/client/hooks/useFleetSSE.ts
+++ b/src/client/hooks/useFleetSSE.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import { useSSEDispatch } from '../context/FleetContext';
+
+/**
+ * Subscribe to specific SSE event types via the FleetProvider's single
+ * EventSource connection.  This avoids opening duplicate SSE connections
+ * from individual components.
+ *
+ * @param eventTypes - A single event type string or an array of event types.
+ * @param onEvent   - Callback invoked with (type, data) when a matching SSE
+ *                     event arrives.  The callback ref is kept current without
+ *                     causing re-subscriptions.
+ */
+export function useFleetSSE(
+  eventTypes: string | string[],
+  onEvent: (type: string, data: unknown) => void,
+): void {
+  const { subscribe } = useSSEDispatch();
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    const types = Array.isArray(eventTypes) ? eventTypes : [eventTypes];
+    const stableCallback = (type: string, data: unknown) => {
+      onEventRef.current(type, data);
+    };
+
+    const unsubscribes = types.map((t) => subscribe(t, stableCallback));
+    return () => {
+      for (const unsub of unsubscribes) {
+        unsub();
+      }
+    };
+    // eventTypes is intentionally serialized to avoid re-subscriptions when the
+    // caller passes a new array reference with the same contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subscribe, JSON.stringify(eventTypes)]);
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useApi } from '../hooks/useApi';
-import { useSSE } from '../hooks/useSSE';
+import { useFleetSSE } from '../hooks/useFleetSSE';
 import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritization';
 import { useCollapseState } from '../hooks/useCollapseState';
 import { useFlattenedTree } from '../hooks/useVirtualizedTree';
@@ -152,7 +152,7 @@ export function IssueTreeView() {
     }
   }, [fetchTree]);
 
-  useSSE({ onEvent: handleSSEEvent });
+  useFleetSSE('dependency_resolved', handleSSEEvent);
 
   // -------------------------------------------------------------------------
   // Refresh (force re-fetch from GitHub)

--- a/src/client/views/UsageViewPage.tsx
+++ b/src/client/views/UsageViewPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApi } from '../hooks/useApi';
-import { useSSE } from '../hooks/useSSE';
+import { useFleetSSE } from '../hooks/useFleetSSE';
 import { getUsageColor } from '../utils/constants';
 import { formatResetsAt } from '../utils/format-resets-at';
 import { UsageChart } from '../components/UsageChart';
@@ -112,7 +112,7 @@ export function UsageViewPage() {
     }
   }, [fetchUsage]);
 
-  useSSE({ onEvent: handleSSEEvent });
+  useFleetSSE('usage_updated', handleSSEEvent);
 
   return (
     <div className="p-6 max-w-4xl mx-auto flex flex-col gap-8">

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -25,12 +25,8 @@ vi.mock('../../src/client/hooks/useApi', () => ({
   useApi: () => mockApi,
 }));
 
-vi.mock('../../src/client/hooks/useSSE', () => ({
-  useSSE: () => ({
-    connected: true,
-    lastEvent: null,
-    lastEventTeamId: null,
-  }),
+vi.mock('../../src/client/hooks/useFleetSSE', () => ({
+  useFleetSSE: () => {},
 }));
 
 vi.mock('../../src/client/hooks/usePrioritization', () => ({

--- a/tests/client/UnifiedTimeline.test.tsx
+++ b/tests/client/UnifiedTimeline.test.tsx
@@ -35,15 +35,14 @@ vi.mock('../../src/client/hooks/useApi', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Mock useSSE — capture the onEvent callback for simulating SSE events
+// Mock useFleetSSE — capture the onEvent callback for simulating SSE events
 // ---------------------------------------------------------------------------
 
 let capturedOnEvent: ((type: string, data: unknown) => void) | undefined;
 
-vi.mock('../../src/client/hooks/useSSE', () => ({
-  useSSE: (options: { onEvent?: (type: string, data: unknown) => void }) => {
-    capturedOnEvent = options.onEvent;
-    return { connected: true, lastEvent: null, lastEventTeamId: null };
+vi.mock('../../src/client/hooks/useFleetSSE', () => ({
+  useFleetSSE: (_eventTypes: string | string[], onEvent: (type: string, data: unknown) => void) => {
+    capturedOnEvent = onEvent;
   },
 }));
 

--- a/tests/client/UsageViewPage.test.tsx
+++ b/tests/client/UsageViewPage.test.tsx
@@ -24,12 +24,8 @@ vi.mock('../../src/client/hooks/useApi', () => ({
   useApi: () => mockApi,
 }));
 
-vi.mock('../../src/client/hooks/useSSE', () => ({
-  useSSE: () => ({
-    connected: true,
-    lastEvent: null,
-    lastEventTeamId: null,
-  }),
+vi.mock('../../src/client/hooks/useFleetSSE', () => ({
+  useFleetSSE: () => {},
 }));
 
 // Mock UsageChart since it depends on recharts (not installed)

--- a/tests/client/useFleetSSE.test.ts
+++ b/tests/client/useFleetSSE.test.ts
@@ -1,0 +1,123 @@
+// =============================================================================
+// Fleet Commander — useFleetSSE Hook Tests
+// =============================================================================
+// Tests for the useFleetSSE hook which subscribes to SSE event types via the
+// FleetProvider's dispatch context, eliminating duplicate EventSource connections.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mock the SSEDispatchContext via useSSEDispatch
+// ---------------------------------------------------------------------------
+
+let mockSubscribe: ReturnType<typeof vi.fn>;
+let mockUnsubscribe: ReturnType<typeof vi.fn>;
+
+vi.mock('../../src/client/context/FleetContext', () => ({
+  useSSEDispatch: () => ({
+    subscribe: mockSubscribe,
+  }),
+}));
+
+// Import after mocks
+import { useFleetSSE } from '../../src/client/hooks/useFleetSSE';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useFleetSSE', () => {
+  beforeEach(() => {
+    mockUnsubscribe = vi.fn();
+    mockSubscribe = vi.fn().mockReturnValue(mockUnsubscribe);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should subscribe on mount with a single event type', () => {
+    const callback = vi.fn();
+    renderHook(() => useFleetSSE('team_output', callback));
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscribe).toHaveBeenCalledWith('team_output', expect.any(Function));
+  });
+
+  it('should subscribe on mount with an array of event types', () => {
+    const callback = vi.fn();
+    renderHook(() => useFleetSSE(['team_output', 'team_event'], callback));
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    expect(mockSubscribe).toHaveBeenCalledWith('team_output', expect.any(Function));
+    expect(mockSubscribe).toHaveBeenCalledWith('team_event', expect.any(Function));
+  });
+
+  it('should unsubscribe on unmount', () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useFleetSSE('team_output', callback));
+
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unsubscribe all event types on unmount when using array', () => {
+    const callback = vi.fn();
+    const unsub1 = vi.fn();
+    const unsub2 = vi.fn();
+    mockSubscribe
+      .mockReturnValueOnce(unsub1)
+      .mockReturnValueOnce(unsub2);
+
+    const { unmount } = renderHook(() => useFleetSSE(['team_output', 'team_event'], callback));
+
+    unmount();
+    expect(unsub1).toHaveBeenCalledTimes(1);
+    expect(unsub2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update callback ref without re-subscribing', () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ cb }) => useFleetSSE('team_output', cb),
+      { initialProps: { cb: callback1 } },
+    );
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+
+    // Re-render with a new callback — should NOT call subscribe again
+    rerender({ cb: callback2 });
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+
+    // Invoke the stable callback that was registered — it should delegate
+    // to the latest callback ref (callback2)
+    const registeredCallback = mockSubscribe.mock.calls[0][1] as (type: string, data: unknown) => void;
+    registeredCallback('team_output', { foo: 'bar' });
+
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).toHaveBeenCalledWith('team_output', { foo: 'bar' });
+  });
+
+  it('should re-subscribe when event types change', () => {
+    const callback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ types }) => useFleetSSE(types, callback),
+      { initialProps: { types: 'team_output' as string | string[] } },
+    );
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscribe).toHaveBeenCalledWith('team_output', expect.any(Function));
+
+    // Change event types — should unsubscribe old and subscribe new
+    rerender({ types: 'team_event' });
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    expect(mockSubscribe).toHaveBeenLastCalledWith('team_event', expect.any(Function));
+  });
+});


### PR DESCRIPTION
Closes #521

## Summary
- Added `SSEDispatchContext` with ref-based subscriber registry in `FleetContext` — single EventSource connection dispatches events to all subscribers
- Created `useFleetSSE` hook for components to subscribe to specific SSE event types without opening new connections
- Migrated `UnifiedTimeline`, `IssueTreeView`, and `UsageViewPage` from direct `useSSE` calls to `useFleetSSE`
- Error isolation: subscriber callback failures are caught and logged without affecting other subscribers

## Test plan
- [x] `npm run test:client` — 65 tests pass (6 new for useFleetSSE hook)
- [x] `npm run build` — TypeScript compiles without errors
- [ ] Verify in browser DevTools Network tab: only 1 SSE connection per tab regardless of navigation
- [ ] Verify real-time updates work in UnifiedTimeline, IssueTreeView, and UsageViewPage