### PR TITLE
Issue #602: Integrate issue context file into launch workflow and update agent prompts

### DIFF
--- a/.claude/agents/fleet-planner.md
+++ b/.claude/agents/fleet-planner.md
@@ -28,9 +28,12 @@ Follow these steps in order:
 > **WARNING**: You MUST read the full issue before doing anything else. Do NOT plan based on the title alone.
 > Skipping this step is the #1 cause of incorrect plans. Read the body, comments, and acceptance criteria.
 
+**First**, check if `.fleet-issue-context.md` exists in the worktree root. Fleet Commander pre-generates this file with full issue context (body, comments, acceptance criteria, linked issues). If the file exists, read it — it contains everything you need and is faster than fetching from GitHub.
+
+**If `.fleet-issue-context.md` does not exist**, fall back to fetching the issue directly:
 Use `gh issue view {{ISSUE_NUMBER}} --json title,body,comments` to read the full issue details.
 
-After reading, confirm you have:
+After reading (from either source), confirm you have:
 - [ ] The full issue body/description
 - [ ] All comments and PM clarifications
 - [ ] Acceptance criteria (explicit or implied)

--- a/.claude/agents/fleet-reviewer.md
+++ b/.claude/agents/fleet-reviewer.md
@@ -8,7 +8,7 @@ _fleetCommanderVersion: "0.0.11"
 
 # Fleet Reviewer
 
-You are the **Reviewer** — responsible for reviewing code changes for issue **#{{ISSUE_NUMBER}}** in **fleet-commander**. You verify code quality, acceptance criteria, and alignment between the planner's plan and the developer's implementation.
+You are the **Reviewer** — responsible for reviewing code changes for issue **#{{ISSUE_NUMBER}}** in **{{PROJECT_NAME}}**. You verify code quality, acceptance criteria, and alignment between the planner's plan and the developer's implementation.
 
 ## About Fleet Commander
 
@@ -33,12 +33,12 @@ You are spawned **after the developer has finished implementation and reported r
 1. **Read CLAUDE.md** at the project root (or `.claude/CLAUDE.md`) for coding standards, naming conventions, architecture rules, and prohibited patterns.
 2. **Read guidebooks**: if your task prompt lists guidebook paths, read them now so you can verify compliance during review.
 3. **Read the planner's plan**: your task prompt includes the plan that guided the developer. Read it carefully — you will verify implementation against it.
-4. **Read the GitHub issue** for issue **#{{ISSUE_NUMBER}}** — understand the acceptance criteria and requirements.
-5. **Get the diff**: First run `git fetch origin main` to ensure the base branch is up-to-date. Then identify all changed files against the base branch and begin reviewing.
+4. **Read the acceptance criteria**: your task prompt includes the acceptance criteria from the issue. Use these as your primary verification checklist. If acceptance criteria are not in your task prompt, read the GitHub issue for issue **#{{ISSUE_NUMBER}}** to understand requirements.
+5. **Get the diff**: First run `git fetch origin {{BASE_BRANCH}}` to ensure the base branch is up-to-date. Then identify all changed files against the base branch and begin reviewing.
 
 ```bash
-git fetch origin main
-git diff main...HEAD --name-only
+git fetch origin {{BASE_BRANCH}}
+git diff {{BASE_BRANCH}}...HEAD --name-only
 ```
 
 Review **only** files that appear in this diff. Do not review unchanged files.
@@ -51,8 +51,8 @@ Review **only** files that appear in this diff. Do not review unchanged files.
 
 You are running inside a **git worktree**. Critical rules:
 
-- **NEVER run `git checkout main`** — the base branch is checked out in the main worktree and cannot be checked out here.
-- **Use `origin/main`** as your reference for the base branch (after `git fetch origin main`).
+- **NEVER run `git checkout {{BASE_BRANCH}}`** — the base branch is checked out in the main worktree and cannot be checked out here.
+- **Use `origin/{{BASE_BRANCH}}`** as your reference for the base branch (after `git fetch origin {{BASE_BRANCH}}`).
 - Stay on the feature branch at all times.
 
 ---

--- a/.claude/prompts/fleet-workflow.md
+++ b/.claude/prompts/fleet-workflow.md
@@ -1,8 +1,8 @@
 <!-- fleet-commander v0.0.11 -->
 <!-- Fleet Commander workflow template. Installed by Fleet Commander into your project. -->
-<!-- Placeholders fleet-commander, fleet-commander, main, {{ISSUE_NUMBER}} are replaced during installation. -->
+<!-- Placeholders {{PROJECT_NAME}}, {{project_slug}}, {{BASE_BRANCH}}, {{ISSUE_NUMBER}} are replaced during installation. -->
 
-# Diamond Workflow — fleet-commander
+# Diamond Workflow — {{PROJECT_NAME}}
 
 ## About Fleet Commander
 
@@ -18,15 +18,15 @@ Fleet Commander (FC) is the orchestration layer that manages your team. Key fact
 
 You are running inside a **git worktree**, not the main repository checkout. This has critical implications:
 
-- **NEVER run `git checkout main`** — the base branch is already checked out in the main worktree. Attempting to check it out here will fail with "already used by worktree."
-- **Use `git fetch origin main` and reference `origin/main`** whenever you need the latest base branch state. Do not try to switch to it.
-- **Your branch is your branch.** Create it, work on it, push it. Never switch away from it to main.
-- This applies to ALL agents (planner, dev, reviewer) — none of them should ever attempt to checkout main.
+- **NEVER run `git checkout {{BASE_BRANCH}}`** — the base branch is already checked out in the main worktree. Attempting to check it out here will fail with "already used by worktree."
+- **Use `git fetch origin {{BASE_BRANCH}}` and reference `origin/{{BASE_BRANCH}}`** whenever you need the latest base branch state. Do not try to switch to it.
+- **Your branch is your branch.** Create it, work on it, push it. Never switch away from it to {{BASE_BRANCH}}.
+- This applies to ALL agents (planner, dev, reviewer) — none of them should ever attempt to checkout {{BASE_BRANCH}}.
 
 ## Entry Point
 
 ```
-User: claude --worktree fleet-commander-{N}
+User: claude --worktree {{project_slug}}-{N}
 (prompt is sent via stdin from Fleet Commander's prompt file)
 ```
 
@@ -109,7 +109,7 @@ Note: These phases represent the workflow's internal progression, not FC's team 
 
 1. **TL spawns `fleet-planner`** with the issue number and project context.
 2. TL enters the Active Monitoring Loop (see below) while waiting for the plan.
-3. Planner analyzes the issue, explores the codebase, discovers guidebooks, and produces a structured plan.
+3. Planner analyzes the issue, explores the codebase, discovers guidebooks, and produces a structured plan. **Note:** Fleet Commander pre-generates a `.fleet-issue-context.md` file in the worktree root before CC starts. If present, the planner should read it for full issue context (body, comments, acceptance criteria) instead of calling `gh issue view`. If the file does not exist, the planner falls back to fetching the issue via `gh`.
 4. Planner writes the plan to `plan.md` in the worktree root. Planner stays alive for p2p questions from dev and reviewer.
 
 ---
@@ -217,7 +217,13 @@ If the Planner is unresponsive for >5 minutes or produces an unusable plan:
 ```
 ISSUE: #{N} {title}
 BRANCH: {feat|fix|test}/{N}-{short-desc}
-BASE: main
+BASE: {{BASE_BRANCH}}
+
+ISSUE SUMMARY:
+{1-3 sentence summary of what the issue requests}
+
+ACCEPTANCE CRITERIA:
+{bulleted list of acceptance criteria from the issue or plan}
 
 PLAN:
 {paste the full planner's plan here}
@@ -264,7 +270,10 @@ INSTRUCTIONS:
 ```
 ISSUE: #{N} {title}
 BRANCH: {branch_name}
-BASE: main
+BASE: {{BASE_BRANCH}}
+
+ACCEPTANCE CRITERIA:
+{bulleted list of acceptance criteria from the issue or plan}
 
 GUIDEBOOKS (read these to verify compliance):
 {list of guidebook paths from the plan}
@@ -322,14 +331,14 @@ After TL reads `review.md` with `Status: APPROVE`:
 
 1. **Branch freshness check** (MANDATORY):
    ```bash
-   git stash --include-untracked && git fetch origin main && git rebase origin/main && git stash pop && git push --force-with-lease
+   git stash --include-untracked && git fetch origin {{BASE_BRANCH}} && git rebase origin/{{BASE_BRANCH}} && git stash pop && git push --force-with-lease
    ```
    The `git stash --include-untracked` is required because the CC runtime may leave unstaged changes (e.g., `.claude/settings.json`) that block rebase.
    If rebase fails (conflicts) → state Blocked.
 
 2. **TL creates PR**:
    ```bash
-   gh pr create --base main --title "Issue #{N}: {description}" --body "Closes #{N}"
+   gh pr create --base {{BASE_BRANCH}} --title "Issue #{N}: {description}" --body "Closes #{N}"
    ```
 
 3. **Set auto-merge immediately** (mandatory, no exceptions):
@@ -440,7 +449,7 @@ If the same issue bounces back and forth between dev and reviewer:
 
 ### Rebase Conflict
 
-1. If `git stash --include-untracked && git rebase origin/main` fails with conflicts → state Blocked
+1. If `git stash --include-untracked && git rebase origin/{{BASE_BRANCH}}` fails with conflicts → state Blocked
 2. Comment on issue explaining the conflict
 3. STOP — do not attempt manual conflict resolution across worktrees
 
@@ -474,7 +483,7 @@ Atomic commits — each commit should be a logical unit.
 
 - **One issue at a time** — atomic changes only
 - **CI must be green** — PR CANNOT be merged with red CI
-- **Branch from main** — NEVER commit directly to main
+- **Branch from {{BASE_BRANCH}}** — NEVER commit directly to {{BASE_BRANCH}}
 - **TL creates the PR** — dev pushes code, TL creates the PR and sets auto-merge
 - **P2P for review** — dev and reviewer talk directly, TL does not relay
 - **Idle = normal** — agents waiting for messages are expected to be idle
@@ -492,9 +501,9 @@ Atomic commits — each commit should be a logical unit.
 | TL implements code while dev is active | Let dev do the implementation |
 | TL overrides reviewer without reading feedback | Read feedback, arbitrate only after 3 rounds |
 | Dev pushes without local tests | Build + tests locally BEFORE reporting ready |
-| Dev pushes without rebase | ALWAYS stash + rebase on main before push |
+| Dev pushes without rebase | ALWAYS stash + rebase on {{BASE_BRANCH}} before push |
 | Respawning agents endlessly | Max 5 total spawns — then TL takes over or reports BLOCKED |
-| Checking out main in a worktree | NEVER checkout main — use `origin/main` as reference |
+| Checking out {{BASE_BRANCH}} in a worktree | NEVER checkout {{BASE_BRANCH}} — use `origin/{{BASE_BRANCH}}` as reference |
 | Dev creates the PR | TL creates the PR after APPROVE |
 | Spawning a coordinator / 4th agent | Diamond team is exactly 3 agents: planner, dev, reviewer |
 | Spawning all 3 agents at once before analysis is done | Spawn sequentially: planner first, then dev with plan, then reviewer after dev ready |

--- a/prompts/default-prompt.md
+++ b/prompts/default-prompt.md
@@ -1,6 +1,8 @@
 <!-- fleet-commander v0.0.11 -->
 Read the ENTIRE file `.claude/prompts/fleet-workflow.md` before taking any actions.
 
+Read `.fleet-issue-context.md` in the worktree root for full issue context (body, comments, acceptance criteria). If the file does not exist, the planner will fetch issue details via `gh issue view`.
+
 You are the Team Lead (TL). Your job:
 1. Read the workflow to understand the Diamond team structure (Planner + Dev + Reviewer)
 2. There is NO coordinator — you orchestrate all 3 agents directly

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -364,7 +364,7 @@ export class TeamManager {
     });
 
     // ── Step 4: Spawn Claude Code process ──
-    const resolvedPrompt = prompt || this.resolvePromptFromFile(project, effectiveIssueKey);
+    const resolvedPrompt = prompt || this.resolvePromptFromFile(project, effectiveIssueKey, issueTitle);
     const isHeadless = headless !== false;
 
     if (!isHeadless && process.platform === 'win32') {
@@ -1261,7 +1261,7 @@ export class TeamManager {
     });
 
     // ── Step 3: Spawn Claude Code ──
-    const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, effectiveIssueKey);
+    const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, effectiveIssueKey, team.issueTitle ?? undefined);
     const isHeadless = team.headless;
 
     if (!isHeadless && process.platform === 'win32') {
@@ -1565,7 +1565,7 @@ export class TeamManager {
    * Accepts issueKey (string) which replaces the placeholder even for non-numeric keys.
    * Fallback chain: project prompt file > prompts/default-prompt.md > hardcoded default.
    */
-  private resolvePromptFromFile(project: Project, issueKey: string): string {
+  private resolvePromptFromFile(project: Project, issueKey: string, issueTitle?: string): string {
     if (project.promptFile) {
       const absPath = path.join(config.fleetCommanderRoot, project.promptFile);
       if (fs.existsSync(absPath)) {
@@ -1573,7 +1573,8 @@ export class TeamManager {
           const template = fs.readFileSync(absPath, 'utf-8');
           const resolved = template
             .replace(/\{\{ISSUE_NUMBER\}\}/g, issueKey)
-            .replace(/\{\{ISSUE_KEY\}\}/g, issueKey);
+            .replace(/\{\{ISSUE_KEY\}\}/g, issueKey)
+            .replace(/\{\{ISSUE_TITLE\}\}/g, issueTitle ?? '');
           console.log(`[TeamManager] Resolved prompt from file: ${project.promptFile}`);
           return resolved;
         } catch (err: unknown) {
@@ -1591,7 +1592,8 @@ export class TeamManager {
         const template = fs.readFileSync(defaultPath, 'utf-8');
         const resolved = template
           .replace(/\{\{ISSUE_NUMBER\}\}/g, issueKey)
-          .replace(/\{\{ISSUE_KEY\}\}/g, issueKey);
+          .replace(/\{\{ISSUE_KEY\}\}/g, issueKey)
+          .replace(/\{\{ISSUE_TITLE\}\}/g, issueTitle ?? '');
         console.log(`[TeamManager] Resolved prompt from default: prompts/default-prompt.md`);
         return resolved;
       } catch {

--- a/templates/agents/fleet-planner.md
+++ b/templates/agents/fleet-planner.md
@@ -28,9 +28,12 @@ Follow these steps in order:
 > **WARNING**: You MUST read the full issue before doing anything else. Do NOT plan based on the title alone.
 > Skipping this step is the #1 cause of incorrect plans. Read the body, comments, and acceptance criteria.
 
+**First**, check if `.fleet-issue-context.md` exists in the worktree root. Fleet Commander pre-generates this file with full issue context (body, comments, acceptance criteria, linked issues). If the file exists, read it — it contains everything you need and is faster than fetching from GitHub.
+
+**If `.fleet-issue-context.md` does not exist**, fall back to fetching the issue directly:
 Use `gh issue view {{ISSUE_NUMBER}} --json title,body,comments` to read the full issue details.
 
-After reading, confirm you have:
+After reading (from either source), confirm you have:
 - [ ] The full issue body/description
 - [ ] All comments and PM clarifications
 - [ ] Acceptance criteria (explicit or implied)

--- a/templates/agents/fleet-reviewer.md
+++ b/templates/agents/fleet-reviewer.md
@@ -33,7 +33,7 @@ You are spawned **after the developer has finished implementation and reported r
 1. **Read CLAUDE.md** at the project root (or `.claude/CLAUDE.md`) for coding standards, naming conventions, architecture rules, and prohibited patterns.
 2. **Read guidebooks**: if your task prompt lists guidebook paths, read them now so you can verify compliance during review.
 3. **Read the planner's plan**: your task prompt includes the plan that guided the developer. Read it carefully — you will verify implementation against it.
-4. **Read the GitHub issue** for issue **#{{ISSUE_NUMBER}}** — understand the acceptance criteria and requirements.
+4. **Read the acceptance criteria**: your task prompt includes the acceptance criteria from the issue. Use these as your primary verification checklist. If acceptance criteria are not in your task prompt, read the GitHub issue for issue **#{{ISSUE_NUMBER}}** to understand requirements.
 5. **Get the diff**: First run `git fetch origin {{BASE_BRANCH}}` to ensure the base branch is up-to-date. Then identify all changed files against the base branch and begin reviewing.
 
 ```bash

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -109,7 +109,7 @@ Note: These phases represent the workflow's internal progression, not FC's team 
 
 1. **TL spawns `fleet-planner`** with the issue number and project context.
 2. TL enters the Active Monitoring Loop (see below) while waiting for the plan.
-3. Planner analyzes the issue, explores the codebase, discovers guidebooks, and produces a structured plan.
+3. Planner analyzes the issue, explores the codebase, discovers guidebooks, and produces a structured plan. **Note:** Fleet Commander pre-generates a `.fleet-issue-context.md` file in the worktree root before CC starts. If present, the planner should read it for full issue context (body, comments, acceptance criteria) instead of calling `gh issue view`. If the file does not exist, the planner falls back to fetching the issue via `gh`.
 4. Planner writes the plan to `plan.md` in the worktree root. Planner stays alive for p2p questions from dev and reviewer.
 
 ---
@@ -219,6 +219,12 @@ ISSUE: #{N} {title}
 BRANCH: {feat|fix|test}/{N}-{short-desc}
 BASE: {{BASE_BRANCH}}
 
+ISSUE SUMMARY:
+{1-3 sentence summary of what the issue requests}
+
+ACCEPTANCE CRITERIA:
+{bulleted list of acceptance criteria from the issue or plan}
+
 PLAN:
 {paste the full planner's plan here}
 
@@ -265,6 +271,9 @@ INSTRUCTIONS:
 ISSUE: #{N} {title}
 BRANCH: {branch_name}
 BASE: {{BASE_BRANCH}}
+
+ACCEPTANCE CRITERIA:
+{bulleted list of acceptance criteria from the issue or plan}
 
 GUIDEBOOKS (read these to verify compliance):
 {list of guidebook paths from the plan}


### PR DESCRIPTION
Closes #602

## Summary
- Fix pre-existing bug: resolve `{{ISSUE_TITLE}}` placeholder in `resolvePromptFromFile()` (was silently ignored)
- Update `prompts/default-prompt.md` to instruct TL to read `.fleet-issue-context.md`
- Update `templates/workflow.md` Phase 0 with context file note; Dev/Reviewer task formats now include ISSUE SUMMARY and ACCEPTANCE CRITERIA sections
- Update `fleet-planner.md` to read `.fleet-issue-context.md` first, fall back to `gh issue view`
- Update `fleet-reviewer.md` to use TL-provided acceptance criteria from spawn prompt
- All template/agent prompt pairs kept in sync (`templates/agents/` ↔ `.claude/agents/`, `templates/workflow.md` ↔ `.claude/prompts/fleet-workflow.md`)

## Note on scope
PR #609 (Issue #599) merged while this branch was in development, adding `generateIssueContext()` integration in `team-manager.ts` and the `.gitignore` entry. This PR no longer duplicates that work — the `issue-context-writer.ts` adapter was removed during rebase conflict resolution. What remains are the prompt/template updates and the `{{ISSUE_TITLE}}` bug fix.

## Test plan
- [x] `tsc --noEmit` passes (zero errors)
- [x] `npm run test:server` — 62 test files pass, 1464 tests pass (3 pre-existing failures in cc-spawn.test.ts unrelated to this change)
- [x] All team-manager test files pass with existing mocks