### PR TITLE
Issue #530: Guard getTeamManager() calls in stuck-detector idle/stuck nudge sends

### DIFF
--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -199,9 +199,13 @@ class StuckDetector {
               IDLE_MINUTES: String(Math.round(idleMinutes)),
             });
             if (idleMsg) {
-              const manager = getTeamManager();
-              manager.sendMessage(team.id, idleMsg, 'fc', 'idle_nudge');
-              console.log(`[StuckDetector] Idle nudge sent to team ${team.id}`);
+              try {
+                const manager = getTeamManager();
+                manager.sendMessage(team.id, idleMsg, 'fc', 'idle_nudge');
+                console.log(`[StuckDetector] Idle nudge sent to team ${team.id}`);
+              } catch {
+                console.warn(`[StuckDetector] Failed to send idle nudge to team ${team.id}`);
+              }
             }
           }
 
@@ -211,9 +215,13 @@ class StuckDetector {
               ISSUE_NUMBER: String(team.issueNumber),
             });
             if (msg) {
-              const manager = getTeamManager();
-              manager.sendMessage(team.id, msg, 'fc', 'stuck_nudge');
-              console.log(`[StuckDetector] Nudge sent to team ${team.id}`);
+              try {
+                const manager = getTeamManager();
+                manager.sendMessage(team.id, msg, 'fc', 'stuck_nudge');
+                console.log(`[StuckDetector] Nudge sent to team ${team.id}`);
+              } catch {
+                console.warn(`[StuckDetector] Failed to send stuck nudge to team ${team.id}`);
+              }
             }
           }
         }

--- a/tests/server/stuck-detector.test.ts
+++ b/tests/server/stuck-detector.test.ts
@@ -24,6 +24,9 @@ const mockSseBroker = {
 const mockManager = {
   stop: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn(),
+  syncStreamActivityToDb: vi.fn(),
+  getLastStreamAt: vi.fn().mockReturnValue(null),
+  thinkingTeams: new Set<number>(),
 };
 
 vi.mock('../../src/server/db.js', () => ({
@@ -34,8 +37,9 @@ vi.mock('../../src/server/services/sse-broker.js', () => ({
   sseBroker: mockSseBroker,
 }));
 
+const mockGetTeamManager = vi.fn(() => mockManager);
 vi.mock('../../src/server/services/team-manager.js', () => ({
-  getTeamManager: () => mockManager,
+  getTeamManager: (...args: unknown[]) => mockGetTeamManager(...args),
 }));
 
 vi.mock('../../src/server/utils/resolve-message.js', () => ({
@@ -92,6 +96,7 @@ function minutesAgo(min: number): string {
 beforeEach(() => {
   vi.clearAllMocks();
   mockDb.getActiveTeams.mockReturnValue([]);
+  mockGetTeamManager.mockImplementation(() => mockManager);
 });
 
 // =============================================================================
@@ -340,6 +345,59 @@ describe('Idle nudge message', () => {
     expect(mockManager.sendMessage).toHaveBeenCalledWith(1, 'Hey, you have been idle for a while', 'fc', 'stuck_nudge');
 
     // Reset mock to default
+    mockedResolveMessage.mockReturnValue(null);
+  });
+
+  it('does not crash check loop when getTeamManager throws during idle nudge', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    mockedResolveMessage.mockReturnValue('FC status check: idle for 6 minutes');
+
+    // Make getTeamManager throw on every call — all existing call sites are
+    // already guarded by try/catch, so only the nudge send is being tested here
+    mockGetTeamManager.mockImplementation(() => { throw new Error('TeamManager not initialized'); });
+
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(6),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    // Should not throw despite getTeamManager throwing
+    expect(() => stuckDetector.check()).not.toThrow();
+
+    // Transition should still happen
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'idle' });
+    // But sendMessage should NOT have been called (getTeamManager threw)
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+
+    // Reset mock
+    mockedResolveMessage.mockReturnValue(null);
+  });
+
+  it('does not crash check loop when getTeamManager throws during stuck nudge', async () => {
+    const { resolveMessage } = await import('../../src/server/utils/resolve-message.js');
+    const mockedResolveMessage = vi.mocked(resolveMessage);
+    mockedResolveMessage.mockReturnValue('Hey, you have been idle for a while');
+
+    // Make getTeamManager throw on every call
+    mockGetTeamManager.mockImplementation(() => { throw new Error('TeamManager not initialized'); });
+
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    // Should not throw despite getTeamManager throwing
+    expect(() => stuckDetector.check()).not.toThrow();
+
+    // Transition should still happen
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
+    // But sendMessage should NOT have been called (getTeamManager threw)
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+
+    // Reset mock
     mockedResolveMessage.mockReturnValue(null);
   });
 


### PR DESCRIPTION
Closes #530

## Summary
- Wrapped two unguarded `getTeamManager()` + `sendMessage()` calls in `stuck-detector.ts` (idle nudge and stuck nudge) with try/catch blocks
- Added `console.warn` logging on failure so nudge send failures are visible in logs
- Status transitions (DB update + SSE broadcast) are unaffected — they execute before the nudge send blocks

## Test plan
- [x] Two new tests verify `check()` does not throw when `getTeamManager()` throws during idle/stuck nudge sends
- [x] Existing 16 stuck-detector tests continue to pass
- [x] `npm run test:server` passes