### PR TITLE
Issue #568: Add dedicated updateTeamHeartbeat() with cached prepared statement

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1229,6 +1229,18 @@ export class FleetDatabase {
     this.db.prepare(sql).run(params);
   }
 
+  /**
+   * Dedicated heartbeat update using a pre-cached prepared statement.
+   * Avoids the dynamic SQL construction of updateTeamSilent() on the
+   * hot path — called on every single hook event via processEventTransaction
+   * and processThrottledUpdate.
+   */
+  private updateTeamHeartbeat(id: number, lastEventAt: string): void {
+    this.stmt(
+      "UPDATE teams SET last_event_at = @lastEventAt, updated_at = datetime('now') WHERE id = @id"
+    ).run({ id, lastEventAt });
+  }
+
   updateTeam(id: number, fields: TeamUpdate): Team | undefined {
     this.updateTeamSilent(id, fields);
     return this.getTeam(id);
@@ -1296,8 +1308,8 @@ export class FleetDatabase {
         this.updateTeamSilent(txOps.statusUpdate.teamId, txOps.statusUpdate.fields);
       }
 
-      // 3. Update heartbeat (lastEventAt) — always required, skip trailing SELECT
-      this.updateTeamSilent(txOps.heartbeatUpdate.teamId, { lastEventAt: txOps.heartbeatUpdate.lastEventAt });
+      // 3. Update heartbeat (lastEventAt) — always required, cached prepared statement
+      this.updateTeamHeartbeat(txOps.heartbeatUpdate.teamId, txOps.heartbeatUpdate.lastEventAt);
 
       // 4. Insert event — always required
       const eventInfo = this.stmt(`
@@ -1374,7 +1386,7 @@ export class FleetDatabase {
       if (txOps.statusUpdate) {
         this.updateTeamSilent(txOps.statusUpdate.teamId, txOps.statusUpdate.fields);
       }
-      this.updateTeamSilent(txOps.heartbeatUpdate.teamId, { lastEventAt: txOps.heartbeatUpdate.lastEventAt });
+      this.updateTeamHeartbeat(txOps.heartbeatUpdate.teamId, txOps.heartbeatUpdate.lastEventAt);
     });
 
     try {

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -1325,6 +1325,140 @@ describe('processEventTransaction', () => {
     expect(transitions[0]!.fromStatus).toBe('launching');
     expect(transitions[0]!.toStatus).toBe('running');
   });
+
+  it('updates last_event_at via heartbeat-only path', () => {
+    const project = db.insertProject({
+      name: 'hb-txn-test',
+      repoPath: '/tmp/hb-txn-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 910,
+      worktreeName: 'hb-txn-test-910',
+      projectId: project.id,
+      status: 'running',
+    });
+
+    const heartbeatTime = '2026-03-27T12:00:00.000Z';
+    db.processEventTransaction({
+      heartbeatUpdate: {
+        teamId: team.id,
+        lastEventAt: heartbeatTime,
+      },
+      eventInsert: {
+        teamId: team.id,
+        sessionId: 'sess-hb',
+        agentName: 'team-lead',
+        eventType: 'tool_use',
+        payload: '{}',
+      },
+    });
+
+    const updated = db.getTeam(team.id);
+    expect(updated!.lastEventAt).toBe(heartbeatTime);
+  });
+
+  it('heartbeat update does not alter other team fields', () => {
+    const project = db.insertProject({
+      name: 'hb-fields-test',
+      repoPath: '/tmp/hb-fields-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 911,
+      worktreeName: 'hb-fields-test-911',
+      projectId: project.id,
+      status: 'running',
+    });
+
+    const before = db.getTeam(team.id)!;
+    const heartbeatTime = '2026-03-27T13:00:00.000Z';
+    db.processEventTransaction({
+      heartbeatUpdate: {
+        teamId: team.id,
+        lastEventAt: heartbeatTime,
+      },
+      eventInsert: {
+        teamId: team.id,
+        sessionId: 'sess-fields',
+        agentName: 'team-lead',
+        eventType: 'tool_use',
+        payload: '{}',
+      },
+    });
+
+    const after = db.getTeam(team.id)!;
+    // lastEventAt and updatedAt should change
+    expect(after.lastEventAt).toBe(heartbeatTime);
+    expect(after.updatedAt).not.toBe(before.updatedAt);
+    // Other fields should remain unchanged
+    expect(after.status).toBe(before.status);
+    expect(after.issueNumber).toBe(before.issueNumber);
+    expect(after.sessionId).toBe(before.sessionId);
+    expect(after.pid).toBe(before.pid);
+    expect(after.branchName).toBe(before.branchName);
+    expect(after.prNumber).toBe(before.prNumber);
+  });
+});
+
+// =============================================================================
+// processThrottledUpdate — heartbeat via cached prepared statement
+// =============================================================================
+
+describe('processThrottledUpdate', () => {
+  it('updates last_event_at via heartbeat-only path', () => {
+    const project = db.insertProject({
+      name: 'throttle-hb-test',
+      repoPath: '/tmp/throttle-hb-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 920,
+      worktreeName: 'throttle-hb-test-920',
+      projectId: project.id,
+      status: 'running',
+    });
+
+    const heartbeatTime = '2026-03-27T14:00:00.000Z';
+    db.processThrottledUpdate({
+      heartbeatUpdate: {
+        teamId: team.id,
+        lastEventAt: heartbeatTime,
+      },
+    });
+
+    const updated = db.getTeam(team.id);
+    expect(updated!.lastEventAt).toBe(heartbeatTime);
+  });
+
+  it('heartbeat update does not alter other team fields', () => {
+    const project = db.insertProject({
+      name: 'throttle-fields-test',
+      repoPath: '/tmp/throttle-fields-test',
+    });
+    const team = db.insertTeam({
+      issueNumber: 921,
+      worktreeName: 'throttle-fields-test-921',
+      projectId: project.id,
+      status: 'running',
+    });
+
+    const before = db.getTeam(team.id)!;
+    const heartbeatTime = '2026-03-27T15:00:00.000Z';
+    db.processThrottledUpdate({
+      heartbeatUpdate: {
+        teamId: team.id,
+        lastEventAt: heartbeatTime,
+      },
+    });
+
+    const after = db.getTeam(team.id)!;
+    expect(after.lastEventAt).toBe(heartbeatTime);
+    expect(after.updatedAt).not.toBe(before.updatedAt);
+    expect(after.status).toBe(before.status);
+    expect(after.issueNumber).toBe(before.issueNumber);
+    expect(after.sessionId).toBe(before.sessionId);
+    expect(after.pid).toBe(before.pid);
+    expect(after.branchName).toBe(before.branchName);
+    expect(after.prNumber).toBe(before.prNumber);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #568

## Summary
- Added a new private `updateTeamHeartbeat(id, lastEventAt)` method in `FleetDatabase` that uses `this.stmt()` for prepared statement caching, eliminating redundant dynamic `db.prepare()` calls on every hook event
- Replaced the two heartbeat-only `updateTeamSilent()` calls in `processEventTransaction` and `processThrottledUpdate` with the new cached method
- Added 4 new test cases verifying heartbeat-only updates through both transaction methods

## Test plan
- [x] `tsc --noEmit` passes with no type errors
- [x] `npm run test:server` passes — 4 new tests, no regressions
- [x] No changes to `EventCollectorDb` interface or other `updateTeamSilent` callers