### PR TITLE
Issue #603: Add IssueUpdatePoller for mid-execution issue change detection

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -115,6 +115,7 @@ const config = Object.freeze({
 
   githubPollIntervalMs: safeParseInt(process.env['FLEET_GITHUB_POLL_MS'] || '30000', 'FLEET_GITHUB_POLL_MS'),
   issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '60000', 'FLEET_ISSUE_POLL_MS'),
+  issueUpdatePollMs: safeParseInt(process.env['FLEET_ISSUE_UPDATE_POLL_MS'] || '30000', 'FLEET_ISSUE_UPDATE_POLL_MS'),
   stuckCheckIntervalMs: safeParseInt(process.env['FLEET_STUCK_CHECK_MS'] || '60000', 'FLEET_STUCK_CHECK_MS'),
   usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '900000', 'FLEET_USAGE_POLL_MS'),
   mapCleanupIntervalMs: safeParseInt(process.env['FLEET_MAP_CLEANUP_MS'] || '3600000', 'FLEET_MAP_CLEANUP_MS'),
@@ -198,6 +199,7 @@ export function validateConfig(): void {
   const positiveIntegers: Array<[string, number]> = [
     ['githubPollIntervalMs', config.githubPollIntervalMs],
     ['issuePollIntervalMs', config.issuePollIntervalMs],
+    ['issueUpdatePollMs', config.issueUpdatePollMs],
     ['stuckCheckIntervalMs', config.stuckCheckIntervalMs],
     ['usagePollIntervalMs', config.usagePollIntervalMs],
     ['mapCleanupIntervalMs', config.mapCleanupIntervalMs],

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,7 @@ import { sseBroker } from './services/sse-broker.js';
 import { getIssueFetcher } from './services/issue-fetcher.js';
 import { stuckDetector } from './services/stuck-detector.js';
 import { githubPoller } from './services/github-poller.js';
+import { issueUpdatePoller } from './services/issue-update-poller.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { getDatabase, closeDatabase } from './db.js';
 import { recoverOnStartup } from './services/startup-recovery.js';
@@ -161,16 +162,18 @@ async function main() {
   issueFetcher.start();
   stuckDetector.start();
   githubPoller.start();
+  issueUpdatePoller.start();
   usagePoller.start();
   dataRetention.start();
   getTeamManager().startPeriodicCleanup();
-  server.log.info('All services started (SSE, issues, stuck detector, GitHub poller, usage poller, data retention, map cleanup)');
+  server.log.info('All services started (SSE, issues, stuck detector, GitHub poller, issue update poller, usage poller, data retention, map cleanup)');
 
   // Graceful shutdown
   server.addHook('onClose', async () => {
     getTeamManager().stopPeriodicCleanup();
     dataRetention.stop();
     usagePoller.stop();
+    issueUpdatePoller.stop();
     githubPoller.stop();
     stuckDetector.stop();
     issueFetcher.stop();

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -250,6 +250,26 @@ INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
   ('stuck_nudge',
    'Hey, you have been idle for a while on issue #{{ISSUE_NUMBER}}. What is the status? Do you need help?',
    'Nudge sent to TL when team transitions to stuck');
+INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
+  ('issue_comment_new',
+   'New comment on issue #{{ISSUE_KEY}} by @{{COMMENT_AUTHOR}}:
+
+{{COMMENT_BODY}}',
+   'Sent to TL when a new non-bot comment is posted on the issue');
+INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
+  ('issue_labels_changed',
+   'Labels changed on issue #{{ISSUE_KEY}}: {{LABELS_ADDED}} added, {{LABELS_REMOVED}} removed. Current labels: {{CURRENT_LABELS}}.',
+   'Sent to TL when priority/blocking labels change on the issue');
+INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
+  ('issue_closed_externally',
+   'Issue #{{ISSUE_KEY}} was closed externally. Wrap up your current work, commit any pending changes, and shut down gracefully.',
+   'Sent to TL when the issue is closed outside of the team workflow');
+INSERT OR IGNORE INTO message_templates (id, template, description) VALUES
+  ('issue_body_updated',
+   'The description of issue #{{ISSUE_KEY}} has been updated. Review the latest requirements:
+
+{{BODY_DIFF_SUMMARY}}',
+   'Sent to TL when the issue body/description is edited');
 
 -- ---------------------------------------------------------------------------
 -- TEAM TRANSITIONS — state machine transition history per team

--- a/src/server/services/issue-update-poller.ts
+++ b/src/server/services/issue-update-poller.ts
@@ -1,0 +1,446 @@
+// =============================================================================
+// Fleet Commander — Issue Update Poller Service
+// =============================================================================
+// Polls running teams' issues every 30s (configurable) for mid-execution
+// changes: new comments, label changes, body edits, and external closure.
+// Detects changes by comparing against in-memory snapshots and sends
+// structured messages to the team lead via stdin.
+//
+// Follows the same singleton + class pattern as github-poller.ts:
+//   - setTimeout (not setInterval) to prevent overlapping poll cycles
+//   - In-memory snapshot map (ephemeral, not persisted)
+//   - First poll initializes snapshots without sending notifications
+//   - Bot comments are filtered out
+//   - Only priority/blocking label changes trigger notifications
+//
+// Supports GitHub (via `gh` CLI). Jira is stubbed for future implementation.
+// =============================================================================
+
+import { getDatabase } from '../db.js';
+import config from '../config.js';
+import { sseBroker } from './sse-broker.js';
+import { resolveMessage } from '../utils/resolve-message.js';
+import { execGHAsync, isValidGithubRepo } from '../utils/exec-gh.js';
+import type { Team } from '../../shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex patterns for labels that trigger notifications when added or removed.
+ * Other label changes (e.g. 'documentation', 'enhancement') are filtered as noise.
+ */
+const PRIORITY_LABEL_PATTERNS: RegExp[] = [
+  /^priority[:/]/i,
+  /^P[0-4]$/,
+  /^block/i,
+  /^urgent$/i,
+  /^critical$/i,
+];
+
+/**
+ * Statuses that represent a team with a live stdin pipe.
+ * We skip 'queued' (no process) and 'launching' (not ready yet).
+ */
+const POLLABLE_STATUSES = new Set(['running', 'idle', 'stuck']);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Per-team snapshot of the issue state for change detection. */
+interface IssueSnapshot {
+  commentCount: number;
+  labels: string[];
+  state: string;
+  bodyHash: string;
+}
+
+/** Shape of the JSON returned by `gh issue view`. */
+interface GHIssueComment {
+  author: { login: string; type?: string };
+  body: string;
+  createdAt: string;
+}
+
+interface GHIssueViewResult {
+  number: number;
+  title: string;
+  state: string;
+  body: string | null;
+  labels: Array<{ name: string }>;
+  comments: GHIssueComment[];
+  updatedAt: string;
+}
+
+/** A detected change to be processed into a message. */
+interface IssueChange {
+  type: 'comment' | 'labels' | 'closed' | 'body';
+  templateId: string;
+  vars: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Issue Update Poller
+// ---------------------------------------------------------------------------
+
+class IssueUpdatePoller {
+  private timer: NodeJS.Timeout | null = null;
+  private isPolling = false;
+
+  /**
+   * In-memory snapshots keyed by team ID.
+   * First poll initializes without sending notifications.
+   * Lost on restart — by design (acceptance criterion).
+   */
+  private snapshots = new Map<number, IssueSnapshot>();
+
+  /**
+   * Start the polling loop. First poll fires after 10s delay, then
+   * every `config.issueUpdatePollMs` milliseconds.
+   */
+  start(): void {
+    if (this.timer) return; // already running
+
+    const initialTimer = setTimeout(() => this.poll(), 10_000);
+    if (initialTimer.unref) initialTimer.unref();
+
+    this.scheduleNextPoll();
+    console.log(
+      `[IssueUpdatePoller] Started — interval ${config.issueUpdatePollMs}ms`,
+    );
+  }
+
+  /** Stop the polling loop. */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+      console.log('[IssueUpdatePoller] Stopped');
+    }
+  }
+
+  /**
+   * Remove the snapshot for a team. Called externally when a team is stopped
+   * so we don't accumulate stale entries.
+   */
+  removeTeam(teamId: number): void {
+    this.snapshots.delete(teamId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: scheduling
+  // -------------------------------------------------------------------------
+
+  private scheduleNextPoll(): void {
+    if (this.timer) clearTimeout(this.timer);
+
+    this.timer = setTimeout(() => {
+      this.poll().finally(() => this.scheduleNextPoll());
+    }, config.issueUpdatePollMs);
+
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: main poll loop
+  // -------------------------------------------------------------------------
+
+  private async poll(): Promise<void> {
+    if (this.isPolling) {
+      return; // previous cycle still running
+    }
+    this.isPolling = true;
+
+    try {
+      const db = getDatabase();
+      const allTeams = db.getActiveTeams();
+
+      // Only poll teams with a live stdin pipe
+      const teams = allTeams.filter((t) => POLLABLE_STATUSES.has(t.status));
+      if (teams.length === 0) return;
+
+      // Build project map for resolving github repos
+      const projects = db.getProjects({ status: 'active' });
+      const projectMap = new Map(
+        projects.map((p) => [p.id, p]),
+      );
+
+      for (const team of teams) {
+        try {
+          if (!team.projectId) continue;
+
+          const project = projectMap.get(team.projectId);
+          if (!project) continue;
+
+          const provider = project.issueProvider || 'github';
+
+          if (provider === 'github' && project.githubRepo) {
+            await this.pollGitHubIssue(team, project.githubRepo);
+          }
+          // Jira / Linear — stub for future implementation
+        } catch (err) {
+          console.error(
+            `[IssueUpdatePoller] Error polling team ${team.id} (issue #${team.issueNumber}):`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    } finally {
+      this.isPolling = false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: GitHub issue polling
+  // -------------------------------------------------------------------------
+
+  private async pollGitHubIssue(
+    team: Team,
+    githubRepo: string,
+  ): Promise<void> {
+    if (!isValidGithubRepo(githubRepo)) {
+      return;
+    }
+
+    const issueKey = team.issueKey || String(team.issueNumber);
+
+    const raw = await execGHAsync(
+      `gh issue view ${team.issueNumber} --repo "${githubRepo}" --json number,state,body,labels,comments,updatedAt`,
+    );
+    if (!raw) return; // gh CLI failed — skip this cycle, don't update snapshot
+
+    let data: GHIssueViewResult;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      console.error(
+        `[IssueUpdatePoller] Failed to parse gh output for issue #${team.issueNumber}`,
+      );
+      return;
+    }
+
+    const currentLabels = (data.labels || []).map((l) => l.name);
+    const currentState = (data.state || 'OPEN').toUpperCase();
+    const currentBodyHash = hashString(data.body || '');
+
+    // Filter out bot comments to get non-bot comment count
+    const nonBotComments = (data.comments || []).filter(
+      (c) => !isBot(c.author),
+    );
+
+    const existing = this.snapshots.get(team.id);
+
+    if (!existing) {
+      // First poll — initialize snapshot without sending notifications
+      this.snapshots.set(team.id, {
+        commentCount: nonBotComments.length,
+        labels: currentLabels,
+        state: currentState,
+        bodyHash: currentBodyHash,
+      });
+      return;
+    }
+
+    // Detect changes
+    const changes: IssueChange[] = [];
+
+    // 1. New non-bot comments
+    if (nonBotComments.length > existing.commentCount) {
+      // Get new comments (those after the previously known count)
+      const newComments = nonBotComments.slice(existing.commentCount);
+      if (newComments.length > 0) {
+        // Send the latest comment to the team. If there are multiple new
+        // comments, include a count note.
+        const latest = newComments[newComments.length - 1]!;
+        let commentBody = latest.body;
+        if (newComments.length > 1) {
+          commentBody = `[${newComments.length} new comments — showing latest]\n\n${commentBody}`;
+        }
+        changes.push({
+          type: 'comment',
+          templateId: 'issue_comment_new',
+          vars: {
+            ISSUE_KEY: issueKey,
+            COMMENT_AUTHOR: latest.author.login,
+            COMMENT_BODY: commentBody,
+          },
+        });
+      }
+    }
+
+    // 2. Label changes (only priority/blocking labels)
+    const addedLabels = currentLabels.filter(
+      (l) => !existing.labels.includes(l),
+    );
+    const removedLabels = existing.labels.filter(
+      (l) => !currentLabels.includes(l),
+    );
+    const priorityAdded = addedLabels.filter(isPriorityLabel);
+    const priorityRemoved = removedLabels.filter(isPriorityLabel);
+
+    if (priorityAdded.length > 0 || priorityRemoved.length > 0) {
+      changes.push({
+        type: 'labels',
+        templateId: 'issue_labels_changed',
+        vars: {
+          ISSUE_KEY: issueKey,
+          LABELS_ADDED: priorityAdded.length > 0 ? priorityAdded.join(', ') : 'none',
+          LABELS_REMOVED: priorityRemoved.length > 0 ? priorityRemoved.join(', ') : 'none',
+          CURRENT_LABELS: currentLabels.length > 0 ? currentLabels.join(', ') : 'none',
+        },
+      });
+    }
+
+    // 3. Issue closed externally
+    if (
+      existing.state === 'OPEN' &&
+      currentState === 'CLOSED'
+    ) {
+      changes.push({
+        type: 'closed',
+        templateId: 'issue_closed_externally',
+        vars: { ISSUE_KEY: issueKey },
+      });
+    }
+
+    // 4. Body updated
+    if (existing.bodyHash !== currentBodyHash) {
+      // Provide a summary — we cannot diff markdown easily, so tell the TL
+      // to review the latest requirements.
+      changes.push({
+        type: 'body',
+        templateId: 'issue_body_updated',
+        vars: {
+          ISSUE_KEY: issueKey,
+          BODY_DIFF_SUMMARY: 'The issue body has been modified. Please re-read the issue for updated requirements.',
+        },
+      });
+    }
+
+    // Update the snapshot with current values
+    this.snapshots.set(team.id, {
+      commentCount: nonBotComments.length,
+      labels: currentLabels,
+      state: currentState,
+      bodyHash: currentBodyHash,
+    });
+
+    // Send messages for all detected changes
+    if (changes.length > 0) {
+      await this.sendChangeMessages(team, changes);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: send messages to the team
+  // -------------------------------------------------------------------------
+
+  private async sendChangeMessages(
+    team: Team,
+    changes: IssueChange[],
+  ): Promise<void> {
+    try {
+      const { getTeamManager } = await import('./team-manager.js');
+      const manager = getTeamManager();
+
+      for (const change of changes) {
+        const msg = resolveMessage(change.templateId, change.vars);
+        if (msg) {
+          manager.sendMessage(team.id, msg, 'fc', change.templateId);
+        }
+
+        // External closure triggers graceful shutdown
+        if (change.type === 'closed') {
+          const db = getDatabase();
+          const previousStatus = team.status;
+
+          db.insertTransition({
+            teamId: team.id,
+            fromStatus: previousStatus,
+            toStatus: 'done',
+            trigger: 'poller',
+            reason: 'Issue closed externally',
+          });
+          db.updateTeamSilent(team.id, {
+            status: 'done',
+            phase: 'done',
+            stoppedAt: new Date().toISOString(),
+          });
+
+          sseBroker.broadcast(
+            'team_status_changed',
+            {
+              team_id: team.id,
+              status: 'done',
+              previous_status: previousStatus,
+            },
+            team.id,
+          );
+
+          console.log(
+            `[IssueUpdatePoller] Team ${team.id} marked done — issue #${team.issueNumber} closed externally`,
+          );
+
+          manager.stop(team.id);
+
+          // Remove snapshot since team is done
+          this.snapshots.delete(team.id);
+
+          // No further changes matter after closure
+          break;
+        }
+      }
+    } catch (err) {
+      console.error(
+        `[IssueUpdatePoller] Failed to send messages to team ${team.id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions (module-level for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a label matches known priority/blocking patterns.
+ */
+function isPriorityLabel(label: string): boolean {
+  return PRIORITY_LABEL_PATTERNS.some((re) => re.test(label));
+}
+
+/**
+ * Check if a comment author is a bot.
+ * Uses the `type` field when available, falls back to login suffix.
+ */
+function isBot(author: { login: string; type?: string }): boolean {
+  if (author.type === 'Bot') return true;
+  if (author.login.endsWith('[bot]')) return true;
+  return false;
+}
+
+/**
+ * Simple djb2 hash of a string, returned as a hex string.
+ * No crypto needed — this is for change detection, not security.
+ */
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0; // hash * 33 + char
+  }
+  // Convert to unsigned 32-bit hex
+  return (hash >>> 0).toString(16);
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+export const issueUpdatePoller = new IssueUpdatePoller();
+
+// Export utilities for testing
+export { isPriorityLabel, isBot, hashString };
+export type { IssueSnapshot, GHIssueViewResult, GHIssueComment, IssueChange };

--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -125,4 +125,32 @@ export const DEFAULT_MESSAGE_TEMPLATES: DefaultMessageTemplate[] = [
     description: 'Sent to TL when PR branch is no longer behind main',
     placeholders: ['PR_NUMBER'],
   },
+  {
+    id: 'issue_comment_new',
+    template:
+      'New comment on issue #{{ISSUE_KEY}} by @{{COMMENT_AUTHOR}}:\n\n{{COMMENT_BODY}}',
+    description: 'Sent to TL when a new non-bot comment is posted on the issue',
+    placeholders: ['ISSUE_KEY', 'COMMENT_AUTHOR', 'COMMENT_BODY'],
+  },
+  {
+    id: 'issue_labels_changed',
+    template:
+      'Labels changed on issue #{{ISSUE_KEY}}: {{LABELS_ADDED}} added, {{LABELS_REMOVED}} removed. Current labels: {{CURRENT_LABELS}}.',
+    description: 'Sent to TL when priority/blocking labels change on the issue',
+    placeholders: ['ISSUE_KEY', 'LABELS_ADDED', 'LABELS_REMOVED', 'CURRENT_LABELS'],
+  },
+  {
+    id: 'issue_closed_externally',
+    template:
+      'Issue #{{ISSUE_KEY}} was closed externally. Wrap up your current work, commit any pending changes, and shut down gracefully.',
+    description: 'Sent to TL when the issue is closed outside of the team workflow',
+    placeholders: ['ISSUE_KEY'],
+  },
+  {
+    id: 'issue_body_updated',
+    template:
+      'The description of issue #{{ISSUE_KEY}} has been updated. Review the latest requirements:\n\n{{BODY_DIFF_SUMMARY}}',
+    description: 'Sent to TL when the issue body/description is edited',
+    placeholders: ['ISSUE_KEY', 'BODY_DIFF_SUMMARY'],
+  },
 ];

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -342,6 +342,48 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     condition: 'Merge status changes from behind to another state (not dirty)',
     hookEvent: null,
   },
+
+  // ---- Issue update poller transitions ----
+  {
+    id: 'issue_comment_new',
+    from: 'running',
+    to: 'running',
+    trigger: 'poller',
+    triggerLabel: 'New issue comment',
+    description: 'A new non-bot comment was posted on the issue. Forwarded to TL for awareness.',
+    condition: 'New comment detected on issue (bot comments filtered)',
+    hookEvent: null,
+  },
+  {
+    id: 'issue_labels_changed',
+    from: 'running',
+    to: 'running',
+    trigger: 'poller',
+    triggerLabel: 'Issue labels changed',
+    description: 'Priority or blocking labels changed on the issue.',
+    condition: 'Priority/blocking label added or removed',
+    hookEvent: null,
+  },
+  {
+    id: 'issue_closed_externally',
+    from: '*',
+    to: 'done',
+    trigger: 'poller',
+    triggerLabel: 'Issue closed externally',
+    description: 'The issue was closed outside of the team workflow. Team receives shutdown message and is stopped gracefully.',
+    condition: 'Issue state changed from open to closed',
+    hookEvent: null,
+  },
+  {
+    id: 'issue_body_updated',
+    from: 'running',
+    to: 'running',
+    trigger: 'poller',
+    triggerLabel: 'Issue body updated',
+    description: 'The issue description was edited. TL is notified to review updated requirements.',
+    condition: 'Issue body hash changed',
+    hookEvent: null,
+  },
 ];
 
 // =============================================================================

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -387,6 +387,10 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 | `pr_merged` | PR is merged | "PR #{PR} merged. Close the issue, clean up, and finish." |
 | `nudge_idle` | Team idle 5+ min | "FC status check: You've been idle for {N} minutes. If waiting for subagents, run TaskList to verify they are still active. If a phase just completed, proceed to the next step." |
 | `nudge_stuck` | Team stuck 10+ min | "You appear stuck. Report status or ask for help." |
+| `issue_comment_new` | New non-bot comment on issue | "New comment on issue #{KEY} by @{author}: {body}" |
+| `issue_labels_changed` | Priority/blocking labels change | "Labels changed on issue #{KEY}: {added} added, {removed} removed." |
+| `issue_closed_externally` | Issue closed outside team | "Issue #{KEY} was closed externally. Wrap up and shut down." |
+| `issue_body_updated` | Issue description edited | "The description of issue #{KEY} has been updated. Review latest requirements." |
 
 ### TL Response to FC Messages
 
@@ -401,6 +405,14 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 **On `nudge_idle`**: Run `TaskList` to verify all subagents are alive. If any agent is missing or crashed, respawn it. Report current status to FC.
 
 **On `nudge_stuck`**: Check which agent is stuck. Send a targeted nudge. If no progress after nudge, escalate to FC by reporting status.
+
+**On `issue_comment_new`**: Review the new comment for any instructions or questions from the issue reporter. If the comment contains new requirements or clarifications, forward relevant details to the dev agent. If it's just acknowledgment, no action needed.
+
+**On `issue_labels_changed`**: Check the label change for priority shifts. If a `blocking` or `urgent` label was added, prioritize accordingly. If `blocked` was added, check what's blocking and report to FC.
+
+**On `issue_closed_externally`**: The issue was closed by someone outside the team. Stop all active work immediately. Commit any pending changes, push to the branch, and shut down all agents gracefully.
+
+**On `issue_body_updated`**: Re-read the issue description for updated requirements. If the changes affect current implementation, forward the updated requirements to dev. If dev has already completed the affected work, assess whether rework is needed.
 
 ---
 

--- a/tests/server/issue-update-poller.test.ts
+++ b/tests/server/issue-update-poller.test.ts
@@ -1,0 +1,580 @@
+// =============================================================================
+// Fleet Commander — Issue Update Poller Tests
+// =============================================================================
+// Tests for the IssueUpdatePoller service: snapshot initialization, comment
+// detection, bot filtering, label filtering, body change detection, external
+// closure, and status filtering.
+//
+// Follows the same mock pattern as github-poller.test.ts.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Team, Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getProjects: vi.fn().mockReturnValue([]),
+  getTeam: vi.fn(),
+  getProject: vi.fn(),
+  updateTeamSilent: vi.fn(),
+  insertTransition: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    issueUpdatePollMs: 30000,
+  },
+}));
+
+const mockSseBroker = {
+  broadcast: vi.fn(),
+};
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+const mockResolveMessage = vi.fn().mockReturnValue(null);
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: (...args: unknown[]) => mockResolveMessage(...args),
+}));
+
+const mockManager = {
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+};
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: () => mockManager,
+}));
+
+const mockExecGHAsync = vi.fn().mockResolvedValue(null);
+vi.mock('../../src/server/utils/exec-gh.js', () => ({
+  execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
+  isValidGithubRepo: (repo: string) => /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(repo),
+}));
+
+// Import after mocks
+const { issueUpdatePoller } = await import(
+  '../../src/server/services/issue-update-poller.js'
+);
+const { isPriorityLabel, isBot, hashString } = await import(
+  '../../src/server/services/issue-update-poller.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides?: Partial<Team>): Partial<Team> {
+  return {
+    id: 1,
+    issueNumber: 42,
+    issueTitle: 'Test issue',
+    issueKey: '42',
+    issueProvider: 'github',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-1',
+    worktreeName: 'proj-42',
+    branchName: 'feat/42-test',
+    prNumber: null,
+    customPrompt: null,
+    headless: false,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCostUsd: 0,
+    launchedAt: new Date().toISOString(),
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    blockedByJson: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeProject(overrides?: Partial<Project>): Partial<Project> {
+  return {
+    id: 1,
+    name: 'my-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 2,
+    promptFile: null,
+    issueProvider: 'github',
+    projectKey: null,
+    providerConfig: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeGHIssueView(overrides?: Record<string, unknown>) {
+  return JSON.stringify({
+    number: 42,
+    title: 'Test issue',
+    state: 'OPEN',
+    body: 'Issue body text',
+    labels: [],
+    comments: [],
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  mockDb.getActiveTeams.mockReturnValue([]);
+  mockDb.getProjects.mockReturnValue([]);
+  // Clear snapshots between tests by removing known team IDs
+  issueUpdatePoller.removeTeam(1);
+  issueUpdatePoller.removeTeam(2);
+});
+
+afterEach(() => {
+  issueUpdatePoller.stop();
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// Utility function tests
+// =============================================================================
+
+describe('isPriorityLabel', () => {
+  it('matches priority/* labels', () => {
+    expect(isPriorityLabel('priority/high')).toBe(true);
+    expect(isPriorityLabel('priority:low')).toBe(true);
+    expect(isPriorityLabel('Priority/Critical')).toBe(true);
+  });
+
+  it('matches P0-P4 labels', () => {
+    expect(isPriorityLabel('P0')).toBe(true);
+    expect(isPriorityLabel('P4')).toBe(true);
+    expect(isPriorityLabel('P5')).toBe(false);
+  });
+
+  it('matches blocking/blocked/urgent/critical', () => {
+    expect(isPriorityLabel('blocking')).toBe(true);
+    expect(isPriorityLabel('blocked')).toBe(true);
+    expect(isPriorityLabel('blocker')).toBe(true);
+    expect(isPriorityLabel('urgent')).toBe(true);
+    expect(isPriorityLabel('critical')).toBe(true);
+  });
+
+  it('does not match general labels', () => {
+    expect(isPriorityLabel('enhancement')).toBe(false);
+    expect(isPriorityLabel('documentation')).toBe(false);
+    expect(isPriorityLabel('bug')).toBe(false);
+  });
+});
+
+describe('isBot', () => {
+  it('detects Bot type', () => {
+    expect(isBot({ login: 'dependabot', type: 'Bot' })).toBe(true);
+  });
+
+  it('detects [bot] suffix', () => {
+    expect(isBot({ login: 'dependabot[bot]' })).toBe(true);
+    expect(isBot({ login: 'github-actions[bot]' })).toBe(true);
+  });
+
+  it('does not flag human users', () => {
+    expect(isBot({ login: 'octocat', type: 'User' })).toBe(false);
+    expect(isBot({ login: 'developer' })).toBe(false);
+  });
+});
+
+describe('hashString', () => {
+  it('produces consistent hashes', () => {
+    expect(hashString('hello')).toBe(hashString('hello'));
+  });
+
+  it('produces different hashes for different strings', () => {
+    expect(hashString('hello')).not.toBe(hashString('world'));
+  });
+
+  it('returns a hex string', () => {
+    expect(hashString('test')).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+// =============================================================================
+// Poll behavior tests
+// =============================================================================
+
+describe('IssueUpdatePoller', () => {
+  it('first poll initializes snapshots without sending messages', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView());
+    mockResolveMessage.mockReturnValue('test message');
+
+    // Trigger poll manually
+    // Access the private poll method via the prototype
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // No messages should be sent on first poll
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+    expect(mockResolveMessage).not.toHaveBeenCalled();
+  });
+
+  it('detects new non-bot comment on second poll', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — initialize snapshot with 0 comments
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ comments: [] }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — one new human comment
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        comments: [
+          {
+            author: { login: 'octocat', type: 'User' },
+            body: 'Please also fix the typo on line 10.',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+    mockResolveMessage.mockReturnValue('New comment on issue #42 by @octocat');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(mockResolveMessage).toHaveBeenCalledWith(
+      'issue_comment_new',
+      expect.objectContaining({
+        ISSUE_KEY: '42',
+        COMMENT_AUTHOR: 'octocat',
+      }),
+    );
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'New comment on issue #42 by @octocat',
+      'fc',
+      'issue_comment_new',
+    );
+  });
+
+  it('filters out bot comments', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — no comments
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ comments: [] }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — only bot comments
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        comments: [
+          {
+            author: { login: 'dependabot[bot]', type: 'Bot' },
+            body: 'Bumped dependency X',
+            createdAt: new Date().toISOString(),
+          },
+          {
+            author: { login: 'github-actions[bot]' },
+            body: 'CI report',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // No messages should be sent — all comments are from bots
+    expect(mockResolveMessage).not.toHaveBeenCalled();
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('detects external issue closure and triggers shutdown', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — issue is OPEN
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'OPEN' }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — issue is CLOSED
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'CLOSED' }));
+    mockResolveMessage.mockReturnValue('Issue #42 was closed externally.');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Should send the closure message
+    expect(mockResolveMessage).toHaveBeenCalledWith(
+      'issue_closed_externally',
+      expect.objectContaining({ ISSUE_KEY: '42' }),
+    );
+
+    // Should insert transition and update team status
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'done',
+        trigger: 'poller',
+        reason: 'Issue closed externally',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        status: 'done',
+        phase: 'done',
+      }),
+    );
+
+    // Should broadcast status change
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({
+        team_id: 1,
+        status: 'done',
+        previous_status: 'running',
+      }),
+      1,
+    );
+
+    // Should stop the team
+    expect(mockManager.stop).toHaveBeenCalledWith(1);
+  });
+
+  it('only notifies for priority/blocking label changes', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — no labels
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ labels: [] }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — added 'enhancement' (non-priority) and 'P0' (priority)
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        labels: [{ name: 'enhancement' }, { name: 'P0' }],
+      }),
+    );
+    mockResolveMessage.mockReturnValue('Labels changed');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Should notify — P0 is a priority label
+    expect(mockResolveMessage).toHaveBeenCalledWith(
+      'issue_labels_changed',
+      expect.objectContaining({
+        ISSUE_KEY: '42',
+        LABELS_ADDED: 'P0',
+      }),
+    );
+  });
+
+  it('does not notify for non-priority label changes only', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — no labels
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ labels: [] }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — only non-priority labels added
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        labels: [{ name: 'enhancement' }, { name: 'documentation' }],
+      }),
+    );
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // No label notification should fire
+    expect(mockResolveMessage).not.toHaveBeenCalled();
+  });
+
+  it('detects body edit', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — initial body
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({ body: 'Original body text' }),
+    );
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — body changed
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({ body: 'Updated body text with new requirements' }),
+    );
+    mockResolveMessage.mockReturnValue('Issue body updated');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    expect(mockResolveMessage).toHaveBeenCalledWith(
+      'issue_body_updated',
+      expect.objectContaining({
+        ISSUE_KEY: '42',
+      }),
+    );
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'Issue body updated',
+      'fc',
+      'issue_body_updated',
+    );
+  });
+
+  it('only polls running/idle/stuck teams, not queued or launching', async () => {
+    const queuedTeam = makeTeam({ id: 1, status: 'queued' });
+    const launchingTeam = makeTeam({ id: 2, status: 'launching' });
+    const runningTeam = makeTeam({ id: 3, status: 'running', issueNumber: 100, issueKey: '100' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([queuedTeam, launchingTeam, runningTeam]);
+    mockDb.getProjects.mockReturnValue([project]);
+    mockExecGHAsync.mockResolvedValue(makeGHIssueView({ number: 100 }));
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Only the running team should have triggered a gh call
+    expect(mockExecGHAsync).toHaveBeenCalledTimes(1);
+    expect(mockExecGHAsync).toHaveBeenCalledWith(
+      expect.stringContaining('100'),
+    );
+  });
+
+  it('batches multiple changes in one poll cycle into one message set', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — initialize
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        body: 'Original',
+        labels: [],
+        comments: [],
+      }),
+    );
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — body changed AND new comment AND priority label added
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        body: 'Updated requirements',
+        labels: [{ name: 'P1' }],
+        comments: [
+          {
+            author: { login: 'human', type: 'User' },
+            body: 'Added priority label.',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+    mockResolveMessage.mockReturnValue('some message');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Should have resolved 3 templates: comment, labels, body
+    expect(mockResolveMessage).toHaveBeenCalledWith('issue_comment_new', expect.any(Object));
+    expect(mockResolveMessage).toHaveBeenCalledWith('issue_labels_changed', expect.any(Object));
+    expect(mockResolveMessage).toHaveBeenCalledWith('issue_body_updated', expect.any(Object));
+    expect(mockResolveMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips team when gh CLI fails', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // gh CLI returns null (failure)
+    mockExecGHAsync.mockResolvedValueOnce(null);
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // No messages, no errors
+    expect(mockResolveMessage).not.toHaveBeenCalled();
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('handles idle and stuck teams', async () => {
+    const idleTeam = makeTeam({ id: 1, status: 'idle', issueNumber: 10, issueKey: '10' });
+    const stuckTeam = makeTeam({ id: 2, status: 'stuck', issueNumber: 20, issueKey: '20' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([idleTeam, stuckTeam]);
+    mockDb.getProjects.mockReturnValue([project]);
+    mockExecGHAsync.mockResolvedValue(makeGHIssueView());
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Both should be polled
+    expect(mockExecGHAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('removeTeam clears snapshot so next poll re-initializes', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — initialize
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ comments: [] }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Remove the team's snapshot
+    issueUpdatePoller.removeTeam(1);
+
+    // Next poll should re-initialize without sending messages
+    mockExecGHAsync.mockResolvedValueOnce(
+      makeGHIssueView({
+        comments: [
+          {
+            author: { login: 'octocat', type: 'User' },
+            body: 'Hello',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Should NOT send a message — this is a re-initialization
+    expect(mockManager.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #603

## Summary
- New `IssueUpdatePoller` service that polls active teams' issues every 30s for changes (new comments, label changes, external closure, body edits) and pushes updates to the TL via stdin
- 4 new message templates (`issue_comment_new`, `issue_labels_changed`, `issue_closed_externally`, `issue_body_updated`) added to `DEFAULT_MESSAGE_TEMPLATES` and seeded in `schema.sql`
- 4 new state machine transitions in `state-machine.ts` documenting the poller-triggered events
- Bot comment filtering (by author type and login suffix `[bot]`)
- Priority/blocking label filtering (only `priority/*`, `P0-P4`, `blocking`, `urgent`, `critical` labels trigger notifications)
- External issue closure triggers graceful team shutdown (transition to `done`)
- First poll after restart initializes snapshots silently (no false notifications)
- Config property `issueUpdatePollMs` (env `FLEET_ISSUE_UPDATE_POLL_MS`, default 30000)
- Workflow template updated with 4 new FC message types and TL response rules
- 22 unit tests covering all key scenarios

## Test plan
- [ ] `npm run test:server` — 22 new tests pass for issue-update-poller
- [ ] Verify first poll after server start does not send notifications
- [ ] Verify new comment on active team's issue is detected and forwarded
- [ ] Verify bot comments are filtered
- [ ] Verify external closure triggers graceful shutdown