### PR TITLE
Issue #569: Add active-team re-check before worktree directory removal

### DIFF
--- a/src/server/services/cleanup.ts
+++ b/src/server/services/cleanup.ts
@@ -13,6 +13,11 @@ import { getDatabase } from '../db.js';
 import config from '../config.js';
 import type { CleanupItem, CleanupPreview, CleanupResult } from '../../shared/types.js';
 
+// Statuses that indicate a team is actively using its worktree/branch.
+// Used in both preview (to exclude active teams) and execute (to re-check
+// before destructive operations in case a team was re-queued between phases).
+const ACTIVE_STATUSES = ['queued', 'launching', 'running', 'idle', 'stuck'] as const;
+
 // ---------------------------------------------------------------------------
 // Preview (dry run)
 // ---------------------------------------------------------------------------
@@ -38,10 +43,9 @@ export function getCleanupPreview(projectId: number, resetTeams: boolean = false
 
   // Build set of worktree names belonging to active teams
   const allTeams = db.getTeams({ projectId });
-  const activeStatuses = ['queued', 'launching', 'running', 'idle', 'stuck'];
   const activeWorktreeNames = new Set(
     allTeams
-      .filter((t) => activeStatuses.includes(t.status))
+      .filter((t) => (ACTIVE_STATUSES as readonly string[]).includes(t.status))
       .map((t) => t.worktreeName),
   );
 
@@ -140,7 +144,7 @@ export function getCleanupPreview(projectId: number, resetTeams: boolean = false
 
       // Defense-in-depth: direct DB check in case activeWorktreeNames is stale
       const branchTeam = db.getTeamByWorktree(worktreeName);
-      if (branchTeam && activeStatuses.includes(branchTeam.status)) continue;
+      if (branchTeam && (ACTIVE_STATUSES as readonly string[]).includes(branchTeam.status)) continue;
       // Skip branches belonging to a different project
       if (branchTeam && branchTeam.projectId !== projectId) continue;
 
@@ -211,6 +215,12 @@ export function executeCleanup(
 
     try {
       if (item.type === 'worktree') {
+        // Re-check: skip if this worktree now belongs to an active/re-queued team
+        const ownerTeam = db.getTeamByWorktree(item.name);
+        if (ownerTeam && (ACTIVE_STATUSES as readonly string[]).includes(ownerTeam.status)) {
+          console.log(`[Cleanup] Skipping worktree ${item.name} — team ${ownerTeam.id} is now ${ownerTeam.status}`);
+          continue;
+        }
         // Try git worktree remove first (properly unlinks)
         try {
           execSync(
@@ -245,7 +255,7 @@ export function executeCleanup(
           ? item.name.slice('worktree-'.length)
           : item.name;
         const ownerTeam = db.getTeamByWorktree(branchWorktree);
-        if (ownerTeam && ['queued', 'launching', 'running', 'idle', 'stuck'].includes(ownerTeam.status)) {
+        if (ownerTeam && (ACTIVE_STATUSES as readonly string[]).includes(ownerTeam.status)) {
           console.log(`[Cleanup] Skipping branch ${item.name} — team ${ownerTeam.id} is now ${ownerTeam.status}`);
           continue;
         }

--- a/tests/server/cleanup.test.ts
+++ b/tests/server/cleanup.test.ts
@@ -484,6 +484,50 @@ describe('executeCleanup', () => {
     expect(branchDeleteCalls.length).toBe(0);
   });
 
+  it('skips worktree removal when team becomes active between preview and execute', () => {
+    const project = makeProject();
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([]);
+
+    // Setup: worktree dir has an orphan directory
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (pathContains(p, '.claude/worktrees')) return true;
+      return false;
+    });
+    mockFs.readdirSync.mockImplementation((p: string, opts?: unknown) => {
+      if (pathContains(p, '.claude/worktrees') && opts) {
+        return [makeDirent('test-project-42')];
+      }
+      return [];
+    });
+    mockExecSync.mockReturnValue('');
+
+    // The preview re-scan (getCleanupPreview inside executeCleanup) returns the
+    // worktree as an orphan because getTeamByWorktree returns undefined during
+    // the preview phase. But the just-before-delete guard finds the team is now queued.
+    let callCount = 0;
+    mockDb.getTeamByWorktree.mockImplementation(() => {
+      callCount++;
+      // First call is from getCleanupPreview (worktree scan) — no team yet
+      if (callCount <= 1) return undefined;
+      // Second call is from executeCleanup just-before-delete guard — team is now queued
+      return makeTeam({ id: 42, status: 'queued', worktreeName: 'test-project-42' });
+    });
+
+    const normalizedPath = '/tmp/repo/.claude/worktrees/test-project-42';
+    const result = executeCleanup(1, [normalizedPath]);
+
+    // Worktree should NOT be removed
+    expect(result.removed).not.toContain('test-project-42');
+    // Verify git worktree remove was NOT called
+    const worktreeRemoveCalls = mockExecSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('worktree remove'),
+    );
+    expect(worktreeRemoveCalls.length).toBe(0);
+    // Verify fs.rmSync was NOT called
+    expect(mockFs.rmSync).not.toHaveBeenCalled();
+  });
+
   it('deletes team records when included in itemPaths', () => {
     const project = makeProject();
     const team = makeTeam({ id: 10, status: 'done' });


### PR DESCRIPTION
Closes #569

## Summary
- Add `db.getTeamByWorktree()` re-check guard in `executeCleanup()` before worktree directory removal to prevent race condition where a team gets re-queued between preview and execute
- Extract inline `activeStatuses` arrays into a shared `ACTIVE_STATUSES` module-level constant to reduce duplication (4 usages)
- Add test verifying the race condition guard correctly skips worktree removal when team becomes active

## Test plan
- [x] New test: `skips worktree removal when team becomes active between preview and execute`
- [x] All 19 cleanup tests pass
- [x] `npm run test:server` passes
- [x] TypeScript compiles cleanly