### PR TITLE
Issue #537: Add ORDER BY id DESC to getTeamDashboard for deterministic pagination

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1951,7 +1951,7 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   getTeamDashboard(pagination?: { limit?: number; offset?: number }): TeamDashboardRow[] {
-    let sql = 'SELECT * FROM v_team_dashboard';
+    let sql = 'SELECT * FROM v_team_dashboard ORDER BY id DESC';
     const params: Record<string, unknown> = {};
 
     if (pagination?.limit) {

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -573,6 +573,32 @@ describe('v_team_dashboard view', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].prState).toBeNull();
   });
+
+  it('returns rows in id DESC order with pagination', () => {
+    // Insert 3 teams; they will get ids 1, 2, 3
+    db.insertTeam({ issueNumber: 100, worktreeName: 'order-100', status: 'running', phase: 'init' });
+    db.insertTeam({ issueNumber: 101, worktreeName: 'order-101', status: 'running', phase: 'init' });
+    db.insertTeam({ issueNumber: 102, worktreeName: 'order-102', status: 'running', phase: 'init' });
+
+    // Without pagination, all 3 returned in id DESC order
+    const all = db.getTeamDashboard();
+    expect(all.map((r) => r.id)).toEqual([3, 2, 1]);
+
+    // Page 1: limit=2, offset=0 -> ids 3, 2
+    const page1 = db.getTeamDashboard({ limit: 2, offset: 0 });
+    expect(page1.map((r) => r.id)).toEqual([3, 2]);
+
+    // Page 2: limit=2, offset=2 -> id 1
+    const page2 = db.getTeamDashboard({ limit: 2, offset: 2 });
+    expect(page2.map((r) => r.id)).toEqual([1]);
+
+    // No overlap between pages
+    const page1Ids = new Set(page1.map((r) => r.id));
+    const page2Ids = new Set(page2.map((r) => r.id));
+    for (const id of page2Ids) {
+      expect(page1Ids.has(id)).toBe(false);
+    }
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #537

## Summary
- Add `ORDER BY id DESC` to `getTeamDashboard()` base query in `db.ts` so LIMIT/OFFSET pagination returns deterministic, non-overlapping results
- Add test verifying ordering and page non-overlap in `db.test.ts`

## Test plan
- [x] `npm run test:server` passes (97 db tests green)
- [x] New test verifies: unpaginated id DESC order, page 1 correctness, page 2 correctness, no overlap between pages
- [x] Existing v_team_dashboard tests unaffected