### PR TITLE
Issue #529: Wrap throttled tool_use DB writes in atomic transaction

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1346,6 +1346,48 @@ export class FleetDatabase {
     }
   }
 
+  /**
+   * Wrap the throttled tool_use path's DB writes in a single transaction.
+   *
+   * The throttled path skips event insertion and SSE broadcast but still
+   * needs to (optionally) record a transition, (optionally) update team
+   * status/phase, and always update the heartbeat timestamp. Wrapping
+   * these in a transaction ensures atomicity (Issue #529).
+   */
+  processThrottledUpdate(ops: {
+    transition?: { teamId: number; fromStatus: TeamStatus; toStatus: TeamStatus; trigger: string; reason: string };
+    statusUpdate?: { teamId: number; fields: TeamUpdate };
+    heartbeatUpdate: { teamId: number; lastEventAt: string };
+  }): void {
+    const runTransaction = this.db.transaction((txOps: typeof ops) => {
+      if (txOps.transition) {
+        this.stmt(
+          'INSERT INTO team_transitions (team_id, from_status, to_status, trigger, reason) VALUES (?, ?, ?, ?, ?)'
+        ).run(
+          txOps.transition.teamId,
+          txOps.transition.fromStatus,
+          txOps.transition.toStatus,
+          txOps.transition.trigger,
+          txOps.transition.reason,
+        );
+      }
+      if (txOps.statusUpdate) {
+        this.updateTeamSilent(txOps.statusUpdate.teamId, txOps.statusUpdate.fields);
+      }
+      this.updateTeamSilent(txOps.heartbeatUpdate.teamId, { lastEventAt: txOps.heartbeatUpdate.lastEventAt });
+    });
+
+    try {
+      runTransaction(ops);
+    } catch (err: unknown) {
+      const sqliteErr = err as { code?: string };
+      if (sqliteErr.code === 'SQLITE_BUSY') {
+        console.warn('[DB] processThrottledUpdate: SQLITE_BUSY after busy_timeout exhausted');
+      }
+      throw err;
+    }
+  }
+
   getEventsByTeam(teamId: number, limit?: number, offset?: number): Event[] {
     let sql = 'SELECT * FROM events WHERE team_id = ? ORDER BY id DESC';
     const params: unknown[] = [teamId];

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -90,6 +90,11 @@ export interface EventCollectorDb {
     eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string };
     agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
   }): { eventId: number };
+  processThrottledUpdate(ops: {
+    transition?: { teamId: number; fromStatus: TeamStatus; toStatus: TeamStatus; trigger: string; reason: string };
+    statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+    heartbeatUpdate: { teamId: number; lastEventAt: string };
+  }): void;
   upsertTeamTask?(data: {
     teamId: number;
     taskId: string;
@@ -397,15 +402,14 @@ export function processEvent(
     const lastTime = lastToolUseByTeam.get(teamKey) || 0;
 
     if (now - lastTime < TOOL_USE_THROTTLE_MS) {
-      // Deduplicated: still apply any transition + heartbeat, but skip
-      // event insert and SSE broadcast.
-      if (transitionData) {
-        db.insertTransition(transitionData);
-      }
-      if (statusUpdateData) {
-        db.updateTeamSilent(statusUpdateData.teamId, statusUpdateData.fields);
-      }
-      db.updateTeamSilent(teamId, { lastEventAt: nowIso });
+      // Deduplicated: still apply any transition + heartbeat atomically,
+      // but skip event insert and SSE broadcast. Wrapped in a transaction
+      // for atomicity (Issue #529).
+      db.processThrottledUpdate({
+        transition: transitionData,
+        statusUpdate: statusUpdateData,
+        heartbeatUpdate: { teamId, lastEventAt: nowIso },
+      });
       if (previousStatus !== undefined) {
         sse.broadcast('team_status_changed', {
           team_id: teamId,

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -65,6 +65,24 @@ function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
     },
   );
 
+  // processThrottledUpdate delegates to individual mocks so existing
+  // assertions on insertTransition, updateTeam, etc. continue to pass.
+  const processThrottledUpdate = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+    },
+  );
+
   return {
     getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
     insertEvent,
@@ -73,6 +91,7 @@ function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
     insertTransition,
     insertAgentMessage,
     processEventTransaction,
+    processThrottledUpdate,
     ...overrides,
   };
 }
@@ -2199,30 +2218,66 @@ describe('Transaction atomicity', () => {
     }
   });
 
-  it('still calls db.updateTeam directly for throttled tool_use heartbeat', () => {
+  it('calls processThrottledUpdate for throttled tool_use heartbeat', () => {
     const db = createMockDb();
     const sse = createMockSse();
 
-    // First tool_use goes through the transaction
+    // First tool_use goes through the full transaction
     processEvent(makePayload({ event: 'tool_use' }), db, sse);
     expect(db.processEventTransaction).toHaveBeenCalledTimes(1);
+    expect(db.processThrottledUpdate).toHaveBeenCalledTimes(0);
 
-    // Second tool_use within throttle window — should NOT call processEventTransaction
+    // Second tool_use within throttle window — should call processThrottledUpdate
     const result = processEvent(makePayload({ event: 'tool_use' }), db, sse);
     expect(result.processed).toBe(false);
     expect(db.processEventTransaction).toHaveBeenCalledTimes(1); // still 1
+    expect(db.processThrottledUpdate).toHaveBeenCalledTimes(1);
 
-    // But updateTeam should have been called directly for the heartbeat
-    const directUpdateCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (call: unknown[]) => {
-        // These are direct calls (not via processEventTransaction delegation)
-        // The delegated calls from processEventTransaction also show up here,
-        // but the throttled path adds an extra direct call with lastEventAt
-        return (call[1] as Record<string, unknown>).lastEventAt !== undefined;
-      },
+    // Verify the heartbeat was passed through
+    const ops = (db.processThrottledUpdate as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.heartbeatUpdate).toEqual({
+      teamId: 1,
+      lastEventAt: expect.any(String),
+    });
+    // No transition or status update for a running team
+    expect(ops.transition).toBeUndefined();
+    expect(ops.statusUpdate).toBeUndefined();
+  });
+
+  it('passes transition data to processThrottledUpdate when idle team receives throttled tool_use', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+
+    // First tool_use goes through the full transaction (and resets idle -> running)
+    processEvent(makePayload({ event: 'tool_use' }), db, sse);
+    expect(db.processEventTransaction).toHaveBeenCalledTimes(1);
+
+    // Second tool_use within throttle window — throttled path
+    // Team is still reported as 'idle' by the mock, so a transition should occur
+    const result = processEvent(makePayload({ event: 'tool_use' }), db, sse);
+    expect(result.processed).toBe(false);
+    expect(db.processThrottledUpdate).toHaveBeenCalledTimes(1);
+
+    const ops = (db.processThrottledUpdate as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(ops.transition).toEqual(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'idle',
+        toStatus: 'running',
+      }),
     );
-    // At least 2: one delegated from transaction + one direct from throttled path
-    expect(directUpdateCalls.length).toBeGreaterThanOrEqual(2);
+    expect(ops.statusUpdate).toEqual(
+      expect.objectContaining({
+        teamId: 1,
+        fields: expect.objectContaining({ status: 'running' }),
+      }),
+    );
+    expect(ops.heartbeatUpdate).toEqual({
+      teamId: 1,
+      lastEventAt: expect.any(String),
+    });
   });
 
   it('wraps terminal-state event inserts in a transaction (no transition)', () => {


### PR DESCRIPTION
Closes #529

## Summary
- Added `processThrottledUpdate` method to `FleetDatabase` that wraps transition insert, status update, and heartbeat update in a single `this.db.transaction()` call
- Updated `EventCollectorDb` interface with the new method declaration
- Replaced 3 independent DB writes in the throttled `tool_use` path with a single atomic `db.processThrottledUpdate()` call
- SQLITE_BUSY error handling follows the existing `processEventTransaction` pattern

## Test plan
- [x] Updated existing throttled heartbeat test to assert on `processThrottledUpdate`
- [x] Added new test for throttled path with idle→running transition
- [x] `tsc --noEmit` passes with no type errors
- [x] All 158 event-collector tests pass