### PR TITLE
Issue #536: Guard undefined child.pid in spawnQuery timeout and clean up .cmd file on spawnInteractive failure

### DIFF
--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -466,48 +466,56 @@ export async function spawnInteractive(options: InteractiveSpawnOptions): Promis
     env,
   });
 
-  const termPref = options.terminalPref ?? config.terminalCmd;
-  let useWindowsTerminal = false;
-  if (termPref === 'wt') {
-    useWindowsTerminal = true;
-  } else if (termPref === 'auto') {
-    useWindowsTerminal = await detectWindowsTerminal();
+  let cleanedUp = false;
+  try {
+    const termPref = options.terminalPref ?? config.terminalCmd;
+    let useWindowsTerminal = false;
+    if (termPref === 'wt') {
+      useWindowsTerminal = true;
+    } else if (termPref === 'auto') {
+      useWindowsTerminal = await detectWindowsTerminal();
+    }
+    // termPref === 'cmd' → useWindowsTerminal remains false
+
+    // Strip `"` from the title; it is embedded inside a `"..."` quoted string
+    // in the launch command. Spaces and other printable chars are fine.
+    const safeTitle = options.windowTitle.replace(/"/g, '');
+    // The .cmd path comes from os.tmpdir() which never contains `"`, so
+    // wrapping in double-quotes is sufficient for paths with spaces.
+    const quotedCmdFile = `"${cmdFilePath}"`;
+
+    let launchCmd: string;
+    if (useWindowsTerminal) {
+      launchCmd = `wt.exe new-tab --title "${safeTitle}" cmd.exe /k ${quotedCmdFile}`;
+    } else {
+      launchCmd = `start "${safeTitle}" cmd.exe /k ${quotedCmdFile}`;
+    }
+
+    console.log(
+      `[cc-spawn] interactive: terminal=${useWindowsTerminal ? 'wt' : 'cmd'}` +
+      ` worktree=${options.worktreeName} launcher=${cmdFilePath}`,
+    );
+
+    // shell:true is required so `start` (a cmd builtin) and `wt.exe` (PATH-resolved)
+    // work correctly. detached:true lets the window outlive the server process.
+    const launcher = spawn(launchCmd, [], {
+      env: env as NodeJS.ProcessEnv,
+      shell: true,
+      detached: true,
+      stdio: 'ignore',
+    });
+    launcher.unref();
+
+    // Best-effort cleanup after 60 s (generous margin for terminal startup)
+    setTimeout(() => {
+      try { fs.unlinkSync(cmdFilePath); } catch { /* ignore */ }
+    }, 60_000);
+    cleanedUp = true;
+  } finally {
+    if (!cleanedUp) {
+      try { fs.unlinkSync(cmdFilePath); } catch { /* ignore */ }
+    }
   }
-  // termPref === 'cmd' → useWindowsTerminal remains false
-
-  // Strip `"` from the title; it is embedded inside a `"..."` quoted string
-  // in the launch command. Spaces and other printable chars are fine.
-  const safeTitle = options.windowTitle.replace(/"/g, '');
-  // The .cmd path comes from os.tmpdir() which never contains `"`, so
-  // wrapping in double-quotes is sufficient for paths with spaces.
-  const quotedCmdFile = `"${cmdFilePath}"`;
-
-  let launchCmd: string;
-  if (useWindowsTerminal) {
-    launchCmd = `wt.exe new-tab --title "${safeTitle}" cmd.exe /k ${quotedCmdFile}`;
-  } else {
-    launchCmd = `start "${safeTitle}" cmd.exe /k ${quotedCmdFile}`;
-  }
-
-  console.log(
-    `[cc-spawn] interactive: terminal=${useWindowsTerminal ? 'wt' : 'cmd'}` +
-    ` worktree=${options.worktreeName} launcher=${cmdFilePath}`,
-  );
-
-  // shell:true is required so `start` (a cmd builtin) and `wt.exe` (PATH-resolved)
-  // work correctly. detached:true lets the window outlive the server process.
-  const launcher = spawn(launchCmd, [], {
-    env: env as NodeJS.ProcessEnv,
-    shell: true,
-    detached: true,
-    stdio: 'ignore',
-  });
-  launcher.unref();
-
-  // Best-effort cleanup after 60 s (generous margin for terminal startup)
-  setTimeout(() => {
-    try { fs.unlinkSync(cmdFilePath); } catch { /* ignore */ }
-  }, 60_000);
 }
 
 // ---------------------------------------------------------------------------
@@ -597,7 +605,9 @@ export function spawnQuery(options: QuerySpawnOptions): Promise<QuerySpawnResult
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
       try {
-        if (process.platform === 'win32') {
+        if (child.pid === undefined) {
+          // spawn failed — no process to kill
+        } else if (process.platform === 'win32') {
           // Kill the full process tree; SIGKILL is not available on Windows.
           spawn('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
             stdio: 'pipe',

--- a/tests/server/cc-spawn.test.ts
+++ b/tests/server/cc-spawn.test.ts
@@ -858,6 +858,34 @@ describe('cc-spawn', () => {
       expect(writeOpts).toEqual({ encoding: 'utf8' });
     });
 
+    it('cleans up temp .cmd file immediately when spawn throws', async () => {
+      // Make spawn throw to simulate a failure after writeLauncherCmdFile
+      mockSpawn.mockImplementation(() => { throw new Error('spawn ENOENT'); });
+
+      await expect(spawnInteractive({
+        mode: 'interactive',
+        cwd: 'C:\\repos\\proj',
+        worktreeName: 'proj-42',
+        windowTitle: 'Team proj-42',
+        fleetContext: makeFleetContext(),
+        prompt: 'Fix it',
+        terminalPref: 'cmd',
+      })).rejects.toThrow('spawn ENOENT');
+
+      // The .cmd file should have been written
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+      // The finally block should have deleted the file immediately (no timer needed)
+      expect(mockUnlinkSync).toHaveBeenCalledTimes(1);
+      const [deletedPath] = mockUnlinkSync.mock.calls[0];
+      expect(deletedPath).toMatch(/fleet-cc-.*\.cmd$/);
+
+      // No timer should have been scheduled for cleanup (it was immediate)
+      vi.advanceTimersByTime(60_000);
+      // Still only 1 call — no timer-based cleanup
+      expect(mockUnlinkSync).toHaveBeenCalledTimes(1);
+    });
+
     it('includes CLAUDE_CODE_GIT_BASH_PATH SET in launcher when findGitBash returns path', async () => {
       mockFindGitBash.mockReturnValue('C:\\Program Files\\Git\\bin\\bash.exe');
 
@@ -1108,6 +1136,40 @@ describe('cc-spawn', () => {
       expect(opts.env['FLEET_PROJECT_ID']).toBeUndefined();
       // But should still have agent teams flag
       expect(opts.env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS']).toBe('1');
+    });
+
+    it('skips taskkill when child.pid is undefined on timeout', async () => {
+      vi.useRealTimers();
+
+      // Create a child with undefined pid to simulate a failed spawn
+      const child = createMockChild();
+      (child as { pid: number | undefined }).pid = undefined;
+
+      let spawnCallCount = 0;
+      mockSpawn.mockImplementation(() => {
+        spawnCallCount++;
+        if (spawnCallCount === 1) return child; // the CC spawn (with undefined pid)
+        return createMockChild(); // should NOT be reached — no taskkill call
+      });
+
+      const promise = spawnQuery({
+        mode: 'query',
+        prompt: 'Analyze',
+        jsonSchema: { type: 'object' },
+        timeoutMs: 50,
+      });
+
+      // After the timeout fires, simulate the child closing
+      setTimeout(() => {
+        child.emit('close', null);
+      }, 100);
+
+      const result = await promise;
+      expect(result.timedOut).toBe(true);
+      expect(result.exitedOk).toBe(false);
+
+      // spawn should have been called exactly once (for CC, not for taskkill)
+      expect(spawnCallCount).toBe(1);
     });
 
     it('handles timeout by setting timedOut:true', async () => {


### PR DESCRIPTION
Closes #536

## Summary
- Guard `child.pid !== undefined` in `spawnQuery()` timeout handler before calling `taskkill` — prevents `String(undefined)` being passed as PID argument
- Wrap `spawnInteractive()` post-`writeLauncherCmdFile` code in `try/finally` to ensure temp `.cmd` file cleanup on error (immediate delete on failure, delayed 60s cleanup on success)

## Test plan
- [x] New test: spawnQuery skips taskkill when child.pid is undefined
- [x] New test: spawnInteractive cleans up .cmd file immediately when spawn throws
- [x] All existing cc-spawn tests pass
- [x] TypeScript compiles without errors