### PR TITLE
Issue #562: Fix Tasks tab SSE auto-refresh

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelection, useConnection, useThinking } from '../context/FleetContext';
 import { useApi } from '../hooks/useApi';
+import { useFleetSSE } from '../hooks/useFleetSSE';
 import { useTeamDetailData } from '../hooks/useTeamDetailData';
 import { StatusBadge } from './StatusBadge';
 import { CIChecks } from './CIChecks';
@@ -49,13 +50,18 @@ export function TeamDetail() {
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const selectedTeamIdRef = useRef(selectedTeamId);
+  const activeTabRef = useRef(activeTab);
 
   const isOpen = selectedTeamId !== null;
 
-  // Keep ref in sync with selectedTeamId for use in async callbacks
+  // Keep refs in sync for use in async callbacks
   useEffect(() => {
     selectedTeamIdRef.current = selectedTeamId;
   }, [selectedTeamId]);
+
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
 
   // Reset active tab, metadata collapse state, and agent filters when team changes
   useEffect(() => {
@@ -92,20 +98,17 @@ export function TeamDetail() {
   }, [activeTab, selectedTeamId, api]);
 
   // Refresh tasks on SSE task_updated events
-  useEffect(() => {
-    if (activeTab !== 'tasks' || !selectedTeamId) return;
-    if (!lastEvent || lastEventTeamId !== selectedTeamId) return;
-    try {
-      const parsed = typeof lastEvent === 'string' ? JSON.parse(lastEvent) : lastEvent;
-      if (parsed?.type === 'task_updated') {
-        api.get<TeamTask[]>(`teams/${selectedTeamId}/tasks`)
-          .then((data) => setTasks(data))
-          .catch(() => { /* SSE refresh is best-effort */ });
-      }
-    } catch {
-      // Ignore parse errors
-    }
-  }, [activeTab, selectedTeamId, lastEvent, lastEventTeamId, api]);
+  const handleTaskUpdated = useCallback((_type: string, data: unknown) => {
+    const payload = data as { team_id: number };
+    const teamId = selectedTeamIdRef.current;
+    if (activeTabRef.current !== 'tasks' || !teamId) return;
+    if (payload.team_id !== teamId) return;
+    api.get<TeamTask[]>(`teams/${teamId}/tasks`)
+      .then((tasks) => setTasks(tasks))
+      .catch(() => { /* SSE refresh is best-effort */ });
+  }, [api]);
+
+  useFleetSSE('task_updated', handleTaskUpdated);
 
   // Close panel handler
   const handleClose = useCallback(() => {

--- a/src/client/hooks/useSSE.ts
+++ b/src/client/hooks/useSSE.ts
@@ -50,7 +50,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
       'pr_updated', 'team_launched', 'team_stopped',
       'usage_updated', 'project_added', 'project_updated', 'project_removed',
       'project_cleanup', 'dependency_resolved', 'heartbeat',
-      'team_thinking_start', 'team_thinking_stop',
+      'team_thinking_start', 'team_thinking_stop', 'task_updated',
     ];
 
     const handleSSEMessage = (event: MessageEvent) => {

--- a/tests/client/TeamDetail.test.tsx
+++ b/tests/client/TeamDetail.test.tsx
@@ -52,6 +52,10 @@ vi.mock('../../src/client/components/CommGraph', () => ({
   CommGraph: () => <div data-testid="comm-graph">CommGraph</div>,
 }));
 
+vi.mock('../../src/client/hooks/useFleetSSE', () => ({
+  useFleetSSE: vi.fn(),
+}));
+
 // Import after mocks
 import { TeamDetail } from '../../src/client/components/TeamDetail';
 


### PR DESCRIPTION
Closes #562

## Summary
- Added `task_updated` to SSE `namedEventTypes` array so EventSource receives these events
- Replaced dead `lastEvent` type-check code in TeamDetail.tsx with proper `useFleetSSE` subscription
- Handler filters by `team_id` and only refreshes when Tasks tab is active
- Added `useFleetSSE` mock in TeamDetail tests

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run test:client` passes (all 16 TeamDetail tests green)