### PR TITLE
Issue #570: Fix refetch guard for partial cache with null cachedAt

### DIFF
--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -507,15 +507,16 @@ export class IssueFetcher {
   }
 
   /**
-   * Returns cached issues for a project. If cache is empty, kicks off a
-   * background fetch and returns an empty array immediately (non-blocking).
+   * Returns cached issues for a project. If cache is missing or was only
+   * partially populated (cachedAt is null), kicks off a background fetch
+   * and returns an empty array immediately (non-blocking).
    * The polling loop or initial fetchAllProjects() will populate the cache.
    * For synchronous access, use getIssuesCached() instead.
    */
   async getIssues(projectId?: number): Promise<IssueNode[]> {
     if (projectId !== undefined) {
       const cached = this.cacheByProject.get(projectId);
-      if (!cached || (cached.issues.length === 0 && !cached.cachedAt)) {
+      if (!cached || !cached.cachedAt) {
         // Fire-and-forget background fetch; return empty immediately
         console.info(`[IssueFetcher] Cache miss for project ${projectId}, triggering background fetch`);
         this.fetchIssueHierarchy(projectId).catch((err) => {

--- a/tests/server/issue-fetcher-performance.test.ts
+++ b/tests/server/issue-fetcher-performance.test.ts
@@ -270,4 +270,37 @@ describe('getIssues non-blocking cache miss', () => {
     // actually update the internal cache, we test via getIssuesCached path)
     fetchSpy.mockRestore();
   });
+
+  it('triggers refetch when cache has issues but cachedAt is null (partial failure)', async () => {
+    // Directly populate internal cache with partial data (non-empty issues, null cachedAt)
+    const cache = (fetcher as any).cacheByProject as Map<number, { issues: IssueNode[]; cachedAt: string | null }>;
+    cache.set(1, {
+      issues: [
+        {
+          number: 42,
+          title: 'Partial issue',
+          state: 'open',
+          labels: [],
+          url: 'https://github.com/owner/repo/issues/42',
+          children: [],
+          activeTeam: null,
+        },
+      ],
+      cachedAt: null,
+    });
+
+    const fetchSpy = vi.spyOn(fetcher, 'fetchIssueHierarchy').mockImplementation(
+      () => new Promise(() => {
+        // Never resolves -- simulates a slow fetch
+      })
+    );
+
+    const result = await fetcher.getIssues(1);
+
+    // Should return empty immediately and trigger background refetch
+    expect(result).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledWith(1);
+
+    fetchSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Closes #570

## Summary
- Fix `getIssues()` refetch guard condition from `cached.issues.length === 0 && !cached.cachedAt` to `!cached.cachedAt` — ensures background refetch triggers when cache has non-empty partial results with null `cachedAt`
- Update JSDoc comment to accurately describe the new behavior
- Add targeted test reproducing the partial-failure scenario

## Test plan
- [x] New test verifies refetch triggers on partial cache (non-empty issues, null cachedAt)
- [x] All existing server tests pass
- [x] TypeScript compilation clean (`tsc --noEmit`)