### PR TITLE
Issue #532: Validate NaN/negative limit/lines query params at API boundary

### DIFF
--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -438,8 +438,13 @@ const teamsRoutes: FastifyPluginCallback = (
         const linesParam = (request.query as OutputQuerystring).lines;
         const lines = linesParam ? parseInt(linesParam, 10) : undefined;
 
+        if (lines !== undefined && (isNaN(lines) || lines < 1)) {
+          return reply.code(400).send({ error: 'Bad Request', message: 'lines must be a positive integer' });
+        }
+        const clampedLines = lines !== undefined ? Math.min(lines, 1000) : undefined;
+
         const service = getTeamService();
-        const result = service.getOutput(teamId, lines);
+        const result = service.getOutput(teamId, clampedLines);
         return reply.code(200).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
@@ -500,7 +505,11 @@ const teamsRoutes: FastifyPluginCallback = (
         }
 
         const limitParam = (request.query as TimelineQuerystring).limit;
-        const limit = limitParam ? parseInt(limitParam, 10) : 500;
+        const rawLimit = limitParam ? parseInt(limitParam, 10) : undefined;
+        if (rawLimit !== undefined && (isNaN(rawLimit) || rawLimit < 1)) {
+          return reply.code(400).send({ error: 'Bad Request', message: 'limit must be a positive integer' });
+        }
+        const limit = rawLimit !== undefined ? Math.min(rawLimit, 5000) : 500;
 
         const service = getTeamService();
         const timeline = service.getTeamTimeline(teamId, limit);
@@ -814,7 +823,11 @@ const teamsRoutes: FastifyPluginCallback = (
       try {
         const teamId = parseInt(request.params.id, 10);
         const limitParam = (request.query as { limit?: string }).limit;
-        const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+        const rawLimit = limitParam ? parseInt(limitParam, 10) : undefined;
+        if (rawLimit !== undefined && (isNaN(rawLimit) || rawLimit < 1)) {
+          return reply.code(400).send({ error: 'Bad Request', message: 'limit must be a positive integer' });
+        }
+        const limit = rawLimit !== undefined ? Math.min(rawLimit, 1000) : undefined;
 
         const service = getTeamService();
         const messages = service.getMessages(teamId, limit);

--- a/src/server/routes/usage.ts
+++ b/src/server/routes/usage.ts
@@ -55,7 +55,11 @@ const usageRoutes: FastifyPluginCallback = (
     async (request: FastifyRequest, reply: FastifyReply) => {
       try {
         const query = request.query as { limit?: string };
-        const limit = query.limit ? parseInt(query.limit, 10) : undefined;
+        const rawLimit = query.limit ? parseInt(query.limit, 10) : undefined;
+        if (rawLimit !== undefined && (isNaN(rawLimit) || rawLimit < 1)) {
+          return reply.code(400).send({ error: 'Bad Request', message: 'limit must be a positive integer' });
+        }
+        const limit = rawLimit !== undefined ? Math.min(rawLimit, 1000) : undefined;
 
         const service = getUsageService();
         const result = service.getHistory(limit);

--- a/tests/server/routes/teams-routes.test.ts
+++ b/tests/server/routes/teams-routes.test.ts
@@ -290,6 +290,27 @@ describe('GET /api/teams/:id/output', () => {
     const res = await server.inject({ method: 'GET', url: '/api/teams/99999/output' });
     expect(res.statusCode).toBe(404);
   });
+
+  it('should return 400 for non-numeric lines param', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/output?lines=abc` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('lines');
+  });
+
+  it('should return 400 for negative lines param', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/output?lines=-5` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('lines');
+  });
+
+  it('should return 400 for zero lines param', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/output?lines=0` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('lines');
+  });
 });
 
 // =============================================================================
@@ -335,6 +356,47 @@ describe('GET /api/teams/:id/timeline', () => {
   it('should return 404 for unknown team', async () => {
     const res = await server.inject({ method: 'GET', url: '/api/teams/99999/timeline' });
     expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for non-numeric limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/timeline?limit=abc` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for negative limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/timeline?limit=-1` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+});
+
+// =============================================================================
+// Tests: GET /api/teams/:id/messages
+// =============================================================================
+
+describe('GET /api/teams/:id/messages', () => {
+  it('should return 400 for non-numeric limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/messages?limit=abc` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for negative limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/messages?limit=-1` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for zero limit', async () => {
+    const team = seedTeam();
+    const res = await server.inject({ method: 'GET', url: `/api/teams/${team.id}/messages?limit=0` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
   });
 });
 

--- a/tests/server/routes/usage-routes.test.ts
+++ b/tests/server/routes/usage-routes.test.ts
@@ -1,0 +1,113 @@
+// =============================================================================
+// Fleet Commander -- Usage Routes: HTTP contract tests
+// =============================================================================
+// Tests the usage route plugin for correct HTTP status codes, response shapes,
+// and parameter validation. Uses a real temp SQLite database.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Service mocks -- must be set up BEFORE importing the route plugin
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/services/usage-tracker.js', () => ({
+  processUsageSnapshot: vi.fn(),
+  getUsageZone: vi.fn().mockReturnValue('green'),
+}));
+
+// Import routes AFTER mocks
+import usageRoutes from '../../../src/server/routes/usage.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let server: FastifyInstance;
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-usage-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  server = Fastify({ logger: false });
+  await server.register(usageRoutes);
+  await server.ready();
+});
+
+afterAll(async () => {
+  sseBroker.stop();
+  await server.close();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// Tests: GET /api/usage/history
+// =============================================================================
+
+describe('GET /api/usage/history', () => {
+  it('should return 400 for non-numeric limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/usage/history?limit=xyz' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for negative limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/usage/history?limit=-1' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should return 400 for zero limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/usage/history?limit=0' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('limit');
+  });
+
+  it('should accept valid limit', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/usage/history?limit=10' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('count');
+    expect(body).toHaveProperty('snapshots');
+  });
+
+  it('should cap limit to 1000', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/usage/history?limit=5000' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('count');
+    expect(body).toHaveProperty('snapshots');
+  });
+});


### PR DESCRIPTION
Closes #532

## Summary
- Add NaN/negative/zero validation and upper-bound capping to four route handlers where `parseInt` results flowed to SQL `LIMIT` without checks
- Fixes: `GET /api/teams/:id/output` (lines), `GET /api/teams/:id/timeline` (limit), `GET /api/teams/:id/messages` (limit), `GET /api/usage/history` (limit)
- Follows the existing validation pattern from `GET /api/events` and `GET /api/teams`

## Test plan
- [x] 8 new tests in `teams-routes.test.ts` covering NaN, negative, zero for output/timeline/messages endpoints
- [x] 5 new tests in `usage-routes.test.ts` covering NaN, negative, zero, valid, and cap scenarios
- [x] All 64 route tests pass
- [x] Previously validated endpoints (`GET /api/teams`, `GET /api/events`) unaffected