### PR TITLE
Issue #526: Fix syncWithOrigin event loss, parallelize stopAll, add createWorktree timeout

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -310,6 +310,12 @@ export class TeamManager {
     // Broadcast immediately so the team appears in the grid right away
     this.broadcastSnapshot();
 
+    // Ensure parsedEvents is initialized before syncWithOrigin so the sync
+    // event can be captured (syncWithOrigin pushes to parsedEvents.get(teamId))
+    if (!this.parsedEvents.has(team.id)) {
+      this.parsedEvents.set(team.id, []);
+    }
+
     // Sync with origin before creating worktree
     await this.syncWithOrigin(project.repoPath, team.id);
 
@@ -630,17 +636,16 @@ export class TeamManager {
 
     const db = getDatabase();
     const activeTeams = db.getActiveTeams();
-    const results: Team[] = [];
 
-    for (const team of activeTeams) {
-      try {
-        const stopped = await this.stop(team.id);
-        results.push(stopped);
-      } catch {
-        // Log but continue stopping other teams
-        results.push(team);
-      }
-    }
+    // Stop all teams in parallel — each stop() waits up to 5s for graceful
+    // shutdown, so sequential execution takes N*5s. Promise.allSettled sends
+    // all stdin EOF signals concurrently and waits for all grace periods in parallel.
+    const settled = await Promise.allSettled(
+      activeTeams.map(team => this.stop(team.id)),
+    );
+    const results: Team[] = settled.map((result, i) =>
+      result.status === 'fulfilled' ? result.value : activeTeams[i],
+    );
 
     return results;
   }
@@ -1182,6 +1187,12 @@ export class TeamManager {
     const worktreeAbsPath = path.join(project.repoPath, config.worktreeDir, team.worktreeName);
     const worktreeRelPath = path.posix.join(config.worktreeDir, team.worktreeName);
     const branchName = team.branchName ?? `worktree-${team.worktreeName}`;
+
+    // Ensure parsedEvents is initialized before syncWithOrigin so the sync
+    // event can be captured (syncWithOrigin pushes to parsedEvents.get(teamId))
+    if (!this.parsedEvents.has(team.id)) {
+      this.parsedEvents.set(team.id, []);
+    }
 
     // Sync with origin before creating worktree
     await this.syncWithOrigin(project.repoPath, team.id);
@@ -1754,6 +1765,7 @@ export class TeamManager {
     try {
       await execAsync(
         `git -C "${repoPath}" worktree add "${worktreeRelPath}" -b "${branchName}"`,
+        { timeout: 30000 },
       );
       return true;
     } catch {
@@ -1761,6 +1773,7 @@ export class TeamManager {
       try {
         await execAsync(
           `git -C "${repoPath}" worktree add "${worktreeRelPath}" "${branchName}"`,
+          { timeout: 30000 },
         );
         return true;
       } catch (err2: unknown) {

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -1,8 +1,10 @@
 // =============================================================================
-// Fleet Commander — TeamManager Lifecycle Tests (stop, sendMessage, process exit)
+// Fleet Commander — TeamManager Lifecycle Tests (stop, stopAll, sendMessage,
+// process exit, gracefulShutdown)
 // =============================================================================
-// Tests for stop(), sendMessage(), attachProcessHandlers exit/error handling,
-// and gracefulShutdown. Does NOT duplicate queue/env tests from other files.
+// Tests for stop(), stopAll(), sendMessage(), attachProcessHandlers
+// exit/error handling, and gracefulShutdown. Does NOT duplicate queue/env
+// tests from other files.
 // =============================================================================
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
@@ -219,6 +221,74 @@ describe('TeamManager.stop', () => {
       { team_id: 1 },
       1,
     );
+  });
+});
+
+// =============================================================================
+// stopAll
+// =============================================================================
+
+describe('TeamManager.stopAll', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    tm = new TeamManager();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should stop teams in parallel, not sequentially', async () => {
+    // Create 3 active teams, each with a stdin pipe and child process
+    const teams = [1, 2, 3].map(id => {
+      const team = makeTeam({ id, status: 'running', pid: 10000 + id });
+      const mockStdin = createMockStdin();
+      (tm as any).stdinPipes.set(id, mockStdin);
+      (tm as any).childProcesses.set(id, createMockChildProcess());
+      return team;
+    });
+
+    mockDb.getActiveTeams.mockReturnValue(teams);
+    mockDb.getTeam.mockImplementation((id: number) =>
+      teams.find(t => t.id === id),
+    );
+    mockDb.updateTeam.mockImplementation((id: number) =>
+      teams.find(t => t.id === id),
+    );
+
+    const stopAllPromise = tm.stopAll();
+
+    // Advance past the 5-second graceful shutdown timeout for all teams.
+    // If stopAll were sequential, we'd need 3 * 5s = 15s.
+    // With parallel execution, 6s is enough for all.
+    await vi.advanceTimersByTimeAsync(6000);
+    const results = await stopAllPromise;
+
+    expect(results).toHaveLength(3);
+  });
+
+  it('should return empty array when no active teams', async () => {
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    const results = await tm.stopAll();
+
+    expect(results).toEqual([]);
+  });
+
+  it('should use fallback team on stop failure', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    // getTeam returns undefined, causing stop() to throw "Team X not found"
+    mockDb.getTeam.mockReturnValue(undefined);
+
+    const results = await tm.stopAll();
+
+    // The rejected promise falls back to the original team object
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(1);
   });
 });
 

--- a/tests/server/team-manager-worktree.test.ts
+++ b/tests/server/team-manager-worktree.test.ts
@@ -1,0 +1,330 @@
+// =============================================================================
+// Fleet Commander — TeamManager worktree & sync tests
+// =============================================================================
+// Tests for:
+//   - createWorktree passes timeout to execAsync
+//   - syncWithOrigin event is captured in parsedEvents when pre-initialized
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures these are available when vi.mock factories run
+// ---------------------------------------------------------------------------
+
+const mockDb = vi.hoisted(() => ({
+  getProject: vi.fn(),
+  getTeam: vi.fn(),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamCountByProject: vi.fn().mockReturnValue(0),
+  getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
+  insertTransition: vi.fn(),
+  getPullRequest: vi.fn(),
+  insertEvent: vi.fn(),
+}));
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    worktreeDir: '.claude/worktrees',
+    outputBufferLines: 500,
+    claudeCmd: 'claude',
+    skipPermissions: true,
+    terminal: 'auto',
+    mergeShutdownGraceMs: 120000,
+    fleetCommanderRoot: '/tmp/fleet',
+    mapCleanupIntervalMs: 3600000,
+  },
+}));
+
+const mockSseBroker = vi.hoisted(() => ({
+  broadcast: vi.fn(),
+  getSnapshot: vi.fn().mockReturnValue([]),
+}));
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+vi.mock('../../src/server/utils/find-git-bash.js', () => ({
+  findGitBash: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue('Shutdown message for PR'),
+}));
+
+vi.mock('../../src/server/services/usage-tracker.js', () => ({
+  getUsageZone: vi.fn().mockReturnValue('green'),
+}));
+
+vi.mock('../../src/server/utils/resolve-claude-path.js', () => ({
+  resolveClaudePath: vi.fn().mockReturnValue('claude'),
+}));
+
+vi.mock('../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: () => ({
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue({
+      issueNumber: 0, blockedBy: [], resolved: true, openCount: 0,
+    }),
+  }),
+  detectCircularDependencies: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock child_process.exec + util.promisify to intercept execAsync calls
+// ---------------------------------------------------------------------------
+
+const mockExec = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  ChildProcess: class {},
+}));
+
+vi.mock('util', async () => {
+  return {
+    promisify: (fn: unknown) => {
+      // Return a function that wraps mockExec into a Promise and captures
+      // the options (including timeout) passed by the caller.
+      return (...args: unknown[]) => {
+        return new Promise((resolve, reject) => {
+          (fn as Function)(...args, (err: Error | null, result: unknown) => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        });
+      };
+    },
+  };
+});
+
+// Mock fs — only existsSync is needed for createWorktree
+const mockFs = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  copyFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn().mockReturnValue([]),
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn(),
+  statSync: vi.fn().mockReturnValue({ isDirectory: () => false }),
+  rmSync: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  default: mockFs,
+  ...mockFs,
+}));
+
+// Mock cc-spawn (uses child_process and execa internally)
+vi.mock('../../src/server/utils/cc-spawn.js', () => ({
+  spawnHeadless: vi.fn(),
+  spawnInteractive: vi.fn(),
+}));
+
+// Mock fc-manifest (uses fs internally)
+vi.mock('../../src/server/utils/fc-manifest.js', () => ({
+  getHookFiles: vi.fn().mockReturnValue([]),
+  getAgentFiles: vi.fn().mockReturnValue([]),
+  getGuideFiles: vi.fn().mockReturnValue([]),
+  getWorkflowFile: vi.fn().mockReturnValue(null),
+}));
+
+// Mock event-collector
+vi.mock('../../src/server/services/event-collector.js', () => ({
+  classifyAgentRole: vi.fn().mockReturnValue('tl'),
+  shouldAdvancePhase: vi.fn().mockReturnValue(false),
+}));
+
+// Mock exec-gh
+vi.mock('../../src/server/utils/exec-gh.js', () => ({
+  isValidGithubRepo: vi.fn().mockResolvedValue(true),
+}));
+
+import { TeamManager } from '../../src/server/services/team-manager.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TeamManager.createWorktree', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset fs.existsSync to false (createWorktree skips when dir exists)
+    mockFs.existsSync.mockReturnValue(false);
+    tm = new TeamManager();
+  });
+
+  it('should pass 30s timeout to both execAsync calls', async () => {
+    // First call (with -b) succeeds
+    mockExec.mockImplementation(
+      (_cmd: string, _opts: unknown, cb: Function) => cb(null, { stdout: '', stderr: '' }),
+    );
+
+    const result = await (tm as any).createWorktree(
+      '/tmp/repo', '.claude/worktrees/proj-10', '/tmp/repo/.claude/worktrees/proj-10',
+      'feat/10-test', 1, 'queued',
+    );
+
+    expect(result).toBe(true);
+    // Verify the exec call included timeout: 30000
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const callArgs = mockExec.mock.calls[0];
+    expect(callArgs[0]).toContain('worktree add');
+    expect(callArgs[0]).toContain('-b');
+    expect(callArgs[1]).toEqual({ timeout: 30000 });
+  });
+
+  it('should pass 30s timeout to fallback execAsync call (without -b)', async () => {
+    // First call (with -b) fails, second call (without -b) succeeds
+    let callCount = 0;
+    mockExec.mockImplementation(
+      (_cmd: string, _opts: unknown, cb: Function) => {
+        callCount++;
+        if (callCount === 1) {
+          cb(new Error('branch already exists'), null);
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+      },
+    );
+
+    const result = await (tm as any).createWorktree(
+      '/tmp/repo', '.claude/worktrees/proj-10', '/tmp/repo/.claude/worktrees/proj-10',
+      'feat/10-test', 1, 'queued',
+    );
+
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    // Both calls should include timeout: 30000
+    expect(mockExec.mock.calls[0][1]).toEqual({ timeout: 30000 });
+    expect(mockExec.mock.calls[1][1]).toEqual({ timeout: 30000 });
+  });
+
+  it('should skip creation when worktree directory already exists', async () => {
+    mockFs.existsSync.mockReturnValue(true);
+
+    const result = await (tm as any).createWorktree(
+      '/tmp/repo', '.claude/worktrees/proj-10', '/tmp/repo/.claude/worktrees/proj-10',
+      'feat/10-test', 1, 'queued',
+    );
+
+    expect(result).toBe(true);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('should transition team to failed when both execAsync calls fail', async () => {
+    mockExec.mockImplementation(
+      (_cmd: string, _opts: unknown, cb: Function) => {
+        cb(new Error('git worktree error'), null);
+      },
+    );
+
+    const result = await (tm as any).createWorktree(
+      '/tmp/repo', '.claude/worktrees/proj-10', '/tmp/repo/.claude/worktrees/proj-10',
+      'feat/10-test', 1, 'queued',
+    );
+
+    expect(result).toBe(false);
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'queued',
+        toStatus: 'failed',
+        trigger: 'system',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+});
+
+describe('TeamManager.syncWithOrigin', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('should capture sync event in parsedEvents when array is pre-initialized', async () => {
+    const teamId = 42;
+    const events: unknown[] = [];
+    (tm as any).parsedEvents.set(teamId, events);
+
+    // Mock git fetch, symbolic-ref, rev-list all succeeding
+    mockExec.mockImplementation(
+      (cmd: string, _opts: unknown, cb: Function) => {
+        if (cmd.includes('fetch')) {
+          cb(null, { stdout: '', stderr: '' });
+        } else if (cmd.includes('symbolic-ref')) {
+          cb(null, { stdout: 'refs/remotes/origin/main', stderr: '' });
+        } else if (cmd.includes('rev-list')) {
+          cb(null, { stdout: '0', stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+      },
+    );
+
+    await (tm as any).syncWithOrigin('/tmp/repo', teamId);
+
+    // The sync event should be pushed into the parsedEvents array
+    expect(events.length).toBe(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.type).toBe('fc');
+    expect(event.subtype).toBe('origin_sync');
+    expect(event.agentName).toBe('__fc__');
+  });
+
+  it('should NOT capture sync event when parsedEvents is not initialized', async () => {
+    const teamId = 99;
+    // Do NOT initialize parsedEvents for this team — simulates the old bug
+
+    mockExec.mockImplementation(
+      (_cmd: string, _opts: unknown, cb: Function) => {
+        cb(null, { stdout: '0', stderr: '' });
+      },
+    );
+
+    await (tm as any).syncWithOrigin('/tmp/repo', teamId);
+
+    // parsedEvents was never initialized, so the event is silently dropped
+    expect((tm as any).parsedEvents.has(teamId)).toBe(false);
+  });
+
+  it('should broadcast team_output SSE event for sync', async () => {
+    const teamId = 7;
+    (tm as any).parsedEvents.set(teamId, []);
+
+    mockExec.mockImplementation(
+      (_cmd: string, _opts: unknown, cb: Function) => {
+        cb(null, { stdout: '0', stderr: '' });
+      },
+    );
+
+    await (tm as any).syncWithOrigin('/tmp/repo', teamId);
+
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_output',
+      expect.objectContaining({ team_id: teamId }),
+      teamId,
+    );
+  });
+});


### PR DESCRIPTION
Closes #526

## Summary
- **syncWithOrigin event lost**: Initialize `parsedEvents` for the team before calling `syncWithOrigin()` in both `launch()` and `launchQueued()` paths, so the `origin_sync` event is captured instead of silently dropped
- **stopAll serialized**: Replace sequential `for...of` loop with `Promise.allSettled()` so all teams are stopped concurrently (~5s total instead of N*5s)
- **createWorktree no timeout**: Add `{ timeout: 30000 }` to both `execAsync` calls in `createWorktree()`, matching existing 30s timeouts in `syncWithOrigin()`

## Test plan
- [ ] `npm run test:server` passes (10 new tests across 2 files)
- [ ] `npm run build` compiles without errors
- [ ] Verify stopAll completes in ~5s with multiple active teams
- [ ] Verify createWorktree times out after 30s if git hangs