### PR TITLE
Issue #538: Prevent partial fetch failure from caching empty results with valid cachedAt

### DIFF
--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -285,16 +285,21 @@ export class IssueFetcher {
     let allNodes: GraphQLIssueNode[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
+    let fetchComplete = true;
 
     while (hasNextPage) {
       const result = await this.executeGraphQL(owner, repo, cursor);
       if (!result) {
         // gh CLI error -- return whatever we have so far (or empty)
+        fetchComplete = false;
         break;
       }
 
       const issues = result.data?.repository?.issues;
-      if (!issues?.nodes) break;
+      if (!issues?.nodes) {
+        fetchComplete = false;
+        break;
+      }
 
       allNodes = allNodes.concat(issues.nodes);
       hasNextPage = issues.pageInfo?.hasNextPage ?? false;
@@ -460,10 +465,20 @@ export class IssueFetcher {
     }
 
     // Update the per-project cache
-    this.cacheByProject.set(projectId, {
-      issues: rootIssues,
-      cachedAt: new Date().toISOString(),
-    });
+    if (fetchComplete) {
+      this.cacheByProject.set(projectId, {
+        issues: rootIssues,
+        cachedAt: new Date().toISOString(),
+      });
+    } else if (!this.cacheByProject.has(projectId)) {
+      // Partial failure on first fetch: store with null cachedAt so
+      // getIssues() will trigger a background refetch next time.
+      this.cacheByProject.set(projectId, {
+        issues: rootIssues,
+        cachedAt: null,
+      });
+    }
+    // else: partial failure with existing cache — keep previous good data
 
     return rootIssues;
   }

--- a/tests/server/issue-fetcher-orphan.test.ts
+++ b/tests/server/issue-fetcher-orphan.test.ts
@@ -330,3 +330,140 @@ describe('IssueFetcher orphan detection', () => {
     fetchParentsSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Partial fetch failure caching tests
+// ---------------------------------------------------------------------------
+
+describe('IssueFetcher partial fetch failure caching', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+  });
+
+  it('should not cache empty results with valid cachedAt when GraphQL fetch fails on first page', async () => {
+    // Simulate gh CLI error on the very first page
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(null);
+
+    const result = await fetcher.fetchIssueHierarchy(1);
+
+    // Should return empty array
+    expect(result).toHaveLength(0);
+
+    // The cache entry should exist but with cachedAt: null (not a valid timestamp)
+    const cache = (fetcher as any).cacheByProject.get(1);
+    expect(cache).toBeDefined();
+    expect(cache.cachedAt).toBeNull();
+    expect(cache.issues).toHaveLength(0);
+
+    graphqlSpy.mockRestore();
+  });
+
+  it('should preserve previous good cache when GraphQL fetch fails mid-pagination', async () => {
+    // First, successfully populate the cache with valid data
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 1, title: 'Issue 1' },
+        { number: 2, title: 'Issue 2' },
+      ])
+    );
+
+    const firstResult = await fetcher.fetchIssueHierarchy(1);
+    expect(firstResult).toHaveLength(2);
+
+    // Capture the original cachedAt timestamp
+    const cacheAfterSuccess = (fetcher as any).cacheByProject.get(1);
+    const originalCachedAt = cacheAfterSuccess.cachedAt;
+    expect(originalCachedAt).not.toBeNull();
+
+    // Now simulate a failure on the next fetch
+    graphqlSpy.mockResolvedValue(null);
+
+    const secondResult = await fetcher.fetchIssueHierarchy(1);
+    // The function still returns whatever it collected (empty in this case)
+    expect(secondResult).toHaveLength(0);
+
+    // But the cache should still hold the previous good data
+    const cacheAfterFailure = (fetcher as any).cacheByProject.get(1);
+    expect(cacheAfterFailure.issues).toHaveLength(2);
+    expect(cacheAfterFailure.cachedAt).toBe(originalCachedAt);
+
+    graphqlSpy.mockRestore();
+  });
+
+  it('should set cachedAt to null on first fetch failure so getIssues triggers refetch', async () => {
+    // No prior cache — simulate gh CLI error
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(null);
+
+    await fetcher.fetchIssueHierarchy(1);
+
+    // cachedAt should be null
+    const cache = (fetcher as any).cacheByProject.get(1);
+    expect(cache.cachedAt).toBeNull();
+
+    // Now spy on fetchIssueHierarchy to verify getIssues triggers a refetch
+    const fetchSpy = vi.spyOn(fetcher, 'fetchIssueHierarchy').mockResolvedValue([]);
+
+    const issues = await fetcher.getIssues(1);
+
+    // getIssues should return empty (from cache) and trigger a background refetch
+    expect(issues).toHaveLength(0);
+    expect(fetchSpy).toHaveBeenCalledWith(1);
+
+    graphqlSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('should cache with valid cachedAt when fetch completes successfully', async () => {
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([
+        { number: 1, title: 'Issue 1' },
+      ])
+    );
+
+    await fetcher.fetchIssueHierarchy(1);
+
+    const cache = (fetcher as any).cacheByProject.get(1);
+    expect(cache).toBeDefined();
+    expect(cache.cachedAt).not.toBeNull();
+    expect(typeof cache.cachedAt).toBe('string');
+    expect(cache.issues).toHaveLength(1);
+
+    graphqlSpy.mockRestore();
+  });
+
+  it('should cache empty repository correctly with valid cachedAt', async () => {
+    // Empty repo — zero issues but fetch completes successfully
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue(
+      makeGraphQLResponse([])
+    );
+
+    await fetcher.fetchIssueHierarchy(1);
+
+    const cache = (fetcher as any).cacheByProject.get(1);
+    expect(cache).toBeDefined();
+    expect(cache.cachedAt).not.toBeNull();
+    expect(typeof cache.cachedAt).toBe('string');
+    expect(cache.issues).toHaveLength(0);
+
+    graphqlSpy.mockRestore();
+  });
+
+  it('should not cache when issues.nodes is falsy on first page with no prior cache', async () => {
+    // Simulate a response where issues.nodes is undefined
+    const graphqlSpy = vi.spyOn(fetcher as any, 'executeGraphQL').mockResolvedValue({
+      data: { repository: { issues: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: undefined } } },
+    });
+
+    await fetcher.fetchIssueHierarchy(1);
+
+    // Should set cachedAt to null since this is a partial failure with no prior cache
+    const cache = (fetcher as any).cacheByProject.get(1);
+    expect(cache).toBeDefined();
+    expect(cache.cachedAt).toBeNull();
+
+    graphqlSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #538

## Summary
- Added `fetchComplete` boolean flag to track whether the GraphQL pagination loop completed fully
- Cache write is now conditional: full success caches with valid `cachedAt`; partial failure on first fetch stores with `cachedAt: null` (triggering background refetch); partial failure with existing cache preserves previous good data
- Added 6 test cases covering all partial failure caching scenarios

## Test plan
- [x] `npm test` passes (13/13 tests in issue-fetcher-orphan.test.ts)
- [x] First-page failure on first fetch → `cachedAt: null`, `getIssues()` triggers refetch
- [x] Mid-pagination failure with existing cache → previous good data preserved
- [x] Successful fetch → cache updated normally with valid `cachedAt`
- [x] Empty repo (zero issues) → valid `cachedAt` (not treated as failure)