### PR TITLE
Issue #597: Group issues by provider when project has multiple sources

### DIFF
--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -257,3 +257,28 @@ export function JiraIcon({ size = 14, className }: IconProps) {
     </svg>
   );
 }
+
+export function LinearIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M.34 9.14a7.97 7.97 0 006.52 6.52L.34 9.14zm-.28-1.6a8.03 8.03 0 018.4-7.48L.06 7.54zm1.28-3.82A8 8 0 0114.28 12.66L1.34 3.72zM8 0a8 8 0 110 16A8 8 0 018 0z"/>
+    </svg>
+  );
+}
+
+/**
+ * Maps a provider name to its icon component.
+ * Falls back to a generic circle icon for unknown providers.
+ */
+export function ProviderIcon({ provider, size = 14, className }: { provider: string; size?: number; className?: string }) {
+  switch (provider) {
+    case 'github':
+      return <GitHubIcon size={size} className={className} />;
+    case 'jira':
+      return <JiraIcon size={size} className={className} />;
+    case 'linear':
+      return <LinearIcon size={size} className={className} />;
+    default:
+      return <CircleDotIcon size={size} className={className} />;
+  }
+}

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -5,6 +5,7 @@ import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritizatio
 import { useCollapseState } from '../hooks/useCollapseState';
 import { useFlattenedTree } from '../hooks/useVirtualizedTree';
 import { VirtualizedTreeList } from '../components/VirtualizedTreeList';
+import { ProviderIcon } from '../components/Icons';
 import type { IssueNode } from '../components/TreeNode';
 import type { ProjectSummary } from '../../shared/types';
 
@@ -36,6 +37,7 @@ interface ProjectIssueGroup {
   tree: IssueNode[];
   cachedAt: string | null;
   count: number;
+  providers?: string[];
 }
 
 /** A top-level group of projects (for the project group collapsible level) */
@@ -80,6 +82,7 @@ export function IssueTreeView() {
   const [groups, setGroups] = useState<ProjectIssueGroup[]>([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [providerFilter, setProviderFilter] = useState<string>('all');
 
   // Collapse state — persisted to localStorage
   const collapseState = useCollapseState();
@@ -385,10 +388,37 @@ export function IssueTreeView() {
   }, [api, depConfirm, fetchTree]);
 
   // -------------------------------------------------------------------------
-  // Filter tree by search query
+  // Compute available providers across all groups/tree for filter pills
   // -------------------------------------------------------------------------
 
-  const filteredTree = useMemo(() => filterTree(tree, search, statusFilter), [tree, search, statusFilter]);
+  const availableProviders = useMemo(() => {
+    const providerSet = new Set<string>();
+    function walkProviders(nodes: IssueNode[]) {
+      for (const node of nodes) {
+        providerSet.add(node.issueProvider ?? 'github');
+        walkProviders(node.children);
+      }
+    }
+    if (groups.length > 0) {
+      for (const g of groups) {
+        // Use server-provided providers if available, else walk the tree
+        if (g.providers && g.providers.length > 0) {
+          for (const p of g.providers) providerSet.add(p);
+        } else {
+          walkProviders(g.tree);
+        }
+      }
+    } else {
+      walkProviders(tree);
+    }
+    return [...providerSet].sort();
+  }, [tree, groups]);
+
+  // -------------------------------------------------------------------------
+  // Filter tree by search query, status, and provider
+  // -------------------------------------------------------------------------
+
+  const filteredTree = useMemo(() => filterTree(tree, search, statusFilter, providerFilter), [tree, search, statusFilter, providerFilter]);
 
   // Filtered groups for the grouped view
   const filteredGroups = useMemo(() => {
@@ -396,10 +426,10 @@ export function IssueTreeView() {
     return groups
       .map((g) => ({
         ...g,
-        tree: filterTree(g.tree, search, statusFilter),
+        tree: filterTree(g.tree, search, statusFilter, providerFilter),
       }))
       .filter((g) => g.tree.length > 0);
-  }, [groups, search, statusFilter]);
+  }, [groups, search, statusFilter, providerFilter]);
 
   // Group filtered project groups into top-level buckets by groupId
   // Only creates buckets when there are multiple distinct groups (at least one project has a groupId)
@@ -434,7 +464,7 @@ export function IssueTreeView() {
 
   // Collect all node IDs from the full (unfiltered) tree for Collapse All
   // Includes group bucket IDs (group-{id}), project group IDs (project-{id}),
-  // and individual issue node IDs
+  // provider sub-group IDs (provider-{projectId}-{providerName}), and individual issue node IDs
   const allNodeIds = useMemo(() => {
     if (groups.length > 0) {
       const hasAnyGroupId = groups.some((g) => g.groupId != null);
@@ -443,10 +473,20 @@ export function IssueTreeView() {
         : [];
       return [
         ...groupKeys,
-        ...groups.flatMap((g) => [
-          `project-${g.projectId}`,
-          ...collectAllNodeIds(g.tree),
-        ]),
+        ...groups.flatMap((g) => {
+          // Collect provider sub-group keys when multiple providers exist
+          const providerKeys: string[] = [];
+          if (g.providers && g.providers.length > 1) {
+            for (const p of g.providers) {
+              providerKeys.push(`provider-${g.projectId}-${p}`);
+            }
+          }
+          return [
+            `project-${g.projectId}`,
+            ...providerKeys,
+            ...collectAllNodeIds(g.tree),
+          ];
+        }),
       ];
     }
     return collectAllNodeIds(tree);
@@ -511,7 +551,7 @@ export function IssueTreeView() {
         <div className="flex items-center gap-3 shrink-0">
           <h2 className="text-sm font-semibold text-dark-text">Issue Tree</h2>
           <span className="text-xs text-dark-muted">
-            {search || statusFilter !== 'all'
+            {search || statusFilter !== 'all' || providerFilter !== 'all'
               ? `${countNodes(filteredTree)} of ${issueCount} issues`
               : `${issueCount} issue${issueCount !== 1 ? 's' : ''}`}
           </span>
@@ -562,6 +602,36 @@ export function IssueTreeView() {
             </button>
           ))}
         </div>
+
+        {/* Provider filter pills — only shown when 2+ providers */}
+        {availableProviders.length > 1 && (
+          <div className="flex items-center gap-1 flex-wrap" data-testid="provider-filter-pills">
+            <button
+              onClick={() => setProviderFilter('all')}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                providerFilter === 'all'
+                  ? 'border-dark-accent/50 bg-dark-accent/20 text-dark-accent'
+                  : 'border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted'
+              }`}
+            >
+              All Sources
+            </button>
+            {availableProviders.map((p) => (
+              <button
+                key={p}
+                onClick={() => setProviderFilter(p)}
+                className={`inline-flex items-center gap-1 px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                  providerFilter === p
+                    ? 'border-dark-accent/50 bg-dark-accent/20 text-dark-accent'
+                    : 'border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted'
+                }`}
+              >
+                <ProviderIcon provider={p} size={12} />
+                {p.charAt(0).toUpperCase() + p.slice(1)}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Expand / Collapse All buttons */}
         <div className="flex items-center gap-1.5 shrink-0">
@@ -642,7 +712,7 @@ export function IssueTreeView() {
                   : <>No issues match filter &ldquo;{STATUS_FILTERS.find(f => f.key === statusFilter)?.label}&rdquo;</>}
             </p>
             <button
-              onClick={() => { setSearch(''); setStatusFilter('all'); }}
+              onClick={() => { setSearch(''); setStatusFilter('all'); setProviderFilter('all'); }}
               className="text-xs text-dark-accent hover:underline"
             >
               Clear filters
@@ -658,7 +728,7 @@ export function IssueTreeView() {
                 onLaunch={handleLaunch}
                 launchingIssues={launchingIssues}
                 launchErrors={launchErrors}
-                forceExpand={!!search || statusFilter !== 'all'}
+                forceExpand={!!search || statusFilter !== 'all' || providerFilter !== 'all'}
                 fetchTree={fetchTree}
                 collapsedNodes={collapseState.collapsedNodes}
                 onToggleCollapse={collapseState.toggleCollapse}
@@ -675,7 +745,7 @@ export function IssueTreeView() {
                 onLaunch={handleLaunch}
                 launchingIssues={launchingIssues}
                 launchErrors={launchErrors}
-                forceExpand={!!search || statusFilter !== 'all'}
+                forceExpand={!!search || statusFilter !== 'all' || providerFilter !== 'all'}
                 fetchTree={fetchTree}
                 collapsedNodes={collapseState.collapsedNodes}
                 onToggleCollapse={collapseState.toggleCollapse}
@@ -690,7 +760,7 @@ export function IssueTreeView() {
             onLaunch={handleLaunch}
             launchingIssues={launchingIssues}
             launchErrors={launchErrors}
-            forceExpand={!!search || statusFilter !== 'all'}
+            forceExpand={!!search || statusFilter !== 'all' || providerFilter !== 'all'}
             fetchTree={fetchTree}
             collapsedNodes={collapseState.collapsedNodes}
             onToggleCollapse={collapseState.toggleCollapse}
@@ -1130,7 +1200,7 @@ function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, 
 // ---------------------------------------------------------------------------
 
 interface ProjectGroupProps {
-  group: { projectId: number; projectName: string; tree: IssueNode[]; count: number };
+  group: { projectId: number; projectName: string; tree: IssueNode[]; count: number; providers?: string[] };
   onLaunch: (issueNumber: number, title: string, projectId?: number, issueKey?: string, issueProvider?: string) => Promise<void>;
   launchingIssues: Set<number>;
   launchErrors: Map<number, string>;
@@ -1147,6 +1217,53 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
   const prioritization = usePrioritization();
   const [showRunAllDialog, setShowRunAllDialog] = useState(false);
 
+  // Detect distinct providers in this group's tree
+  const distinctProviders = useMemo(() => {
+    if (group.providers && group.providers.length > 0) return group.providers;
+    const providerSet = new Set<string>();
+    function walk(nodes: IssueNode[]) {
+      for (const n of nodes) {
+        providerSet.add(n.issueProvider ?? 'github');
+        walk(n.children);
+      }
+    }
+    walk(group.tree);
+    return [...providerSet].sort();
+  }, [group.tree, group.providers]);
+
+  const hasMultipleProviders = distinctProviders.length > 1;
+
+  // Per-provider issue counts for the header badges
+  const providerCounts = useMemo(() => {
+    if (!hasMultipleProviders) return null;
+    const counts = new Map<string, number>();
+    function walk(nodes: IssueNode[]) {
+      for (const n of nodes) {
+        const p = n.issueProvider ?? 'github';
+        counts.set(p, (counts.get(p) ?? 0) + 1);
+        walk(n.children);
+      }
+    }
+    walk(group.tree);
+    return counts;
+  }, [group.tree, hasMultipleProviders]);
+
+  // Split tree into per-provider buckets (only when multiple providers exist)
+  const providerBuckets = useMemo(() => {
+    if (!hasMultipleProviders) return null;
+    const buckets = new Map<string, IssueNode[]>();
+    function walk(nodes: IssueNode[]): Map<string, IssueNode[]> {
+      for (const node of nodes) {
+        const p = node.issueProvider ?? 'github';
+        if (!buckets.has(p)) buckets.set(p, []);
+        buckets.get(p)!.push(node);
+      }
+      return buckets;
+    }
+    walk(group.tree);
+    return buckets;
+  }, [group.tree, hasMultipleProviders]);
+
   const displayTree = useMemo(() => {
     if (!prioritization.hasPriority) return group.tree;
     return sortTreeByPriority(group.tree, prioritization.priorityMap);
@@ -1155,6 +1272,18 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
   const launchableInfo = useMemo(() => collectLaunchableIssues(group.tree), [group.tree]);
 
   const flatRows = useFlattenedTree(displayTree, collapsedNodes, forceExpand);
+
+  // Build header count text
+  const totalCount = countNodes(group.tree);
+  const headerCountText = useMemo(() => {
+    if (!hasMultipleProviders || !providerCounts) {
+      return `${totalCount} issue${totalCount !== 1 ? 's' : ''}`;
+    }
+    const parts = distinctProviders
+      .filter((p) => providerCounts.has(p))
+      .map((p) => `${p.charAt(0).toUpperCase() + p.slice(1)}: ${providerCounts.get(p)}`);
+    return `${totalCount} issue${totalCount !== 1 ? 's' : ''} (${parts.join(', ')})`;
+  }, [totalCount, hasMultipleProviders, providerCounts, distinctProviders]);
 
   return (
     <div>
@@ -1178,7 +1307,7 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
             {group.projectName}
           </span>
           <span className="text-xs text-dark-muted shrink-0">
-            {countNodes(group.tree)} issue{countNodes(group.tree) !== 1 ? 's' : ''}
+            {headerCountText}
           </span>
         </button>
 
@@ -1216,24 +1345,52 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
         fetchTree={fetchTree}
       />
 
-      {/* Issue tree within this project group (virtualized) */}
+      {/* Issue tree within this project group */}
       {expanded && (
         <div className="ml-2 border-l border-dark-border/40 pl-1">
-          <VirtualizedTreeList
-            rows={flatRows}
-            onLaunch={onLaunch}
-            launchingIssues={launchingIssues}
-            launchErrors={launchErrors}
-            projectId={group.projectId}
-            priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
-            checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
-            onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
-            onPrioritizeSubtree={prioritization.prioritizeSubtree}
-            prioritizing={prioritization.loading}
-            collapsedNodes={collapsedNodes}
-            onToggleCollapse={onToggleCollapse}
-            className="max-h-[70vh]"
-          />
+          {hasMultipleProviders && providerBuckets ? (
+            /* Multi-provider: render per-provider sub-groups */
+            <div className="space-y-1">
+              {distinctProviders.map((provider) => {
+                const providerIssues = providerBuckets.get(provider) ?? [];
+                if (providerIssues.length === 0) return null;
+                return (
+                  <ProviderSubGroup
+                    key={`provider-${group.projectId}-${provider}`}
+                    provider={provider}
+                    issues={providerIssues}
+                    projectId={group.projectId}
+                    nodeKey={`provider-${group.projectId}-${provider}`}
+                    onLaunch={onLaunch}
+                    launchingIssues={launchingIssues}
+                    launchErrors={launchErrors}
+                    forceExpand={forceExpand}
+                    fetchTree={fetchTree}
+                    collapsedNodes={collapsedNodes}
+                    onToggleCollapse={onToggleCollapse}
+                    api={api}
+                  />
+                );
+              })}
+            </div>
+          ) : (
+            /* Single provider: flat list as before (virtualized) */
+            <VirtualizedTreeList
+              rows={flatRows}
+              onLaunch={onLaunch}
+              launchingIssues={launchingIssues}
+              launchErrors={launchErrors}
+              projectId={group.projectId}
+              priorityMap={prioritization.hasPriority ? prioritization.priorityMap : undefined}
+              checkedIssues={prioritization.hasPriority ? prioritization.checkedIssues : undefined}
+              onCheckChange={prioritization.hasPriority ? prioritization.toggleCheck : undefined}
+              onPrioritizeSubtree={prioritization.prioritizeSubtree}
+              prioritizing={prioritization.loading}
+              collapsedNodes={collapsedNodes}
+              onToggleCollapse={onToggleCollapse}
+              className="max-h-[70vh]"
+            />
+          )}
         </div>
       )}
 
@@ -1244,6 +1401,104 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
           skippedActive={launchableInfo.skippedActive}
           blockedIssues={launchableInfo.blocked}
           projectId={group.projectId}
+          api={api}
+          fetchTree={fetchTree}
+          onClose={() => setShowRunAllDialog(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ProviderSubGroup — collapsible sub-group for a single provider within a project
+// ---------------------------------------------------------------------------
+
+interface ProviderSubGroupProps {
+  provider: string;
+  issues: IssueNode[];
+  projectId: number;
+  nodeKey: string;
+  onLaunch: (issueNumber: number, title: string, projectId?: number, issueKey?: string, issueProvider?: string) => Promise<void>;
+  launchingIssues: Set<number>;
+  launchErrors: Map<number, string>;
+  forceExpand: boolean;
+  fetchTree: () => Promise<void>;
+  collapsedNodes: Set<string>;
+  onToggleCollapse: (nodeId: string) => void;
+  api: ReturnType<typeof useApi>;
+}
+
+function ProviderSubGroup({ provider, issues, projectId, nodeKey, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, api }: ProviderSubGroupProps) {
+  const expanded = !collapsedNodes.has(nodeKey);
+  const [showRunAllDialog, setShowRunAllDialog] = useState(false);
+
+  const flatRows = useFlattenedTree(issues, collapsedNodes, forceExpand);
+  const launchableInfo = useMemo(() => collectLaunchableIssues(issues), [issues]);
+  const issueCount = countNodes(issues);
+  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+
+  return (
+    <div data-testid={`provider-subgroup-${provider}`}>
+      {/* Provider sub-group header */}
+      <div className="flex items-center gap-2 py-1.5 px-2 rounded hover:bg-dark-surface/40 transition-colors">
+        <button
+          onClick={() => onToggleCollapse(nodeKey)}
+          className="flex items-center gap-2 flex-1 text-left min-w-0"
+        >
+          {/* Expand/collapse arrow */}
+          <span className={`w-3.5 h-3.5 flex items-center justify-center text-dark-muted shrink-0 transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}>
+            <svg className="w-2.5 h-2.5" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+            </svg>
+          </span>
+          {/* Provider icon */}
+          <ProviderIcon provider={provider} size={14} className="text-dark-muted shrink-0" />
+          <span className="text-xs font-medium text-dark-text">
+            {providerLabel}
+          </span>
+          <span className="text-xs text-dark-muted shrink-0">
+            {issueCount} issue{issueCount !== 1 ? 's' : ''}
+          </span>
+        </button>
+
+        {/* Provider-scoped Run All */}
+        <button
+          onClick={() => setShowRunAllDialog(true)}
+          disabled={launchableInfo.launchable.length === 0 && launchableInfo.blocked.length === 0}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded border border-[#3FB950]/50 text-[#3FB950] hover:bg-[#3FB950]/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title={`Launch teams for all ${providerLabel} issues`}
+        >
+          <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M1.5 3.5a.5.5 0 0 1 .8-.4l4.5 3.4a.5.5 0 0 1 0 .8l-4.5 3.4a.5.5 0 0 1-.8-.4V3.5Zm7 0a.5.5 0 0 1 .8-.4l4.5 3.4a.5.5 0 0 1 0 .8l-4.5 3.4a.5.5 0 0 1-.8-.4V3.5Z" />
+          </svg>
+          Run All
+        </button>
+      </div>
+
+      {/* Provider sub-group issue tree */}
+      {expanded && (
+        <div className="ml-2 border-l border-dark-border/20 pl-1">
+          <VirtualizedTreeList
+            rows={flatRows}
+            onLaunch={onLaunch}
+            launchingIssues={launchingIssues}
+            launchErrors={launchErrors}
+            projectId={projectId}
+            collapsedNodes={collapsedNodes}
+            onToggleCollapse={onToggleCollapse}
+            className="max-h-[60vh]"
+          />
+        </div>
+      )}
+
+      {/* Provider-scoped Run All dialog */}
+      {showRunAllDialog && (
+        <RunAllConfirmDialog
+          issues={launchableInfo.launchable}
+          skippedActive={launchableInfo.skippedActive}
+          blockedIssues={launchableInfo.blocked}
+          projectId={projectId}
           api={api}
           fetchTree={fetchTree}
           onClose={() => setShowRunAllDialog(false)}
@@ -1367,13 +1622,14 @@ function matchesStatusFilter(node: IssueNode, filter: string): boolean {
   return node.activeTeam?.status === filter;
 }
 
-/** Filter tree nodes by search query and status filter, keeping parents of matching children */
-function filterTree(nodes: IssueNode[], query: string, statusFilter: string): IssueNode[] {
+/** Filter tree nodes by search query, status filter, and provider filter, keeping parents of matching children */
+function filterTree(nodes: IssueNode[], query: string, statusFilter: string, providerFilter: string = 'all'): IssueNode[] {
   const hasQuery = query.trim().length > 0;
   const hasStatusFilter = statusFilter !== 'all';
+  const hasProviderFilter = providerFilter !== 'all';
 
   // No filters active — return as-is
-  if (!hasQuery && !hasStatusFilter) return nodes;
+  if (!hasQuery && !hasStatusFilter && !hasProviderFilter) return nodes;
 
   const q = query.toLowerCase().trim();
   const isNumericQuery = /^\d+$/.test(q);
@@ -1388,11 +1644,15 @@ function filterTree(nodes: IssueNode[], query: string, statusFilter: string): Is
     // Check if this node matches the status filter
     const matchesStatus = matchesStatusFilter(node, statusFilter);
 
-    // A node directly matches if it passes BOTH filters
-    const directMatch = matchesSearch && matchesStatus;
+    // Check if this node matches the provider filter
+    const matchesProvider = !hasProviderFilter ||
+      (node.issueProvider ?? 'github') === providerFilter;
+
+    // A node directly matches if it passes ALL filters
+    const directMatch = matchesSearch && matchesStatus && matchesProvider;
 
     // Recursively filter children
-    const filteredChildren = filterTree(node.children, query, statusFilter);
+    const filteredChildren = filterTree(node.children, query, statusFilter, providerFilter);
 
     // Include node if it directly matches OR has matching children
     if (directMatch || filteredChildren.length > 0) {

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -89,6 +89,8 @@ function mapGraphQLNodeToIssueNode(node: GraphQLIssueNode): IssueNode {
     url: node.url,
     children: [],   // populated later by buildHierarchy in fetchIssueHierarchy
     activeTeam: null,
+    issueKey: String(node.number),
+    issueProvider: 'github',
   };
 
   if (node.subIssuesSummary) {
@@ -140,6 +142,8 @@ function mapParentNodeToIssueNode(node: GraphQLIssueNode): IssueNode {
     url: node.url,
     children: [],
     activeTeam: null,
+    issueKey: String(node.number),
+    issueProvider: 'github',
   };
 }
 

--- a/src/server/services/issue-service.ts
+++ b/src/server/services/issue-service.ts
@@ -32,6 +32,24 @@ function countIssues(tree: Array<{ children?: Array<unknown> }>): number {
 }
 
 /**
+ * Collect distinct issueProvider values from a tree (recursive).
+ * Defaults to 'github' for nodes without an explicit issueProvider.
+ */
+function collectProviders(nodes: Array<{ issueProvider?: string; children?: Array<unknown> }>): string[] {
+  const providers: string[] = [];
+  const walk = (list: Array<{ issueProvider?: string; children?: Array<unknown> }>): void => {
+    for (const node of list) {
+      providers.push(node.issueProvider ?? 'github');
+      if (node.children && Array.isArray(node.children)) {
+        walk(node.children as Array<{ issueProvider?: string; children?: Array<unknown> }>);
+      }
+    }
+  };
+  walk(nodes);
+  return providers;
+}
+
+/**
  * Flatten an issue tree into a single-level array of all issues.
  */
 function flattenIssueTree(nodes: Array<{ number: number; children: Array<unknown> }>): Array<{ number: number }> {
@@ -84,6 +102,7 @@ export class IssueService {
       tree: IssueNode[];
       cachedAt: string | null;
       count: number;
+      providers: string[];
     }>;
     cachedAt: string | null;
     count: number;
@@ -97,6 +116,7 @@ export class IssueService {
       const enriched = fetcher.enrichWithTeamInfo(entry.tree, entry.projectId);
       const groupId = project?.groupId ?? null;
       const group = groupId != null ? db.getProjectGroup(groupId) : undefined;
+      const providers = [...new Set(collectProviders(enriched))];
       return {
         projectId: entry.projectId,
         projectName: project?.name ?? `Project #${entry.projectId}`,
@@ -105,6 +125,7 @@ export class IssueService {
         tree: enriched,
         cachedAt: entry.cachedAt,
         count: countIssues(enriched),
+        providers,
       };
     }));
 

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -965,4 +965,219 @@ describe('IssueTreeView', () => {
     fireEvent.click(screen.getByText('My Group'));
     expect(mockToggleCollapse).toHaveBeenCalledWith('group-100');
   });
+
+  // -------------------------------------------------------------------------
+  // Provider grouping (Issue #597)
+  // -------------------------------------------------------------------------
+
+  it('does not show provider filter pills when single provider', async () => {
+    const issue = { number: 10, title: 'GitHub Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issue],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'my-project',
+              tree: [issue],
+              cachedAt: null,
+              count: 1,
+              providers: ['github'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 1,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('my-project')).toBeInTheDocument();
+    });
+    // Provider filter pills should NOT be rendered
+    expect(screen.queryByTestId('provider-filter-pills')).not.toBeInTheDocument();
+  });
+
+  it('shows provider filter pills when multiple providers exist', async () => {
+    const ghIssue = { number: 10, title: 'GitHub Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    const jiraIssue = { number: 20, title: 'Jira Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'jira', issueKey: 'PROJ-20' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [ghIssue, jiraIssue],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'multi-source-project',
+              tree: [ghIssue, jiraIssue],
+              cachedAt: null,
+              count: 2,
+              providers: ['github', 'jira'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-filter-pills')).toBeInTheDocument();
+    });
+    // Should have "All Sources" pill and individual provider pills inside the filter bar
+    const filterPills = screen.getByTestId('provider-filter-pills');
+    expect(filterPills).toHaveTextContent('All Sources');
+    expect(filterPills).toHaveTextContent('Github');
+    expect(filterPills).toHaveTextContent('Jira');
+  });
+
+  it('renders provider sub-groups when project has multiple providers', async () => {
+    const ghIssue = { number: 10, title: 'GitHub Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    const jiraIssue = { number: 20, title: 'Jira Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'jira', issueKey: 'PROJ-20' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [ghIssue, jiraIssue],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'multi-source-project',
+              tree: [ghIssue, jiraIssue],
+              cachedAt: null,
+              count: 2,
+              providers: ['github', 'jira'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('multi-source-project')).toBeInTheDocument();
+    });
+    // Should render provider sub-group sections
+    expect(screen.getByTestId('provider-subgroup-github')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-subgroup-jira')).toBeInTheDocument();
+    // Sub-group headers should have provider names inside them
+    expect(screen.getByTestId('provider-subgroup-github')).toHaveTextContent('Github');
+    expect(screen.getByTestId('provider-subgroup-jira')).toHaveTextContent('Jira');
+  });
+
+  it('does not render provider sub-groups when project has single provider', async () => {
+    const issue = { number: 10, title: 'Only GitHub', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issue],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'single-source-project',
+              tree: [issue],
+              cachedAt: null,
+              count: 1,
+              providers: ['github'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 1,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('single-source-project')).toBeInTheDocument();
+    });
+    // Should NOT render provider sub-group sections
+    expect(screen.queryByTestId('provider-subgroup-github')).not.toBeInTheDocument();
+    // Should render the tree directly
+    expect(screen.getByTestId('tree-node-10')).toBeInTheDocument();
+  });
+
+  it('shows per-provider count badges in project header when multiple providers', async () => {
+    const ghIssue = { number: 10, title: 'GH Issue', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    const jiraIssue1 = { number: 20, title: 'Jira 1', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'jira' };
+    const jiraIssue2 = { number: 30, title: 'Jira 2', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'jira' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [ghIssue, jiraIssue1, jiraIssue2],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'mixed-project',
+              tree: [ghIssue, jiraIssue1, jiraIssue2],
+              cachedAt: null,
+              count: 3,
+              providers: ['github', 'jira'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 3,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('mixed-project')).toBeInTheDocument();
+    });
+    // Header should show per-provider breakdown
+    expect(screen.getByText(/3 issues \(Github: 1, Jira: 2\)/)).toBeInTheDocument();
+  });
+
+  it('collapseAll includes provider sub-group IDs when multiple providers exist', async () => {
+    const ghIssue = { number: 10, title: 'GH', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'github' };
+    const jiraIssue = { number: 20, title: 'Jira', state: 'open', labels: [], children: [], activeTeam: null, issueProvider: 'jira' };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [ghIssue, jiraIssue],
+          groups: [
+            {
+              projectId: 1,
+              projectName: 'multi',
+              tree: [ghIssue, jiraIssue],
+              cachedAt: null,
+              count: 2,
+              providers: ['github', 'jira'],
+            },
+          ],
+          cachedAt: '2026-03-28T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') return Promise.resolve(makeProjectsResponse());
+      return Promise.resolve({});
+    });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Collapse All')).toBeInTheDocument();
+    });
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Collapse All'));
+
+    // collapseAll should include provider sub-group IDs
+    expect(mockCollapseAll).toHaveBeenCalledWith(
+      expect.arrayContaining(['provider-1-github', 'provider-1-jira', 'project-1', '10', '20']),
+    );
+  });
 });

--- a/tests/client/TreeNode.test.tsx
+++ b/tests/client/TreeNode.test.tsx
@@ -113,7 +113,7 @@ describe('TreeNode', () => {
       />,
     );
     fireEvent.click(screen.getByTitle('Launch team for #50'));
-    expect(onLaunch).toHaveBeenCalledWith(50, 'Launch me', undefined);
+    expect(onLaunch).toHaveBeenCalledWith(50, 'Launch me', undefined, undefined, undefined);
   });
 
   it('shows "Launching..." indicator when issue is launching', () => {
@@ -306,5 +306,30 @@ describe('TreeNode', () => {
     // depth 15 * 20 = 300, capped at 200, plus 8 = 208px
     const row = container.querySelector('.flex.items-center.gap-2') as HTMLElement;
     expect(row.style.paddingLeft).toBe('208px');
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider display (Issue #597)
+  // -------------------------------------------------------------------------
+
+  it('renders Jira issue key when issueProvider is jira', () => {
+    render(
+      <TreeNode
+        node={makeNode({ number: 123, title: 'Jira task', issueProvider: 'jira', issueKey: 'PROJ-123' })}
+        {...defaultProps}
+      />,
+    );
+    // Should display the Jira key (PROJ-123) instead of #123
+    expect(screen.getByText('PROJ-123')).toBeInTheDocument();
+  });
+
+  it('renders GitHub issue number when issueProvider is github', () => {
+    render(
+      <TreeNode
+        node={makeNode({ number: 42, title: 'GH bug', issueProvider: 'github', issueKey: '42' })}
+        {...defaultProps}
+      />,
+    );
+    expect(screen.getByText('#42')).toBeInTheDocument();
   });
 });

--- a/tests/server/services/issue-service.test.ts
+++ b/tests/server/services/issue-service.test.ts
@@ -184,6 +184,60 @@ describe('IssueService.getAllIssues', () => {
     expect(result.groups).toHaveLength(0);
     expect(result.count).toBe(0);
   });
+
+  it('should include providers array in each group', async () => {
+    const project = seedProject();
+    const mixedProviderTree = [
+      {
+        number: 10,
+        title: 'GitHub issue',
+        state: 'open',
+        labels: [],
+        children: [],
+        issueProvider: 'github',
+      },
+      {
+        number: 20,
+        title: 'Jira issue',
+        state: 'open',
+        labels: [],
+        children: [],
+        issueProvider: 'jira',
+      },
+    ];
+    mockGetIssuesByProject.mockReturnValue([
+      { projectId: project.id, tree: mixedProviderTree, cachedAt: '2026-03-25T12:00:00Z' },
+    ]);
+
+    const result = await service.getAllIssues();
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toHaveProperty('providers');
+    expect(result.groups[0].providers).toContain('github');
+    expect(result.groups[0].providers).toContain('jira');
+  });
+
+  it('should default to github provider when issueProvider is undefined', async () => {
+    const project = seedProject();
+    const treeWithoutProvider = [
+      {
+        number: 10,
+        title: 'Legacy issue',
+        state: 'open',
+        labels: [],
+        children: [],
+        // No issueProvider set
+      },
+    ];
+    mockGetIssuesByProject.mockReturnValue([
+      { projectId: project.id, tree: treeWithoutProvider, cachedAt: '2026-03-25T12:00:00Z' },
+    ]);
+
+    const result = await service.getAllIssues();
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].providers).toEqual(['github']);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #597

## Summary
- Add provider sub-groups (e.g. "GitHub Issues (12)" / "Jira Issues (8)") in Issue Tree when a project has multiple issue sources
- Provider filter toolbar to show issues from a single provider
- Per-provider issue count badges in project header
- Collapsible provider groups (default expanded), respecting Expand All / Collapse All
- Run All scoped per provider sub-group or across all providers
- Single-source projects show flat list (no sub-grouping)

## Changes
- **Server**: Set `issueProvider: 'github'` on GitHub issues in `issue-fetcher.ts`; add `providers[]` to group response in `issue-service.ts`
- **Client**: New `ProviderSubGroup` component, provider filter pills, `GitHubIcon`/`JiraIcon`/`LinearIcon`/`ProviderIcon` icons, composite React keys for cross-provider deduplication
- **Tests**: 13 new tests across IssueTreeView, TreeNode, and issue-service

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 83 tests pass (server + client)
- [ ] Manual: verify single-provider project shows flat list
- [ ] Manual: verify multi-provider project shows provider sub-groups
- [ ] Manual: verify provider filter pills work
- [ ] Manual: verify Run All per provider group