### PR TITLE
Issue #615: Strip credentialsJson from API responses, add dedicated credentials endpoint

### DIFF
--- a/src/client/components/JiraSourceDialog.tsx
+++ b/src/client/components/JiraSourceDialog.tsx
@@ -6,7 +6,7 @@
 // =============================================================================
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { ProjectIssueSource, JiraSourceConfig, JiraSourceCredentials } from '../../shared/types';
+import type { ProjectIssueSourceResponse, JiraSourceConfig, JiraSourceCredentials } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -15,7 +15,7 @@ import type { ProjectIssueSource, JiraSourceConfig, JiraSourceCredentials } from
 interface JiraSourceDialogProps {
   open: boolean;
   projectId: number;
-  source?: ProjectIssueSource | null;
+  source?: ProjectIssueSourceResponse | null;
   onClose: () => void;
   onSave: (data: {
     provider: string;
@@ -55,7 +55,7 @@ export function JiraSourceDialog({ open, projectId, source, onClose, onSave }: J
   useEffect(() => {
     if (open) {
       if (source) {
-        // Edit mode: parse existing config/credentials
+        // Edit mode: parse existing config
         try {
           const config: JiraSourceConfig = JSON.parse(source.configJson);
           setJiraUrl(config.jiraUrl || '');
@@ -64,18 +64,26 @@ export function JiraSourceDialog({ open, projectId, source, onClose, onSave }: J
           setJiraUrl('');
           setProjectKey('');
         }
-        try {
-          if (source.credentialsJson) {
-            const creds: JiraSourceCredentials = JSON.parse(source.credentialsJson);
-            setEmail(creds.email || '');
-            setApiToken(creds.apiToken || '');
-          } else {
-            setEmail('');
-            setApiToken('');
-          }
-        } catch {
-          setEmail('');
-          setApiToken('');
+        // Fetch credentials from the dedicated endpoint
+        setEmail('');
+        setApiToken('');
+        if (source.hasCredentials) {
+          fetch(`/api/projects/${projectId}/issue-sources/${source.id}/credentials`)
+            .then((res) => res.json())
+            .then((data: { credentialsJson: string | null }) => {
+              if (data.credentialsJson) {
+                try {
+                  const creds: JiraSourceCredentials = JSON.parse(data.credentialsJson);
+                  setEmail(creds.email || '');
+                  setApiToken(creds.apiToken || '');
+                } catch {
+                  // Invalid credentials JSON — leave fields empty
+                }
+              }
+            })
+            .catch(() => {
+              // Failed to fetch credentials — leave fields empty
+            });
         }
         setLabel(source.label || '');
         setEnabled(source.enabled);
@@ -94,7 +102,7 @@ export function JiraSourceDialog({ open, projectId, source, onClose, onSave }: J
       setTesting(false);
       setTimeout(() => urlInputRef.current?.focus(), 50);
     }
-  }, [open, source]);
+  }, [open, source, projectId]);
 
   const validate = useCallback((): string | null => {
     if (!jiraUrl.trim()) return 'Jira URL is required';

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -6,7 +6,7 @@ import { CleanupModal } from '../components/CleanupModal';
 import { JiraSourceDialog } from '../components/JiraSourceDialog';
 import { OverflowMenu } from '../components/OverflowMenu';
 import { ChevronRightIcon, PencilIcon } from '../components/Icons';
-import type { ProjectSummary, ProjectStatus, ProjectGroup, ProjectIssueSource, RepoSettings } from '../../shared/types';
+import type { ProjectSummary, ProjectStatus, ProjectGroup, ProjectIssueSourceResponse, RepoSettings } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Status badge colors
@@ -362,14 +362,14 @@ function InstallHealthDetail({ project, repoSettings }: { project: ProjectSummar
 // ---------------------------------------------------------------------------
 
 /** Status badge color: green=enabled+credentials, red=enabled+no credentials, gray=disabled */
-function sourceStatusColor(source: ProjectIssueSource): string {
+function sourceStatusColor(source: ProjectIssueSourceResponse): string {
   if (!source.enabled) return '#8B949E';
-  return source.credentialsJson ? '#3FB950' : '#F85149';
+  return source.hasCredentials ? '#3FB950' : '#F85149';
 }
 
-function sourceStatusLabel(source: ProjectIssueSource): string {
+function sourceStatusLabel(source: ProjectIssueSourceResponse): string {
   if (!source.enabled) return 'Disabled';
-  return source.credentialsJson ? 'Connected' : 'No credentials';
+  return source.hasCredentials ? 'Connected' : 'No credentials';
 }
 
 function IssueSourcesSection({
@@ -378,15 +378,15 @@ function IssueSourcesSection({
   projectId: number;
 }) {
   const api = useApi();
-  const [sources, setSources] = useState<ProjectIssueSource[]>([]);
+  const [sources, setSources] = useState<ProjectIssueSourceResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingSource, setEditingSource] = useState<ProjectIssueSource | null>(null);
+  const [editingSource, setEditingSource] = useState<ProjectIssueSourceResponse | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
 
   const fetchSources = useCallback(async () => {
     try {
-      const data = await api.get<{ sources: ProjectIssueSource[] }>(`projects/${projectId}/issue-sources`);
+      const data = await api.get<{ sources: ProjectIssueSourceResponse[] }>(`projects/${projectId}/issue-sources`);
       setSources(Array.isArray(data.sources) ? data.sources : []);
     } catch {
       // Silently handle — sources section is supplementary
@@ -416,7 +416,7 @@ function IssueSourcesSection({
     await fetchSources();
   }, [api, projectId, editingSource, fetchSources]);
 
-  const handleToggle = useCallback(async (source: ProjectIssueSource) => {
+  const handleToggle = useCallback(async (source: ProjectIssueSourceResponse) => {
     const prev = sources;
     // Optimistic update
     setSources(sources.map((s) => s.id === source.id ? { ...s, enabled: !s.enabled } : s));

--- a/src/server/routes/issue-sources.ts
+++ b/src/server/routes/issue-sources.ts
@@ -4,16 +4,36 @@
 // Registered as a Fastify plugin. Provides CRUD endpoints for managing
 // per-project issue sources (multi-provider support).
 //
-//   GET    /api/projects/:projectId/issue-sources              — list all sources
-//   POST   /api/projects/:projectId/issue-sources              — create a source
-//   PATCH  /api/projects/:projectId/issue-sources/:sourceId    — update a source
-//   DELETE /api/projects/:projectId/issue-sources/:sourceId    — delete a source
+//   GET    /api/projects/:projectId/issue-sources                          — list all sources
+//   POST   /api/projects/:projectId/issue-sources                          — create a source
+//   PATCH  /api/projects/:projectId/issue-sources/:sourceId                — update a source
+//   GET    /api/projects/:projectId/issue-sources/:sourceId/credentials    — get decrypted credentials
+//   DELETE /api/projects/:projectId/issue-sources/:sourceId                — delete a source
 // =============================================================================
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getDatabase } from '../db.js';
 import { ServiceError, validationError, notFoundError } from '../services/service-error.js';
 import { parseIdParam } from '../utils/parse-params.js';
+import type { ProjectIssueSource, ProjectIssueSourceResponse } from '../../shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip credentialsJson from a source and replace with hasCredentials boolean */
+function toIssueSourceResponse(source: ProjectIssueSource): ProjectIssueSourceResponse {
+  return {
+    id: source.id,
+    projectId: source.projectId,
+    provider: source.provider,
+    label: source.label,
+    configJson: source.configJson,
+    hasCredentials: source.credentialsJson !== null && source.credentialsJson !== '',
+    enabled: source.enabled,
+    createdAt: source.createdAt,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Fastify plugin
@@ -36,7 +56,7 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
         }
 
         const sources = db.getIssueSources(projectId);
-        return { sources };
+        return { sources: sources.map(toIssueSourceResponse) };
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
@@ -95,7 +115,7 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
           credentialsJson: typeof body.credentialsJson === 'string' ? body.credentialsJson : null,
         });
 
-        return reply.code(201).send(source);
+        return reply.code(201).send(toIssueSourceResponse(source));
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
@@ -166,12 +186,53 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
           enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
         });
 
-        return updated;
+        return toIssueSourceResponse(updated!);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
         }
         request.log.error(err, 'Failed to update issue source');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  /**
+   * GET /api/projects/:projectId/issue-sources/:sourceId/credentials
+   *
+   * Returns the decrypted credentialsJson for a single issue source.
+   * Used by the edit dialog to populate credential fields.
+   */
+  server.get<{ Params: { projectId: string; sourceId: string } }>(
+    '/api/projects/:projectId/issue-sources/:sourceId/credentials',
+    async (
+      request: FastifyRequest<{ Params: { projectId: string; sourceId: string } }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const projectId = parseIdParam(request.params.projectId, 'projectId');
+        const sourceId = parseIdParam(request.params.sourceId, 'sourceId');
+        const db = getDatabase();
+
+        const project = db.getProject(projectId);
+        if (!project) {
+          throw notFoundError(`Project ${projectId} not found`);
+        }
+
+        const source = db.getIssueSource(sourceId);
+        if (!source || source.projectId !== projectId) {
+          throw notFoundError(`Issue source ${sourceId} not found for project ${projectId}`);
+        }
+
+        return { credentialsJson: source.credentialsJson };
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to get issue source credentials');
         return reply.code(500).send({
           error: 'Internal Server Error',
           message: err instanceof Error ? err.message : String(err),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,6 +74,18 @@ export interface ProjectIssueSource {
   createdAt: string;
 }
 
+/** API response shape for issue sources — credentials stripped, hasCredentials flag added */
+export interface ProjectIssueSourceResponse {
+  id: number;
+  projectId: number;
+  provider: string;
+  label: string | null;
+  configJson: string;
+  hasCredentials: boolean;
+  enabled: boolean;
+  createdAt: string;
+}
+
 /** Jira source configuration stored in configJson */
 export interface JiraSourceConfig {
   jiraUrl: string;

--- a/tests/server/routes/issue-sources-routes.test.ts
+++ b/tests/server/routes/issue-sources-routes.test.ts
@@ -115,6 +115,49 @@ describe('GET /api/projects/:projectId/issue-sources', () => {
     expect(body.sources[1].provider).toBe('jira');
   });
 
+  it('should not include credentialsJson in list response', async () => {
+    const db = getDatabase();
+    db.insertIssueSource({
+      projectId,
+      provider: 'jira',
+      label: 'Secure Jira',
+      configJson: JSON.stringify({ projectKey: 'SEC' }),
+      credentialsJson: JSON.stringify({ email: 'a@b.com', apiToken: 'secret-token' }),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sources).toHaveLength(1);
+    expect(body.sources[0]).not.toHaveProperty('credentialsJson');
+    expect(body.sources[0].hasCredentials).toBe(true);
+  });
+
+  it('should return hasCredentials: false when source has no credentials', async () => {
+    const db = getDatabase();
+    db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      label: 'No creds',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sources).toHaveLength(1);
+    expect(body.sources[0]).not.toHaveProperty('credentialsJson');
+    expect(body.sources[0].hasCredentials).toBe(false);
+  });
+
   it('should return 404 when project does not exist', async () => {
     const res = await app.inject({
       method: 'GET',
@@ -152,6 +195,25 @@ describe('POST /api/projects/:projectId/issue-sources', () => {
     expect(body.label).toBe('GitHub Issues');
     expect(body.enabled).toBe(true);
     expect(body.projectId).toBe(projectId);
+  });
+
+  it('should not include credentialsJson in create response', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/projects/${projectId}/issue-sources`,
+      payload: {
+        provider: 'jira',
+        label: 'Jira with creds',
+        configJson: JSON.stringify({ projectKey: 'CRED' }),
+        credentialsJson: JSON.stringify({ email: 'x@y.com', apiToken: 'super-secret' }),
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body).not.toHaveProperty('credentialsJson');
+    expect(body.hasCredentials).toBe(true);
+    expect(body.provider).toBe('jira');
   });
 
   it('should return 400 when provider is missing', async () => {
@@ -246,6 +308,30 @@ describe('PATCH /api/projects/:projectId/issue-sources/:sourceId', () => {
     const body = JSON.parse(res.body);
     expect(body.label).toBe('New Label');
     expect(body.enabled).toBe(false);
+  });
+
+  it('should not include credentialsJson in update response', async () => {
+    const db = getDatabase();
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'jira',
+      label: 'Patch Test',
+      configJson: JSON.stringify({ projectKey: 'PT' }),
+      credentialsJson: JSON.stringify({ email: 'u@v.com', apiToken: 'old-token' }),
+    });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+      payload: {
+        credentialsJson: JSON.stringify({ email: 'u@v.com', apiToken: 'new-token' }),
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).not.toHaveProperty('credentialsJson');
+    expect(body.hasCredentials).toBe(true);
   });
 
   it('should return 404 when source does not exist', async () => {
@@ -347,6 +433,98 @@ describe('DELETE /api/projects/:projectId/issue-sources/:sourceId', () => {
     const res = await app.inject({
       method: 'DELETE',
       url: `/api/projects/${projectId}/issue-sources/${source.id}`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/projects/:projectId/issue-sources/:sourceId/credentials
+// ---------------------------------------------------------------------------
+
+describe('GET /api/projects/:projectId/issue-sources/:sourceId/credentials', () => {
+  it('should return decrypted credentialsJson for existing source', async () => {
+    const db = getDatabase();
+    const creds = JSON.stringify({ email: 'cred@test.com', apiToken: 'the-secret' });
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'jira',
+      label: 'Cred Test',
+      configJson: JSON.stringify({ projectKey: 'CT' }),
+      credentialsJson: creds,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}/credentials`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.credentialsJson).toBeTruthy();
+    // Verify the decrypted credentials are returned (may be encrypted at rest,
+    // but mapIssueSourceRow decrypts them)
+    const parsed = JSON.parse(body.credentialsJson);
+    expect(parsed.email).toBe('cred@test.com');
+    expect(parsed.apiToken).toBe('the-secret');
+  });
+
+  it('should return null credentialsJson when source has no credentials', async () => {
+    const db = getDatabase();
+    const source = db.insertIssueSource({
+      projectId,
+      provider: 'github',
+      label: 'No creds',
+      configJson: JSON.stringify({ owner: 'a', repo: 'b' }),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}/credentials`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.credentialsJson).toBeNull();
+  });
+
+  it('should return 404 when source does not exist', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources/99999/credentials`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 404 when source belongs to a different project', async () => {
+    const db = getDatabase();
+    const otherProject = db.insertProject({
+      name: `cred-other-${Date.now()}`,
+      repoPath: `/tmp/cred-other-${Date.now()}`,
+      githubRepo: 'credother/repo',
+    });
+
+    const source = db.insertIssueSource({
+      projectId: otherProject.id,
+      provider: 'jira',
+      configJson: JSON.stringify({ projectKey: 'OTH' }),
+      credentialsJson: JSON.stringify({ email: 'a@b.com', apiToken: 'tok' }),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/projects/${projectId}/issue-sources/${source.id}/credentials`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('should return 404 when project does not exist', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/99999/issue-sources/1/credentials',
     });
 
     expect(res.statusCode).toBe(404);


### PR DESCRIPTION
Closes #615

## Summary
- Strip `credentialsJson` from all issue-source API responses (GET list, POST create, PATCH update) and replace with `hasCredentials: boolean`
- Add dedicated `GET /api/projects/:projectId/issue-sources/:sourceId/credentials` endpoint for edit-flow credential retrieval
- Add `ProjectIssueSourceResponse` type for compile-time safety on the client
- Update `JiraSourceDialog` to fetch credentials from the new endpoint when editing
- Update `ProjectsPage` status dot to use `hasCredentials` instead of `credentialsJson`
- Add 10 new tests covering credential stripping, hasCredentials flag, and credentials endpoint error cases

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] All 31 issue-sources route tests pass (`npm run test:server`)
- [ ] Manual: verify GET /issue-sources no longer returns credentialsJson
- [ ] Manual: verify editing a Jira source still populates credential fields
- [ ] Manual: verify status dot shows correct color based on hasCredentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)