### PR TITLE
Issue #563: prevent stop() from overwriting done with failed and make 5s sleep cancellable

### DIFF
--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -430,12 +430,18 @@ export class TeamManager {
     // Try graceful shutdown via stdin.end() first — closing stdin signals
     // Claude Code to finish its current work and exit cleanly.
     const stdin = this.stdinPipes.get(teamId);
+    const child = this.childProcesses.get(teamId);
     if (stdin && !stdin.destroyed) {
       try {
         stdin.end();
         console.log(`[TeamManager] Sent stdin EOF to team ${teamId} for graceful shutdown`);
-        // Give the process 5 seconds to finish gracefully before force-killing
-        await new Promise(resolve => setTimeout(resolve, 5000));
+        // Give the process 5 seconds to finish gracefully before force-killing.
+        // If the child process exits early, resolve immediately instead of
+        // blocking for the full 5 seconds.
+        await new Promise<void>(resolve => {
+          const timer = setTimeout(resolve, 5000);
+          child?.once('exit', () => { clearTimeout(timer); resolve(); });
+        });
       } catch {
         // stdin.end() failed — fall through to force kill
       }
@@ -464,13 +470,12 @@ export class TeamManager {
         trigger: 'pm_action',
         reason: 'PM stopped team',
       });
+      db.updateTeamSilent(teamId, {
+        status: 'failed',
+        pid: null,
+        stoppedAt: new Date().toISOString(),
+      });
     }
-
-    const updated = db.updateTeam(teamId, {
-      status: 'failed',
-      pid: null,
-      stoppedAt: new Date().toISOString(),
-    });
 
     sseBroker.broadcast(
       'team_stopped',
@@ -487,7 +492,7 @@ export class TeamManager {
       });
     }
 
-    return updated!;
+    return db.getTeam(teamId)!;
   }
 
   // -------------------------------------------------------------------------

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -222,6 +222,63 @@ describe('TeamManager.stop', () => {
       1,
     );
   });
+
+  it('should not overwrite done status when process exits cleanly during grace period', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+    const mockStdin = createMockStdin();
+    const child = createMockChildProcess();
+
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).childProcesses.set(1, child);
+
+    // First call: initial team lookup (running)
+    // Second call: after grace period, freshTeam for killProcess (pid gone)
+    // Third call: stopTeam re-read shows 'done' (exit handler ran)
+    // Fourth call: final return
+    mockDb.getTeam
+      .mockReturnValueOnce(team)                                    // initial
+      .mockReturnValueOnce({ ...team, pid: null, status: 'done' }) // freshTeam
+      .mockReturnValueOnce({ ...team, pid: null, status: 'done' }) // stopTeam
+      .mockReturnValueOnce({ ...team, pid: null, status: 'done' }); // return
+
+    const stopPromise = tm.stop(1);
+
+    // Simulate process exiting immediately (triggers early resolve of the sleep)
+    child.emit('exit', 0, null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await stopPromise;
+
+    // insertTransition should NOT have been called with 'failed'
+    // because stopTeam.status was already 'done'
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    // updateTeamSilent should NOT have been called to overwrite done with failed
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
+    expect(mockDb.updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('should resolve the 5s grace period early when process exits', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+    const mockStdin = createMockStdin();
+    const child = createMockChildProcess();
+
+    (tm as any).stdinPipes.set(1, mockStdin);
+    (tm as any).childProcesses.set(1, child);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    const stopPromise = tm.stop(1);
+
+    // Emit exit immediately — should cancel the 5s timer
+    child.emit('exit', 0, null);
+
+    // Advance only 100ms — if the race works, stop() should already resolve
+    await vi.advanceTimersByTimeAsync(100);
+    await stopPromise;
+
+    // stop() completed without needing the full 5000ms
+    expect(mockStdin.end).toHaveBeenCalled();
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #563

## Summary
- Guard `db.updateTeamSilent` and `db.insertTransition` inside `stop()` to skip when team is already in terminal state (`done`/`failed`), preventing the 5s grace period from overwriting a clean exit
- Race the 5s grace-period timer against the child process `exit` event so it resolves immediately when the process exits early
- Add two new tests covering both fixes

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run test:server` passes (3 pre-existing failures in `cc-spawn.test.ts` unrelated)
- [x] New test: stop() does not overwrite done with failed
- [x] New test: 5s sleep resolves early on process exit
- [x] Existing stop() tests pass unchanged