### PR TITLE
Issue #535: Memoize activeProjects to stabilize handleLaunch callback identity

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -115,8 +115,8 @@ export function IssueTreeView() {
 
   // Resolve which project to use for launches:
   // If only one project exists, auto-use it. Otherwise null — user must pick.
-  const activeProjects = projects.filter((p) => p.status === 'active');
-  const launchProjectId = activeProjects.length === 1 ? activeProjects[0].id : null;
+  const activeProjects = useMemo(() => projects.filter((p) => p.status === 'active'), [projects]);
+  const launchProjectId = useMemo(() => activeProjects.length === 1 ? activeProjects[0].id : null, [activeProjects]);
 
   // -------------------------------------------------------------------------
   // Fetch issue tree


### PR DESCRIPTION
## Summary
- Wrap `activeProjects` in `useMemo(() => ..., [projects])` in IssueTreeView.tsx to prevent new array ref on every render
- Wrap `launchProjectId` in `useMemo(() => ..., [activeProjects])` to stabilize the derived value
- This stabilizes the `handleLaunch` useCallback identity, preventing unnecessary re-renders

Closes #535

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Client tests pass (`npm run test:client`)
- [x] IssueTreeView renders correctly with memoized values
- [x] Play button launches teams as before