### PR TITLE
Issue #531: Preserve lastEventAt for idle/stuck teams during startup recovery

### DIFF
--- a/src/server/services/startup-recovery.ts
+++ b/src/server/services/startup-recovery.ts
@@ -46,7 +46,11 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: 'Server restart recovery: no PID recorded',
       });
-      db.updateTeamSilent(team.id, { status: 'idle', lastEventAt: new Date().toISOString() });
+      const shouldResetClock = team.status === 'running' || team.status === 'launching';
+      db.updateTeamSilent(team.id, {
+        status: 'idle',
+        ...(shouldResetClock && { lastEventAt: new Date().toISOString() }),
+      });
       continue;
     }
 
@@ -73,7 +77,12 @@ export async function recoverOnStartup(): Promise<void> {
         trigger: 'system',
         reason: `Server restart recovery: process (PID ${team.pid}) no longer alive`,
       });
-      db.updateTeamSilent(team.id, { status: newStatus, pid: null, lastEventAt: new Date().toISOString() });
+      const shouldResetClock = team.status === 'running' || team.status === 'launching';
+      db.updateTeamSilent(team.id, {
+        status: newStatus,
+        pid: null,
+        ...(shouldResetClock && { lastEventAt: new Date().toISOString() }),
+      });
     }
   }
 

--- a/tests/server/startup-recovery.test.ts
+++ b/tests/server/startup-recovery.test.ts
@@ -144,6 +144,7 @@ describe('Dead PID recovery', () => {
     expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, expect.objectContaining({
       status: 'idle',
       pid: null,
+      lastEventAt: expect.any(String),
     }));
   });
 
@@ -165,10 +166,11 @@ describe('Dead PID recovery', () => {
     expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(2, expect.objectContaining({
       status: 'failed',
       pid: null,
+      lastEventAt: expect.any(String),
     }));
   });
 
-  it('marks idle team with dead PID as idle (keeps idle)', async () => {
+  it('marks idle team with dead PID as idle and preserves lastEventAt', async () => {
     const team = makeTeam({ id: 3, status: 'idle', pid: 7777 });
     mockDb.getActiveTeams.mockReturnValue([team]);
     mockIsProcessAlive.mockReturnValue(false);
@@ -187,9 +189,12 @@ describe('Dead PID recovery', () => {
       status: 'idle',
       pid: null,
     }));
+    // lastEventAt must NOT be reset for already-idle teams
+    const updateFields = mockDb.updateTeamSilent.mock.calls[0]![1];
+    expect(updateFields).not.toHaveProperty('lastEventAt');
   });
 
-  it('marks stuck team with dead PID as idle', async () => {
+  it('marks stuck team with dead PID as idle and preserves lastEventAt', async () => {
     const team = makeTeam({ id: 4, status: 'stuck', pid: 6666 });
     mockDb.getActiveTeams.mockReturnValue([team]);
     mockIsProcessAlive.mockReturnValue(false);
@@ -208,6 +213,9 @@ describe('Dead PID recovery', () => {
       status: 'idle',
       pid: null,
     }));
+    // lastEventAt must NOT be reset for already-stuck teams
+    const updateFields = mockDb.updateTeamSilent.mock.calls[0]![1];
+    expect(updateFields).not.toHaveProperty('lastEventAt');
   });
 });
 
@@ -241,7 +249,7 @@ describe('Alive PID recovery', () => {
 // =============================================================================
 
 describe('No PID recovery', () => {
-  it('marks team with no PID as idle', async () => {
+  it('marks running team with no PID as idle and resets lastEventAt', async () => {
     const team = makeTeam({ id: 6, status: 'running', pid: null });
     mockDb.getActiveTeams.mockReturnValue([team]);
 
@@ -258,6 +266,7 @@ describe('No PID recovery', () => {
     );
     expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(6, expect.objectContaining({
       status: 'idle',
+      lastEventAt: expect.any(String),
     }));
   });
 
@@ -269,6 +278,52 @@ describe('No PID recovery', () => {
 
     expect(mockDb.insertTransition).not.toHaveBeenCalled();
     expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
+  });
+
+  it('marks idle team with no PID as idle and preserves lastEventAt', async () => {
+    const team = makeTeam({ id: 8, status: 'idle', pid: null });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 8,
+        fromStatus: 'idle',
+        toStatus: 'idle',
+        trigger: 'system',
+        reason: expect.stringContaining('no PID'),
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(8, expect.objectContaining({
+      status: 'idle',
+    }));
+    // lastEventAt must NOT be reset for already-idle teams
+    const updateFields = mockDb.updateTeamSilent.mock.calls[0]![1];
+    expect(updateFields).not.toHaveProperty('lastEventAt');
+  });
+
+  it('marks stuck team with no PID as idle and preserves lastEventAt', async () => {
+    const team = makeTeam({ id: 9, status: 'stuck', pid: null });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    await recoverOnStartup();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 9,
+        fromStatus: 'stuck',
+        toStatus: 'idle',
+        trigger: 'system',
+        reason: expect.stringContaining('no PID'),
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(9, expect.objectContaining({
+      status: 'idle',
+    }));
+    // lastEventAt must NOT be reset for already-stuck teams
+    const updateFields = mockDb.updateTeamSilent.mock.calls[0]![1];
+    expect(updateFields).not.toHaveProperty('lastEventAt');
   });
 });
 


### PR DESCRIPTION
Closes #531

## Summary
- Fix `startup-recovery.ts` to only reset `lastEventAt` to `now()` for teams that were `running` or `launching` before server shutdown
- Teams already `idle` or `stuck` preserve their original `lastEventAt`, so the stuck-detector correctly measures time since actual last activity (not since server restart)
- Applied fix in both code paths: no-PID branch (line 49) and dead-PID branch (line 80)

## Test plan
- [x] Existing tests updated with explicit `lastEventAt` assertions for running/launching cases
- [x] New tests for no-PID + idle and no-PID + stuck verify `lastEventAt` is NOT reset
- [x] All 15 startup-recovery tests pass
- [x] `npm run test:server` passes