### PR TITLE
Issue #578: Implement JiraIssueProvider with Jira REST API integration

### DIFF
--- a/src/client/components/AddProjectDialog.tsx
+++ b/src/client/components/AddProjectDialog.tsx
@@ -37,6 +37,13 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Issue provider state
+  const [issueProvider, setIssueProvider] = useState<'github' | 'jira'>('github');
+  const [jiraBaseUrl, setJiraBaseUrl] = useState('');
+  const [jiraEmail, setJiraEmail] = useState('');
+  const [jiraApiToken, setJiraApiToken] = useState('');
+  const [jiraProjectKey, setJiraProjectKey] = useState('');
+
   // Path picker state
   const [suggestions, setSuggestions] = useState<DirEntry[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -86,6 +93,11 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
       setShowSuggestions(false);
       setSelectedSuggestion(-1);
       setParentPath('');
+      setIssueProvider('github');
+      setJiraBaseUrl('');
+      setJiraEmail('');
+      setJiraApiToken('');
+      setJiraProjectKey('');
     }
   }, [open]);
 
@@ -238,15 +250,52 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
       return;
     }
 
+    // Validate Jira fields
+    if (issueProvider === 'jira') {
+      if (!jiraBaseUrl.trim()) {
+        setError('Jira Base URL is required');
+        return;
+      }
+      if (!jiraEmail.trim()) {
+        setError('Jira Email is required');
+        return;
+      }
+      if (!jiraApiToken.trim()) {
+        setError('Jira API Token is required');
+        return;
+      }
+      if (!jiraProjectKey.trim()) {
+        setError('Jira Project Key is required');
+        return;
+      }
+      if (!/^[A-Z][A-Z0-9]*$/.test(jiraProjectKey.trim())) {
+        setError('Jira Project Key must be uppercase letters/numbers (e.g. "PROJ")');
+        return;
+      }
+    }
+
     setLoading(true);
     try {
-      await api.post('projects', {
+      const body: Record<string, unknown> = {
         name: name.trim(),
         repoPath: repoPath.trim(),
         githubRepo: githubRepo.trim() || undefined,
         maxActiveTeams,
         model: model.trim() || undefined,
-      });
+        issueProvider,
+      };
+
+      if (issueProvider === 'jira') {
+        body.projectKey = jiraProjectKey.trim();
+        body.providerConfig = JSON.stringify({
+          baseUrl: jiraBaseUrl.trim(),
+          email: jiraEmail.trim(),
+          apiToken: jiraApiToken.trim(),
+          projectKey: jiraProjectKey.trim(),
+        });
+      }
+
+      await api.post('projects', body);
       onAdded();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -254,7 +303,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
     } finally {
       setLoading(false);
     }
-  }, [name, repoPath, githubRepo, maxActiveTeams, model, api, onAdded]);
+  }, [name, repoPath, githubRepo, maxActiveTeams, model, issueProvider, jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey, api, onAdded]);
 
   // Keyboard navigation for suggestions + Enter to submit
   const handlePathKeyDown = useCallback(
@@ -455,21 +504,124 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
             )}
           </div>
 
-          {/* GitHub repo (optional) */}
+          {/* Issue Provider selector */}
           <div>
             <label className="block text-sm text-dark-muted mb-1">
-              GitHub Repo <span className="text-dark-muted/50">(optional)</span>
+              Issue Provider
             </label>
-            <input
-              type="text"
-              value={githubRepo}
-              onChange={(e) => setGithubRepo(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="org/repo (auto-detected)"
-              className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
-              disabled={loading}
-            />
+            <div className="flex gap-4">
+              <label className="inline-flex items-center gap-1.5 text-sm text-dark-text cursor-pointer">
+                <input
+                  type="radio"
+                  name="issueProvider"
+                  value="github"
+                  checked={issueProvider === 'github'}
+                  onChange={() => setIssueProvider('github')}
+                  className="accent-dark-accent"
+                  disabled={loading}
+                />
+                GitHub
+              </label>
+              <label className="inline-flex items-center gap-1.5 text-sm text-dark-text cursor-pointer">
+                <input
+                  type="radio"
+                  name="issueProvider"
+                  value="jira"
+                  checked={issueProvider === 'jira'}
+                  onChange={() => setIssueProvider('jira')}
+                  className="accent-dark-accent"
+                  disabled={loading}
+                />
+                Jira
+              </label>
+            </div>
           </div>
+
+          {/* GitHub repo (optional, shown for GitHub provider) */}
+          {issueProvider === 'github' && (
+            <div>
+              <label className="block text-sm text-dark-muted mb-1">
+                GitHub Repo <span className="text-dark-muted/50">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={githubRepo}
+                onChange={(e) => setGithubRepo(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="org/repo (auto-detected)"
+                className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+                disabled={loading}
+              />
+            </div>
+          )}
+
+          {/* Jira configuration fields */}
+          {issueProvider === 'jira' && (
+            <>
+              <div>
+                <label className="block text-sm text-dark-muted mb-1">
+                  Jira Base URL <span className="text-[#F85149]">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={jiraBaseUrl}
+                  onChange={(e) => setJiraBaseUrl(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="https://mycompany.atlassian.net"
+                  className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+                  disabled={loading}
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-dark-muted mb-1">
+                  Jira Email <span className="text-[#F85149]">*</span>
+                </label>
+                <input
+                  type="email"
+                  value={jiraEmail}
+                  onChange={(e) => setJiraEmail(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="user@example.com"
+                  className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+                  disabled={loading}
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-dark-muted mb-1">
+                  Jira API Token <span className="text-[#F85149]">*</span>
+                </label>
+                <input
+                  type="password"
+                  value={jiraApiToken}
+                  onChange={(e) => setJiraApiToken(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Your Jira API token"
+                  className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+                  disabled={loading}
+                />
+                <p className="mt-1 text-xs text-dark-muted/60">
+                  Generate at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener noreferrer" className="text-dark-accent hover:underline">Atlassian API tokens</a>
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm text-dark-muted mb-1">
+                  Jira Project Key <span className="text-[#F85149]">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={jiraProjectKey}
+                  onChange={(e) => setJiraProjectKey(e.target.value.toUpperCase())}
+                  onKeyDown={handleKeyDown}
+                  placeholder="PROJ"
+                  className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text placeholder:text-dark-muted/50 focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+                  disabled={loading}
+                />
+                <p className="mt-1 text-xs text-dark-muted/60">
+                  The Jira project key (e.g. "PROJ"). Must be uppercase.
+                </p>
+              </div>
+            </>
+          )}
 
           {/* Max Active Teams */}
           <div>

--- a/src/client/components/TreeNode.tsx
+++ b/src/client/components/TreeNode.tsx
@@ -3,6 +3,7 @@ import { StatusBadge } from './StatusBadge';
 import { PRBadge } from './PRBadge';
 import { PlayIcon, LockIcon } from './Icons';
 import type { TeamStatus, PrioritizedIssue, IssueDependencyInfo, CIStatus } from '../../shared/types';
+import { formatIssueKey } from '../../shared/issue-provider';
 
 // ---------------------------------------------------------------------------
 // Types (mirrors IssueNode from the server issue-fetcher)
@@ -20,6 +21,10 @@ export interface IssueNode {
   children: IssueNode[];
   activeTeam?: { id: number; status: string } | null;
   dependencies?: IssueDependencyInfo;
+  /** Universal issue key (e.g. "42" for GitHub, "PROJ-123" for Jira) */
+  issueKey?: string;
+  /** Provider name (e.g. 'github', 'jira') */
+  issueProvider?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,14 +234,14 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
               onCheckChange(node.number, e.target.checked);
             }}
             className="w-3.5 h-3.5 shrink-0 accent-dark-accent cursor-pointer"
-            aria-label={`Select issue #${node.number}`}
+            aria-label={`Select issue ${formatIssueKey(node.issueKey ?? String(node.number), node.issueProvider ?? null)}`}
           />
         )}
 
         {/* Issue state icon */}
         <IssueStateBadge state={node.state} />
 
-        {/* Issue number */}
+        {/* Issue key / number */}
         <a
           href={node.url}
           target="_blank"
@@ -244,7 +249,7 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
           className="text-sm text-dark-muted hover:text-dark-accent transition-colors shrink-0"
           onClick={(e) => e.stopPropagation()}
         >
-          #{node.number}
+          {formatIssueKey(node.issueKey ?? String(node.number), node.issueProvider ?? null)}
         </a>
 
         {/* Issue title */}
@@ -310,7 +315,7 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
             className={`ml-auto shrink-0 transition-opacity inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded border border-[#A371F7]/50 text-[#A371F7] hover:bg-[#A371F7]/10 disabled:opacity-50 disabled:cursor-not-allowed ${
               prioritizing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
             }`}
-            title={`Prioritize sub-issues under #${node.number}`}
+            title={`Prioritize sub-issues under ${formatIssueKey(node.issueKey ?? String(node.number), node.issueProvider ?? null)}`}
           >
             {prioritizing ? (
               <svg className="animate-spin w-3 h-3" viewBox="0 0 24 24" fill="none">
@@ -338,7 +343,7 @@ export const TreeNode = React.memo(function TreeNode({ node, depth, onLaunch, la
                 ? 'border-[#D29922]/50 text-[#D29922] hover:text-[#D29922] hover:border-[#D29922]'
                 : 'border-dark-border text-dark-muted hover:text-[#3FB950] hover:border-[#3FB950]/50'
             }`}
-            title={isBlocked ? `Launch team for #${node.number} (blocked — will prompt for confirmation)` : `Launch team for #${node.number}`}
+            title={isBlocked ? `Launch team for ${formatIssueKey(node.issueKey ?? String(node.number), node.issueProvider ?? null)} (blocked — will prompt for confirmation)` : `Launch team for ${formatIssueKey(node.issueKey ?? String(node.number), node.issueProvider ?? null)}`}
           >
             {launching ? (
               <svg className="animate-spin w-3 h-3" viewBox="0 0 24 24" fill="none">

--- a/src/server/providers/index.ts
+++ b/src/server/providers/index.ts
@@ -6,24 +6,34 @@
 // singletons keyed by provider name.
 // =============================================================================
 
-import type { IssueProvider } from '../../shared/issue-provider.js';
+import type { IssueProvider, NormalizedStatus } from '../../shared/issue-provider.js';
 import type { Project } from '../../shared/types.js';
 import { GitHubIssueProvider } from './github-issue-provider.js';
+import { JiraIssueProvider, type JiraConfig } from './jira-issue-provider.js';
 
-// Singleton cache: provider name -> provider instance
+// Singleton cache: provider key -> provider instance
+// GitHub is keyed by 'github' (stateless singleton).
+// Jira is keyed by 'jira:<projectId>' since each Jira project may have
+// different credentials/baseUrl.
 const providerCache = new Map<string, IssueProvider>();
 
 /**
  * Get or create an IssueProvider instance for the given project.
  * Reads `project.issueProvider` (defaulting to 'github') and returns
- * the appropriate provider. Providers are singletons keyed by name.
+ * the appropriate provider.
+ *
+ * GitHub providers are singletons keyed by 'github'.
+ * Jira providers are cached per-project (keyed by 'jira:<projectId>').
  *
  * @throws Error if the provider type is not supported.
  */
 export function getIssueProvider(project: Project): IssueProvider {
   const providerName = project.issueProvider ?? 'github';
 
-  const cached = providerCache.get(providerName);
+  // Compute the cache key: GitHub is global, Jira is per-project
+  const cacheKey = providerName === 'jira' ? `jira:${project.id}` : providerName;
+
+  const cached = providerCache.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -34,15 +44,20 @@ export function getIssueProvider(project: Project): IssueProvider {
     case 'github':
       provider = new GitHubIssueProvider();
       break;
+    case 'jira': {
+      const jiraConfig = parseJiraConfig(project);
+      provider = new JiraIssueProvider(jiraConfig);
+      break;
+    }
     default:
       throw new Error(
         `Unsupported issue provider: "${providerName}". ` +
-        `Supported providers: github. ` +
+        `Supported providers: github, jira. ` +
         `Check the issueProvider setting for project "${project.name}" (id: ${project.id}).`
       );
   }
 
-  providerCache.set(providerName, provider);
+  providerCache.set(cacheKey, provider);
   return provider;
 }
 
@@ -60,4 +75,49 @@ export function getCachedProvider(name: string): IssueProvider | undefined {
  */
 export function resetProviders(): void {
   providerCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Jira config parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse JiraConfig from a Project's providerConfig JSON and projectKey fields.
+ * Validates that all required fields are present.
+ *
+ * @throws Error if required Jira configuration fields are missing.
+ */
+function parseJiraConfig(project: Project): JiraConfig {
+  let parsed: Record<string, unknown> = {};
+  if (project.providerConfig) {
+    try {
+      parsed = JSON.parse(project.providerConfig) as Record<string, unknown>;
+    } catch {
+      throw new Error(
+        `Invalid providerConfig JSON for Jira project "${project.name}" (id: ${project.id}).`
+      );
+    }
+  }
+
+  const baseUrl = (parsed.baseUrl as string) || '';
+  const email = (parsed.email as string) || '';
+  const apiToken = (parsed.apiToken as string) || '';
+  const projectKey = project.projectKey || (parsed.projectKey as string) || '';
+
+  if (!baseUrl) {
+    throw new Error(`Jira baseUrl is required in providerConfig for project "${project.name}" (id: ${project.id}).`);
+  }
+  if (!email) {
+    throw new Error(`Jira email is required in providerConfig for project "${project.name}" (id: ${project.id}).`);
+  }
+  if (!apiToken) {
+    throw new Error(`Jira apiToken is required in providerConfig for project "${project.name}" (id: ${project.id}).`);
+  }
+  if (!projectKey) {
+    throw new Error(`Jira projectKey is required for project "${project.name}" (id: ${project.id}).`);
+  }
+
+  const statusMapping = parsed.statusMapping as Record<string, NormalizedStatus> | undefined;
+
+  return { baseUrl, email, apiToken, projectKey, statusMapping };
 }

--- a/src/server/providers/jira-issue-provider.ts
+++ b/src/server/providers/jira-issue-provider.ts
@@ -1,0 +1,585 @@
+// =============================================================================
+// Fleet Commander -- Jira Issue Provider
+// =============================================================================
+// Implements the IssueProvider interface for Jira Cloud issues using the
+// Jira REST API v3 via native fetch. Handles issue fetching, status mapping,
+// dependency extraction from issue links, and linked PR detection.
+//
+// Authentication: HTTP Basic Auth (email + API token), the standard approach
+// for Jira Cloud. Jira Server/Data Center is not supported.
+// =============================================================================
+
+import type {
+  IssueProvider,
+  GenericIssue,
+  GenericDependencyRef,
+  LinkedPR,
+  IssueQuery,
+  IssueQueryResult,
+  ProviderCapabilities,
+  NormalizedStatus,
+} from '../../shared/issue-provider.js';
+
+// ---------------------------------------------------------------------------
+// Jira configuration
+// ---------------------------------------------------------------------------
+
+export interface JiraConfig {
+  /** Jira Cloud base URL (e.g. "https://mycompany.atlassian.net") */
+  baseUrl: string;
+  /** Jira account email */
+  email: string;
+  /** Jira API token */
+  apiToken: string;
+  /** Jira project key (e.g. "PROJ") */
+  projectKey: string;
+  /** Custom status mapping overrides (lowercase Jira status -> NormalizedStatus) */
+  statusMapping?: Record<string, NormalizedStatus>;
+}
+
+// ---------------------------------------------------------------------------
+// Jira REST API response types (internal)
+// ---------------------------------------------------------------------------
+
+interface JiraUser {
+  displayName?: string;
+  accountId?: string;
+  emailAddress?: string;
+}
+
+interface JiraStatus {
+  name: string;
+  statusCategory?: {
+    key: string;
+    name: string;
+  };
+}
+
+interface JiraPriority {
+  id: string;
+  name: string;
+}
+
+interface JiraIssueType {
+  name: string;
+  subtask: boolean;
+}
+
+interface JiraIssueLink {
+  id: string;
+  type: {
+    name: string;
+    inward: string;
+    outward: string;
+  };
+  inwardIssue?: JiraIssueFields;
+  outwardIssue?: JiraIssueFields;
+}
+
+interface JiraIssueFields {
+  key?: string;
+  id?: string;
+  fields?: {
+    summary?: string;
+    status?: JiraStatus;
+    issuetype?: JiraIssueType;
+    priority?: JiraPriority;
+    assignee?: JiraUser;
+    labels?: string[];
+    parent?: { key: string; fields?: { summary?: string } };
+    issuelinks?: JiraIssueLink[];
+    created?: string;
+    updated?: string;
+  };
+  self?: string;
+}
+
+interface JiraIssue {
+  key: string;
+  id: string;
+  fields: {
+    summary: string;
+    status: JiraStatus;
+    issuetype: JiraIssueType;
+    priority?: JiraPriority;
+    assignee?: JiraUser | null;
+    labels?: string[];
+    parent?: { key: string; fields?: { summary?: string } };
+    issuelinks?: JiraIssueLink[];
+    created: string;
+    updated?: string;
+  };
+  self: string;
+}
+
+interface JiraSearchResponse {
+  issues: JiraIssue[];
+  startAt: number;
+  maxResults: number;
+  total: number;
+}
+
+interface JiraRemoteLink {
+  id: number;
+  self: string;
+  object: {
+    url: string;
+    title: string;
+    icon?: { url16x16?: string };
+    status?: { resolved?: boolean; icon?: { url16x16?: string } };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default status mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Default mapping from lowercase Jira status names to NormalizedStatus.
+ * Users can override this via the statusMapping field in JiraConfig.
+ * The mapping also falls back to Jira's statusCategory for unmapped statuses.
+ */
+export const DEFAULT_JIRA_STATUS_MAP: Record<string, NormalizedStatus> = {
+  'to do': 'open',
+  'backlog': 'open',
+  'open': 'open',
+  'reopened': 'open',
+  'new': 'open',
+  'in progress': 'in_progress',
+  'in review': 'in_progress',
+  'in development': 'in_progress',
+  'code review': 'in_progress',
+  'testing': 'in_progress',
+  'done': 'closed',
+  'closed': 'closed',
+  'resolved': 'closed',
+  'cancelled': 'closed',
+  'won\'t do': 'closed',
+  'won\'t fix': 'closed',
+};
+
+/**
+ * Fallback mapping from Jira statusCategory keys to NormalizedStatus.
+ * Used when the exact status name is not found in the custom or default map.
+ */
+const STATUS_CATEGORY_MAP: Record<string, NormalizedStatus> = {
+  'new': 'open',
+  'indeterminate': 'in_progress',
+  'done': 'closed',
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum issues per search page (Jira Cloud caps at 100) */
+const MAX_RESULTS_PER_PAGE = 100;
+
+/** Maximum total issues to fetch across all pages */
+const MAX_TOTAL_ISSUES = 1000;
+
+/** Request timeout in milliseconds */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// JiraIssueProvider class
+// ---------------------------------------------------------------------------
+
+export class JiraIssueProvider implements IssueProvider {
+  readonly name = 'jira';
+  readonly capabilities: ProviderCapabilities = {
+    dependencies: true,
+    subIssues: true,
+    labels: true,
+    boardStatuses: true,
+    priorities: true,
+    assignees: true,
+    linkedPRs: true,
+  };
+
+  private readonly config: JiraConfig;
+  private readonly authHeader: string;
+  private readonly effectiveStatusMap: Record<string, NormalizedStatus>;
+
+  constructor(config: JiraConfig) {
+    this.config = config;
+
+    // Pre-compute the Base64-encoded auth header
+    const credentials = `${config.email}:${config.apiToken}`;
+    this.authHeader = `Basic ${Buffer.from(credentials).toString('base64')}`;
+
+    // Merge custom status mapping on top of defaults (custom wins)
+    this.effectiveStatusMap = {
+      ...DEFAULT_JIRA_STATUS_MAP,
+      ...(config.statusMapping ?? {}),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // IssueProvider interface methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch a single issue by key (e.g. "PROJ-123").
+   */
+  async getIssue(key: string): Promise<GenericIssue | null> {
+    try {
+      const fields = 'summary,status,issuetype,priority,assignee,labels,parent,issuelinks,created,updated';
+      const issue = await this.jiraFetch<JiraIssue>(
+        `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${fields}`,
+      );
+      return this.mapToGenericIssue(issue);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('404') || message.includes('not found')) {
+        return null;
+      }
+      console.warn(`[JiraIssueProvider] Failed to fetch issue ${key}: ${message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Query issues with filtering and pagination via JQL.
+   */
+  async queryIssues(query: IssueQuery): Promise<IssueQueryResult> {
+    try {
+      const projectKey = query.projectKey ?? this.config.projectKey;
+      const jqlParts: string[] = [`project = "${projectKey}"`];
+
+      // Status filter
+      if (query.status) {
+        const statuses = Array.isArray(query.status) ? query.status : [query.status];
+        const jiraStatuses = this.normalizedToJiraStatuses(statuses);
+        if (jiraStatuses.length > 0) {
+          jqlParts.push(`status IN (${jiraStatuses.map((s) => `"${s}"`).join(', ')})`);
+        }
+      } else {
+        // Default: fetch open issues (exclude Done/Closed category)
+        jqlParts.push('statusCategory != Done');
+      }
+
+      // Label filter
+      if (query.labels && query.labels.length > 0) {
+        const labelConditions = query.labels.map((l) => `labels = "${l}"`);
+        jqlParts.push(`(${labelConditions.join(' OR ')})`);
+      }
+
+      // Assignee filter
+      if (query.assignee) {
+        jqlParts.push(`assignee = "${query.assignee}"`);
+      }
+
+      const jql = jqlParts.join(' AND ');
+      const limit = Math.min(query.limit ?? MAX_RESULTS_PER_PAGE, MAX_RESULTS_PER_PAGE);
+      const startAt = query.cursor ? parseInt(query.cursor, 10) : 0;
+
+      const result = await this.jiraFetch<JiraSearchResponse>('/rest/api/3/search', {
+        method: 'POST',
+        body: JSON.stringify({
+          jql,
+          startAt,
+          maxResults: limit,
+          fields: ['summary', 'status', 'issuetype', 'priority', 'assignee', 'labels', 'parent', 'issuelinks', 'created', 'updated'],
+        }),
+      });
+
+      const issues = result.issues.map((issue) => this.mapToGenericIssue(issue));
+      const nextStart = result.startAt + result.issues.length;
+      const hasMore = nextStart < result.total && nextStart < MAX_TOTAL_ISSUES;
+
+      return {
+        issues,
+        cursor: hasMore ? String(nextStart) : null,
+        hasMore,
+        total: result.total,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[JiraIssueProvider] Failed to query issues: ${message}`);
+      return { issues: [], cursor: null, hasMore: false };
+    }
+  }
+
+  /**
+   * Get dependency references (blocking issues) for a given issue.
+   * Extracts "is blocked by" links from the issue's issuelinks field.
+   */
+  async getDependencies(key: string): Promise<GenericDependencyRef[]> {
+    try {
+      const fields = 'issuelinks,status';
+      const issue = await this.jiraFetch<JiraIssue>(
+        `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${fields}`,
+      );
+
+      return this.extractBlockingDependencies(issue);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[JiraIssueProvider] Failed to fetch dependencies for ${key}: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Get pull requests linked to a given issue via remote links.
+   * Jira stores PR links as "remote issue links" with URLs pointing to
+   * GitHub/GitLab/Bitbucket pull request pages.
+   */
+  async getLinkedPRs(key: string): Promise<LinkedPR[]> {
+    try {
+      const remoteLinks = await this.jiraFetch<JiraRemoteLink[]>(
+        `/rest/api/3/issue/${encodeURIComponent(key)}/remotelink`,
+      );
+
+      const prs: LinkedPR[] = [];
+      for (const link of remoteLinks) {
+        const prInfo = this.parsePRFromRemoteLink(link);
+        if (prInfo) {
+          prs.push(prInfo);
+        }
+      }
+      return prs;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[JiraIssueProvider] Failed to fetch linked PRs for ${key}: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Fetch all open issues with pagination for the full hierarchy.
+   * Used by IssueFetcher's generic fetch path to build the issue tree.
+   * Pages through all results up to MAX_TOTAL_ISSUES.
+   */
+  async fetchAllOpenIssues(): Promise<GenericIssue[]> {
+    const allIssues: GenericIssue[] = [];
+    let cursor: string | null = null;
+    let hasMore = true;
+
+    while (hasMore && allIssues.length < MAX_TOTAL_ISSUES) {
+      const result = await this.queryIssues({
+        projectKey: this.config.projectKey,
+        cursor: cursor ?? undefined,
+        limit: MAX_RESULTS_PER_PAGE,
+      });
+
+      allIssues.push(...result.issues);
+      cursor = result.cursor;
+      hasMore = result.hasMore;
+    }
+
+    return allIssues;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Make an authenticated request to the Jira REST API.
+   */
+  private async jiraFetch<T>(path: string, options?: { method?: string; body?: string }): Promise<T> {
+    const url = `${this.config.baseUrl.replace(/\/+$/, '')}${path}`;
+    const method = options?.method ?? 'GET';
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Authorization': this.authHeader,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: options?.body,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        throw new Error(`Jira API ${method} ${path} failed (${response.status}): ${text.slice(0, 200)}`);
+      }
+
+      return await response.json() as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Map a Jira issue to a GenericIssue.
+   */
+  private mapToGenericIssue(issue: JiraIssue): GenericIssue {
+    const status = this.mapStatus(issue.fields.status);
+    const rawStatus = issue.fields.status.name;
+
+    // Extract priority as a numeric value (Jira priorities have string IDs)
+    const priorityId = issue.fields.priority?.id;
+    const priority = priorityId ? parseInt(priorityId, 10) : null;
+
+    // Build the issue URL from the base URL and key
+    const url = `${this.config.baseUrl.replace(/\/+$/, '')}/browse/${issue.key}`;
+
+    return {
+      key: issue.key,
+      title: issue.fields.summary,
+      status,
+      rawStatus,
+      url,
+      labels: issue.fields.labels ?? [],
+      assignee: issue.fields.assignee?.displayName ?? null,
+      priority: isNaN(priority ?? NaN) ? null : priority,
+      parentKey: issue.fields.parent?.key ?? null,
+      createdAt: issue.fields.created,
+      updatedAt: issue.fields.updated ?? null,
+      provider: 'jira',
+    };
+  }
+
+  /**
+   * Map a Jira status to a NormalizedStatus.
+   * Checks custom mapping first, then default mapping, then status category.
+   */
+  private mapStatus(jiraStatus: JiraStatus): NormalizedStatus {
+    const statusName = jiraStatus.name.toLowerCase();
+
+    // Check the effective (merged custom + default) map
+    const mapped = this.effectiveStatusMap[statusName];
+    if (mapped) return mapped;
+
+    // Fallback to status category
+    const categoryKey = jiraStatus.statusCategory?.key?.toLowerCase();
+    if (categoryKey) {
+      const categoryMapped = STATUS_CATEGORY_MAP[categoryKey];
+      if (categoryMapped) return categoryMapped;
+    }
+
+    return 'unknown';
+  }
+
+  /**
+   * Reverse-map NormalizedStatus values to Jira status names for JQL queries.
+   * Returns status names from the effective map that correspond to the given normalized statuses.
+   */
+  private normalizedToJiraStatuses(statuses: NormalizedStatus[]): string[] {
+    const result: string[] = [];
+    const statusSet = new Set(statuses);
+
+    for (const [jiraStatus, normalized] of Object.entries(this.effectiveStatusMap)) {
+      if (statusSet.has(normalized)) {
+        result.push(jiraStatus);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract blocking dependencies from a Jira issue's issuelinks.
+   * Looks for link types containing "block" (case-insensitive) where
+   * the current issue is blocked by the linked issue (inward direction).
+   */
+  private extractBlockingDependencies(issue: JiraIssue): GenericDependencyRef[] {
+    const links = issue.fields.issuelinks ?? [];
+    const deps: GenericDependencyRef[] = [];
+
+    for (const link of links) {
+      // Check if this is a "blocks" type link
+      const linkTypeName = link.type.name.toLowerCase();
+      const isBlockingType = linkTypeName.includes('block');
+
+      if (!isBlockingType) continue;
+
+      // The inward description typically says "is blocked by"
+      // If we have an inwardIssue, it means THAT issue blocks THIS issue
+      // (this issue "is blocked by" the inward issue)
+      const inwardDesc = link.type.inward.toLowerCase();
+      const isBlockedByDirection = inwardDesc.includes('blocked by');
+
+      if (isBlockedByDirection && link.inwardIssue) {
+        const blockerKey = link.inwardIssue.key ?? '';
+        const blockerFields = link.inwardIssue.fields;
+        const blockerStatus = blockerFields?.status
+          ? this.mapStatus(blockerFields.status)
+          : 'unknown';
+
+        if (blockerKey) {
+          deps.push({
+            key: blockerKey,
+            title: blockerFields?.summary ?? '',
+            status: blockerStatus,
+            provider: 'jira',
+            projectKey: blockerKey.split('-')[0] ?? null,
+          });
+        }
+      }
+
+      // Also handle outward direction: if outward says "blocks" and we have an outwardIssue,
+      // that means THIS issue blocks the outward issue -- skip (not a dependency OF this issue)
+
+      // Handle reverse: if inward says "blocks" (not "blocked by"), then outwardIssue is the blocker
+      const isBlocksDirection = !isBlockedByDirection && inwardDesc.includes('block');
+      if (isBlocksDirection && link.outwardIssue) {
+        // This means the outward issue blocks this one through the "blocks" inward link
+        // Actually, let's be more precise: if inward = "blocks" and we have outwardIssue,
+        // that doesn't make this issue blocked. Let's check the outward description too.
+        const outwardDesc = link.type.outward.toLowerCase();
+        if (outwardDesc.includes('blocked by') && link.outwardIssue) {
+          // outwardIssue is blocked by this issue -- not a dep of this issue
+          // skip
+        }
+      }
+    }
+
+    return deps;
+  }
+
+  /**
+   * Parse a PR URL from a Jira remote link.
+   * Detects GitHub, GitLab, and Bitbucket PR URLs.
+   */
+  private parsePRFromRemoteLink(link: JiraRemoteLink): LinkedPR | null {
+    const url = link.object.url;
+    if (!url) return null;
+
+    // GitHub PR: https://github.com/owner/repo/pull/123
+    const githubMatch = url.match(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
+    if (githubMatch) {
+      const prNumber = parseInt(githubMatch[1], 10);
+      const resolved = link.object.status?.resolved;
+      return {
+        number: prNumber,
+        state: resolved ? 'merged' : 'open',
+        url,
+      };
+    }
+
+    // GitLab MR: https://gitlab.com/owner/repo/-/merge_requests/123
+    const gitlabMatch = url.match(/gitlab\.[^/]+\/[^/]+\/[^/]+\/-\/merge_requests\/(\d+)/);
+    if (gitlabMatch) {
+      const prNumber = parseInt(gitlabMatch[1], 10);
+      const resolved = link.object.status?.resolved;
+      return {
+        number: prNumber,
+        state: resolved ? 'merged' : 'open',
+        url,
+      };
+    }
+
+    // Bitbucket PR: https://bitbucket.org/owner/repo/pull-requests/123
+    const bitbucketMatch = url.match(/bitbucket\.[^/]+\/[^/]+\/[^/]+\/pull-requests\/(\d+)/);
+    if (bitbucketMatch) {
+      const prNumber = parseInt(bitbucketMatch[1], 10);
+      const resolved = link.object.status?.resolved;
+      return {
+        number: prNumber,
+        state: resolved ? 'merged' : 'open',
+        url,
+      };
+    }
+
+    return null;
+  }
+}

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -27,6 +27,9 @@ interface CreateProjectBody {
   githubRepo?: string;
   maxActiveTeams?: number;
   model?: string;
+  issueProvider?: string;
+  projectKey?: string;
+  providerConfig?: string;
 }
 
 interface UpdateProjectBody {
@@ -38,6 +41,9 @@ interface UpdateProjectBody {
   maxActiveTeams?: number;
   promptFile?: string | null;
   model?: string | null;
+  issueProvider?: string | null;
+  projectKey?: string | null;
+  providerConfig?: string | null;
 }
 
 interface ProjectIdParams {

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -13,6 +13,7 @@
 import config from '../config.js';
 import { getDatabase } from '../db.js';
 import type { DependencyRef, IssueDependencyInfo } from '../../shared/types.js';
+import type { GenericIssue, GenericDependencyRef } from '../../shared/issue-provider.js';
 import { getIssueProvider, resetProviders } from '../providers/index.js';
 import {
   type GraphQLIssueNode,
@@ -21,6 +22,7 @@ import {
   runWithConcurrency,
   parseRepo,
 } from '../providers/github-issue-provider.js';
+import { JiraIssueProvider } from '../providers/jira-issue-provider.js';
 
 // ---------------------------------------------------------------------------
 // Re-exports for backward compatibility
@@ -47,6 +49,10 @@ export interface IssueNode {
   children: IssueNode[];
   activeTeam?: { id: number; status: string } | null;
   dependencies?: IssueDependencyInfo;
+  /** Universal issue key (e.g. "42" for GitHub, "PROJ-123" for Jira) */
+  issueKey?: string;
+  /** Provider name (e.g. 'github', 'jira') */
+  issueProvider?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +144,53 @@ function mapParentNodeToIssueNode(node: GraphQLIssueNode): IssueNode {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: map a GenericIssue (from any provider) to our IssueNode format
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a GenericIssue from a non-GitHub provider to our IssueNode format.
+ * For Jira, issue.key is "PROJ-123" and is stored in issueKey.
+ * The `number` field uses a hash of the key for compatibility with
+ * numeric-only consumers (e.g. activeTeam enrichment).
+ */
+function mapGenericIssueToIssueNode(issue: GenericIssue): IssueNode {
+  // For Jira/Linear, we need a numeric "number" for backward compat.
+  // Extract trailing digits from the key (e.g. "PROJ-123" -> 123).
+  const numMatch = issue.key.match(/(\d+)$/);
+  const number = numMatch ? parseInt(numMatch[1], 10) : 0;
+
+  return {
+    number,
+    title: issue.title,
+    state: issue.status === 'closed' ? 'closed' : 'open',
+    labels: issue.labels,
+    url: issue.url ?? '',
+    children: [],
+    activeTeam: null,
+    issueKey: issue.key,
+    issueProvider: issue.provider,
+  };
+}
+
+/**
+ * Convert a GenericDependencyRef to a DependencyRef (for backward compat).
+ * Jira deps use key-based identification; the DependencyRef structure
+ * is GitHub-centric (owner/repo), so we set placeholder values.
+ */
+function genericDepToDepRef(dep: GenericDependencyRef): DependencyRef {
+  const numMatch = dep.key.match(/(\d+)$/);
+  const number = numMatch ? parseInt(numMatch[1], 10) : 0;
+
+  return {
+    number,
+    owner: dep.projectKey ?? dep.provider,
+    repo: dep.provider,
+    state: dep.status === 'closed' ? 'closed' : 'open',
+    title: dep.title,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Issue Fetcher class
 // ---------------------------------------------------------------------------
 
@@ -163,19 +216,21 @@ export class IssueFetcher {
       return [];
     }
 
+    // Get the provider and delegate based on type
+    const provider = getIssueProvider(project);
+
+    // Non-GitHub providers use the generic fetch path
+    if (!(provider instanceof GitHubIssueProvider)) {
+      return this.fetchIssueHierarchyGeneric(projectId, project, provider);
+    }
+
+    // GitHub path requires githubRepo
     if (!project.githubRepo) {
       console.error(`[IssueFetcher] Project ${projectId} has no githubRepo configured`);
       return [];
     }
 
     const [owner, repo] = parseRepo(project.githubRepo);
-
-    // Get the provider and delegate the raw issue fetch
-    const provider = getIssueProvider(project);
-    if (!(provider instanceof GitHubIssueProvider)) {
-      console.error(`[IssueFetcher] Provider for project ${projectId} is not a GitHubIssueProvider`);
-      return [];
-    }
 
     const { nodes: allNodes, fetchComplete } = await provider.fetchRawIssueHierarchy(owner, repo);
 
@@ -364,11 +419,16 @@ export class IssueFetcher {
    * serial iteration, significantly reducing total wall-clock time.
    */
   async fetchAllProjects(): Promise<void> {
-    // Recovery mechanism: tick the provider's retry countdown so it re-enables
-    // blockedBy support after a few poll cycles (circuit-breaker pattern).
-    const provider = getIssueProvider({ issueProvider: 'github' } as Parameters<typeof getIssueProvider>[0]);
-    if (provider instanceof GitHubIssueProvider) {
-      provider.tickRetryCountdown();
+    // Recovery mechanism: tick the GitHub provider's retry countdown so it
+    // re-enables blockedBy support after a few poll cycles (circuit-breaker pattern).
+    // Only applies to GitHub providers; Jira/Linear do not have this mechanism.
+    try {
+      const ghProvider = getIssueProvider({ issueProvider: 'github' } as Parameters<typeof getIssueProvider>[0]);
+      if (ghProvider instanceof GitHubIssueProvider) {
+        ghProvider.tickRetryCountdown();
+      }
+    } catch {
+      // No GitHub provider configured -- that's fine, Jira-only setups skip this
     }
 
     const db = getDatabase();
@@ -386,6 +446,120 @@ export class IssueFetcher {
     });
 
     await runWithConcurrency(tasks, 3);
+  }
+
+  /**
+   * Generic fetch path for non-GitHub providers (Jira, Linear, etc.).
+   * Calls the standard IssueProvider interface methods (queryIssues,
+   * getDependencies) and maps GenericIssue[] to IssueNode[], then
+   * builds the parent-child hierarchy tree.
+   */
+  private async fetchIssueHierarchyGeneric(
+    projectId: number,
+    project: { id: number; name: string; issueProvider: string | null },
+    provider: import('../../shared/issue-provider.js').IssueProvider,
+  ): Promise<IssueNode[]> {
+    let fetchComplete = true;
+
+    // Fetch all open issues via the provider's queryIssues (paginated)
+    let allGenericIssues: GenericIssue[] = [];
+
+    // If the provider is a JiraIssueProvider, use the dedicated fetchAllOpenIssues
+    if (provider instanceof JiraIssueProvider) {
+      try {
+        allGenericIssues = await provider.fetchAllOpenIssues();
+      } catch (err) {
+        console.error(
+          `[IssueFetcher] Generic fetch failed for project ${projectId}:`,
+          err instanceof Error ? err.message : err,
+        );
+        fetchComplete = false;
+      }
+    } else {
+      // Fallback: page through queryIssues for any other provider
+      let cursor: string | undefined;
+      let hasMore = true;
+      try {
+        while (hasMore && allGenericIssues.length < 1000) {
+          const result = await provider.queryIssues({ cursor, limit: 100 });
+          allGenericIssues.push(...result.issues);
+          cursor = result.cursor ?? undefined;
+          hasMore = result.hasMore;
+        }
+      } catch (err) {
+        console.error(
+          `[IssueFetcher] Generic fetch failed for project ${projectId}:`,
+          err instanceof Error ? err.message : err,
+        );
+        fetchComplete = false;
+      }
+    }
+
+    // Convert GenericIssue to IssueNode (flat, no children yet)
+    const flatIssues = allGenericIssues.map((gi) => mapGenericIssueToIssueNode(gi));
+
+    // Build parent-child hierarchy from parentKey references
+    const issueByKey = new Map<string, IssueNode>();
+    for (const issue of flatIssues) {
+      issueByKey.set(issue.issueKey ?? String(issue.number), issue);
+    }
+
+    const childKeys = new Set<string>();
+    for (const gi of allGenericIssues) {
+      if (gi.parentKey) {
+        const childKey = gi.key;
+        const parentNode = issueByKey.get(gi.parentKey);
+        const childNode = issueByKey.get(childKey);
+        if (parentNode && childNode) {
+          parentNode.children.push(childNode);
+          childKeys.add(childKey);
+        }
+      }
+    }
+
+    // Root issues are those with no parent (or parent not in fetched set)
+    const rootIssues = flatIssues.filter(
+      (issue) => !childKeys.has(issue.issueKey ?? String(issue.number)),
+    );
+
+    // Fetch dependencies for each issue
+    if (provider.capabilities.dependencies) {
+      const depTasks = flatIssues.map((issue) => async () => {
+        const key = issue.issueKey ?? String(issue.number);
+        try {
+          const deps = await provider.getDependencies(key);
+          if (deps.length > 0) {
+            const openCount = deps.filter((d) => d.status === 'open').length;
+            issue.dependencies = {
+              issueNumber: issue.number,
+              issueKey: key,
+              blockedBy: deps.map((d) => genericDepToDepRef(d)),
+              resolved: openCount === 0,
+              openCount,
+            };
+          }
+        } catch {
+          // Non-fatal: skip dependency info for this issue
+        }
+      });
+
+      await runWithConcurrency(depTasks, 5);
+    }
+
+    // Update the per-project cache
+    if (fetchComplete) {
+      this.cacheByProject.set(projectId, {
+        issues: rootIssues,
+        cachedAt: new Date().toISOString(),
+      });
+    } else if (!this.cacheByProject.has(projectId)) {
+      this.cacheByProject.set(projectId, {
+        issues: rootIssues,
+        cachedAt: null,
+      });
+    }
+
+    return rootIssues;
   }
 
   /**
@@ -672,13 +846,40 @@ export class IssueFetcher {
   }
 
   /**
-   * Fetch dependencies for a specific project + issue number.
-   * Convenience wrapper that resolves owner/repo from projectId.
+   * Fetch dependencies for a specific project + issue number (or issue key).
+   * For GitHub: resolves owner/repo and delegates to fetchDependenciesFromProvider.
+   * For non-GitHub providers: calls the provider's getDependencies directly.
    */
-  async fetchDependenciesForIssue(projectId: number, issueNumber: number): Promise<IssueDependencyInfo | null> {
+  async fetchDependenciesForIssue(projectId: number, issueNumber: number, issueKey?: string): Promise<IssueDependencyInfo | null> {
     const db = getDatabase();
     const project = db.getProject(projectId);
-    if (!project?.githubRepo) return null;
+    if (!project) return null;
+
+    const provider = getIssueProvider(project);
+
+    // Non-GitHub providers: use the generic getDependencies interface
+    if (!(provider instanceof GitHubIssueProvider)) {
+      const key = issueKey ?? String(issueNumber);
+      try {
+        const deps = await provider.getDependencies(key);
+        if (deps.length === 0) {
+          return { issueNumber, issueKey: key, blockedBy: [], resolved: true, openCount: 0 };
+        }
+        const openCount = deps.filter((d) => d.status === 'open').length;
+        return {
+          issueNumber,
+          issueKey: key,
+          blockedBy: deps.map((d) => genericDepToDepRef(d)),
+          resolved: openCount === 0,
+          openCount,
+        };
+      } catch {
+        return null;
+      }
+    }
+
+    // GitHub path requires githubRepo
+    if (!project.githubRepo) return null;
 
     const [owner, repo] = parseRepo(project.githubRepo);
     return this.fetchDependencies(owner, repo, issueNumber);

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -760,8 +760,11 @@ export class ProjectService {
     githubRepo?: string;
     maxActiveTeams?: number;
     model?: string;
+    issueProvider?: string;
+    projectKey?: string;
+    providerConfig?: string;
   }): Promise<unknown> {
-    const { name, repoPath, githubRepo, maxActiveTeams, model } = data;
+    const { name, repoPath, githubRepo, maxActiveTeams, model, issueProvider, projectKey, providerConfig } = data;
 
     // Validate name
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -784,8 +787,53 @@ export class ProjectService {
       );
     }
 
-    // Auto-detect githubRepo if not provided
-    const resolvedGithubRepo = githubRepo || await detectGithubRepo(normalizedPath);
+    // Validate Jira-specific fields when issueProvider is 'jira'
+    const resolvedIssueProvider = issueProvider || 'github';
+    let resolvedProjectKey = projectKey || null;
+    let resolvedProviderConfig = providerConfig || null;
+
+    if (resolvedIssueProvider === 'jira') {
+      // Parse and validate the provider config JSON
+      if (!providerConfig) {
+        throw validationError('providerConfig is required for Jira projects');
+      }
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(providerConfig) as Record<string, unknown>;
+      } catch {
+        throw validationError('providerConfig must be valid JSON for Jira projects');
+      }
+
+      if (!parsed.baseUrl || typeof parsed.baseUrl !== 'string') {
+        throw validationError('Jira baseUrl is required in providerConfig');
+      }
+      if (!parsed.email || typeof parsed.email !== 'string') {
+        throw validationError('Jira email is required in providerConfig');
+      }
+      if (!parsed.apiToken || typeof parsed.apiToken !== 'string') {
+        throw validationError('Jira apiToken is required in providerConfig');
+      }
+
+      // Resolve projectKey from the explicit field or from providerConfig
+      resolvedProjectKey = projectKey || (parsed.projectKey as string) || null;
+      if (!resolvedProjectKey) {
+        throw validationError('projectKey is required for Jira projects');
+      }
+
+      // Validate project key format: uppercase letters followed optionally by more
+      if (!/^[A-Z][A-Z0-9]*$/.test(resolvedProjectKey)) {
+        throw validationError('Jira projectKey must match [A-Z][A-Z0-9]* pattern (e.g. "PROJ")');
+      }
+
+      // Store the resolved providerConfig as-is (already valid JSON)
+      resolvedProviderConfig = providerConfig;
+    }
+
+    // Auto-detect githubRepo if not provided (only for GitHub projects)
+    const resolvedGithubRepo = resolvedIssueProvider === 'github'
+      ? (githubRepo || await detectGithubRepo(normalizedPath))
+      : (githubRepo || null);
 
     // Validate maxActiveTeams if provided
     if (maxActiveTeams !== undefined) {
@@ -828,6 +876,9 @@ export class ProjectService {
       maxActiveTeams: maxActiveTeams ?? 5,
       promptFile: promptRelPath,
       model: model?.trim() || null,
+      issueProvider: resolvedIssueProvider,
+      projectKey: resolvedProjectKey,
+      providerConfig: resolvedProviderConfig,
     });
 
     // Install hooks (non-fatal)

--- a/tests/client/AddProjectDialog.test.tsx
+++ b/tests/client/AddProjectDialog.test.tsx
@@ -113,6 +113,7 @@ describe('AddProjectDialog', () => {
         githubRepo: 'user/test',
         maxActiveTeams: 5,
         model: undefined,
+        issueProvider: 'github',
       });
     });
   });

--- a/tests/server/providers/jira-issue-provider.test.ts
+++ b/tests/server/providers/jira-issue-provider.test.ts
@@ -1,0 +1,563 @@
+// =============================================================================
+// Fleet Commander -- JiraIssueProvider Tests
+// =============================================================================
+// Tests for the JiraIssueProvider class, including:
+//   - Issue mapping (Jira issue -> GenericIssue)
+//   - Status mapping (default + custom + category fallback)
+//   - Dependency extraction from issue links
+//   - Linked PR parsing from remote links
+//   - Error handling (401, 404, 429, timeouts)
+//   - Provider capabilities and interface compliance
+//   - queryIssues JQL construction
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  JiraIssueProvider,
+  DEFAULT_JIRA_STATUS_MAP,
+  type JiraConfig,
+} from '../../../src/server/providers/jira-issue-provider.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<JiraConfig> = {}): JiraConfig {
+  return {
+    baseUrl: 'https://test.atlassian.net',
+    email: 'test@example.com',
+    apiToken: 'test-token-123',
+    projectKey: 'TEST',
+    ...overrides,
+  };
+}
+
+function makeJiraIssue(overrides: { key?: string; fields?: Record<string, unknown>; [k: string]: unknown } = {}) {
+  const { fields: fieldOverrides, ...topOverrides } = overrides;
+  return {
+    key: 'TEST-42',
+    id: '10042',
+    fields: {
+      summary: 'Fix the login bug',
+      status: { name: 'In Progress', statusCategory: { key: 'indeterminate', name: 'In Progress' } },
+      issuetype: { name: 'Story', subtask: false },
+      priority: { id: '2', name: 'High' },
+      assignee: { displayName: 'Alice', accountId: 'abc123' },
+      labels: ['bug', 'frontend'],
+      parent: null,
+      issuelinks: [],
+      created: '2026-03-01T12:00:00.000Z',
+      updated: '2026-03-15T14:30:00.000Z',
+      ...(fieldOverrides ?? {}),
+    },
+    self: 'https://test.atlassian.net/rest/api/3/issue/10042',
+    ...topOverrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock setup
+// ---------------------------------------------------------------------------
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchResponse(body: unknown, status = 200) {
+  fetchMock.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response);
+}
+
+// ---------------------------------------------------------------------------
+// DEFAULT_JIRA_STATUS_MAP
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_JIRA_STATUS_MAP', () => {
+  it('should map common open statuses to open', () => {
+    expect(DEFAULT_JIRA_STATUS_MAP['to do']).toBe('open');
+    expect(DEFAULT_JIRA_STATUS_MAP['backlog']).toBe('open');
+    expect(DEFAULT_JIRA_STATUS_MAP['open']).toBe('open');
+    expect(DEFAULT_JIRA_STATUS_MAP['new']).toBe('open');
+  });
+
+  it('should map in-progress statuses to in_progress', () => {
+    expect(DEFAULT_JIRA_STATUS_MAP['in progress']).toBe('in_progress');
+    expect(DEFAULT_JIRA_STATUS_MAP['in review']).toBe('in_progress');
+    expect(DEFAULT_JIRA_STATUS_MAP['code review']).toBe('in_progress');
+  });
+
+  it('should map done statuses to closed', () => {
+    expect(DEFAULT_JIRA_STATUS_MAP['done']).toBe('closed');
+    expect(DEFAULT_JIRA_STATUS_MAP['closed']).toBe('closed');
+    expect(DEFAULT_JIRA_STATUS_MAP['resolved']).toBe('closed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider capabilities
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider capabilities', () => {
+  it('should have correct name', () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    expect(provider.name).toBe('jira');
+  });
+
+  it('should declare all capabilities as true', () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    expect(provider.capabilities).toEqual({
+      dependencies: true,
+      subIssues: true,
+      labels: true,
+      boardStatuses: true,
+      priorities: true,
+      assignees: true,
+      linkedPRs: true,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getIssue
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider.getIssue', () => {
+  it('should fetch and map a single issue', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    const jiraIssue = makeJiraIssue();
+    mockFetchResponse(jiraIssue);
+
+    const result = await provider.getIssue('TEST-42');
+
+    expect(result).not.toBeNull();
+    expect(result!.key).toBe('TEST-42');
+    expect(result!.title).toBe('Fix the login bug');
+    expect(result!.status).toBe('in_progress');
+    expect(result!.rawStatus).toBe('In Progress');
+    expect(result!.url).toBe('https://test.atlassian.net/browse/TEST-42');
+    expect(result!.labels).toEqual(['bug', 'frontend']);
+    expect(result!.assignee).toBe('Alice');
+    expect(result!.priority).toBe(2);
+    expect(result!.provider).toBe('jira');
+    expect(result!.parentKey).toBeNull();
+    expect(result!.createdAt).toBe('2026-03-01T12:00:00.000Z');
+    expect(result!.updatedAt).toBe('2026-03-15T14:30:00.000Z');
+  });
+
+  it('should return null for 404 responses', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    mockFetchResponse({ errorMessages: ['Issue not found'] }, 404);
+
+    const result = await provider.getIssue('TEST-999');
+    expect(result).toBeNull();
+  });
+
+  it('should return null on network errors', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await provider.getIssue('TEST-42');
+    expect(result).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('should map parent key when present', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    const jiraIssue = makeJiraIssue({
+      fields: { parent: { key: 'TEST-10', fields: { summary: 'Parent Epic' } } },
+    });
+    mockFetchResponse(jiraIssue);
+
+    const result = await provider.getIssue('TEST-42');
+    expect(result!.parentKey).toBe('TEST-10');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status mapping
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider status mapping', () => {
+  it('should use default mapping for known statuses', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    const issue = makeJiraIssue({
+      fields: { status: { name: 'To Do', statusCategory: { key: 'new', name: 'To Do' } } },
+    });
+    mockFetchResponse(issue);
+
+    const result = await provider.getIssue('TEST-42');
+    expect(result!.status).toBe('open');
+  });
+
+  it('should use custom status mapping when provided', async () => {
+    const provider = new JiraIssueProvider(makeConfig({
+      statusMapping: { 'custom status': 'in_progress' },
+    }));
+
+    const issue = makeJiraIssue({
+      fields: { status: { name: 'Custom Status', statusCategory: { key: 'indeterminate', name: 'Custom' } } },
+    });
+    mockFetchResponse(issue);
+
+    const result = await provider.getIssue('TEST-42');
+    expect(result!.status).toBe('in_progress');
+  });
+
+  it('should fall back to status category for unknown statuses', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    const issue = makeJiraIssue({
+      fields: { status: { name: 'Bizarre Custom Status', statusCategory: { key: 'done', name: 'Done' } } },
+    });
+    mockFetchResponse(issue);
+
+    const result = await provider.getIssue('TEST-42');
+    expect(result!.status).toBe('closed');
+  });
+
+  it('should return unknown for completely unrecognized statuses', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    const issue = makeJiraIssue({
+      fields: { status: { name: 'Alien Status' } },
+    });
+    mockFetchResponse(issue);
+
+    const result = await provider.getIssue('TEST-42');
+    expect(result!.status).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryIssues
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider.queryIssues', () => {
+  it('should construct JQL and return mapped issues', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse({
+      issues: [makeJiraIssue(), makeJiraIssue({ key: 'TEST-43', fields: { summary: 'Another issue' } })],
+      startAt: 0,
+      maxResults: 100,
+      total: 2,
+    });
+
+    const result = await provider.queryIssues({});
+
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0].key).toBe('TEST-42');
+    expect(result.hasMore).toBe(false);
+    expect(result.cursor).toBeNull();
+  });
+
+  it('should use POST method for search', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse({ issues: [], startAt: 0, maxResults: 100, total: 0 });
+
+    await provider.queryIssues({});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/rest/api/3/search');
+    expect(options.method).toBe('POST');
+  });
+
+  it('should paginate when hasMore is true', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse({
+      issues: [makeJiraIssue()],
+      startAt: 0,
+      maxResults: 1,
+      total: 5,
+    });
+
+    const result = await provider.queryIssues({ limit: 1 });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.cursor).toBe('1');
+    expect(result.total).toBe(5);
+  });
+
+  it('should return empty results on error', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    fetchMock.mockRejectedValueOnce(new Error('Connection refused'));
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await provider.queryIssues({});
+    expect(result.issues).toHaveLength(0);
+    expect(result.hasMore).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDependencies
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider.getDependencies', () => {
+  it('should extract blocking dependencies from issuelinks', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    const issue = makeJiraIssue({
+      fields: {
+        issuelinks: [
+          {
+            id: '1',
+            type: { name: 'Blocks', inward: 'is blocked by', outward: 'blocks' },
+            inwardIssue: {
+              key: 'TEST-10',
+              fields: {
+                summary: 'Blocking issue',
+                status: { name: 'Open', statusCategory: { key: 'new', name: 'To Do' } },
+              },
+            },
+          },
+        ],
+      },
+    });
+    mockFetchResponse(issue);
+
+    const deps = await provider.getDependencies('TEST-42');
+
+    expect(deps).toHaveLength(1);
+    expect(deps[0].key).toBe('TEST-10');
+    expect(deps[0].title).toBe('Blocking issue');
+    expect(deps[0].status).toBe('open');
+    expect(deps[0].provider).toBe('jira');
+    expect(deps[0].projectKey).toBe('TEST');
+  });
+
+  it('should ignore non-blocking link types', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    const issue = makeJiraIssue({
+      fields: {
+        issuelinks: [
+          {
+            id: '1',
+            type: { name: 'Relates', inward: 'relates to', outward: 'relates to' },
+            inwardIssue: {
+              key: 'TEST-10',
+              fields: { summary: 'Related issue', status: { name: 'Open' } },
+            },
+          },
+        ],
+      },
+    });
+    mockFetchResponse(issue);
+
+    const deps = await provider.getDependencies('TEST-42');
+    expect(deps).toHaveLength(0);
+  });
+
+  it('should return empty array on error', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    fetchMock.mockRejectedValueOnce(new Error('API error'));
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps = await provider.getDependencies('TEST-42');
+    expect(deps).toHaveLength(0);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLinkedPRs
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider.getLinkedPRs', () => {
+  it('should parse GitHub PR URLs from remote links', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse([
+      {
+        id: 1,
+        self: 'https://test.atlassian.net/rest/api/3/issue/TEST-42/remotelink/1',
+        object: {
+          url: 'https://github.com/myorg/myrepo/pull/42',
+          title: 'PR #42',
+          status: { resolved: false },
+        },
+      },
+    ]);
+
+    const prs = await provider.getLinkedPRs('TEST-42');
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(42);
+    expect(prs[0].state).toBe('open');
+    expect(prs[0].url).toBe('https://github.com/myorg/myrepo/pull/42');
+  });
+
+  it('should detect merged PRs from resolved status', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse([
+      {
+        id: 1,
+        self: '',
+        object: {
+          url: 'https://github.com/myorg/myrepo/pull/99',
+          title: 'Merged PR',
+          status: { resolved: true },
+        },
+      },
+    ]);
+
+    const prs = await provider.getLinkedPRs('TEST-42');
+    expect(prs[0].state).toBe('merged');
+  });
+
+  it('should parse GitLab MR URLs', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse([
+      {
+        id: 1,
+        self: '',
+        object: {
+          url: 'https://gitlab.com/myorg/myrepo/-/merge_requests/55',
+          title: 'MR !55',
+        },
+      },
+    ]);
+
+    const prs = await provider.getLinkedPRs('TEST-42');
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(55);
+  });
+
+  it('should ignore non-PR remote links', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    mockFetchResponse([
+      {
+        id: 1,
+        self: '',
+        object: {
+          url: 'https://confluence.example.com/page/123',
+          title: 'Design doc',
+        },
+      },
+    ]);
+
+    const prs = await provider.getLinkedPRs('TEST-42');
+    expect(prs).toHaveLength(0);
+  });
+
+  it('should return empty array on error', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    fetchMock.mockRejectedValueOnce(new Error('API error'));
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const prs = await provider.getLinkedPRs('TEST-42');
+    expect(prs).toHaveLength(0);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider authentication', () => {
+  it('should send Basic auth header with base64 credentials', async () => {
+    const provider = new JiraIssueProvider(makeConfig({
+      email: 'user@test.com',
+      apiToken: 'my-secret-token',
+    }));
+
+    mockFetchResponse(makeJiraIssue());
+
+    await provider.getIssue('TEST-42');
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const expectedAuth = `Basic ${Buffer.from('user@test.com:my-secret-token').toString('base64')}`;
+    expect((options.headers as Record<string, string>)['Authorization']).toBe(expectedAuth);
+  });
+
+  it('should include correct content-type headers', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    mockFetchResponse(makeJiraIssue());
+
+    await provider.getIssue('TEST-42');
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect((options.headers as Record<string, string>)['Accept']).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider error handling', () => {
+  it('should handle 401 unauthorized gracefully', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    mockFetchResponse({ errorMessages: ['Unauthorized'] }, 401);
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await provider.getIssue('TEST-42');
+    expect(result).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('should handle 429 rate limiting gracefully', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+    mockFetchResponse({ errorMessages: ['Rate limit exceeded'] }, 429);
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await provider.queryIssues({});
+    expect(result.issues).toHaveLength(0);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchAllOpenIssues
+// ---------------------------------------------------------------------------
+
+describe('JiraIssueProvider.fetchAllOpenIssues', () => {
+  it('should fetch all pages of open issues', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    // First page
+    mockFetchResponse({
+      issues: [makeJiraIssue({ key: 'TEST-1' }), makeJiraIssue({ key: 'TEST-2' })],
+      startAt: 0,
+      maxResults: 2,
+      total: 3,
+    });
+
+    // Second page
+    mockFetchResponse({
+      issues: [makeJiraIssue({ key: 'TEST-3' })],
+      startAt: 2,
+      maxResults: 2,
+      total: 3,
+    });
+
+    const issues = await provider.fetchAllOpenIssues();
+
+    expect(issues).toHaveLength(3);
+    expect(issues[0].key).toBe('TEST-1');
+    expect(issues[2].key).toBe('TEST-3');
+  });
+});

--- a/tests/server/providers/provider-registry.test.ts
+++ b/tests/server/providers/provider-registry.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getIssueProvider, resetProviders, getCachedProvider } from '../../../src/server/providers/index.js';
 import { GitHubIssueProvider } from '../../../src/server/providers/github-issue-provider.js';
+import { JiraIssueProvider } from '../../../src/server/providers/jira-issue-provider.js';
 import type { Project } from '../../../src/shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -19,8 +20,8 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     name: 'test-project',
     repoPath: '/tmp/test',
     githubRepo: 'octocat/hello-world',
-    slug: 'test-project',
     status: 'active',
+    hooksInstalled: false,
     maxActiveTeams: 3,
     promptFile: null,
     model: null,
@@ -28,7 +29,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     projectKey: null,
     providerConfig: null,
     createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: null,
+    updatedAt: '2026-01-01T00:00:00.000Z',
     groupId: null,
     ...overrides,
   };
@@ -66,9 +67,58 @@ describe('getIssueProvider', () => {
     expect(provider1).toBe(provider2); // Same instance
   });
 
+  it('should return a JiraIssueProvider when issueProvider is "jira"', () => {
+    const project = makeProject({
+      issueProvider: 'jira',
+      projectKey: 'TEST',
+      providerConfig: JSON.stringify({
+        baseUrl: 'https://test.atlassian.net',
+        email: 'test@example.com',
+        apiToken: 'token-123',
+        projectKey: 'TEST',
+      }),
+    });
+    const provider = getIssueProvider(project);
+    expect(provider).toBeInstanceOf(JiraIssueProvider);
+    expect(provider.name).toBe('jira');
+  });
+
+  it('should cache Jira providers per project ID', () => {
+    const project1 = makeProject({
+      id: 1,
+      issueProvider: 'jira',
+      projectKey: 'PROJ1',
+      providerConfig: JSON.stringify({
+        baseUrl: 'https://proj1.atlassian.net',
+        email: 'a@example.com',
+        apiToken: 'token-1',
+        projectKey: 'PROJ1',
+      }),
+    });
+    const project2 = makeProject({
+      id: 2,
+      issueProvider: 'jira',
+      projectKey: 'PROJ2',
+      providerConfig: JSON.stringify({
+        baseUrl: 'https://proj2.atlassian.net',
+        email: 'b@example.com',
+        apiToken: 'token-2',
+        projectKey: 'PROJ2',
+      }),
+    });
+
+    const provider1 = getIssueProvider(project1);
+    const provider2 = getIssueProvider(project2);
+
+    // Different projects should get different Jira provider instances
+    expect(provider1).not.toBe(provider2);
+    expect(provider1).toBeInstanceOf(JiraIssueProvider);
+    expect(provider2).toBeInstanceOf(JiraIssueProvider);
+  });
+
   it('should throw for unsupported provider type', () => {
-    const project = makeProject({ issueProvider: 'jira' });
-    expect(() => getIssueProvider(project)).toThrow('Unsupported issue provider: "jira"');
+    const project = makeProject({ issueProvider: 'linear' });
+    expect(() => getIssueProvider(project)).toThrow('Unsupported issue provider: "linear"');
   });
 
   it('should include project name in error message for unsupported provider', () => {
@@ -78,7 +128,17 @@ describe('getIssueProvider', () => {
 
   it('should mention supported providers in error message', () => {
     const project = makeProject({ issueProvider: 'unknown' });
-    expect(() => getIssueProvider(project)).toThrow('Supported providers: github');
+    expect(() => getIssueProvider(project)).toThrow('Supported providers: github, jira');
+  });
+
+  it('should throw for Jira provider with missing providerConfig', () => {
+    const project = makeProject({ issueProvider: 'jira', providerConfig: null });
+    expect(() => getIssueProvider(project)).toThrow('Jira baseUrl is required');
+  });
+
+  it('should throw for Jira provider with invalid JSON in providerConfig', () => {
+    const project = makeProject({ issueProvider: 'jira', providerConfig: 'not json' });
+    expect(() => getIssueProvider(project)).toThrow('Invalid providerConfig JSON');
   });
 });
 
@@ -104,7 +164,24 @@ describe('getCachedProvider', () => {
   it('should return undefined for a non-existent provider name', () => {
     const project = makeProject({ issueProvider: 'github' });
     getIssueProvider(project);
-    expect(getCachedProvider('jira')).toBeUndefined();
+    expect(getCachedProvider('linear')).toBeUndefined();
+  });
+
+  it('should return Jira provider cached by project-specific key', () => {
+    const project = makeProject({
+      id: 42,
+      issueProvider: 'jira',
+      projectKey: 'TEST',
+      providerConfig: JSON.stringify({
+        baseUrl: 'https://test.atlassian.net',
+        email: 'test@example.com',
+        apiToken: 'token',
+        projectKey: 'TEST',
+      }),
+    });
+    const provider = getIssueProvider(project);
+    expect(getCachedProvider('jira:42')).toBe(provider);
+    expect(getCachedProvider('jira')).toBeUndefined(); // Not cached under plain 'jira'
   });
 });
 


### PR DESCRIPTION
Closes #578

## Summary
- Implements `JiraIssueProvider` class (`src/server/providers/jira-issue-provider.ts`) with full `IssueProvider` interface compliance
- Jira REST API v3 client with Basic Auth, 15s timeout, pagination, and graceful error handling
- Configurable status mapping (Jira workflow statuses → NormalizedStatus) with sensible defaults
- Epic > Story > Sub-task hierarchy via `parent` field
- Dependency extraction from Jira "is blocked by" issue links → `GenericDependencyRef`
- Provider registry updated with per-project caching for Jira instances
- `IssueFetcher` extended with generic fetch path for non-GitHub providers
- Add Project UI extended with provider selector (GitHub/Jira) and conditional Jira config fields
- Issue tree displays Jira keys as "PROJ-123" instead of "#0" using `formatIssueKey`
- Credentials masked in API responses (null in list, '[configured]' in detail)
- 30 unit tests for Jira provider + 16 updated registry tests

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run test:server` passes (all provider tests green)
- [ ] Verify Add Project dialog shows provider selector and Jira fields
- [ ] Verify Jira issues display correctly in Issue Tree with hierarchy
- [ ] Verify dependency blocking works for Jira issues