### PR TITLE
Issue #589: Fix blockedBy dependencies lost after server restart

### DIFF
--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -316,7 +316,11 @@ export class IssueFetcher {
   // Whether the GitHub GraphQL schema supports blockedBy/issueDependenciesSummary.
   // Starts true; set to false on first query failure caused by unsupported fields,
   // after which all subsequent queries use the basic query without those fields.
+  // Recovery: after `blockedByRetryCountdown` poll cycles, re-tests the full query.
   private blockedBySupported = true;
+  // Countdown to retry the full query after blockedBySupported was set to false.
+  // When this reaches 0, the next fetchAllProjects() cycle re-enables blockedBySupported.
+  private blockedByRetryCountdown = 0;
 
   // -------------------------------------------------------------------------
   // Public API
@@ -547,6 +551,19 @@ export class IssueFetcher {
    * serial iteration, significantly reducing total wall-clock time.
    */
   async fetchAllProjects(): Promise<void> {
+    // Recovery mechanism: if blockedBySupported was disabled, periodically re-test
+    // the full query (circuit-breaker pattern: trip on failure, retry after N polls).
+    if (!this.blockedBySupported) {
+      this.blockedByRetryCountdown--;
+      if (this.blockedByRetryCountdown <= 0) {
+        console.warn(
+          '[IssueFetcher] blockedBySupported recovery: re-enabling full query ' +
+          'to re-test GraphQL schema support'
+        );
+        this.blockedBySupported = true;
+      }
+    }
+
     const db = getDatabase();
     const projects = db.getProjects({ status: 'active' });
 
@@ -726,6 +743,7 @@ export class IssueFetcher {
     this.stop();
     this.clearAll();
     this.blockedBySupported = true;
+    this.blockedByRetryCountdown = 0;
   }
 
   /**
@@ -870,8 +888,9 @@ export class IssueFetcher {
 
       const blockedBy: DependencyRef[] = [];
 
-      // 1. Process blockedBy nodes FIRST (GitHub's native issue dependencies)
-      const blockedByNodes = issue.blockedBy?.nodes ?? [];
+      // 1. Process blockedBy nodes FIRST (GitHub's native issue dependencies).
+      //    Skip nodes where repository is null/undefined (cross-repo edge case).
+      const blockedByNodes = (issue.blockedBy?.nodes ?? []).filter((n) => n.repository);
       for (const node of blockedByNodes) {
         blockedBy.push({
           number: node.number,
@@ -882,8 +901,9 @@ export class IssueFetcher {
         });
       }
 
-      // 2. Process trackedInIssues, deduplicating against blockedBy
-      const trackedNodes = issue.trackedInIssues?.nodes ?? [];
+      // 2. Process trackedInIssues, deduplicating against blockedBy.
+      //    Skip nodes where repository is null/undefined.
+      const trackedNodes = (issue.trackedInIssues?.nodes ?? []).filter((n) => n.repository);
       for (const node of trackedNodes) {
         const exists = blockedBy.some(
           (b) => b.number === node.number &&
@@ -955,9 +975,10 @@ export class IssueFetcher {
     // If the full query failed and blockedBy was enabled, downgrade and retry
     if (this.blockedBySupported) {
       this.blockedBySupported = false;
+      this.blockedByRetryCountdown = 5;
       console.warn(
-        '[IssueFetcher] Single-issue deps query with blockedBy failed; ' +
-        'falling back to basic query without blockedBy field'
+        '[IssueFetcher] blockedBySupported changed: true -> false ' +
+        '(single-issue deps query field error; will retry after 5 poll cycles)'
       );
       return this.runSingleIssueDepsQuery(SINGLE_ISSUE_DEPS_QUERY_BASIC, owner, repo, issueNumber);
     }
@@ -967,7 +988,9 @@ export class IssueFetcher {
 
   /**
    * Run a single-issue dependency GraphQL query and return the parsed issue data.
-   * Returns null on error (gh CLI failure, missing data, or GraphQL errors).
+   * Returns null only on field-not-found errors (triggering fallback to BASIC).
+   * Non-field GraphQL errors (rate limits, deprecation warnings) are logged as
+   * warnings but the response data is still used if present.
    */
   private async runSingleIssueDepsQuery(
     query: string,
@@ -995,9 +1018,21 @@ export class IssueFetcher {
       };
 
       if (parsed.errors?.length) {
-        const msg = parsed.errors.map((e) => e.message).join('; ');
-        console.error(`[IssueFetcher] Single-issue deps GraphQL errors: ${msg}`);
-        return null;
+        const hasFieldError = parsed.errors.some(
+          (e) => /field\b.*\bdoesn't exist/i.test(e.message) ||
+                 /field\b.*\bblockedBy\b.*\bdoesn't exist/i.test(e.message) ||
+                 /field\b.*\bissueDependenciesSummary\b.*\bdoesn't exist/i.test(e.message)
+        );
+        if (hasFieldError) {
+          console.error(
+            `[IssueFetcher] Single-issue deps GraphQL field errors: ${parsed.errors.map((e) => e.message).join('; ')}`
+          );
+          return null;
+        }
+        // Non-field errors (rate limits, deprecation warnings, etc.): log but still use data
+        console.warn(
+          `[IssueFetcher] Single-issue deps GraphQL non-field errors (data still used): ${parsed.errors.map((e) => e.message).join('; ')}`
+        );
       }
 
       return parsed.data?.repository?.issue ?? null;
@@ -1207,9 +1242,10 @@ export class IssueFetcher {
     // If the full query failed and blockedBy was enabled, downgrade and retry
     if (this.blockedBySupported) {
       this.blockedBySupported = false;
+      this.blockedByRetryCountdown = 5;
       console.warn(
-        '[IssueFetcher] Full query with blockedBy fields failed; ' +
-        'falling back to basic query without dependency fields'
+        '[IssueFetcher] blockedBySupported changed: true -> false ' +
+        '(batch query field error; will retry after 5 poll cycles)'
       );
       return this.runGraphQLQuery(ISSUES_QUERY_BASIC, owner, repo, cursor);
     }
@@ -1290,12 +1326,14 @@ export class IssueFetcher {
 
       const parsed = JSON.parse(stdout) as GraphQLResponse;
 
-      // Check for GraphQL-level errors indicating unsupported fields
+      // Check for GraphQL-level errors indicating unsupported fields.
+      // Only match field-not-found errors; non-field errors (rate limits,
+      // deprecation warnings) should not discard valid data.
       if (parsed.errors?.length) {
         const hasFieldError = parsed.errors.some(
           (e) => /field\b.*\bdoesn't exist/i.test(e.message) ||
-                 /blockedBy/i.test(e.message) ||
-                 /issueDependenciesSummary/i.test(e.message)
+                 /field\b.*\bblockedBy\b.*\bdoesn't exist/i.test(e.message) ||
+                 /field\b.*\bissueDependenciesSummary\b.*\bdoesn't exist/i.test(e.message)
         );
         if (hasFieldError) {
           console.error(
@@ -1303,6 +1341,10 @@ export class IssueFetcher {
           );
           return null;
         }
+        // Non-field errors: log but still return the data
+        console.warn(
+          `[IssueFetcher] GraphQL non-field errors (data still used): ${parsed.errors.map((e) => e.message).join('; ')}`
+        );
       }
 
       return parsed;
@@ -1348,8 +1390,9 @@ export class IssueFetcher {
       issueNode.prReferences = prRefs;
     }
 
-    // Map inline blockedBy nodes to DependencyRef[] and populate dependencies
-    const blockedByNodes = node.blockedBy?.nodes ?? [];
+    // Map inline blockedBy nodes to DependencyRef[] and populate dependencies.
+    // Skip nodes where repository is null/undefined (can happen with cross-repo deps).
+    const blockedByNodes = (node.blockedBy?.nodes ?? []).filter((dep) => dep.repository);
     if (blockedByNodes.length > 0) {
       const blockedBy: DependencyRef[] = blockedByNodes.map((dep) => ({
         number: dep.number,

--- a/tests/server/issue-fetcher-blockedby-recovery.test.ts
+++ b/tests/server/issue-fetcher-blockedby-recovery.test.ts
@@ -1,0 +1,488 @@
+// =============================================================================
+// Fleet Commander -- Issue Fetcher blockedBy Recovery Tests
+// =============================================================================
+// Tests for:
+//   - runSingleIssueDepsQuery: non-field GraphQL errors do not discard data
+//   - runSingleIssueDepsQuery: field-not-found errors correctly trigger fallback
+//   - runGraphQLQuery: non-field errors do not discard batch query data
+//   - blockedBySupported recovery after retry countdown expires
+//   - mapGraphQLNode: null repository in blockedBy nodes is safely skipped
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks -- must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getProject: vi.fn().mockReturnValue({
+    id: 1,
+    name: 'test-repo',
+    githubRepo: 'owner/repo',
+  }),
+  getProjects: vi.fn().mockReturnValue([]),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamsByProject: vi.fn().mockReturnValue([]),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    issuePollIntervalMs: 60000,
+  },
+}));
+
+// Mock child_process (exec used by resolveIssueStates, spawn used by runGHGraphQL)
+const mockExec = vi.fn();
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+  spawn: vi.fn(),
+}));
+
+// Mock util.promisify so that execAsync uses our mockExec
+vi.mock('util', () => ({
+  promisify: (fn: unknown) => {
+    return (...args: unknown[]) => {
+      return new Promise((resolve, reject) => {
+        (fn as Function)(...args, (err: Error | null, result: unknown) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      });
+    };
+  },
+}));
+
+// Import after mocks
+import IssueFetcher from '../../src/server/services/issue-fetcher.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Helper to create a minimal batch GraphQL response */
+function makeGraphQLResponse(nodes: Array<{
+  number: number;
+  title: string;
+  state?: string;
+  url?: string;
+  blockedBy?: { nodes?: Array<{
+    number: number;
+    title: string;
+    state: string;
+    repository: { owner: { login: string }; name: string } | null;
+  }> };
+}>, errors?: Array<{ message: string }>) {
+  const response: Record<string, unknown> = {
+    data: {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: nodes.map((n) => ({
+            number: n.number,
+            title: n.title,
+            state: n.state ?? 'OPEN',
+            url: n.url ?? `https://github.com/owner/repo/issues/${n.number}`,
+            labels: { nodes: [] },
+            parent: null,
+            subIssuesSummary: undefined,
+            closedByPullRequestsReferences: undefined,
+            blockedBy: n.blockedBy ?? undefined,
+            issueDependenciesSummary: undefined,
+          })),
+        },
+      },
+    },
+  };
+  if (errors) {
+    response.errors = errors;
+  }
+  return response;
+}
+
+/** Helper to create a single-issue deps GraphQL response */
+function makeSingleIssueDepsResponse(
+  issue: {
+    body: string | null;
+    blockedBy?: { nodes: Array<{
+      number: number;
+      title: string;
+      state: string;
+      repository: { owner: { login: string }; name: string };
+    }> };
+    trackedInIssues?: { nodes: Array<{
+      number: number;
+      title: string;
+      state: string;
+      repository: { owner: { login: string }; name: string };
+    }> };
+  } | null,
+  errors?: Array<{ message: string }>,
+) {
+  const response: Record<string, unknown> = {
+    data: {
+      repository: {
+        issue,
+      },
+    },
+  };
+  if (errors) {
+    response.errors = errors;
+  }
+  return response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: runSingleIssueDepsQuery error handling
+// ---------------------------------------------------------------------------
+
+describe('runSingleIssueDepsQuery error handling', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+  });
+
+  it('should not reject data when response has non-field GraphQL errors', async () => {
+    // Simulate a GraphQL response with data AND a non-field error (e.g. rate limit warning)
+    const mockResponse = makeSingleIssueDepsResponse(
+      {
+        body: null,
+        blockedBy: {
+          nodes: [{
+            number: 10,
+            title: 'Blocker',
+            state: 'OPEN',
+            repository: { owner: { login: 'owner' }, name: 'repo' },
+          }],
+        },
+        trackedInIssues: { nodes: [] },
+      },
+      [{ message: 'API rate limit exceeded' }],
+    );
+
+    // Mock runGHGraphQL to return our response
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    // Call the private method directly
+    const result = await (fetcher as any).runSingleIssueDepsQuery(
+      'query { ... }', 'owner', 'repo', 42,
+    );
+
+    // Data should be returned despite the non-field error
+    expect(result).not.toBeNull();
+    expect(result.blockedBy.nodes).toHaveLength(1);
+    expect(result.blockedBy.nodes[0].number).toBe(10);
+
+    ghSpy.mockRestore();
+  });
+
+  it('should reject data when response has field-not-found errors', async () => {
+    const mockResponse = makeSingleIssueDepsResponse(
+      null,
+      [{ message: "Field 'blockedBy' doesn't exist on type 'Issue'" }],
+    );
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runSingleIssueDepsQuery(
+      'query { ... }', 'owner', 'repo', 42,
+    );
+
+    // Should return null on field-not-found error
+    expect(result).toBeNull();
+
+    ghSpy.mockRestore();
+  });
+
+  it('should reject data when response has issueDependenciesSummary field error', async () => {
+    const mockResponse = makeSingleIssueDepsResponse(
+      null,
+      [{ message: "Field 'issueDependenciesSummary' doesn't exist on type 'Issue'" }],
+    );
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runSingleIssueDepsQuery(
+      'query { ... }', 'owner', 'repo', 42,
+    );
+
+    expect(result).toBeNull();
+
+    ghSpy.mockRestore();
+  });
+
+  it('should not reject data when error message contains "blockedBy" but is not a field error', async () => {
+    // An error message that mentions "blockedBy" but is NOT a field-not-found error
+    const mockResponse = makeSingleIssueDepsResponse(
+      {
+        body: null,
+        blockedBy: { nodes: [] },
+        trackedInIssues: { nodes: [] },
+      },
+      [{ message: 'The blockedBy connection is temporarily unavailable' }],
+    );
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runSingleIssueDepsQuery(
+      'query { ... }', 'owner', 'repo', 42,
+    );
+
+    // Should still return data because this is not a field-not-found error
+    expect(result).not.toBeNull();
+
+    ghSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runGraphQLQuery (batch) error handling
+// ---------------------------------------------------------------------------
+
+describe('runGraphQLQuery batch error handling', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+  });
+
+  it('should not reject data when batch response has non-field GraphQL errors', async () => {
+    const mockResponse = makeGraphQLResponse(
+      [{ number: 1, title: 'Issue 1' }],
+      [{ message: 'API rate limit warning: approaching limit' }],
+    );
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runGraphQLQuery(
+      'query { ... }', 'owner', 'repo', null,
+    );
+
+    // Data should be returned despite the non-field error
+    expect(result).not.toBeNull();
+    expect(result.data.repository.issues.nodes).toHaveLength(1);
+
+    ghSpy.mockRestore();
+  });
+
+  it('should reject data when batch response has field-not-found errors', async () => {
+    const mockResponse = {
+      data: null,
+      errors: [{ message: "Field 'blockedBy' doesn't exist on type 'Issue'" }],
+    };
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runGraphQLQuery(
+      'query { ... }', 'owner', 'repo', null,
+    );
+
+    expect(result).toBeNull();
+
+    ghSpy.mockRestore();
+  });
+
+  it('should not reject batch data when error mentions blockedBy without field error pattern', async () => {
+    // This verifies the narrowed regex: a message containing "blockedBy" that is
+    // NOT a field-not-found error should not cause data to be discarded
+    const mockResponse = makeGraphQLResponse(
+      [{ number: 1, title: 'Issue 1' }],
+      [{ message: 'Deprecation warning: blockedBy will be renamed in v2' }],
+    );
+
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify(mockResponse));
+
+    const result = await (fetcher as any).runGraphQLQuery(
+      'query { ... }', 'owner', 'repo', null,
+    );
+
+    // Data should be returned because this is NOT a field-not-found error
+    expect(result).not.toBeNull();
+
+    ghSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: blockedBySupported recovery mechanism
+// ---------------------------------------------------------------------------
+
+describe('blockedBySupported recovery mechanism', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+    mockDb.getProjects.mockReturnValue([]);
+  });
+
+  it('should set blockedByRetryCountdown to 5 when blockedBySupported is disabled', async () => {
+    // Start with blockedBySupported = true, then trigger a field error
+    const ghSpy = vi.spyOn(fetcher as any, 'runGHGraphQL')
+      .mockResolvedValue(JSON.stringify({
+        data: null,
+        errors: [{ message: "Field 'blockedBy' doesn't exist on type 'Issue'" }],
+      }));
+
+    // Call executeGraphQL to trigger the downgrade
+    await (fetcher as any).executeGraphQL('owner', 'repo', null);
+
+    expect((fetcher as any).blockedBySupported).toBe(false);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(5);
+
+    ghSpy.mockRestore();
+  });
+
+  it('should recover blockedBySupported after retry countdown expires', async () => {
+    // Manually set the state to "disabled with countdown"
+    (fetcher as any).blockedBySupported = false;
+    (fetcher as any).blockedByRetryCountdown = 1; // will decrement to 0 on next call
+
+    // fetchAllProjects with empty project list
+    mockDb.getProjects.mockReturnValue([]);
+    await fetcher.fetchAllProjects();
+
+    // After the countdown reaches 0, blockedBySupported should be re-enabled
+    expect((fetcher as any).blockedBySupported).toBe(true);
+  });
+
+  it('should not recover blockedBySupported before countdown expires', async () => {
+    (fetcher as any).blockedBySupported = false;
+    (fetcher as any).blockedByRetryCountdown = 3;
+
+    mockDb.getProjects.mockReturnValue([]);
+    await fetcher.fetchAllProjects();
+
+    // countdown: 3 -> 2, not yet 0
+    expect((fetcher as any).blockedBySupported).toBe(false);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(2);
+  });
+
+  it('should count down across multiple fetchAllProjects calls', async () => {
+    (fetcher as any).blockedBySupported = false;
+    (fetcher as any).blockedByRetryCountdown = 3;
+
+    mockDb.getProjects.mockReturnValue([]);
+
+    // Call 1: 3 -> 2
+    await fetcher.fetchAllProjects();
+    expect((fetcher as any).blockedBySupported).toBe(false);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(2);
+
+    // Call 2: 2 -> 1
+    await fetcher.fetchAllProjects();
+    expect((fetcher as any).blockedBySupported).toBe(false);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(1);
+
+    // Call 3: 1 -> 0, recovery
+    await fetcher.fetchAllProjects();
+    expect((fetcher as any).blockedBySupported).toBe(true);
+  });
+
+  it('should reset blockedByRetryCountdown on reset()', () => {
+    (fetcher as any).blockedBySupported = false;
+    (fetcher as any).blockedByRetryCountdown = 3;
+
+    fetcher.reset();
+
+    expect((fetcher as any).blockedBySupported).toBe(true);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(0);
+  });
+
+  it('should not attempt recovery when blockedBySupported is already true', async () => {
+    (fetcher as any).blockedBySupported = true;
+    (fetcher as any).blockedByRetryCountdown = 0;
+
+    mockDb.getProjects.mockReturnValue([]);
+    await fetcher.fetchAllProjects();
+
+    // Should remain true, countdown unchanged
+    expect((fetcher as any).blockedBySupported).toBe(true);
+    expect((fetcher as any).blockedByRetryCountdown).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: mapGraphQLNode null repository handling
+// ---------------------------------------------------------------------------
+
+describe('mapGraphQLNode null repository handling', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new IssueFetcher();
+  });
+
+  it('should skip blockedBy nodes where repository is null', () => {
+    const node = {
+      number: 42,
+      title: 'Test issue',
+      state: 'OPEN',
+      url: 'https://github.com/owner/repo/issues/42',
+      labels: { nodes: [] },
+      blockedBy: {
+        nodes: [
+          {
+            number: 10,
+            title: 'Valid dep',
+            state: 'OPEN',
+            repository: { owner: { login: 'owner' }, name: 'repo' },
+          },
+          {
+            number: 20,
+            title: 'Null repo dep',
+            state: 'OPEN',
+            repository: null as unknown as { owner: { login: string }; name: string },
+          },
+        ],
+      },
+    };
+
+    const result = (fetcher as any).mapGraphQLNode(node);
+
+    // Should only have 1 dependency (the one with valid repository)
+    expect(result.dependencies).toBeDefined();
+    expect(result.dependencies.blockedBy).toHaveLength(1);
+    expect(result.dependencies.blockedBy[0].number).toBe(10);
+  });
+
+  it('should handle all blockedBy nodes having null repository', () => {
+    const node = {
+      number: 42,
+      title: 'Test issue',
+      state: 'OPEN',
+      url: 'https://github.com/owner/repo/issues/42',
+      labels: { nodes: [] },
+      blockedBy: {
+        nodes: [
+          {
+            number: 20,
+            title: 'Null repo dep',
+            state: 'OPEN',
+            repository: null as unknown as { owner: { login: string }; name: string },
+          },
+        ],
+      },
+    };
+
+    const result = (fetcher as any).mapGraphQLNode(node);
+
+    // No valid dependencies -> dependencies should not be set
+    expect(result.dependencies).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #589

## Summary
- Fixed overly broad GraphQL error regex in `runSingleIssueDepsQuery` and `runGraphQLQuery` that discarded valid `blockedBy` data on any error (including transient rate limits and deprecation warnings)
- Added circuit-breaker recovery for `blockedBySupported` flag — re-tests every 5 poll cycles instead of staying permanently disabled
- Added null repository filtering in `mapGraphQLNode` and dependency processing to prevent crashes on cross-repo nodes with missing repository data
- Added 15 new tests covering all fixed error handling paths

## Test plan
- [x] `npm run test:server` passes (3 pre-existing failures in cc-spawn.test.ts unrelated to this change)
- [x] `tsc --noEmit` passes cleanly
- [x] New test file `tests/server/issue-fetcher-blockedby-recovery.test.ts` with 15 tests
- [ ] Manual: restart FC server, verify blockedBy dependencies are re-populated from GraphQL