### PR TITLE
Issue #571: Add try/catch error handling to zero-arg MCP tools

### DIFF
--- a/src/server/mcp/tools/get-usage.ts
+++ b/src/server/mcp/tools/get-usage.ts
@@ -12,6 +12,7 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getUsageService } from '../../services/usage-service.js';
+import { ServiceError } from '../../services/service-error.js';
 
 /**
  * Registers the `fleet_get_usage` tool on the given MCP server.
@@ -24,17 +25,27 @@ export function registerGetUsageTool(server: McpServer): void {
     'fleet_get_usage',
     'Get current usage percentages (daily, weekly, sonnet, extra) with zone indicator',
     async () => {
-      const usageService = getUsageService();
-      const usage = usageService.getLatest();
+      try {
+        const usageService = getUsageService();
+        const usage = usageService.getLatest();
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(usage, null, 2),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(usage, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
     },
   );
 }

--- a/src/server/mcp/tools/list-projects.ts
+++ b/src/server/mcp/tools/list-projects.ts
@@ -11,6 +11,7 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getProjectService } from '../../services/project-service.js';
+import { ServiceError } from '../../services/service-error.js';
 
 /**
  * Registers the `fleet_list_projects` tool on the given MCP server.
@@ -23,17 +24,27 @@ export function registerListProjectsTool(server: McpServer): void {
     'fleet_list_projects',
     'Returns all registered projects with team counts and install status',
     async () => {
-      const service = getProjectService();
-      const projects = service.listProjects();
+      try {
+        const service = getProjectService();
+        const projects = service.listProjects();
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(projects, null, 2),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(projects, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
     },
   );
 }

--- a/src/server/mcp/tools/system-health.ts
+++ b/src/server/mcp/tools/system-health.ts
@@ -11,6 +11,7 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getDiagnosticsService } from '../../services/diagnostics-service.js';
+import { ServiceError } from '../../services/service-error.js';
 
 /**
  * Registers the `fleet_system_health` tool on the given MCP server.
@@ -23,17 +24,27 @@ export function registerSystemHealthTool(server: McpServer): void {
     'fleet_system_health',
     'Returns a fleet health summary with team counts by status and phase',
     async () => {
-      const diagnostics = getDiagnosticsService();
-      const summary = diagnostics.getHealthSummary();
+      try {
+        const diagnostics = getDiagnosticsService();
+        const summary = diagnostics.getHealthSummary();
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(summary, null, 2),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(summary, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
     },
   );
 }

--- a/tests/server/mcp/get-usage.test.ts
+++ b/tests/server/mcp/get-usage.test.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before imports
@@ -154,15 +155,32 @@ describe('fleet_get_usage MCP tool', () => {
     expect(parsed).toBeNull();
   });
 
-  it('handler propagates service errors (no try/catch in zero-arg tool)', async () => {
+  it('handler returns isError on ServiceError', async () => {
     mockGetLatest.mockImplementationOnce(() => {
-      throw new Error('DB read failure');
+      throw new ServiceError('DB read failure', 'EXTERNAL_ERROR', 502);
     });
 
     registerGetUsageTool(mockMcpServer as any);
 
     const handler = registeredTools[0]!.handler;
-    await expect(handler()).rejects.toThrow('DB read failure');
+    const result = (await handler()) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('DB read failure');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockGetLatest.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerGetUsageTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler()).rejects.toThrow('unexpected');
   });
 
   it('handler serializes all percentage fields in output', async () => {

--- a/tests/server/mcp/list-projects.test.ts
+++ b/tests/server/mcp/list-projects.test.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before imports
@@ -125,15 +126,32 @@ describe('fleet_list_projects MCP tool', () => {
     expect(parsed).toEqual([]);
   });
 
-  it('handler propagates service errors (no try/catch in zero-arg tool)', async () => {
+  it('handler returns isError on ServiceError', async () => {
     mockListProjects.mockImplementationOnce(() => {
-      throw new Error('DB connection lost');
+      throw new ServiceError('DB connection lost', 'EXTERNAL_ERROR', 502);
     });
 
     registerListProjectsTool(mockMcpServer as any);
 
     const handler = registeredTools[0]!.handler;
-    await expect(handler()).rejects.toThrow('DB connection lost');
+    const result = (await handler()) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('DB connection lost');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockListProjects.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerListProjectsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler()).rejects.toThrow('unexpected');
   });
 
   it('handler calls listProjects exactly once per invocation', async () => {

--- a/tests/server/mcp/system-health.test.ts
+++ b/tests/server/mcp/system-health.test.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
 import type { HealthSummary } from '../../../src/server/services/diagnostics-service.js';
 
 // ---------------------------------------------------------------------------
@@ -140,15 +141,32 @@ describe('fleet_system_health MCP tool', () => {
     expect(parsed.byPhase).toEqual({});
   });
 
-  it('handler propagates service errors (no try/catch in zero-arg tool)', async () => {
+  it('handler returns isError on ServiceError', async () => {
     mockGetHealthSummary.mockImplementationOnce(() => {
-      throw new Error('diagnostics unavailable');
+      throw new ServiceError('diagnostics unavailable', 'EXTERNAL_ERROR', 502);
     });
 
     registerSystemHealthTool(mockMcpServer as any);
 
     const handler = registeredTools[0]!.handler;
-    await expect(handler()).rejects.toThrow('diagnostics unavailable');
+    const result = (await handler()) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('diagnostics unavailable');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockGetHealthSummary.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerSystemHealthTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler()).rejects.toThrow('unexpected');
   });
 
   it('handler includes byStatus and byPhase breakdowns', async () => {


### PR DESCRIPTION
Closes #571

## Summary
- Add try/catch + `isError: true` error handling to `fleet_list_projects`, `fleet_system_health`, and `fleet_get_usage` MCP tools
- Catches `ServiceError` instances and returns structured error response; re-throws non-`ServiceError` exceptions
- Follows the existing pattern already used in 8 other parameterized MCP tools (e.g., `get-team.ts`, `launch-team.ts`)
- Updates corresponding tests: replaces old propagation tests with ServiceError catch + re-throw assertions

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 94 MCP tests pass across 12 test files
- [x] Each tool catches `ServiceError` and returns `{ isError: true }`
- [x] Each tool re-throws non-`ServiceError` exceptions