### PR TITLE
Issue #611: Fix dependency gate silently bypassed by permissive null fallback

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -863,11 +863,21 @@ function RunAllConfirmDialog({ issues, skippedActive, blockedIssues, projectId, 
     try {
       await api.post('teams/launch-batch', {
         projectId,
-        issues: [...issues, ...blockedIssues].map((n) => ({
+        issues: issues.map((n) => ({
           number: n.number,
           title: n.title,
           issueKey: n.issueKey,
         })),
+        blockedIssues: blockedIssues.length > 0
+          ? blockedIssues.map((n) => ({
+              number: n.number,
+              title: n.title,
+              issueKey: n.issueKey,
+              blockedBy: n.dependencies?.blockedBy
+                ?.filter((b) => b.state === 'open')
+                .map((b) => b.number) ?? [],
+            }))
+          : undefined,
       });
       onClose();
       // Give the server a moment to process, then refresh

--- a/src/server/providers/github-issue-provider.ts
+++ b/src/server/providers/github-issue-provider.ts
@@ -614,13 +614,13 @@ export class GitHubIssueProvider implements IssueProvider {
       return result;
     }
 
-    // If the full query failed and blockedBy was enabled, downgrade and retry
+    // If the full query failed and blockedBy was enabled, retry with basic
+    // query locally but do NOT persist the flag change -- only batch queries
+    // should toggle blockedBySupported to avoid cascading downgrades.
     if (this.blockedBySupported) {
-      this.blockedBySupported = false;
-      this.blockedByRetryCountdown = 5;
       console.warn(
-        '[GitHubIssueProvider] blockedBySupported changed: true -> false ' +
-        '(single-issue deps query field error; will retry after 5 poll cycles)'
+        '[GitHubIssueProvider] Single-issue deps query failed with full query; ' +
+        'retrying with basic query (blockedBySupported flag NOT changed)'
       );
       return this.runSingleIssueDepsQuery(SINGLE_ISSUE_DEPS_QUERY_BASIC, owner, repo, issueNumber);
     }
@@ -652,13 +652,13 @@ export class GitHubIssueProvider implements IssueProvider {
 
     let result = await this.runIssueContextQuery(query, owner, repo, issueNumber);
 
-    // If the full query failed and blockedBy was enabled, downgrade and retry
+    // If the full query failed and blockedBy was enabled, retry with basic
+    // query locally but do NOT persist the flag change -- only batch queries
+    // should toggle blockedBySupported to avoid cascading downgrades.
     if (result === null && this.blockedBySupported) {
-      this.blockedBySupported = false;
-      this.blockedByRetryCountdown = 5;
       console.warn(
-        '[GitHubIssueProvider] blockedBySupported changed: true -> false ' +
-        '(issue context query field error; will retry after 5 poll cycles)'
+        '[GitHubIssueProvider] Issue context query failed with full query; ' +
+        'retrying with basic query (blockedBySupported flag NOT changed)'
       );
       result = await this.runIssueContextQuery(
         ISSUE_CONTEXT_QUERY_BASIC,

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -36,6 +36,7 @@ interface LaunchBody {
 interface LaunchBatchBody {
   projectId: number;
   issues: Array<{ number: number; title?: string; issueKey?: string }>;
+  blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; blockedBy?: number[] }>;
   prompt?: string;
   delayMs?: number;
   headless?: boolean;

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -1001,18 +1001,18 @@ export class IssueFetcher {
       const project = projects.find((p) => p.githubRepo === `${owner}/${repo}`);
       if (!project) {
         console.error(`[IssueFetcher] No project found for ${owner}/${repo}`);
-        return this.buildEmptyDependencyInfo(issueNumber);
+        return null;
       }
 
       const provider = getIssueProvider(project);
       if (!(provider instanceof GitHubIssueProvider)) {
         console.error(`[IssueFetcher] Provider for ${owner}/${repo} is not a GitHubIssueProvider`);
-        return this.buildEmptyDependencyInfo(issueNumber);
+        return null;
       }
 
       const issue = await provider.fetchSingleIssueDeps(owner, repo, issueNumber);
       if (!issue) {
-        return this.buildEmptyDependencyInfo(issueNumber);
+        return null;
       }
 
       const blockedBy: DependencyRef[] = [];

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -34,8 +34,9 @@ function summarize(e: Record<string, unknown>): string {
 
 /**
  * Check whether an issue has unresolved dependencies.
- * Returns the dependency info, or null if dependencies cannot be determined
- * (which is treated as "no blockers" -- permissive fallback).
+ * Returns the dependency info, or null if dependencies cannot be determined.
+ * A null return means "status unknown" -- callers should treat this
+ * conservatively (queue the issue rather than launching it).
  */
 async function checkDependencies(projectId: number, issueNumber: number): Promise<IssueDependencyInfo | null> {
   try {
@@ -99,7 +100,24 @@ export class TeamService {
     // Dependency check -- block launch if unresolved dependencies exist
     if (!force && issueNumber > 0) {
       const depInfo = await checkDependencies(projectId, issueNumber);
-      if (depInfo && !depInfo.resolved) {
+
+      // null means dependency status is unknown -- treat conservatively
+      if (depInfo === null) {
+        if (queue) {
+          const manager = getTeamManager();
+          return await manager.queueTeamWithBlockers(
+            projectId, issueNumber, [], issueTitle, headless, prompt, issueKey,
+          );
+        }
+        const displayKey = issueKey ?? `#${issueNumber}`;
+        throw new ServiceError(
+          `Dependency check failed for issue ${displayKey} — cannot confirm dependencies are resolved`,
+          'DEPENDENCY_CHECK_FAILED',
+          503,
+        );
+      }
+
+      if (!depInfo.resolved) {
         const blockerNumbers = depInfo.blockedBy
           .filter((b) => b.state === 'open')
           .map((b) => b.number);
@@ -142,23 +160,28 @@ export class TeamService {
   async launchBatch(params: {
     projectId: number;
     issues: Array<{ number: number; title?: string; issueKey?: string }>;
+    blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; blockedBy?: number[] }>;
     prompt?: string;
     delayMs?: number;
     headless?: boolean;
   }): Promise<{ launched: unknown[]; queued?: Array<{ issueNumber: number; team: unknown; blockedBy: number[] }> }> {
-    const { projectId, issues, prompt, delayMs, headless } = params;
+    const { projectId, issues, blockedIssues, prompt, delayMs, headless } = params;
 
     if (!projectId || typeof projectId !== 'number' || projectId < 1) {
       throw validationError('projectId is required and must be a positive integer');
     }
 
-    if (!issues || !Array.isArray(issues) || issues.length === 0) {
-      throw validationError('issues array is required and must not be empty');
+    const hasIssues = issues && Array.isArray(issues) && issues.length > 0;
+    const hasBlockedIssues = blockedIssues && Array.isArray(blockedIssues) && blockedIssues.length > 0;
+    if (!hasIssues && !hasBlockedIssues) {
+      throw validationError('issues array is required and must not be empty (unless blockedIssues is provided)');
     }
 
-    for (const issue of issues) {
-      if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
-        throw validationError(`Invalid issue number: ${JSON.stringify(issue)}`);
+    if (hasIssues) {
+      for (const issue of issues) {
+        if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
+          throw validationError(`Invalid issue number: ${JSON.stringify(issue)}`);
+        }
       }
     }
 
@@ -175,15 +198,19 @@ export class TeamService {
     const launchable: Array<{ number: number; title?: string; issueKey?: string }> = [];
     const queueable: Array<{ issue: { number: number; title?: string; issueKey?: string }; blockerNumbers: number[] }> = [];
 
-    for (const issue of issues) {
+    for (const issue of (issues ?? [])) {
       const depInfo = await checkDependencies(projectId, issue.number);
-      if (depInfo && !depInfo.resolved) {
+
+      // null means dependency status is unknown -- queue conservatively
+      if (depInfo === null) {
+        queueable.push({ issue, blockerNumbers: [] });
+      } else if (!depInfo.resolved) {
         const openBlockerNumbers = depInfo.blockedBy
           .filter((b) => b.state === 'open')
           .map((b) => b.number);
 
-        // Permissive fallback: if we have unresolved deps but no valid open
-        // blocker numbers, treat as launchable rather than blocking forever
+        // If we have unresolved deps but no valid open blocker numbers,
+        // treat as launchable rather than blocking forever
         if (openBlockerNumbers.length === 0) {
           launchable.push(issue);
         } else {
@@ -191,6 +218,17 @@ export class TeamService {
         }
       } else {
         launchable.push(issue);
+      }
+    }
+
+    // Process client-provided blocked issues -- queue directly without
+    // re-checking dependencies (client already classified them as blocked)
+    if (blockedIssues && blockedIssues.length > 0) {
+      for (const bi of blockedIssues) {
+        queueable.push({
+          issue: { number: bi.number, title: bi.title, issueKey: bi.issueKey },
+          blockerNumbers: bi.blockedBy ?? [],
+        });
       }
     }
 

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -542,6 +542,7 @@ describe('IssueTreeView', () => {
           { number: 10, title: 'Fix login' },
           { number: 20, title: 'Add feature' },
         ],
+        blockedIssues: undefined,
       });
     });
   });
@@ -581,7 +582,9 @@ describe('IssueTreeView', () => {
         projectId: 1,
         issues: [
           { number: 10, title: 'Launchable' },
-          { number: 30, title: 'Blocked' },
+        ],
+        blockedIssues: [
+          { number: 30, title: 'Blocked', blockedBy: [5] },
         ],
       });
     });

--- a/tests/server/providers/github-issue-provider.test.ts
+++ b/tests/server/providers/github-issue-provider.test.ts
@@ -313,4 +313,42 @@ describe('GitHubIssueProvider', () => {
     provider.resetBlockedBySupport();
     expect(provider.isBlockedBySupported).toBe(true);
   });
+
+  it('should NOT change blockedBySupported when fetchSingleIssueDeps fails', async () => {
+    // Ensure blockedBySupported starts as true
+    provider.resetBlockedBySupport();
+    expect(provider.isBlockedBySupported).toBe(true);
+
+    // Mock the private runSingleIssueDepsQuery to return null (simulating failure)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spy = vi.spyOn(provider as any, 'runSingleIssueDepsQuery').mockResolvedValue(null);
+
+    const result = await provider.fetchSingleIssueDeps('owner', 'repo', 42);
+
+    // The result should be null (both full and basic queries failed)
+    expect(result).toBeNull();
+    // Crucially, the flag must NOT have been flipped to false
+    expect(provider.isBlockedBySupported).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it('should NOT change blockedBySupported when fetchFullIssueContext fails', async () => {
+    // Ensure blockedBySupported starts as true
+    provider.resetBlockedBySupport();
+    expect(provider.isBlockedBySupported).toBe(true);
+
+    // Mock the private runIssueContextQuery to return null (simulating failure)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spy = vi.spyOn(provider as any, 'runIssueContextQuery').mockResolvedValue(null);
+
+    const result = await provider.fetchFullIssueContext('owner', 'repo', 42);
+
+    // The result should be null (both full and basic queries failed)
+    expect(result).toBeNull();
+    // Crucially, the flag must NOT have been flipped to false
+    expect(provider.isBlockedBySupported).toBe(true);
+
+    spy.mockRestore();
+  });
 });

--- a/tests/server/services/team-service.test.ts
+++ b/tests/server/services/team-service.test.ts
@@ -230,10 +230,58 @@ describe('TeamService.launchTeam', () => {
   });
 
   it('should delegate to manager.launch on success', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 42, blockedBy: [], resolved: true, openCount: 0,
+    });
     const result = await service.launchTeam({ projectId: 1, issueNumber: 42 });
 
     expect(result).toEqual({ id: 99, status: 'launching' });
     expect(mockLaunch).toHaveBeenCalledWith(1, 42, undefined, undefined, undefined, undefined, undefined);
+  });
+
+  it('should throw DEPENDENCY_CHECK_FAILED when dep check returns null without queue', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue(null);
+
+    try {
+      await service.launchTeam({ projectId: 1, issueNumber: 42 });
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('DEPENDENCY_CHECK_FAILED');
+      expect((err as ServiceError).statusCode).toBe(503);
+    }
+  });
+
+  it('should queue team when dep check returns null with queue=true', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue(null);
+    mockQueueTeamWithBlockers.mockResolvedValue({ id: 1, status: 'queued' });
+
+    const result = await service.launchTeam({
+      projectId: 1,
+      issueNumber: 42,
+      queue: true,
+    });
+
+    expect(result).toEqual({ id: 1, status: 'queued' });
+    expect(mockQueueTeamWithBlockers).toHaveBeenCalledWith(
+      1, 42, [], undefined, undefined, undefined, undefined,
+    );
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
+
+  it('should bypass dep check and launch when force=true even if deps would fail', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue(null);
+
+    const result = await service.launchTeam({
+      projectId: 1,
+      issueNumber: 42,
+      force: true,
+    });
+
+    expect(result).toEqual({ id: 99, status: 'launching' });
+    expect(mockLaunch).toHaveBeenCalled();
+    // fetchDependenciesForIssue should NOT have been called (force skips dep check)
+    expect(mockFetchDependenciesForIssue).not.toHaveBeenCalled();
   });
 });
 
@@ -287,8 +335,13 @@ describe('TeamService.launchBatch', () => {
     }
   });
 
-  it('should launch all issues when none have dependencies', async () => {
-    mockFetchDependenciesForIssue.mockResolvedValue(null);
+  it('should launch all issues when dependencies are confirmed resolved', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 0,
+      blockedBy: [],
+      resolved: true,
+      openCount: 0,
+    });
     mockLaunchBatch.mockResolvedValue([
       { id: 10, status: 'launching' },
       { id: 11, status: 'launching' },
@@ -309,10 +362,28 @@ describe('TeamService.launchBatch', () => {
     expect(mockQueueTeamWithBlockers).not.toHaveBeenCalled();
   });
 
+  it('should queue issues when dependency check returns null (unknown status)', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue(null);
+    mockQueueTeamWithBlockers.mockResolvedValue({ id: 1, status: 'queued' });
+
+    const result = await service.launchBatch({
+      projectId: 1,
+      issues: [{ number: 10 }, { number: 11 }],
+    });
+
+    // All issues should be queued, none launched
+    expect(result.launched).toHaveLength(0);
+    expect(result.queued).toBeDefined();
+    expect(result.queued).toHaveLength(2);
+    expect(result.queued![0].blockedBy).toEqual([]);
+    expect(result.queued![1].blockedBy).toEqual([]);
+    expect(mockLaunchBatch).not.toHaveBeenCalled();
+  });
+
   it('should queue issues with unresolved external dependencies', async () => {
-    // Issue #10 has no deps; issue #11 is blocked by external issue #5
+    // Issue #10 has no deps (confirmed resolved); issue #11 is blocked by external issue #5
     mockFetchDependenciesForIssue.mockImplementation(async (_pid: number, issueNumber: number) => {
-      if (issueNumber === 10) return null;
+      if (issueNumber === 10) return { issueNumber: 10, blockedBy: [], resolved: true, openCount: 0 };
       if (issueNumber === 11) {
         return {
           issueNumber: 11,
@@ -321,7 +392,7 @@ describe('TeamService.launchBatch', () => {
           openCount: 1,
         };
       }
-      return null;
+      return { issueNumber, blockedBy: [], resolved: true, openCount: 0 };
     });
     mockLaunchBatch.mockResolvedValue([{ id: 10, status: 'launching' }]);
     mockQueueTeamWithBlockers.mockResolvedValue({ id: 11, status: 'queued' });
@@ -351,9 +422,9 @@ describe('TeamService.launchBatch', () => {
   });
 
   it('should queue issues with intra-batch dependencies instead of launching them', async () => {
-    // Issue #10 has no deps; issue #11 is blocked by #10 (both in the batch)
+    // Issue #10 has no deps (confirmed resolved); issue #11 is blocked by #10 (both in the batch)
     mockFetchDependenciesForIssue.mockImplementation(async (_pid: number, issueNumber: number) => {
-      if (issueNumber === 10) return null;
+      if (issueNumber === 10) return { issueNumber: 10, blockedBy: [], resolved: true, openCount: 0 };
       if (issueNumber === 11) {
         return {
           issueNumber: 11,
@@ -362,7 +433,7 @@ describe('TeamService.launchBatch', () => {
           openCount: 1,
         };
       }
-      return null;
+      return { issueNumber, blockedBy: [], resolved: true, openCount: 0 };
     });
     mockLaunchBatch.mockResolvedValue([{ id: 10, status: 'launching' }]);
     mockQueueTeamWithBlockers.mockResolvedValue({ id: 11, status: 'queued' });
@@ -392,7 +463,7 @@ describe('TeamService.launchBatch', () => {
   it('should return queued teams in the response with correct structure', async () => {
     // All 3 issues blocked: #577 by #576, #578 by #577, #579 by #578
     mockFetchDependenciesForIssue.mockImplementation(async (_pid: number, issueNumber: number) => {
-      if (issueNumber === 576) return null;
+      if (issueNumber === 576) return { issueNumber: 576, blockedBy: [], resolved: true, openCount: 0 };
       const blockerMap: Record<number, number> = { 577: 576, 578: 577, 579: 578 };
       const blocker = blockerMap[issueNumber];
       if (blocker) {
@@ -403,7 +474,7 @@ describe('TeamService.launchBatch', () => {
           openCount: 1,
         };
       }
-      return null;
+      return { issueNumber, blockedBy: [], resolved: true, openCount: 0 };
     });
     mockLaunchBatch.mockResolvedValue([{ id: 576, status: 'launching' }]);
 
@@ -451,7 +522,7 @@ describe('TeamService.launchBatch', () => {
 
   it('should track blocked issues in github poller', async () => {
     mockFetchDependenciesForIssue.mockImplementation(async (_pid: number, issueNumber: number) => {
-      if (issueNumber === 10) return null;
+      if (issueNumber === 10) return { issueNumber: 10, blockedBy: [], resolved: true, openCount: 0 };
       if (issueNumber === 11) {
         return {
           issueNumber: 11,
@@ -463,7 +534,7 @@ describe('TeamService.launchBatch', () => {
           openCount: 1,
         };
       }
-      return null;
+      return { issueNumber, blockedBy: [], resolved: true, openCount: 0 };
     });
     mockLaunchBatch.mockResolvedValue([{ id: 10, status: 'launching' }]);
     mockQueueTeamWithBlockers.mockResolvedValue({ id: 11, status: 'queued' });
@@ -482,7 +553,7 @@ describe('TeamService.launchBatch', () => {
   it('should continue batch when queueTeamWithBlockers throws for one issue', async () => {
     // Issues #11 and #12 are both blocked; #11 throws on queue, #12 succeeds
     mockFetchDependenciesForIssue.mockImplementation(async (_pid: number, issueNumber: number) => {
-      if (issueNumber === 10) return null;
+      if (issueNumber === 10) return { issueNumber: 10, blockedBy: [], resolved: true, openCount: 0 };
       return {
         issueNumber,
         blockedBy: [{ number: 5, owner: 'o', repo: 'r', state: 'open', title: 'Ext' }],
@@ -526,6 +597,66 @@ describe('TeamService.launchBatch', () => {
     expect(result.launched).toHaveLength(1);
     expect(result.queued).toBeUndefined();
     expect(mockQueueTeamWithBlockers).not.toHaveBeenCalled();
+  });
+
+  it('should queue blockedIssues directly without re-checking dependencies', async () => {
+    mockFetchDependenciesForIssue.mockResolvedValue({
+      issueNumber: 10, blockedBy: [], resolved: true, openCount: 0,
+    });
+    mockLaunchBatch.mockResolvedValue([{ id: 10, status: 'launching' }]);
+    mockQueueTeamWithBlockers.mockResolvedValue({ id: 30, status: 'queued' });
+
+    const result = await service.launchBatch({
+      projectId: 1,
+      issues: [{ number: 10 }],
+      blockedIssues: [
+        { number: 30, title: 'Blocked Issue', blockedBy: [5, 6] },
+      ],
+    });
+
+    // Issue #10 should be launched, issue #30 should be queued
+    expect(result.launched).toHaveLength(1);
+    expect(result.queued).toBeDefined();
+    expect(result.queued).toHaveLength(1);
+    expect(result.queued![0].issueNumber).toBe(30);
+    expect(result.queued![0].blockedBy).toEqual([5, 6]);
+
+    // fetchDependenciesForIssue should only be called for issue #10, not #30
+    expect(mockFetchDependenciesForIssue).toHaveBeenCalledTimes(1);
+    expect(mockFetchDependenciesForIssue).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('should accept blockedIssues with empty issues array', async () => {
+    mockQueueTeamWithBlockers.mockResolvedValue({ id: 30, status: 'queued' });
+
+    const result = await service.launchBatch({
+      projectId: 1,
+      issues: [],
+      blockedIssues: [
+        { number: 30, title: 'Blocked Issue', blockedBy: [5] },
+      ],
+    });
+
+    expect(result.launched).toHaveLength(0);
+    expect(result.queued).toBeDefined();
+    expect(result.queued).toHaveLength(1);
+    expect(result.queued![0].issueNumber).toBe(30);
+  });
+
+  it('should handle blockedIssues with empty blockedBy array', async () => {
+    mockQueueTeamWithBlockers.mockResolvedValue({ id: 30, status: 'queued' });
+
+    const result = await service.launchBatch({
+      projectId: 1,
+      issues: [],
+      blockedIssues: [
+        { number: 30, title: 'Unknown deps' },
+      ],
+    });
+
+    expect(result.queued).toBeDefined();
+    expect(result.queued).toHaveLength(1);
+    expect(result.queued![0].blockedBy).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Inverts the permissive null fallback in `checkDependencies()` so unknown dependency status queues issues conservatively instead of launching them
- Changes `fetchDependenciesFromProvider()` to return `null` instead of `buildEmptyDependencyInfo()` on lookup failures, distinguishing "no dependencies" from "could not determine"
- Scopes `blockedBySupported` flag mutations to batch queries only, preventing single-issue query failures from cascading across the entire batch
- Forwards client-side blocked issue metadata to the server via a separate `blockedIssues` array in the `launch-batch` API, reducing redundant dependency re-checking

Closes #611

## Test plan

- [ ] Verify `npm test` passes (server tests including 7 new tests for null-dep-info queuing, blockedIssues passthrough, and flag isolation)
- [ ] Verify `npm run test:client` passes (updated IssueTreeView tests for separate blockedIssues field)
- [ ] Verify `npm run build` succeeds with no type errors
- [ ] Manual: batch-launch issues with dependency chain — blocked issues should be queued, not launched