### PR TITLE
Issue #593: Add multi-provider issue sources (GH + Jira)

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -22,6 +22,7 @@ import type {
   ProjectGroup,
   ProjectSummary,
   ProjectStatus,
+  ProjectIssueSource,
   MessageTemplate,
   TeamTransition,
   TeamMember,
@@ -246,6 +247,22 @@ export interface ProjectGroupUpdate {
   description?: string | null;
 }
 
+export interface ProjectIssueSourceInsert {
+  projectId: number;
+  provider: string;
+  label?: string | null;
+  configJson: string;
+  credentialsJson?: string | null;
+  enabled?: boolean;
+}
+
+export interface ProjectIssueSourceUpdate {
+  label?: string | null;
+  configJson?: string;
+  credentialsJson?: string | null;
+  enabled?: boolean;
+}
+
 export interface ProjectFilter {
   status?: ProjectStatus;
 }
@@ -372,6 +389,9 @@ export class FleetDatabase {
 
     // Encrypt existing plaintext provider_config values (v12 migration)
     this.migrateProviderConfigEncryption();
+
+    // Add project_issue_sources table and backfill from projects (v13 migration)
+    this.addProjectIssueSourcesTable();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -940,6 +960,63 @@ export class FleetDatabase {
   }
 
   /**
+   * v13 migration: Add project_issue_sources table and backfill from existing
+   * projects that have a non-null github_repo. Each project gets one row with
+   * provider='github' and config_json='{"owner":"X","repo":"Y"}'.
+   */
+  private addProjectIssueSourcesTable(): void {
+    try {
+      const row = this.db.prepare(
+        'SELECT MAX(version) AS version FROM schema_version'
+      ).get() as { version: number } | undefined;
+      const version = row?.version ?? 0;
+      if (version >= 13) return; // Already migrated
+
+      // Create the table if it does not exist
+      const tableCols = this.db.prepare("PRAGMA table_info(project_issue_sources)").all() as Array<{ name: string }>;
+      if (tableCols.length === 0) {
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS project_issue_sources (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id      INTEGER NOT NULL REFERENCES projects(id),
+            provider        TEXT NOT NULL,
+            label           TEXT,
+            config_json     TEXT NOT NULL,
+            credentials_json TEXT,
+            enabled         INTEGER NOT NULL DEFAULT 1,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(project_id, provider, config_json)
+          );
+          CREATE INDEX IF NOT EXISTS idx_issue_sources_project ON project_issue_sources(project_id);
+        `);
+      }
+
+      // Backfill: create a github source for every project with a github_repo
+      const projects = this.db.prepare(
+        'SELECT id, github_repo FROM projects WHERE github_repo IS NOT NULL'
+      ).all() as Array<{ id: number; github_repo: string }>;
+
+      const insertStmt = this.db.prepare(
+        `INSERT OR IGNORE INTO project_issue_sources (project_id, provider, label, config_json, enabled)
+         VALUES (?, 'github', 'GitHub Issues', ?, 1)`
+      );
+
+      for (const proj of projects) {
+        const parts = proj.github_repo.split('/');
+        if (parts.length === 2) {
+          const configJson = JSON.stringify({ owner: parts[0], repo: parts[1] });
+          insertStmt.run(proj.id, configJson);
+        }
+      }
+
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (13)');
+      console.log(`[DB] Migrated to v13: project_issue_sources table created, backfilled ${projects.length} project(s)`);
+    } catch {
+      // Tables may not exist yet (fresh database) — schema.sql will create them
+    }
+  }
+
+  /**
    * Migrate any projects with status 'paused' to 'active'.
    * The paused status was removed in issue #228.
    */
@@ -1095,6 +1172,8 @@ export class FleetDatabase {
   }
 
   deleteProject(id: number): boolean {
+    // Delete associated issue sources first (foreign key constraint)
+    this.deleteIssueSourcesByProject(id);
     const result = this.stmt('DELETE FROM projects WHERE id = ?').run(id);
     return result.changes > 0;
   }
@@ -1165,6 +1244,88 @@ export class FleetDatabase {
     this.stmt('UPDATE projects SET group_id = NULL WHERE group_id = ?').run(id);
     const result = this.stmt('DELETE FROM project_groups WHERE id = ?').run(id);
     return result.changes > 0;
+  }
+
+  // -------------------------------------------------------------------------
+  // Project Issue Sources
+  // -------------------------------------------------------------------------
+
+  insertIssueSource(data: ProjectIssueSourceInsert): ProjectIssueSource {
+    const stmt = this.stmt(`
+      INSERT INTO project_issue_sources (project_id, provider, label, config_json, credentials_json, enabled)
+      VALUES (@projectId, @provider, @label, @configJson, @credentialsJson, @enabled)
+    `);
+
+    const info = stmt.run({
+      projectId: data.projectId,
+      provider: data.provider,
+      label: data.label ?? null,
+      configJson: data.configJson,
+      credentialsJson: data.credentialsJson ?? null,
+      enabled: (data.enabled ?? true) ? 1 : 0,
+    });
+
+    return this.getIssueSource(Number(info.lastInsertRowid))!;
+  }
+
+  getIssueSources(projectId: number, enabledOnly?: boolean): ProjectIssueSource[] {
+    if (enabledOnly) {
+      const stmt = this.stmt(
+        'SELECT * FROM project_issue_sources WHERE project_id = ? AND enabled = 1 ORDER BY id ASC'
+      );
+      const rows = stmt.all(projectId) as Record<string, unknown>[];
+      return rows.map((r) => this.mapIssueSourceRow(r));
+    }
+
+    const stmt = this.stmt(
+      'SELECT * FROM project_issue_sources WHERE project_id = ? ORDER BY id ASC'
+    );
+    const rows = stmt.all(projectId) as Record<string, unknown>[];
+    return rows.map((r) => this.mapIssueSourceRow(r));
+  }
+
+  getIssueSource(id: number): ProjectIssueSource | undefined {
+    const stmt = this.stmt('SELECT * FROM project_issue_sources WHERE id = ?');
+    const row = stmt.get(id) as Record<string, unknown> | undefined;
+    return row ? this.mapIssueSourceRow(row) : undefined;
+  }
+
+  updateIssueSource(id: number, fields: ProjectIssueSourceUpdate): ProjectIssueSource | undefined {
+    const setClauses: string[] = [];
+    const params: Record<string, unknown> = { id };
+
+    if (fields.label !== undefined) {
+      setClauses.push('label = @label');
+      params.label = fields.label;
+    }
+    if (fields.configJson !== undefined) {
+      setClauses.push('config_json = @configJson');
+      params.configJson = fields.configJson;
+    }
+    if (fields.credentialsJson !== undefined) {
+      setClauses.push('credentials_json = @credentialsJson');
+      params.credentialsJson = fields.credentialsJson;
+    }
+    if (fields.enabled !== undefined) {
+      setClauses.push('enabled = @enabled');
+      params.enabled = fields.enabled ? 1 : 0;
+    }
+
+    if (setClauses.length === 0) return this.getIssueSource(id);
+
+    const sql = `UPDATE project_issue_sources SET ${setClauses.join(', ')} WHERE id = @id`;
+    this.db.prepare(sql).run(params);
+    return this.getIssueSource(id);
+  }
+
+  deleteIssueSource(id: number): boolean {
+    const result = this.stmt('DELETE FROM project_issue_sources WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  deleteIssueSourcesByProject(projectId: number): number {
+    const result = this.stmt('DELETE FROM project_issue_sources WHERE project_id = ?').run(projectId);
+    return result.changes;
   }
 
   // -------------------------------------------------------------------------
@@ -2350,6 +2511,7 @@ export class FleetDatabase {
       this.stmt('DELETE FROM pull_requests').run();
       this.stmt('DELETE FROM teams').run();
       this.stmt('DELETE FROM message_templates').run();
+      this.stmt('DELETE FROM project_issue_sources').run();
       this.stmt('DELETE FROM projects').run();
     })();
 
@@ -2543,6 +2705,19 @@ export class FleetDatabase {
       description: (row.description as string | null) ?? null,
       createdAt: utcify(row.created_at as string),
       updatedAt: utcify(row.updated_at as string),
+    };
+  }
+
+  private mapIssueSourceRow(row: Record<string, unknown>): ProjectIssueSource {
+    return {
+      id: row.id as number,
+      projectId: row.project_id as number,
+      provider: row.provider as string,
+      label: (row.label as string | null) ?? null,
+      configJson: row.config_json as string,
+      credentialsJson: (row.credentials_json as string | null) ?? null,
+      enabled: (row.enabled as number) === 1,
+      createdAt: utcify(row.created_at as string),
     };
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,6 +17,7 @@ import projectsRoutes from './routes/projects.js';
 import projectGroupsRoutes from './routes/project-groups.js';
 import stateMachineRoutes from './routes/state-machine.js';
 import queryRoutes from './routes/query.js';
+import issueSourcesRoutes from './routes/issue-sources.js';
 import { sseBroker } from './services/sse-broker.js';
 import { getIssueFetcher } from './services/issue-fetcher.js';
 import { stuckDetector } from './services/stuck-detector.js';
@@ -72,6 +73,7 @@ async function main() {
   await server.register(projectGroupsRoutes);
   await server.register(stateMachineRoutes);
   await server.register(queryRoutes);
+  await server.register(issueSourcesRoutes);
 
   // Static file serving for production builds
   const clientDistPath = path.resolve(__dirname, '..', 'client');

--- a/src/server/routes/issue-sources.ts
+++ b/src/server/routes/issue-sources.ts
@@ -1,0 +1,223 @@
+// =============================================================================
+// Fleet Commander -- Issue Sources Routes (REST endpoints for project issue sources)
+// =============================================================================
+// Registered as a Fastify plugin. Provides CRUD endpoints for managing
+// per-project issue sources (multi-provider support).
+//
+//   GET    /api/projects/:projectId/issue-sources              — list all sources
+//   POST   /api/projects/:projectId/issue-sources              — create a source
+//   PATCH  /api/projects/:projectId/issue-sources/:sourceId    — update a source
+//   DELETE /api/projects/:projectId/issue-sources/:sourceId    — delete a source
+// =============================================================================
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getDatabase } from '../db.js';
+import { ServiceError, validationError, notFoundError } from '../services/service-error.js';
+import { parseIdParam } from '../utils/parse-params.js';
+
+// ---------------------------------------------------------------------------
+// Fastify plugin
+// ---------------------------------------------------------------------------
+
+async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
+  /**
+   * GET /api/projects/:projectId/issue-sources — List all sources for a project
+   */
+  server.get<{ Params: { projectId: string } }>(
+    '/api/projects/:projectId/issue-sources',
+    async (request: FastifyRequest<{ Params: { projectId: string } }>, reply: FastifyReply) => {
+      try {
+        const projectId = parseIdParam(request.params.projectId, 'projectId');
+        const db = getDatabase();
+
+        const project = db.getProject(projectId);
+        if (!project) {
+          throw notFoundError(`Project ${projectId} not found`);
+        }
+
+        const sources = db.getIssueSources(projectId);
+        return { sources };
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to list issue sources');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  /**
+   * POST /api/projects/:projectId/issue-sources — Create a new source
+   */
+  server.post<{ Params: { projectId: string } }>(
+    '/api/projects/:projectId/issue-sources',
+    async (request: FastifyRequest<{ Params: { projectId: string } }>, reply: FastifyReply) => {
+      try {
+        const projectId = parseIdParam(request.params.projectId, 'projectId');
+        const db = getDatabase();
+
+        const project = db.getProject(projectId);
+        if (!project) {
+          throw notFoundError(`Project ${projectId} not found`);
+        }
+
+        const body = request.body as Record<string, unknown> | null;
+        if (!body) {
+          throw validationError('Request body is required');
+        }
+
+        const provider = body.provider;
+        const configJson = body.configJson;
+
+        if (!provider || typeof provider !== 'string') {
+          throw validationError('provider is required and must be a string');
+        }
+        if (!configJson || typeof configJson !== 'string') {
+          throw validationError('configJson is required and must be a string');
+        }
+
+        // Validate configJson is parseable JSON
+        try {
+          JSON.parse(configJson);
+        } catch {
+          throw validationError('configJson must be valid JSON');
+        }
+
+        const source = db.insertIssueSource({
+          projectId,
+          provider,
+          label: typeof body.label === 'string' ? body.label : null,
+          configJson,
+          credentialsJson: typeof body.credentialsJson === 'string' ? body.credentialsJson : null,
+        });
+
+        return reply.code(201).send(source);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        // Handle UNIQUE constraint violation (duplicate source)
+        if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+          return reply.code(409).send({
+            error: 'CONFLICT',
+            message: 'A source with this provider and config already exists for this project',
+          });
+        }
+        request.log.error(err, 'Failed to create issue source');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  /**
+   * PATCH /api/projects/:projectId/issue-sources/:sourceId — Update a source
+   */
+  server.patch<{ Params: { projectId: string; sourceId: string } }>(
+    '/api/projects/:projectId/issue-sources/:sourceId',
+    async (
+      request: FastifyRequest<{ Params: { projectId: string; sourceId: string } }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const projectId = parseIdParam(request.params.projectId, 'projectId');
+        const sourceId = parseIdParam(request.params.sourceId, 'sourceId');
+        const db = getDatabase();
+
+        const project = db.getProject(projectId);
+        if (!project) {
+          throw notFoundError(`Project ${projectId} not found`);
+        }
+
+        const existing = db.getIssueSource(sourceId);
+        if (!existing || existing.projectId !== projectId) {
+          throw notFoundError(`Issue source ${sourceId} not found for project ${projectId}`);
+        }
+
+        const body = request.body as Record<string, unknown> | null;
+        if (!body) {
+          throw validationError('Request body is required');
+        }
+
+        // Validate configJson if provided
+        if (body.configJson !== undefined) {
+          if (typeof body.configJson !== 'string') {
+            throw validationError('configJson must be a string');
+          }
+          try {
+            JSON.parse(body.configJson);
+          } catch {
+            throw validationError('configJson must be valid JSON');
+          }
+        }
+
+        const updated = db.updateIssueSource(sourceId, {
+          label: body.label !== undefined ? (typeof body.label === 'string' ? body.label : null) : undefined,
+          configJson: typeof body.configJson === 'string' ? body.configJson : undefined,
+          credentialsJson: body.credentialsJson !== undefined
+            ? (typeof body.credentialsJson === 'string' ? body.credentialsJson : null)
+            : undefined,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
+        });
+
+        return updated;
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to update issue source');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  /**
+   * DELETE /api/projects/:projectId/issue-sources/:sourceId — Delete a source
+   */
+  server.delete<{ Params: { projectId: string; sourceId: string } }>(
+    '/api/projects/:projectId/issue-sources/:sourceId',
+    async (
+      request: FastifyRequest<{ Params: { projectId: string; sourceId: string } }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const projectId = parseIdParam(request.params.projectId, 'projectId');
+        const sourceId = parseIdParam(request.params.sourceId, 'sourceId');
+        const db = getDatabase();
+
+        const project = db.getProject(projectId);
+        if (!project) {
+          throw notFoundError(`Project ${projectId} not found`);
+        }
+
+        const existing = db.getIssueSource(sourceId);
+        if (!existing || existing.projectId !== projectId) {
+          throw notFoundError(`Issue source ${sourceId} not found for project ${projectId}`);
+        }
+
+        db.deleteIssueSource(sourceId);
+        return reply.code(204).send();
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to delete issue source');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+}
+
+export default issueSourcesRoutes;

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -44,6 +44,23 @@ CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
 CREATE INDEX IF NOT EXISTS idx_projects_group ON projects(group_id);
 
 -- ---------------------------------------------------------------------------
+-- PROJECT ISSUE SOURCES — multiple issue providers per project
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS project_issue_sources (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id      INTEGER NOT NULL REFERENCES projects(id),
+  provider        TEXT NOT NULL,
+  label           TEXT,
+  config_json     TEXT NOT NULL,
+  credentials_json TEXT,
+  enabled         INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(project_id, provider, config_json)
+);
+
+CREATE INDEX IF NOT EXISTS idx_issue_sources_project ON project_issue_sources(project_id);
+
+-- ---------------------------------------------------------------------------
 -- TEAMS — a Claude Code worktree session working on an issue
 -- ---------------------------------------------------------------------------
 -- Lifecycle: queued -> launching -> running -> idle (3min) -> stuck (5min) -> done/failed
@@ -298,4 +315,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_team_tasks_team_task ON team_tasks(team_id
 CREATE INDEX IF NOT EXISTS idx_team_tasks_team ON team_tasks(team_id);
 
 -- Insert schema version 9 (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (12);
+INSERT OR IGNORE INTO schema_version (version) VALUES (13);

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -224,15 +224,80 @@ export class IssueFetcher {
       return this.fetchIssueHierarchyGeneric(projectId, project, provider);
     }
 
-    // GitHub path requires githubRepo
-    if (!project.githubRepo) {
-      console.error(`[IssueFetcher] Project ${projectId} has no githubRepo configured`);
+    // Resolve issue sources: prefer project_issue_sources table, fall back to project.githubRepo
+    const sources = db.getIssueSources(projectId, true);
+
+    let allNodes: GraphQLIssueNode[] = [];
+    let fetchComplete = true;
+    let owner = '';
+    let repo = '';
+
+    if (sources.length > 0) {
+      // Iterate all enabled sources and merge results
+      for (const source of sources) {
+        if (source.provider === 'github') {
+          let sourceConfig: { owner: string; repo: string };
+          try {
+            sourceConfig = JSON.parse(source.configJson) as { owner: string; repo: string };
+          } catch (parseErr) {
+            console.warn(
+              `[IssueFetcher] Malformed config_json for source ${source.id} (project ${projectId}), skipping:`,
+              parseErr instanceof Error ? parseErr.message : parseErr,
+            );
+            continue;
+          }
+
+          if (!sourceConfig.owner || !sourceConfig.repo) {
+            console.warn(`[IssueFetcher] Missing owner/repo in source ${source.id} config, skipping`);
+            continue;
+          }
+
+          // Use the first GitHub source's owner/repo as the primary context for
+          // body-based dependency parsing (subsequent sources add to the node list)
+          if (!owner) {
+            owner = sourceConfig.owner;
+            repo = sourceConfig.repo;
+          }
+
+          const ghProvider = getIssueProvider(project);
+          if (!(ghProvider instanceof GitHubIssueProvider)) {
+            console.warn(`[IssueFetcher] Provider for source ${source.id} is not a GitHubIssueProvider, skipping`);
+            continue;
+          }
+
+          try {
+            const result = await ghProvider.fetchRawIssueHierarchy(sourceConfig.owner, sourceConfig.repo);
+            allNodes = allNodes.concat(result.nodes);
+            if (!result.fetchComplete) fetchComplete = false;
+          } catch (err) {
+            console.error(
+              `[IssueFetcher] Failed to fetch from source ${source.id} (${source.provider}):`,
+              err instanceof Error ? err.message : err,
+            );
+            fetchComplete = false;
+          }
+        } else {
+          console.warn(`[IssueFetcher] Unsupported provider '${source.provider}' for source ${source.id}, skipping`);
+        }
+      }
+
+      if (!owner) {
+        // No usable sources produced an owner/repo — return empty
+        console.error(`[IssueFetcher] No valid issue sources for project ${projectId}`);
+        return [];
+      }
+    } else if (project.githubRepo) {
+      // Fallback: no issue sources configured, use project.githubRepo directly
+      console.warn(`[IssueFetcher] No issue sources configured for project ${projectId}, falling back to project.githubRepo`);
+      [owner, repo] = parseRepo(project.githubRepo);
+
+      const result = await provider.fetchRawIssueHierarchy(owner, repo);
+      allNodes = result.nodes;
+      fetchComplete = result.fetchComplete;
+    } else {
+      console.error(`[IssueFetcher] Project ${projectId} has no githubRepo or issue sources configured`);
       return [];
     }
-
-    const [owner, repo] = parseRepo(project.githubRepo);
-
-    const { nodes: allNodes, fetchComplete } = await provider.fetchRawIssueHierarchy(owner, repo);
 
     // Convert GraphQL nodes to our IssueNode format (flat, no children yet)
     const flatIssues = allNodes.map((node) => mapGraphQLNodeToIssueNode(node));
@@ -269,9 +334,11 @@ export class IssueFetcher {
     // Fetch missing (closed) parents so their open children stay visible
     // in the tree instead of being silently hidden.
     if (orphanParentNumbers.size > 0) {
-      const fetchedParentNodes = await provider.fetchMissingParents(
-        owner, repo, Array.from(orphanParentNumbers),
-      );
+      const parentProvider = getIssueProvider(project);
+      let fetchedParentNodes: GraphQLIssueNode[] = [];
+      if (parentProvider instanceof GitHubIssueProvider) {
+        fetchedParentNodes = await parentProvider.fetchMissingParents(owner, repo, Array.from(orphanParentNumbers));
+      }
 
       const fetchedParents = fetchedParentNodes.map((n) => mapParentNodeToIssueNode(n));
 
@@ -878,9 +945,22 @@ export class IssueFetcher {
       }
     }
 
-    // GitHub path requires githubRepo
-    if (!project.githubRepo) return null;
+    // Try issue sources first, fall back to project.githubRepo
+    const sources = db.getIssueSources(projectId, true);
+    const ghSource = sources.find((s) => s.provider === 'github');
 
+    if (ghSource) {
+      try {
+        const config = JSON.parse(ghSource.configJson) as { owner: string; repo: string };
+        if (config.owner && config.repo) {
+          return this.fetchDependencies(config.owner, config.repo, issueNumber);
+        }
+      } catch {
+        // Fall through to project.githubRepo
+      }
+    }
+
+    if (!project.githubRepo) return null;
     const [owner, repo] = parseRepo(project.githubRepo);
     return this.fetchDependencies(owner, repo, issueNumber);
   }

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -881,6 +881,23 @@ export class ProjectService {
       providerConfig: resolvedProviderConfig,
     });
 
+    // Auto-create a GitHub issue source if githubRepo is resolved
+    if (resolvedGithubRepo) {
+      const parts = resolvedGithubRepo.split('/');
+      if (parts.length === 2) {
+        try {
+          db.insertIssueSource({
+            projectId: project.id,
+            provider: 'github',
+            label: 'GitHub Issues',
+            configJson: JSON.stringify({ owner: parts[0], repo: parts[1] }),
+          });
+        } catch (sourceErr: unknown) {
+          console.warn('[ProjectService] Failed to create issue source (non-fatal):', sourceErr);
+        }
+      }
+    }
+
     // Install hooks (non-fatal)
     const installResult = installHooks(normalizedPath, _minimalLogger);
     if (!installResult.ok) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -62,6 +62,18 @@ export interface Project {
   updatedAt: string;
 }
 
+/** An issue source configuration for a project (multi-provider support) */
+export interface ProjectIssueSource {
+  id: number;
+  projectId: number;
+  provider: string;        // 'github' | 'jira' | 'linear'
+  label: string | null;
+  configJson: string;      // JSON: provider-specific config
+  credentialsJson: string | null;
+  enabled: boolean;
+  createdAt: string;
+}
+
 /** Detailed file-level info for a single install artifact */
 export interface InstallFileStatus {
   name: string;

--- a/tests/server/issue-fetcher-blockedby-recovery.test.ts
+++ b/tests/server/issue-fetcher-blockedby-recovery.test.ts
@@ -26,6 +26,7 @@ const mockDb = {
     githubRepo: 'owner/repo',
   }),
   getProjects: vi.fn().mockReturnValue([]),
+  getIssueSources: vi.fn().mockReturnValue([]),
   getActiveTeams: vi.fn().mockReturnValue([]),
   getActiveTeamsByProject: vi.fn().mockReturnValue([]),
 };

--- a/tests/server/issue-fetcher-orphan.test.ts
+++ b/tests/server/issue-fetcher-orphan.test.ts
@@ -39,6 +39,7 @@ const {
       providerConfig: null,
     }),
     getProjects: vi.fn().mockReturnValue([]),
+    getIssueSources: vi.fn().mockReturnValue([]),
     getActiveTeams: vi.fn().mockReturnValue([]),
     getActiveTeamsByProject: vi.fn().mockReturnValue([]),
   },

--- a/tests/server/issue-fetcher-performance.test.ts
+++ b/tests/server/issue-fetcher-performance.test.ts
@@ -21,6 +21,7 @@ const mockDb = {
     githubRepo: 'owner/repo',
   }),
   getProjects: vi.fn().mockReturnValue([]),
+  getIssueSources: vi.fn().mockReturnValue([]),
   getActiveTeams: vi.fn().mockReturnValue([]),
   getActiveTeamsByProject: vi.fn().mockReturnValue([]),
 };

--- a/tests/server/routes/issue-sources-routes.test.ts
+++ b/tests/server/routes/issue-sources-routes.test.ts
@@ -1,0 +1,354 @@
+// =============================================================================
+// Fleet Commander -- Issue Sources Routes: HTTP contract tests
+// =============================================================================
+// Tests the issue-sources route plugin for correct HTTP status codes, response
+// shapes, parameter validation, and error handling. Uses a real temp SQLite
+// database with the route plugin mounted on a Fastify instance.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// Import routes
+import issueSourcesRoutes from '../../../src/server/routes/issue-sources.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+let app: FastifyInstance;
+let projectId: number;
+
+// ---------------------------------------------------------------------------
+// DB + app lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-issue-src-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  app = Fastify({ logger: false });
+  await app.register(issueSourcesRoutes);
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  // Seed a fresh project for each test
+  const db = getDatabase();
+  const project = db.insertProject({
+    name: `routes-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    repoPath: `/tmp/routes-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    githubRepo: 'owner/repo',
+  });
+  projectId = project.id;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/projects/:projectId/issue-sources', () => {
+  it('should return empty sources array when none exist', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sources).toEqual([]);
+  });
+
+  it('should return all sources for a project', async () => {
+    const db = getDatabase();
+    db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      label: 'GH',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+    db.insertIssueSource({
+      projectId,
+      provider: 'jira',
+      label: 'Jira',
+      configJson: JSON.stringify({ projectKey: 'X' }),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sources).toHaveLength(2);
+    expect(body.sources[0].provider).toBe('github');
+    expect(body.sources[1].provider).toBe('jira');
+  });
+
+  it('should return 404 when project does not exist', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/99999/issue-sources',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 for invalid projectId', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/abc/issue-sources',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/projects/:projectId/issue-sources', () => {
+  it('should create a source and return 201', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: {
+        provider: 'github',
+        label: 'GitHub Issues',
+        configJson: JSON.stringify({ owner: 'octocat', repo: 'hello-world' }),
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.provider).toBe('github');
+    expect(body.label).toBe('GitHub Issues');
+    expect(body.enabled).toBe(true);
+    expect(body.projectId).toBe(projectId);
+  });
+
+  it('should return 400 when provider is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: {
+        configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 when configJson is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: {
+        provider: 'github',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 400 when configJson is invalid JSON', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: {
+        provider: 'github',
+        configJson: 'not-json',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should return 404 when project does not exist', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/99999/issue-sources',
+      payload: {
+        provider: 'github',
+        configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 409 when creating duplicate source', async () => {
+    const config = JSON.stringify({ owner: 'dup', repo: 'test' });
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: { provider: 'github', configJson: config },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: { provider: 'github', configJson: config },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe('PATCH /api/projects/:projectId/issue-sources/:sourceId', () => {
+  it('should update a source and return the updated record', async () => {
+    const db = getDatabase();
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      label: 'Old Label',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+      payload: {
+        label: 'New Label',
+        enabled: false,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.label).toBe('New Label');
+    expect(body.enabled).toBe(false);
+  });
+
+  it('should return 404 when source does not exist', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/projects/${projectId}/issue-sources/99999`,
+      payload: { label: 'test' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 404 when source belongs to a different project', async () => {
+    const db = getDatabase();
+    const otherProject = db.insertProject({
+      name: `other-${Date.now()}`,
+      repoPath: `/tmp/other-${Date.now()}`,
+      githubRepo: 'other/repo',
+    });
+
+    const source = db.insertIssueSource({
+      projectId: otherProject.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+      payload: { label: 'test' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 400 when configJson is invalid JSON', async () => {
+    const db = getDatabase();
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+      payload: { configJson: 'not-json' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('DELETE /api/projects/:projectId/issue-sources/:sourceId', () => {
+  it('should delete a source and return 204', async () => {
+    const db = getDatabase();
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
+
+    // Verify deletion
+    const fetched = db.getIssueSource(source.id);
+    expect(fetched).toBeUndefined();
+  });
+
+  it('should return 404 when source does not exist', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/projects/${projectId}/issue-sources/99999`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 404 when source belongs to a different project', async () => {
+    const db = getDatabase();
+    const otherProject = db.insertProject({
+      name: `del-other-${Date.now()}`,
+      repoPath: `/tmp/del-other-${Date.now()}`,
+      githubRepo: 'delother/repo',
+    });
+
+    const source = db.insertIssueSource({
+      projectId: otherProject.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/tests/server/services/issue-sources.test.ts
+++ b/tests/server/services/issue-sources.test.ts
@@ -1,0 +1,377 @@
+// =============================================================================
+// Fleet Commander -- ProjectIssueSource DB CRUD tests
+// =============================================================================
+// Tests the DB methods for the project_issue_sources table:
+// insertIssueSource, getIssueSources, getIssueSource, updateIssueSource,
+// deleteIssueSource, deleteIssueSourcesByProject, and v13 migration backfill.
+// Uses a real temp SQLite database.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// DB lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-issue-sources-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+});
+
+afterAll(() => {
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedProject(overrides: {
+  name?: string;
+  repoPath?: string;
+  githubRepo?: string | null;
+} = {}) {
+  const db = getDatabase();
+  return db.insertProject({
+    name: overrides.name ?? `test-project-${Date.now()}`,
+    repoPath: overrides.repoPath ?? `/tmp/test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    githubRepo: overrides.githubRepo !== undefined ? overrides.githubRepo : 'owner/repo',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ProjectIssueSource CRUD', () => {
+  it('should insert a source and return it with correct fields', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const source = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      label: 'GitHub Issues',
+      configJson: JSON.stringify({ owner: 'octocat', repo: 'hello-world' }),
+    });
+
+    expect(source.id).toBeGreaterThan(0);
+    expect(source.projectId).toBe(project.id);
+    expect(source.provider).toBe('github');
+    expect(source.label).toBe('GitHub Issues');
+    expect(source.configJson).toBe('{"owner":"octocat","repo":"hello-world"}');
+    expect(source.credentialsJson).toBeNull();
+    expect(source.enabled).toBe(true);
+    expect(source.createdAt).toBeTruthy();
+  });
+
+  it('should insert a source with credentials and disabled', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const source = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'jira',
+      label: 'Jira Board',
+      configJson: JSON.stringify({ projectKey: 'PROJ' }),
+      credentialsJson: JSON.stringify({ token: 'secret' }),
+      enabled: false,
+    });
+
+    expect(source.provider).toBe('jira');
+    expect(source.credentialsJson).toBe('{"token":"secret"}');
+    expect(source.enabled).toBe(false);
+  });
+
+  it('should get all sources for a project', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'jira',
+      configJson: JSON.stringify({ projectKey: 'X' }),
+    });
+
+    const sources = db.getIssueSources(project.id);
+    expect(sources).toHaveLength(2);
+    expect(sources[0].provider).toBe('github');
+    expect(sources[1].provider).toBe('jira');
+  });
+
+  it('should filter sources by enabledOnly', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+      enabled: true,
+    });
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'jira',
+      configJson: JSON.stringify({ projectKey: 'X' }),
+      enabled: false,
+    });
+
+    const allSources = db.getIssueSources(project.id);
+    expect(allSources).toHaveLength(2);
+
+    const enabledSources = db.getIssueSources(project.id, true);
+    expect(enabledSources).toHaveLength(1);
+    expect(enabledSources[0].provider).toBe('github');
+  });
+
+  it('should get a single source by id', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const created = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const fetched = db.getIssueSource(created.id);
+    expect(fetched).toBeDefined();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.provider).toBe('github');
+  });
+
+  it('should return undefined for non-existent source', () => {
+    const db = getDatabase();
+    const fetched = db.getIssueSource(99999);
+    expect(fetched).toBeUndefined();
+  });
+
+  it('should update a source label and enabled status', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const created = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      label: 'Old Label',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const updated = db.updateIssueSource(created.id, {
+      label: 'New Label',
+      enabled: false,
+    });
+
+    expect(updated).toBeDefined();
+    expect(updated!.label).toBe('New Label');
+    expect(updated!.enabled).toBe(false);
+  });
+
+  it('should update configJson', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const created = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'old', repo: 'config' }),
+    });
+
+    const newConfig = JSON.stringify({ owner: 'new', repo: 'config' });
+    const updated = db.updateIssueSource(created.id, { configJson: newConfig });
+
+    expect(updated!.configJson).toBe(newConfig);
+  });
+
+  it('should return unchanged source when update has no fields', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const created = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const updated = db.updateIssueSource(created.id, {});
+    expect(updated!.id).toBe(created.id);
+    expect(updated!.provider).toBe('github');
+  });
+
+  it('should delete a source by id', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const created = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    const deleted = db.deleteIssueSource(created.id);
+    expect(deleted).toBe(true);
+
+    const fetched = db.getIssueSource(created.id);
+    expect(fetched).toBeUndefined();
+  });
+
+  it('should return false when deleting non-existent source', () => {
+    const db = getDatabase();
+    const deleted = db.deleteIssueSource(99999);
+    expect(deleted).toBe(false);
+  });
+
+  it('should delete all sources for a project', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'jira',
+      configJson: JSON.stringify({ projectKey: 'X' }),
+    });
+
+    const count = db.deleteIssueSourcesByProject(project.id);
+    expect(count).toBe(2);
+
+    const remaining = db.getIssueSources(project.id);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('should enforce UNIQUE constraint on (project_id, provider, config_json)', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const config = JSON.stringify({ owner: 'x', repo: 'y' });
+
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: config,
+    });
+
+    expect(() =>
+      db.insertIssueSource({
+        projectId: project.id,
+        provider: 'github',
+        configJson: config,
+      })
+    ).toThrow(/UNIQUE constraint/);
+  });
+
+  it('should allow same provider with different config for same project', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    const source1 = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const source2 = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'c', repo: 'd' }),
+    });
+
+    expect(source1.id).not.toBe(source2.id);
+    const sources = db.getIssueSources(project.id);
+    expect(sources).toHaveLength(2);
+  });
+});
+
+describe('Project deletion cascades to issue sources', () => {
+  it('should delete issue sources when project is deleted', () => {
+    const db = getDatabase();
+    const project = seedProject();
+
+    db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      configJson: JSON.stringify({ owner: 'x', repo: 'y' }),
+    });
+
+    db.deleteProject(project.id);
+
+    const sources = db.getIssueSources(project.id);
+    expect(sources).toHaveLength(0);
+  });
+});
+
+describe('v13 migration backfill', () => {
+  it('should create a source for projects with github_repo during migration', () => {
+    // The migration already ran during DB init (via initSchema).
+    // We verify that a newly created project with github_repo gets a source
+    // backfilled when migration runs (or already has one from the migration).
+    // Since the migration already completed during beforeAll, we verify the
+    // DB CRUD methods work correctly for the pattern the migration uses.
+    const db = getDatabase();
+    const project = seedProject({ githubRepo: 'testowner/testrepo' });
+
+    // Simulate what the migration does
+    const configJson = JSON.stringify({ owner: 'testowner', repo: 'testrepo' });
+    const source = db.insertIssueSource({
+      projectId: project.id,
+      provider: 'github',
+      label: 'GitHub Issues',
+      configJson,
+    });
+
+    expect(source.provider).toBe('github');
+    expect(source.label).toBe('GitHub Issues');
+
+    const parsed = JSON.parse(source.configJson) as { owner: string; repo: string };
+    expect(parsed.owner).toBe('testowner');
+    expect(parsed.repo).toBe('testrepo');
+    expect(source.enabled).toBe(true);
+  });
+
+  it('should not create a source for projects without github_repo', () => {
+    const db = getDatabase();
+    const project = seedProject({ githubRepo: null });
+
+    // With no github_repo, migration would skip this project
+    const sources = db.getIssueSources(project.id);
+    expect(sources).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #593

## Summary
- New `project_issue_sources` table with v13 migration that backfills existing GitHub projects
- CRUD REST API at `/api/projects/:projectId/issue-sources` (GET/POST/PATCH/DELETE)
- `IssueFetcher.fetchIssueHierarchy` iterates all enabled sources per project, merging results
- Backward compatible: falls back to `project.githubRepo` when no sources configured
- New projects automatically get a GitHub issue source created
- `projects.github_repo` column preserved for PR polling and git operations
- 34 new tests across DB CRUD and route integration test files

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` passes (1366/1369 pass; 3 pre-existing cc-spawn failures unrelated)
- [ ] Verify existing projects auto-migrate on startup
- [ ] Verify multi-source merge in Issue Tree view