### PR TITLE
Issue #599: Add issue context generator service (.fleet-issue-context.md)

### DIFF
--- a/src/server/services/cleanup.ts
+++ b/src/server/services/cleanup.ts
@@ -106,7 +106,7 @@ export function getCleanupPreview(projectId: number, resetTeams: boolean = false
         files = [];
       }
 
-      const signalPatterns = ['.fleet-pm-message'];
+      const signalPatterns = ['.fleet-pm-message', '.fleet-issue-context.md'];
       const prWatcherFiles = files.filter((f) => f.startsWith('.pr-watcher-'));
 
       for (const sf of [...signalPatterns, ...prWatcherFiles]) {

--- a/src/server/services/issue-context-generator.ts
+++ b/src/server/services/issue-context-generator.ts
@@ -1,0 +1,345 @@
+// =============================================================================
+// Fleet Commander — Issue Context Generator Service
+// =============================================================================
+// Generates a `.fleet-issue-context.md` file in the worktree root before CC
+// starts, providing the agent with full issue context (description, comments,
+// linked PRs, dependencies) so it does not need to fetch this data itself.
+//
+// Supports GitHub (via `gh` CLI) and Jira (via provider API). For unsupported
+// providers, generates a minimal context file with just key/title.
+//
+// Errors are caught and logged — context generation must NEVER block a launch.
+// =============================================================================
+
+import path from 'path';
+import fs from 'fs';
+import { execGHAsync } from '../utils/exec-gh.js';
+import { isValidGithubRepo } from '../utils/exec-gh.js';
+import { getIssueProvider } from '../providers/index.js';
+import type { Project } from '../../shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CONTEXT_FILENAME = '.fleet-issue-context.md';
+const MAX_BODY_LENGTH = 10_000;
+const MAX_COMMENTS = 20;
+
+// ---------------------------------------------------------------------------
+// Internal Types
+// ---------------------------------------------------------------------------
+
+interface IssueComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+interface IssueLinkedPR {
+  number: number;
+  state: string;
+}
+
+interface IssueDependency {
+  key: string;
+  title: string;
+  state: string;
+}
+
+interface IssueContext {
+  key: string;
+  title: string;
+  state: string;
+  url: string | null;
+  body: string | null;
+  labels: string[];
+  assignees: string[];
+  comments: IssueComment[];
+  linkedPRs: IssueLinkedPR[];
+  dependencies: IssueDependency[];
+  milestone: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Issue Fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch full issue context from GitHub using the `gh` CLI.
+ * Returns null on any error (network, auth, rate-limit, etc.).
+ */
+async function fetchGitHubIssueContext(
+  issueNumber: number,
+  githubRepo: string,
+): Promise<IssueContext | null> {
+  if (!isValidGithubRepo(githubRepo)) {
+    console.warn(`[IssueContextGenerator] Invalid GitHub repo slug: "${githubRepo}"`);
+    return null;
+  }
+
+  const fields = 'number,title,body,state,url,labels,assignees,comments,milestone,closedByPullRequests';
+  const raw = await execGHAsync(
+    `gh issue view ${issueNumber} --repo "${githubRepo}" --json ${fields}`,
+    { timeout: 15_000 },
+  );
+
+  if (!raw) return null;
+
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+
+    // Map labels: [{name: string}] -> string[]
+    const rawLabels = Array.isArray(data.labels) ? data.labels : [];
+    const labels = rawLabels
+      .map((l: unknown) => (typeof l === 'object' && l !== null && 'name' in l ? (l as { name: string }).name : ''))
+      .filter(Boolean);
+
+    // Map assignees: [{login: string}] -> string[]
+    const rawAssignees = Array.isArray(data.assignees) ? data.assignees : [];
+    const assignees = rawAssignees
+      .map((a: unknown) => (typeof a === 'object' && a !== null && 'login' in a ? (a as { login: string }).login : ''))
+      .filter(Boolean);
+
+    // Map comments: [{author:{login}, body, createdAt}] -> IssueComment[]
+    const rawComments = Array.isArray(data.comments) ? data.comments : [];
+    const comments: IssueComment[] = rawComments
+      .filter((c: unknown): c is Record<string, unknown> => typeof c === 'object' && c !== null)
+      .map((c: Record<string, unknown>) => ({
+        author: typeof c.author === 'object' && c.author !== null && 'login' in c.author
+          ? String((c.author as { login: string }).login)
+          : 'unknown',
+        body: typeof c.body === 'string' ? c.body : '',
+        createdAt: typeof c.createdAt === 'string' ? c.createdAt : '',
+      }));
+
+    // Map closedByPullRequests: [{number, state}] -> IssueLinkedPR[]
+    const rawPRs = Array.isArray(data.closedByPullRequests) ? data.closedByPullRequests : [];
+    const linkedPRs: IssueLinkedPR[] = rawPRs
+      .filter((pr: unknown): pr is Record<string, unknown> => typeof pr === 'object' && pr !== null)
+      .map((pr: Record<string, unknown>) => ({
+        number: typeof pr.number === 'number' ? pr.number : 0,
+        state: typeof pr.state === 'string' ? pr.state : 'unknown',
+      }))
+      .filter((pr) => pr.number > 0);
+
+    // Milestone
+    const milestoneObj = typeof data.milestone === 'object' && data.milestone !== null ? data.milestone : null;
+    const milestone = milestoneObj && 'title' in milestoneObj
+      ? String((milestoneObj as { title: string }).title)
+      : null;
+
+    return {
+      key: String(data.number ?? issueNumber),
+      title: typeof data.title === 'string' ? data.title : `Issue #${issueNumber}`,
+      state: typeof data.state === 'string' ? data.state : 'unknown',
+      url: typeof data.url === 'string' ? data.url : null,
+      body: typeof data.body === 'string' ? data.body : null,
+      labels,
+      assignees,
+      comments,
+      linkedPRs,
+      dependencies: [], // GitHub dependencies require separate GraphQL query — skip for now
+      milestone,
+    };
+  } catch (err) {
+    console.warn(`[IssueContextGenerator] Failed to parse GitHub issue JSON:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Jira Issue Fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch issue context from Jira using the provider API.
+ * Returns null on any error.
+ */
+async function fetchJiraIssueContext(
+  issueKey: string,
+  project: Project,
+): Promise<IssueContext | null> {
+  try {
+    const provider = getIssueProvider(project);
+    const issue = await provider.getIssue(issueKey);
+    if (!issue) return null;
+
+    // Fetch linked PRs and dependencies in parallel
+    const [linkedPRs, dependencies] = await Promise.all([
+      provider.getLinkedPRs(issueKey).catch(() => [] as Array<{ number: number; state: string }>),
+      provider.getDependencies(issueKey).catch(() => [] as Array<{ key: string; title: string; status: string }>),
+    ]);
+
+    return {
+      key: issue.key,
+      title: issue.title,
+      state: issue.rawStatus,
+      url: issue.url,
+      body: null, // Jira REST v3 body is ADF (Atlassian Document Format), not plain text
+      labels: issue.labels,
+      assignees: issue.assignee ? [issue.assignee] : [],
+      comments: [], // Jira comments require a separate API call — skip for MVP
+      linkedPRs: linkedPRs.map((pr) => ({ number: pr.number, state: pr.state })),
+      dependencies: dependencies.map((dep) => ({ key: dep.key, title: dep.title, state: dep.status })),
+      milestone: null, // Jira uses fixVersions, not milestones
+    };
+  } catch (err) {
+    console.warn(`[IssueContextGenerator] Failed to fetch Jira issue ${issueKey}:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Render an IssueContext into a structured markdown string.
+ * Empty sections are omitted.
+ */
+export function formatContextMarkdown(ctx: IssueContext): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# Issue ${ctx.key}: ${ctx.title}`);
+  lines.push('');
+
+  // Metadata table
+  lines.push('| Field | Value |');
+  lines.push('|-------|-------|');
+  lines.push(`| **Key** | ${ctx.key} |`);
+  lines.push(`| **Title** | ${ctx.title} |`);
+  lines.push(`| **State** | ${ctx.state} |`);
+  if (ctx.url) {
+    lines.push(`| **URL** | ${ctx.url} |`);
+  }
+  if (ctx.milestone) {
+    lines.push(`| **Milestone** | ${ctx.milestone} |`);
+  }
+  if (ctx.labels.length > 0) {
+    lines.push(`| **Labels** | ${ctx.labels.join(', ')} |`);
+  }
+  if (ctx.assignees.length > 0) {
+    lines.push(`| **Assignees** | ${ctx.assignees.join(', ')} |`);
+  }
+  lines.push('');
+
+  // Description
+  if (ctx.body) {
+    const truncatedBody = ctx.body.length > MAX_BODY_LENGTH
+      ? ctx.body.substring(0, MAX_BODY_LENGTH) + '\n\n*(truncated — original exceeds 10,000 characters)*'
+      : ctx.body;
+    lines.push('## Description');
+    lines.push('');
+    lines.push(truncatedBody);
+    lines.push('');
+  }
+
+  // Comments (most recent N)
+  if (ctx.comments.length > 0) {
+    const recentComments = ctx.comments.slice(-MAX_COMMENTS);
+    const omitted = ctx.comments.length - recentComments.length;
+
+    lines.push('## Comments');
+    lines.push('');
+    if (omitted > 0) {
+      lines.push(`*${omitted} older comment(s) omitted — showing most recent ${MAX_COMMENTS}.*`);
+      lines.push('');
+    }
+    for (const comment of recentComments) {
+      const dateStr = comment.createdAt ? ` (${comment.createdAt})` : '';
+      lines.push(`### @${comment.author}${dateStr}`);
+      lines.push('');
+      lines.push(comment.body);
+      lines.push('');
+    }
+  }
+
+  // Linked PRs
+  if (ctx.linkedPRs.length > 0) {
+    lines.push('## Linked Pull Requests');
+    lines.push('');
+    for (const pr of ctx.linkedPRs) {
+      lines.push(`- PR #${pr.number} — ${pr.state}`);
+    }
+    lines.push('');
+  }
+
+  // Dependencies
+  if (ctx.dependencies.length > 0) {
+    lines.push('## Dependencies');
+    lines.push('');
+    for (const dep of ctx.dependencies) {
+      lines.push(`- ${dep.key}: ${dep.title} — ${dep.state}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GenerateIssueContextParams {
+  worktreeAbsPath: string;
+  issueKey: string;
+  issueNumber: number;
+  issueTitle: string | null;
+  issueProvider: string;
+  project: Project;
+}
+
+/**
+ * Generate a `.fleet-issue-context.md` file in the worktree root.
+ *
+ * Fetches full issue context from the appropriate provider (GitHub, Jira),
+ * formats it as structured markdown, and writes it to the worktree.
+ *
+ * This function NEVER throws — errors are caught and logged as warnings.
+ * A failed context generation must not block a team launch.
+ */
+export async function generateIssueContext(params: GenerateIssueContextParams): Promise<void> {
+  const { worktreeAbsPath, issueKey, issueNumber, issueTitle, issueProvider, project } = params;
+
+  try {
+    let ctx: IssueContext | null = null;
+
+    if (issueProvider === 'github' && project.githubRepo) {
+      ctx = await fetchGitHubIssueContext(issueNumber, project.githubRepo);
+    } else if (issueProvider === 'jira') {
+      ctx = await fetchJiraIssueContext(issueKey, project);
+    }
+
+    // Fallback: minimal context for unsupported providers or fetch failures
+    if (!ctx) {
+      ctx = {
+        key: issueKey,
+        title: issueTitle ?? `Issue ${issueKey}`,
+        state: 'unknown',
+        url: null,
+        body: null,
+        labels: [],
+        assignees: [],
+        comments: [],
+        linkedPRs: [],
+        dependencies: [],
+        milestone: null,
+      };
+    }
+
+    const markdown = formatContextMarkdown(ctx);
+    const filePath = path.join(worktreeAbsPath, CONTEXT_FILENAME);
+    fs.writeFileSync(filePath, markdown, 'utf-8');
+
+    console.log(`[IssueContextGenerator] Wrote ${CONTEXT_FILENAME} to ${worktreeAbsPath}`);
+  } catch (err) {
+    console.warn(
+      `[IssueContextGenerator] Failed to generate issue context for ${issueKey}:`,
+      err instanceof Error ? err.message : err,
+    );
+    // Never throw — context generation failure must not block launch
+  }
+}

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -28,6 +28,7 @@ import { getHookFiles as getManifestHookFiles, getAgentFiles as getManifestAgent
 import { classifyAgentRole, shouldAdvancePhase } from './event-collector.js';
 import type { TeamPhase } from '../../shared/types.js';
 import { isValidGithubRepo } from '../utils/exec-gh.js';
+import { generateIssueContext } from './issue-context-generator.js';
 
 const execAsync = promisify(execCallback);
 
@@ -351,6 +352,16 @@ export class TeamManager {
 
     // ── Step 3: Copy hook scripts and settings into worktree ──
     this.copyFCFiles(worktreeAbsPath);
+
+    // ── Step 3b: Generate issue context file ──
+    await generateIssueContext({
+      worktreeAbsPath,
+      issueKey: effectiveIssueKey,
+      issueNumber,
+      issueTitle: issueTitle ?? null,
+      issueProvider: project.issueProvider ?? 'github',
+      project,
+    });
 
     // ── Step 4: Spawn Claude Code process ──
     const resolvedPrompt = prompt || this.resolvePromptFromFile(project, effectiveIssueKey);
@@ -1238,8 +1249,18 @@ export class TeamManager {
     // ── Step 2: Copy hooks and settings ──
     this.copyFCFiles(worktreeAbsPath);
 
-    // ── Step 3: Spawn Claude Code ──
+    // ── Step 2b: Generate issue context file ──
     const effectiveIssueKey = team.issueKey ?? String(team.issueNumber);
+    await generateIssueContext({
+      worktreeAbsPath,
+      issueKey: effectiveIssueKey,
+      issueNumber: team.issueNumber,
+      issueTitle: team.issueTitle ?? null,
+      issueProvider: team.issueProvider ?? project.issueProvider ?? 'github',
+      project,
+    });
+
+    // ── Step 3: Spawn Claude Code ──
     const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, effectiveIssueKey);
     const isHeadless = team.headless;
 
@@ -1906,6 +1927,7 @@ export class TeamManager {
     const toAdd: string[] = [];
     if (!lines.includes('plan.md')) toAdd.push('plan.md');
     if (!lines.includes('review.md')) toAdd.push('review.md');
+    if (!lines.includes('.fleet-issue-context.md')) toAdd.push('.fleet-issue-context.md');
     if (toAdd.length > 0) {
       const suffix = gitignoreContent.length > 0 && !gitignoreContent.endsWith('\n') ? '\n' : '';
       fs.writeFileSync(gitignorePath, gitignoreContent + suffix + toAdd.join('\n') + '\n', 'utf-8');

--- a/tests/server/services/issue-context-generator.test.ts
+++ b/tests/server/services/issue-context-generator.test.ts
@@ -1,0 +1,382 @@
+// =============================================================================
+// Fleet Commander — Issue Context Generator Tests
+// =============================================================================
+// Tests for the issue context generator service that creates
+// `.fleet-issue-context.md` files in worktrees before CC spawn.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockExecGHAsync = vi.hoisted(() => vi.fn());
+const mockIsValidGithubRepo = vi.hoisted(() => vi.fn().mockReturnValue(true));
+
+vi.mock('../../../src/server/utils/exec-gh.js', () => ({
+  execGHAsync: mockExecGHAsync,
+  isValidGithubRepo: mockIsValidGithubRepo,
+}));
+
+const mockGetIssue = vi.hoisted(() => vi.fn());
+const mockGetLinkedPRs = vi.hoisted(() => vi.fn());
+const mockGetDependencies = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/server/providers/index.js', () => ({
+  getIssueProvider: () => ({
+    name: 'jira',
+    getIssue: mockGetIssue,
+    getLinkedPRs: mockGetLinkedPRs,
+    getDependencies: mockGetDependencies,
+  }),
+}));
+
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+vi.mock('fs', () => ({
+  default: { writeFileSync: mockWriteFileSync },
+  writeFileSync: mockWriteFileSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { formatContextMarkdown, generateIssueContext } from '../../../src/server/services/issue-context-generator.js';
+import type { Project } from '../../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    groupId: null,
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 3,
+    promptFile: null,
+    model: null,
+    issueProvider: 'github',
+    projectKey: null,
+    providerConfig: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatContextMarkdown Tests
+// ---------------------------------------------------------------------------
+
+describe('formatContextMarkdown', () => {
+  it('should render full context with all sections', () => {
+    const md = formatContextMarkdown({
+      key: '42',
+      title: 'Add user authentication',
+      state: 'OPEN',
+      url: 'https://github.com/owner/repo/issues/42',
+      body: 'We need OAuth2 support for the login flow.',
+      labels: ['feature', 'auth'],
+      assignees: ['alice', 'bob'],
+      comments: [
+        { author: 'carol', body: 'Looks good!', createdAt: '2026-01-15T10:00:00Z' },
+      ],
+      linkedPRs: [{ number: 50, state: 'OPEN' }],
+      dependencies: [{ key: '40', title: 'Setup database', state: 'CLOSED' }],
+      milestone: 'v1.0',
+    });
+
+    expect(md).toContain('# Issue 42: Add user authentication');
+    expect(md).toContain('| **Key** | 42 |');
+    expect(md).toContain('| **State** | OPEN |');
+    expect(md).toContain('| **URL** | https://github.com/owner/repo/issues/42 |');
+    expect(md).toContain('| **Milestone** | v1.0 |');
+    expect(md).toContain('| **Labels** | feature, auth |');
+    expect(md).toContain('| **Assignees** | alice, bob |');
+    expect(md).toContain('## Description');
+    expect(md).toContain('We need OAuth2 support');
+    expect(md).toContain('## Comments');
+    expect(md).toContain('### @carol (2026-01-15T10:00:00Z)');
+    expect(md).toContain('Looks good!');
+    expect(md).toContain('## Linked Pull Requests');
+    expect(md).toContain('- PR #50 — OPEN');
+    expect(md).toContain('## Dependencies');
+    expect(md).toContain('- 40: Setup database — CLOSED');
+  });
+
+  it('should omit empty sections', () => {
+    const md = formatContextMarkdown({
+      key: '10',
+      title: 'Simple bug fix',
+      state: 'OPEN',
+      url: null,
+      body: null,
+      labels: [],
+      assignees: [],
+      comments: [],
+      linkedPRs: [],
+      dependencies: [],
+      milestone: null,
+    });
+
+    expect(md).toContain('# Issue 10: Simple bug fix');
+    expect(md).toContain('| **Key** | 10 |');
+    expect(md).toContain('| **State** | OPEN |');
+    expect(md).not.toContain('## Description');
+    expect(md).not.toContain('## Comments');
+    expect(md).not.toContain('## Linked Pull Requests');
+    expect(md).not.toContain('## Dependencies');
+    expect(md).not.toContain('**URL**');
+    expect(md).not.toContain('**Milestone**');
+    expect(md).not.toContain('**Labels**');
+    expect(md).not.toContain('**Assignees**');
+  });
+
+  it('should truncate body exceeding 10,000 characters', () => {
+    const longBody = 'A'.repeat(15_000);
+    const md = formatContextMarkdown({
+      key: '1',
+      title: 'Long body test',
+      state: 'OPEN',
+      url: null,
+      body: longBody,
+      labels: [],
+      assignees: [],
+      comments: [],
+      linkedPRs: [],
+      dependencies: [],
+      milestone: null,
+    });
+
+    expect(md).toContain('*(truncated — original exceeds 10,000 characters)*');
+    // The body portion should not contain the full 15k characters
+    expect(md.length).toBeLessThan(15_000);
+  });
+
+  it('should limit comments to 20 most recent', () => {
+    const comments = Array.from({ length: 30 }, (_, i) => ({
+      author: `user${i}`,
+      body: `Comment ${i}`,
+      createdAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+    }));
+
+    const md = formatContextMarkdown({
+      key: '5',
+      title: 'Many comments',
+      state: 'OPEN',
+      url: null,
+      body: null,
+      labels: [],
+      assignees: [],
+      comments,
+      linkedPRs: [],
+      dependencies: [],
+      milestone: null,
+    });
+
+    expect(md).toContain('*10 older comment(s) omitted');
+    // Should contain the last 20 comments (user10..user29), not the first 10
+    expect(md).toContain('@user10');
+    expect(md).toContain('@user29');
+    expect(md).not.toContain('@user0 ');
+    expect(md).not.toContain('@user9 ');
+  });
+
+  it('should handle null body gracefully', () => {
+    const md = formatContextMarkdown({
+      key: '7',
+      title: 'No body',
+      state: 'CLOSED',
+      url: null,
+      body: null,
+      labels: [],
+      assignees: [],
+      comments: [],
+      linkedPRs: [],
+      dependencies: [],
+      milestone: null,
+    });
+
+    expect(md).toContain('# Issue 7: No body');
+    expect(md).not.toContain('## Description');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateIssueContext Tests
+// ---------------------------------------------------------------------------
+
+describe('generateIssueContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch GitHub issue and write context file', async () => {
+    const ghResponse = JSON.stringify({
+      number: 42,
+      title: 'Add feature X',
+      body: 'Feature description here.',
+      state: 'OPEN',
+      url: 'https://github.com/owner/repo/issues/42',
+      labels: [{ name: 'feature' }],
+      assignees: [{ login: 'alice' }],
+      comments: [{ author: { login: 'bob' }, body: 'LGTM', createdAt: '2026-01-10T00:00:00Z' }],
+      milestone: { title: 'v2.0' },
+      closedByPullRequests: [{ number: 55, state: 'MERGED' }],
+    });
+    mockExecGHAsync.mockResolvedValue(ghResponse);
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'Add feature X',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    expect(mockExecGHAsync).toHaveBeenCalledTimes(1);
+    expect(mockExecGHAsync.mock.calls[0][0]).toContain('gh issue view 42');
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    const writtenPath = mockWriteFileSync.mock.calls[0][0];
+    const writtenContent = mockWriteFileSync.mock.calls[0][1];
+    expect(writtenPath).toContain('.fleet-issue-context.md');
+    expect(writtenContent).toContain('# Issue 42: Add feature X');
+    expect(writtenContent).toContain('Feature description here.');
+    expect(writtenContent).toContain('LGTM');
+    expect(writtenContent).toContain('PR #55');
+  });
+
+  it('should fetch Jira issue and write context file', async () => {
+    mockGetIssue.mockResolvedValue({
+      key: 'PROJ-123',
+      title: 'Jira task',
+      status: 'in_progress',
+      rawStatus: 'In Progress',
+      url: 'https://jira.example.com/browse/PROJ-123',
+      labels: ['backend'],
+      assignee: 'dave',
+      priority: 2,
+      parentKey: null,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: null,
+      provider: 'jira',
+    });
+    mockGetLinkedPRs.mockResolvedValue([{ number: 10, state: 'open', url: null }]);
+    mockGetDependencies.mockResolvedValue([
+      { key: 'PROJ-100', title: 'Setup DB', status: 'closed', provider: 'jira', projectKey: 'PROJ' },
+    ]);
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: 'PROJ-123',
+      issueNumber: 123,
+      issueTitle: 'Jira task',
+      issueProvider: 'jira',
+      project: makeProject({ issueProvider: 'jira', githubRepo: null }),
+    });
+
+    expect(mockGetIssue).toHaveBeenCalledWith('PROJ-123');
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    const writtenContent = mockWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain('# Issue PROJ-123: Jira task');
+    expect(writtenContent).toContain('In Progress');
+    expect(writtenContent).toContain('PR #10');
+    expect(writtenContent).toContain('PROJ-100: Setup DB');
+  });
+
+  it('should generate minimal context on GitHub fetch failure', async () => {
+    mockExecGHAsync.mockResolvedValue(null);
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '99',
+      issueNumber: 99,
+      issueTitle: 'Fallback test',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const writtenContent = mockWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain('# Issue 99: Fallback test');
+    expect(writtenContent).toContain('| **State** | unknown |');
+  });
+
+  it('should generate minimal context for unknown provider', async () => {
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: 'LIN-50',
+      issueNumber: 50,
+      issueTitle: 'Linear issue',
+      issueProvider: 'linear',
+      project: makeProject({ issueProvider: 'linear', githubRepo: null }),
+    });
+
+    // Should not call GitHub or Jira APIs
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+    expect(mockGetIssue).not.toHaveBeenCalled();
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const writtenContent = mockWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain('# Issue LIN-50: Linear issue');
+  });
+
+  it('should not throw when context generation fails', async () => {
+    mockExecGHAsync.mockRejectedValue(new Error('Network error'));
+
+    // Should NOT throw
+    await expect(generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '1',
+      issueNumber: 1,
+      issueTitle: null,
+      issueProvider: 'github',
+      project: makeProject(),
+    })).resolves.toBeUndefined();
+  });
+
+  it('should handle Jira provider error gracefully', async () => {
+    mockGetIssue.mockRejectedValue(new Error('Jira auth failed'));
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: 'PROJ-999',
+      issueNumber: 999,
+      issueTitle: 'Jira fail',
+      issueProvider: 'jira',
+      project: makeProject({ issueProvider: 'jira', githubRepo: null }),
+    });
+
+    // Should still write a minimal context file
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const writtenContent = mockWriteFileSync.mock.calls[0][1];
+    expect(writtenContent).toContain('# Issue PROJ-999: Jira fail');
+  });
+
+  it('should handle invalid GitHub repo slug', async () => {
+    mockIsValidGithubRepo.mockReturnValue(false);
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '5',
+      issueNumber: 5,
+      issueTitle: 'Bad repo',
+      issueProvider: 'github',
+      project: makeProject({ githubRepo: 'invalid repo!' }),
+    });
+
+    // Should not call gh CLI
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+    // Should still write minimal context
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -86,6 +86,10 @@ vi.mock('../../src/server/services/github-poller.js', () => ({
   },
 }));
 
+vi.mock('../../src/server/services/issue-context-generator.js', () => ({
+  generateIssueContext: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { TeamManager } from '../../src/server/services/team-manager.js';
 
 // ---------------------------------------------------------------------------

--- a/tests/server/team-manager-process-queue.test.ts
+++ b/tests/server/team-manager-process-queue.test.ts
@@ -68,6 +68,10 @@ vi.mock('../../src/server/services/github-poller.js', () => ({
   },
 }));
 
+vi.mock('../../src/server/services/issue-context-generator.js', () => ({
+  generateIssueContext: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { TeamManager } from '../../src/server/services/team-manager.js';
 import type { Team, Project } from '../../src/shared/types.js';
 

--- a/tests/server/team-manager-worktree.test.ts
+++ b/tests/server/team-manager-worktree.test.ts
@@ -39,6 +39,11 @@ vi.mock('../../src/server/config.js', () => ({
     mergeShutdownGraceMs: 120000,
     fleetCommanderRoot: '/tmp/fleet',
     mapCleanupIntervalMs: 3600000,
+    fcHooksDir: '/tmp/fleet/hooks',
+    hookDir: '.claude/hooks',
+    fcAgentsDir: '/tmp/fleet/agents',
+    fcGuidesDir: '/tmp/fleet/guides',
+    fcWorkflowTemplate: '/tmp/fleet/templates/workflow.md',
   },
 }));
 
@@ -151,6 +156,11 @@ vi.mock('../../src/server/services/event-collector.js', () => ({
 // Mock exec-gh
 vi.mock('../../src/server/utils/exec-gh.js', () => ({
   isValidGithubRepo: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock issue-context-generator
+vi.mock('../../src/server/services/issue-context-generator.js', () => ({
+  generateIssueContext: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { TeamManager } from '../../src/server/services/team-manager.js';
@@ -326,5 +336,53 @@ describe('TeamManager.syncWithOrigin', () => {
       expect.objectContaining({ team_id: teamId }),
       teamId,
     );
+  });
+});
+
+describe('TeamManager.copyFCFiles gitignore', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFs.existsSync.mockReturnValue(false);
+    mockFs.readFileSync.mockReturnValue('');
+    tm = new TeamManager();
+  });
+
+  it('should add .fleet-issue-context.md to gitignore', () => {
+    // Simulate an empty gitignore
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p.includes('.gitignore')) return true;
+      return false;
+    });
+    mockFs.readFileSync.mockReturnValue('node_modules\n');
+
+    (tm as any).copyFCFiles('/tmp/worktree');
+
+    // Find the writeFileSync call that writes the .gitignore
+    const gitignoreCall = mockFs.writeFileSync.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('.gitignore'),
+    );
+    expect(gitignoreCall).toBeDefined();
+    const writtenContent = gitignoreCall![1] as string;
+    expect(writtenContent).toContain('.fleet-issue-context.md');
+    expect(writtenContent).toContain('plan.md');
+    expect(writtenContent).toContain('review.md');
+  });
+
+  it('should not duplicate .fleet-issue-context.md if already in gitignore', () => {
+    mockFs.existsSync.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p.includes('.gitignore')) return true;
+      return false;
+    });
+    mockFs.readFileSync.mockReturnValue('plan.md\nreview.md\n.fleet-issue-context.md\n');
+
+    (tm as any).copyFCFiles('/tmp/worktree');
+
+    // Should not write gitignore at all since all entries are already present
+    const gitignoreCall = mockFs.writeFileSync.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('.gitignore'),
+    );
+    expect(gitignoreCall).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #599

## Summary
- Add new `issue-context-generator.ts` service that generates `.fleet-issue-context.md` files in worktrees at team launch time
- Fetches issue metadata (title, body, labels, assignees, comments, linked PRs) from GitHub via `gh` CLI or from Jira via provider API
- Renders structured markdown with automatic body truncation (10k chars) and comment limiting (20 most recent)
- Graceful fallback: context generation failures never block team launch
- Integrated into both launch paths (initial launch and dequeued launch) in team-manager
- `.fleet-issue-context.md` added to worktree `.gitignore` and cleanup signal patterns
- 12 unit tests covering all scenarios (GitHub/Jira fetch, error handling, formatting, truncation)

## Test plan
- [x] `npm run build` passes with zero type errors
- [x] `npm test` passes (12 new tests + existing tests)
- [x] Code review APPROVED (1 round, no issues found)