### PR TITLE
Issue #533: Fix manual POST snapshot not triggering queue drain on red→green

### DIFF
--- a/src/server/routes/usage.ts
+++ b/src/server/routes/usage.ts
@@ -96,7 +96,7 @@ const usageRoutes: FastifyPluginCallback = (
         } | null;
 
         const service = getUsageService();
-        const result = service.submitSnapshot(body);
+        const result = await service.submitSnapshot(body);
         return reply.code(201).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {

--- a/src/server/services/usage-service.ts
+++ b/src/server/services/usage-service.ts
@@ -74,7 +74,7 @@ export class UsageService {
    * @returns The latest usage snapshot after insertion
    * @throws ServiceError with code VALIDATION if body is missing
    */
-  submitSnapshot(data: {
+  async submitSnapshot(data: {
     teamId?: number;
     projectId?: number;
     sessionId?: string;
@@ -83,12 +83,12 @@ export class UsageService {
     sonnetPercent?: number;
     extraPercent?: number;
     rawOutput?: string;
-  } | null): unknown {
+  } | null): Promise<unknown> {
     if (!data) {
       throw validationError('Request body is required');
     }
 
-    processUsageSnapshot({
+    await processUsageSnapshot({
       teamId: data.teamId,
       projectId: data.projectId,
       sessionId: data.sessionId,

--- a/src/server/services/usage-tracker.ts
+++ b/src/server/services/usage-tracker.ts
@@ -48,8 +48,10 @@ interface OAuthUsageResponse {
 
 /**
  * Process and store a usage snapshot, then broadcast via SSE.
+ * Updates module-level usage variables so getUsageZone() reflects the
+ * submitted values, and triggers queue drain on red-to-green transitions.
  */
-export function processUsageSnapshot(data: {
+export async function processUsageSnapshot(data: {
   teamId?: number;
   projectId?: number;
   sessionId?: string;
@@ -60,7 +62,15 @@ export function processUsageSnapshot(data: {
   dailyResetsAt?: string;
   weeklyResetsAt?: string;
   rawOutput?: string;
-}): void {
+}): Promise<void> {
+  const previousZone = _lastZone;
+
+  // Update module-level tracking variables so getUsageZone() reflects the submitted values
+  _latestDaily = data.dailyPercent ?? 0;
+  _latestWeekly = data.weeklyPercent ?? 0;
+
+  const currentZone = getUsageZone();
+
   const db = getDatabase();
   db.insertUsageSnapshot(data);
 
@@ -69,8 +79,16 @@ export function processUsageSnapshot(data: {
     weekly_percent: data.weeklyPercent ?? 0,
     sonnet_percent: data.sonnetPercent ?? 0,
     extra_percent: data.extraPercent ?? 0,
-    zone: getUsageZone(),
+    zone: currentZone,
   });
+
+  await checkZoneTransitionAndDrain(previousZone, currentZone);
+
+  _lastZone = currentZone;
+
+  console.log(
+    `[UsageTracker] Manual snapshot — daily=${data.dailyPercent ?? 0}% weekly=${data.weeklyPercent ?? 0}% zone=${currentZone}`,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +107,42 @@ export function getUsageZone(): UsageZone {
     return 'red';
   }
   return 'green';
+}
+
+// ---------------------------------------------------------------------------
+// Zone transition — shared drain logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Check for a red-to-green zone transition and trigger queue processing
+ * for all active projects with queued teams.  Used by both the poller's
+ * fetchUsage() and the manual processUsageSnapshot() path.
+ *
+ * Uses a dynamic import for team-manager to avoid circular dependencies.
+ */
+export async function checkZoneTransitionAndDrain(
+  previousZone: UsageZone,
+  currentZone: UsageZone,
+): Promise<void> {
+  if (previousZone === 'red' && currentZone === 'green') {
+    console.log('[UsageTracker] Zone transition: red -> green — draining queues');
+    try {
+      const { getTeamManager } = await import('./team-manager.js');
+      const manager = getTeamManager();
+      const db = getDatabase();
+      const projects = db.getProjects({ status: 'active' });
+      for (const project of projects) {
+        const queued = db.getQueuedTeamsByProject(project.id);
+        if (queued.length > 0) {
+          manager.processQueue(project.id).catch((err: unknown) => {
+            console.error(`[UsageTracker] processQueue error for project ${project.id}:`, err);
+          });
+        }
+      }
+    } catch (err: unknown) {
+      console.error('[UsageTracker] Failed to drain queues on zone transition:', err);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -261,25 +315,7 @@ class UsagePoller {
     );
 
     // Zone transition: red -> green => trigger queue processing for all projects
-    if (previousZone === 'red' && currentZone === 'green') {
-      console.log('[UsagePoller] Zone transition: red -> green — draining queues');
-      try {
-        // Dynamically import to avoid circular dependency
-        const { getTeamManager } = await import('./team-manager.js');
-        const manager = getTeamManager();
-        const projects = db.getProjects({ status: 'active' });
-        for (const project of projects) {
-          const queued = db.getQueuedTeamsByProject(project.id);
-          if (queued.length > 0) {
-            manager.processQueue(project.id).catch((err: unknown) => {
-              console.error(`[UsagePoller] processQueue error for project ${project.id}:`, err);
-            });
-          }
-        }
-      } catch (err: unknown) {
-        console.error('[UsagePoller] Failed to drain queues on zone transition:', err);
-      }
-    }
+    await checkZoneTransitionAndDrain(previousZone, currentZone);
 
     _lastZone = currentZone;
   }

--- a/tests/server/usage-tracker.test.ts
+++ b/tests/server/usage-tracker.test.ts
@@ -1,9 +1,9 @@
 // =============================================================================
-// Fleet Commander — UsagePoller.start() DB seeding tests (issue #66)
+// Fleet Commander — UsageTracker tests
 // =============================================================================
-// Verifies that _lastZone, _latestDaily, and _latestWeekly are hydrated from
-// the latest usage_snapshots DB row on startup, so that zone transitions
-// (especially red -> green) are correctly detected after a server restart.
+// Tests for:
+// 1. UsagePoller.start() DB seeding of zone state (issue #66)
+// 2. processUsageSnapshot() zone transition and queue drain (issue #533)
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -13,11 +13,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const mockGetLatestUsage = vi.fn();
+const mockInsertUsageSnapshot = vi.fn();
+const mockGetProjects = vi.fn();
+const mockGetQueuedTeamsByProject = vi.fn();
 
 vi.mock('../../src/server/db.js', () => ({
   getDatabase: () => ({
     getLatestUsage: mockGetLatestUsage,
-    insertUsageSnapshot: vi.fn(),
+    insertUsageSnapshot: mockInsertUsageSnapshot,
+    getProjects: mockGetProjects,
+    getQueuedTeamsByProject: mockGetQueuedTeamsByProject,
   }),
 }));
 
@@ -35,11 +40,19 @@ vi.mock('../../src/server/services/sse-broker.js', () => ({
   },
 }));
 
+const mockProcessQueue = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: () => ({
+    processQueue: mockProcessQueue,
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import { usagePoller, getUsageZone } from '../../src/server/services/usage-tracker.js';
+import { usagePoller, getUsageZone, processUsageSnapshot } from '../../src/server/services/usage-tracker.js';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -160,5 +173,75 @@ describe('UsagePoller.start() — DB seeding of zone state', () => {
 
     usagePoller.stop();
     pollSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processUsageSnapshot() — zone transition and queue drain (issue #533)
+// ---------------------------------------------------------------------------
+
+describe('processUsageSnapshot() — zone transition and queue drain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProjects.mockReturnValue([]);
+    mockGetQueuedTeamsByProject.mockReturnValue([]);
+  });
+
+  it('should update _latestDaily and _latestWeekly from submitted data', async () => {
+    // Submit low values => zone should be green
+    await processUsageSnapshot({ dailyPercent: 50, weeklyPercent: 60 });
+    expect(getUsageZone()).toBe('green');
+
+    // Submit high daily value => zone should be red (85 threshold)
+    await processUsageSnapshot({ dailyPercent: 90, weeklyPercent: 50 });
+    expect(getUsageZone()).toBe('red');
+  });
+
+  it('should trigger queue drain on red-to-green transition', async () => {
+    mockGetProjects.mockReturnValue([{ id: 1, slug: 'test-proj', status: 'active' }]);
+    mockGetQueuedTeamsByProject.mockReturnValue([{ id: 10, status: 'queued' }]);
+
+    // Set zone to red
+    await processUsageSnapshot({ dailyPercent: 90, weeklyPercent: 50 });
+    expect(getUsageZone()).toBe('red');
+    expect(mockProcessQueue).not.toHaveBeenCalled();
+
+    // Transition to green
+    await processUsageSnapshot({ dailyPercent: 10, weeklyPercent: 10 });
+    expect(getUsageZone()).toBe('green');
+    expect(mockProcessQueue).toHaveBeenCalledWith(1);
+  });
+
+  it('should not trigger queue drain when zone stays green', async () => {
+    await processUsageSnapshot({ dailyPercent: 10, weeklyPercent: 10 });
+    expect(getUsageZone()).toBe('green');
+
+    await processUsageSnapshot({ dailyPercent: 20, weeklyPercent: 20 });
+    expect(getUsageZone()).toBe('green');
+
+    expect(mockProcessQueue).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger queue drain when zone stays red', async () => {
+    mockGetProjects.mockReturnValue([{ id: 1, slug: 'test-proj', status: 'active' }]);
+    mockGetQueuedTeamsByProject.mockReturnValue([{ id: 10, status: 'queued' }]);
+
+    await processUsageSnapshot({ dailyPercent: 90, weeklyPercent: 50 });
+    expect(getUsageZone()).toBe('red');
+
+    await processUsageSnapshot({ dailyPercent: 92, weeklyPercent: 50 });
+    expect(getUsageZone()).toBe('red');
+
+    expect(mockProcessQueue).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger queue drain on green-to-red transition', async () => {
+    await processUsageSnapshot({ dailyPercent: 10, weeklyPercent: 10 });
+    expect(getUsageZone()).toBe('green');
+
+    await processUsageSnapshot({ dailyPercent: 90, weeklyPercent: 50 });
+    expect(getUsageZone()).toBe('red');
+
+    expect(mockProcessQueue).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #533

## Summary
- Extract zone-transition drain logic into shared `checkZoneTransitionAndDrain()` function used by both `fetchUsage()` (poller) and `processUsageSnapshot()` (manual POST)
- Update `processUsageSnapshot()` to set module-level `_latestDaily`/`_latestWeekly` before computing zone, so `getUsageZone()` reflects submitted values
- Make `processUsageSnapshot()` async to support dynamic import of team-manager for queue drain
- Update `_lastZone` after drain check to prevent duplicate drains

## Test plan
- [x] 5 new tests covering all zone transition scenarios (red→green drain, green→green no drain, red→red no drain, green→red no drain, variable updates)
- [x] All 10 usage-tracker tests pass
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] Existing tests unaffected