### PR TITLE
Issue #616: Align issue context generator with spec — YAML frontmatter, correct limits, use GitHubIssueProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ fleet.db-wal
 plan.md
 .fleet-pm-message
 review.md
+.fleet-issue-context.md

--- a/src/server/services/issue-context-generator.ts
+++ b/src/server/services/issue-context-generator.ts
@@ -5,148 +5,32 @@
 // starts, providing the agent with full issue context (description, comments,
 // linked PRs, dependencies) so it does not need to fetch this data itself.
 //
-// Supports GitHub (via `gh` CLI) and Jira (via provider API). For unsupported
-// providers, generates a minimal context file with just key/title.
+// GitHub issues are fetched via GitHubIssueProvider.fetchFullIssueContext()
+// (GraphQL), which returns rich data including dependencies, sub-issues,
+// parent references, and pre-filtered comments (no bots, no minimized).
+//
+// Jira issues are fetched via the Jira provider API and converted to
+// IssueContextData format for rendering by the shared generator.
+//
+// For unsupported providers or fetch failures, generates a minimal context
+// file with YAML frontmatter and just key/title.
 //
 // Errors are caught and logged — context generation must NEVER block a launch.
 // =============================================================================
 
 import path from 'path';
 import fs from 'fs';
-import { execGHAsync } from '../utils/exec-gh.js';
-import { isValidGithubRepo } from '../utils/exec-gh.js';
 import { getIssueProvider } from '../providers/index.js';
+import { GitHubIssueProvider, parseRepo } from '../providers/github-issue-provider.js';
+import { generateIssueContextMarkdown } from '../../shared/issue-context.js';
+import type { IssueContextData } from '../../shared/issue-context.js';
 import type { Project } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const CONTEXT_FILENAME = '.fleet-issue-context.md';
-const MAX_BODY_LENGTH = 10_000;
-const MAX_COMMENTS = 20;
-
-// ---------------------------------------------------------------------------
-// Internal Types
-// ---------------------------------------------------------------------------
-
-interface IssueComment {
-  author: string;
-  body: string;
-  createdAt: string;
-}
-
-interface IssueLinkedPR {
-  number: number;
-  state: string;
-}
-
-interface IssueDependency {
-  key: string;
-  title: string;
-  state: string;
-}
-
-interface IssueContext {
-  key: string;
-  title: string;
-  state: string;
-  url: string | null;
-  body: string | null;
-  labels: string[];
-  assignees: string[];
-  comments: IssueComment[];
-  linkedPRs: IssueLinkedPR[];
-  dependencies: IssueDependency[];
-  milestone: string | null;
-}
-
-// ---------------------------------------------------------------------------
-// GitHub Issue Fetching
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch full issue context from GitHub using the `gh` CLI.
- * Returns null on any error (network, auth, rate-limit, etc.).
- */
-async function fetchGitHubIssueContext(
-  issueNumber: number,
-  githubRepo: string,
-): Promise<IssueContext | null> {
-  if (!isValidGithubRepo(githubRepo)) {
-    console.warn(`[IssueContextGenerator] Invalid GitHub repo slug: "${githubRepo}"`);
-    return null;
-  }
-
-  const fields = 'number,title,body,state,url,labels,assignees,comments,milestone,closedByPullRequests';
-  const raw = await execGHAsync(
-    `gh issue view ${issueNumber} --repo "${githubRepo}" --json ${fields}`,
-    { timeout: 15_000 },
-  );
-
-  if (!raw) return null;
-
-  try {
-    const data = JSON.parse(raw) as Record<string, unknown>;
-
-    // Map labels: [{name: string}] -> string[]
-    const rawLabels = Array.isArray(data.labels) ? data.labels : [];
-    const labels = rawLabels
-      .map((l: unknown) => (typeof l === 'object' && l !== null && 'name' in l ? (l as { name: string }).name : ''))
-      .filter(Boolean);
-
-    // Map assignees: [{login: string}] -> string[]
-    const rawAssignees = Array.isArray(data.assignees) ? data.assignees : [];
-    const assignees = rawAssignees
-      .map((a: unknown) => (typeof a === 'object' && a !== null && 'login' in a ? (a as { login: string }).login : ''))
-      .filter(Boolean);
-
-    // Map comments: [{author:{login}, body, createdAt}] -> IssueComment[]
-    const rawComments = Array.isArray(data.comments) ? data.comments : [];
-    const comments: IssueComment[] = rawComments
-      .filter((c: unknown): c is Record<string, unknown> => typeof c === 'object' && c !== null)
-      .map((c: Record<string, unknown>) => ({
-        author: typeof c.author === 'object' && c.author !== null && 'login' in c.author
-          ? String((c.author as { login: string }).login)
-          : 'unknown',
-        body: typeof c.body === 'string' ? c.body : '',
-        createdAt: typeof c.createdAt === 'string' ? c.createdAt : '',
-      }));
-
-    // Map closedByPullRequests: [{number, state}] -> IssueLinkedPR[]
-    const rawPRs = Array.isArray(data.closedByPullRequests) ? data.closedByPullRequests : [];
-    const linkedPRs: IssueLinkedPR[] = rawPRs
-      .filter((pr: unknown): pr is Record<string, unknown> => typeof pr === 'object' && pr !== null)
-      .map((pr: Record<string, unknown>) => ({
-        number: typeof pr.number === 'number' ? pr.number : 0,
-        state: typeof pr.state === 'string' ? pr.state : 'unknown',
-      }))
-      .filter((pr) => pr.number > 0);
-
-    // Milestone
-    const milestoneObj = typeof data.milestone === 'object' && data.milestone !== null ? data.milestone : null;
-    const milestone = milestoneObj && 'title' in milestoneObj
-      ? String((milestoneObj as { title: string }).title)
-      : null;
-
-    return {
-      key: String(data.number ?? issueNumber),
-      title: typeof data.title === 'string' ? data.title : `Issue #${issueNumber}`,
-      state: typeof data.state === 'string' ? data.state : 'unknown',
-      url: typeof data.url === 'string' ? data.url : null,
-      body: typeof data.body === 'string' ? data.body : null,
-      labels,
-      assignees,
-      comments,
-      linkedPRs,
-      dependencies: [], // GitHub dependencies require separate GraphQL query — skip for now
-      milestone,
-    };
-  } catch (err) {
-    console.warn(`[IssueContextGenerator] Failed to parse GitHub issue JSON:`, err instanceof Error ? err.message : err);
-    return null;
-  }
-}
+export const CONTEXT_FILENAME = '.fleet-issue-context.md';
 
 // ---------------------------------------------------------------------------
 // Jira Issue Fetching
@@ -154,12 +38,12 @@ async function fetchGitHubIssueContext(
 
 /**
  * Fetch issue context from Jira using the provider API.
- * Returns null on any error.
+ * Returns an IssueContextData object on success, or null on error.
  */
 async function fetchJiraIssueContext(
   issueKey: string,
   project: Project,
-): Promise<IssueContext | null> {
+): Promise<IssueContextData | null> {
   try {
     const provider = getIssueProvider(project);
     const issue = await provider.getIssue(issueKey);
@@ -171,18 +55,35 @@ async function fetchJiraIssueContext(
       provider.getDependencies(issueKey).catch(() => [] as Array<{ key: string; title: string; status: string }>),
     ]);
 
+    // Convert to IssueContextData format for the shared generator
     return {
-      key: issue.key,
+      number: parseInt(issueKey.replace(/\D/g, ''), 10) || 0,
       title: issue.title,
       state: issue.rawStatus,
-      url: issue.url,
-      body: null, // Jira REST v3 body is ADF (Atlassian Document Format), not plain text
+      repo: project.githubRepo ?? '',
+      author: '',
+      createdAt: issue.createdAt ?? '',
+      updatedAt: issue.updatedAt ?? '',
       labels: issue.labels,
       assignees: issue.assignee ? [issue.assignee] : [],
-      comments: [], // Jira comments require a separate API call — skip for MVP
+      milestone: null,
+      parent: null,
+      children: [],
+      blockedBy: dependencies.map((dep) => ({
+        number: parseInt(dep.key.replace(/\D/g, ''), 10) || 0,
+        title: dep.title,
+        state: dep.status,
+      })),
+      blocking: [],
       linkedPRs: linkedPRs.map((pr) => ({ number: pr.number, state: pr.state })),
-      dependencies: dependencies.map((dep) => ({ key: dep.key, title: dep.title, state: dep.status })),
-      milestone: null, // Jira uses fixVersions, not milestones
+      body: '', // Jira REST v3 body is ADF (Atlassian Document Format), not plain text
+      comments: [], // Jira comments require a separate API call — skip for MVP
+      truncation: {
+        bodyTruncated: false,
+        commentsTruncated: false,
+        totalComments: 0,
+        includedComments: 0,
+      },
     };
   } catch (err) {
     console.warn(`[IssueContextGenerator] Failed to fetch Jira issue ${issueKey}:`, err instanceof Error ? err.message : err);
@@ -191,92 +92,43 @@ async function fetchJiraIssueContext(
 }
 
 // ---------------------------------------------------------------------------
-// Markdown Formatting
+// Fallback: minimal IssueContextData
 // ---------------------------------------------------------------------------
 
 /**
- * Render an IssueContext into a structured markdown string.
- * Empty sections are omitted.
+ * Build a minimal IssueContextData for unsupported providers or fetch failures.
  */
-export function formatContextMarkdown(ctx: IssueContext): string {
-  const lines: string[] = [];
-
-  // Header
-  lines.push(`# Issue ${ctx.key}: ${ctx.title}`);
-  lines.push('');
-
-  // Metadata table
-  lines.push('| Field | Value |');
-  lines.push('|-------|-------|');
-  lines.push(`| **Key** | ${ctx.key} |`);
-  lines.push(`| **Title** | ${ctx.title} |`);
-  lines.push(`| **State** | ${ctx.state} |`);
-  if (ctx.url) {
-    lines.push(`| **URL** | ${ctx.url} |`);
-  }
-  if (ctx.milestone) {
-    lines.push(`| **Milestone** | ${ctx.milestone} |`);
-  }
-  if (ctx.labels.length > 0) {
-    lines.push(`| **Labels** | ${ctx.labels.join(', ')} |`);
-  }
-  if (ctx.assignees.length > 0) {
-    lines.push(`| **Assignees** | ${ctx.assignees.join(', ')} |`);
-  }
-  lines.push('');
-
-  // Description
-  if (ctx.body) {
-    const truncatedBody = ctx.body.length > MAX_BODY_LENGTH
-      ? ctx.body.substring(0, MAX_BODY_LENGTH) + '\n\n*(truncated — original exceeds 10,000 characters)*'
-      : ctx.body;
-    lines.push('## Description');
-    lines.push('');
-    lines.push(truncatedBody);
-    lines.push('');
-  }
-
-  // Comments (most recent N)
-  if (ctx.comments.length > 0) {
-    const recentComments = ctx.comments.slice(-MAX_COMMENTS);
-    const omitted = ctx.comments.length - recentComments.length;
-
-    lines.push('## Comments');
-    lines.push('');
-    if (omitted > 0) {
-      lines.push(`*${omitted} older comment(s) omitted — showing most recent ${MAX_COMMENTS}.*`);
-      lines.push('');
-    }
-    for (const comment of recentComments) {
-      const dateStr = comment.createdAt ? ` (${comment.createdAt})` : '';
-      lines.push(`### @${comment.author}${dateStr}`);
-      lines.push('');
-      lines.push(comment.body);
-      lines.push('');
-    }
-  }
-
-  // Linked PRs
-  if (ctx.linkedPRs.length > 0) {
-    lines.push('## Linked Pull Requests');
-    lines.push('');
-    for (const pr of ctx.linkedPRs) {
-      lines.push(`- PR #${pr.number} — ${pr.state}`);
-    }
-    lines.push('');
-  }
-
-  // Dependencies
-  if (ctx.dependencies.length > 0) {
-    lines.push('## Dependencies');
-    lines.push('');
-    for (const dep of ctx.dependencies) {
-      lines.push(`- ${dep.key}: ${dep.title} — ${dep.state}`);
-    }
-    lines.push('');
-  }
-
-  return lines.join('\n');
+function buildFallbackContextData(
+  issueKey: string,
+  issueNumber: number,
+  issueTitle: string | null,
+  project: Project,
+): IssueContextData {
+  return {
+    number: issueNumber,
+    title: issueTitle ?? `Issue ${issueKey}`,
+    state: 'unknown',
+    repo: project.githubRepo ?? '',
+    author: '',
+    createdAt: '',
+    updatedAt: '',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    parent: null,
+    children: [],
+    blockedBy: [],
+    blocking: [],
+    linkedPRs: [],
+    body: '',
+    comments: [],
+    truncation: {
+      bodyTruncated: false,
+      commentsTruncated: false,
+      totalComments: 0,
+      includedComments: 0,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -295,8 +147,10 @@ export interface GenerateIssueContextParams {
 /**
  * Generate a `.fleet-issue-context.md` file in the worktree root.
  *
- * Fetches full issue context from the appropriate provider (GitHub, Jira),
- * formats it as structured markdown, and writes it to the worktree.
+ * Fetches full issue context from the appropriate provider (GitHub via
+ * GitHubIssueProvider.fetchFullIssueContext GraphQL, Jira via provider API),
+ * formats it as structured markdown with YAML frontmatter using the shared
+ * generateIssueContextMarkdown(), and writes it to the worktree.
  *
  * This function NEVER throws — errors are caught and logged as warnings.
  * A failed context generation must not block a team launch.
@@ -305,32 +159,24 @@ export async function generateIssueContext(params: GenerateIssueContextParams): 
   const { worktreeAbsPath, issueKey, issueNumber, issueTitle, issueProvider, project } = params;
 
   try {
-    let ctx: IssueContext | null = null;
+    let contextData: IssueContextData | null = null;
 
     if (issueProvider === 'github' && project.githubRepo) {
-      ctx = await fetchGitHubIssueContext(issueNumber, project.githubRepo);
+      const provider = getIssueProvider(project);
+      if (provider instanceof GitHubIssueProvider) {
+        const [owner, repo] = parseRepo(project.githubRepo);
+        contextData = await provider.fetchFullIssueContext(owner, repo, issueNumber);
+      }
     } else if (issueProvider === 'jira') {
-      ctx = await fetchJiraIssueContext(issueKey, project);
+      contextData = await fetchJiraIssueContext(issueKey, project);
     }
 
     // Fallback: minimal context for unsupported providers or fetch failures
-    if (!ctx) {
-      ctx = {
-        key: issueKey,
-        title: issueTitle ?? `Issue ${issueKey}`,
-        state: 'unknown',
-        url: null,
-        body: null,
-        labels: [],
-        assignees: [],
-        comments: [],
-        linkedPRs: [],
-        dependencies: [],
-        milestone: null,
-      };
+    if (!contextData) {
+      contextData = buildFallbackContextData(issueKey, issueNumber, issueTitle, project);
     }
 
-    const markdown = formatContextMarkdown(ctx);
+    const markdown = generateIssueContextMarkdown(contextData);
     const filePath = path.join(worktreeAbsPath, CONTEXT_FILENAME);
     fs.writeFileSync(filePath, markdown, 'utf-8');
 

--- a/tests/server/services/issue-context-generator.test.ts
+++ b/tests/server/services/issue-context-generator.test.ts
@@ -3,6 +3,11 @@
 // =============================================================================
 // Tests for the issue context generator service that creates
 // `.fleet-issue-context.md` files in worktrees before CC spawn.
+//
+// The generator delegates to:
+//   - GitHubIssueProvider.fetchFullIssueContext() for GitHub issues (GraphQL)
+//   - Jira provider API for Jira issues
+//   - generateIssueContextMarkdown() from shared/issue-context.ts for rendering
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -11,25 +16,32 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockExecGHAsync = vi.hoisted(() => vi.fn());
-const mockIsValidGithubRepo = vi.hoisted(() => vi.fn().mockReturnValue(true));
-
-vi.mock('../../../src/server/utils/exec-gh.js', () => ({
-  execGHAsync: mockExecGHAsync,
-  isValidGithubRepo: mockIsValidGithubRepo,
-}));
-
+const mockFetchFullIssueContext = vi.hoisted(() => vi.fn());
 const mockGetIssue = vi.hoisted(() => vi.fn());
 const mockGetLinkedPRs = vi.hoisted(() => vi.fn());
 const mockGetDependencies = vi.hoisted(() => vi.fn());
 
+// Mock GitHubIssueProvider as a class with fetchFullIssueContext
+vi.mock('../../../src/server/providers/github-issue-provider.js', () => {
+  class MockGitHubIssueProvider {
+    name = 'github';
+    fetchFullIssueContext = mockFetchFullIssueContext;
+  }
+  return {
+    GitHubIssueProvider: MockGitHubIssueProvider,
+    parseRepo: (slug: string) => {
+      const parts = slug.split('/');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) return ['unknown', 'unknown'];
+      return [parts[0], parts[1]];
+    },
+  };
+});
+
+// We need dynamic provider returns: GitHub provider for GitHub tests, Jira provider for Jira tests
+const mockGetIssueProvider = vi.hoisted(() => vi.fn());
+
 vi.mock('../../../src/server/providers/index.js', () => ({
-  getIssueProvider: () => ({
-    name: 'jira',
-    getIssue: mockGetIssue,
-    getLinkedPRs: mockGetLinkedPRs,
-    getDependencies: mockGetDependencies,
-  }),
+  getIssueProvider: mockGetIssueProvider,
 }));
 
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
@@ -38,12 +50,19 @@ vi.mock('fs', () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
+const mockGenerateIssueContextMarkdown = vi.hoisted(() => vi.fn().mockReturnValue('# Mocked markdown'));
+vi.mock('../../../src/shared/issue-context.js', () => ({
+  generateIssueContextMarkdown: mockGenerateIssueContextMarkdown,
+}));
+
 // ---------------------------------------------------------------------------
-// Import after mocks
+// Import after mocks — need the real GitHubIssueProvider for instanceof checks
 // ---------------------------------------------------------------------------
 
-import { formatContextMarkdown, generateIssueContext } from '../../../src/server/services/issue-context-generator.js';
+import { generateIssueContext } from '../../../src/server/services/issue-context-generator.js';
+import { GitHubIssueProvider } from '../../../src/server/providers/github-issue-provider.js';
 import type { Project } from '../../../src/shared/types.js';
+import type { IssueContextData } from '../../../src/shared/issue-context.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,143 +89,34 @@ function makeProject(overrides: Partial<Project> = {}): Project {
   };
 }
 
-// ---------------------------------------------------------------------------
-// formatContextMarkdown Tests
-// ---------------------------------------------------------------------------
-
-describe('formatContextMarkdown', () => {
-  it('should render full context with all sections', () => {
-    const md = formatContextMarkdown({
-      key: '42',
-      title: 'Add user authentication',
-      state: 'OPEN',
-      url: 'https://github.com/owner/repo/issues/42',
-      body: 'We need OAuth2 support for the login flow.',
-      labels: ['feature', 'auth'],
-      assignees: ['alice', 'bob'],
-      comments: [
-        { author: 'carol', body: 'Looks good!', createdAt: '2026-01-15T10:00:00Z' },
-      ],
-      linkedPRs: [{ number: 50, state: 'OPEN' }],
-      dependencies: [{ key: '40', title: 'Setup database', state: 'CLOSED' }],
-      milestone: 'v1.0',
-    });
-
-    expect(md).toContain('# Issue 42: Add user authentication');
-    expect(md).toContain('| **Key** | 42 |');
-    expect(md).toContain('| **State** | OPEN |');
-    expect(md).toContain('| **URL** | https://github.com/owner/repo/issues/42 |');
-    expect(md).toContain('| **Milestone** | v1.0 |');
-    expect(md).toContain('| **Labels** | feature, auth |');
-    expect(md).toContain('| **Assignees** | alice, bob |');
-    expect(md).toContain('## Description');
-    expect(md).toContain('We need OAuth2 support');
-    expect(md).toContain('## Comments');
-    expect(md).toContain('### @carol (2026-01-15T10:00:00Z)');
-    expect(md).toContain('Looks good!');
-    expect(md).toContain('## Linked Pull Requests');
-    expect(md).toContain('- PR #50 — OPEN');
-    expect(md).toContain('## Dependencies');
-    expect(md).toContain('- 40: Setup database — CLOSED');
-  });
-
-  it('should omit empty sections', () => {
-    const md = formatContextMarkdown({
-      key: '10',
-      title: 'Simple bug fix',
-      state: 'OPEN',
-      url: null,
-      body: null,
-      labels: [],
-      assignees: [],
-      comments: [],
-      linkedPRs: [],
-      dependencies: [],
-      milestone: null,
-    });
-
-    expect(md).toContain('# Issue 10: Simple bug fix');
-    expect(md).toContain('| **Key** | 10 |');
-    expect(md).toContain('| **State** | OPEN |');
-    expect(md).not.toContain('## Description');
-    expect(md).not.toContain('## Comments');
-    expect(md).not.toContain('## Linked Pull Requests');
-    expect(md).not.toContain('## Dependencies');
-    expect(md).not.toContain('**URL**');
-    expect(md).not.toContain('**Milestone**');
-    expect(md).not.toContain('**Labels**');
-    expect(md).not.toContain('**Assignees**');
-  });
-
-  it('should truncate body exceeding 10,000 characters', () => {
-    const longBody = 'A'.repeat(15_000);
-    const md = formatContextMarkdown({
-      key: '1',
-      title: 'Long body test',
-      state: 'OPEN',
-      url: null,
-      body: longBody,
-      labels: [],
-      assignees: [],
-      comments: [],
-      linkedPRs: [],
-      dependencies: [],
-      milestone: null,
-    });
-
-    expect(md).toContain('*(truncated — original exceeds 10,000 characters)*');
-    // The body portion should not contain the full 15k characters
-    expect(md.length).toBeLessThan(15_000);
-  });
-
-  it('should limit comments to 20 most recent', () => {
-    const comments = Array.from({ length: 30 }, (_, i) => ({
-      author: `user${i}`,
-      body: `Comment ${i}`,
-      createdAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
-    }));
-
-    const md = formatContextMarkdown({
-      key: '5',
-      title: 'Many comments',
-      state: 'OPEN',
-      url: null,
-      body: null,
-      labels: [],
-      assignees: [],
-      comments,
-      linkedPRs: [],
-      dependencies: [],
-      milestone: null,
-    });
-
-    expect(md).toContain('*10 older comment(s) omitted');
-    // Should contain the last 20 comments (user10..user29), not the first 10
-    expect(md).toContain('@user10');
-    expect(md).toContain('@user29');
-    expect(md).not.toContain('@user0 ');
-    expect(md).not.toContain('@user9 ');
-  });
-
-  it('should handle null body gracefully', () => {
-    const md = formatContextMarkdown({
-      key: '7',
-      title: 'No body',
-      state: 'CLOSED',
-      url: null,
-      body: null,
-      labels: [],
-      assignees: [],
-      comments: [],
-      linkedPRs: [],
-      dependencies: [],
-      milestone: null,
-    });
-
-    expect(md).toContain('# Issue 7: No body');
-    expect(md).not.toContain('## Description');
-  });
-});
+function makeSampleIssueContextData(overrides: Partial<IssueContextData> = {}): IssueContextData {
+  return {
+    number: 42,
+    title: 'Add feature X',
+    state: 'OPEN',
+    repo: 'owner/repo',
+    author: 'alice',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-10T00:00:00Z',
+    labels: ['feature'],
+    assignees: ['alice'],
+    milestone: 'v2.0',
+    parent: null,
+    children: [],
+    blockedBy: [],
+    blocking: [],
+    linkedPRs: [{ number: 55, state: 'MERGED' }],
+    body: 'Feature description here.',
+    comments: [{ author: 'bob', date: '2026-01-10T00:00:00Z', body: 'LGTM' }],
+    truncation: {
+      bodyTruncated: false,
+      commentsTruncated: false,
+      totalComments: 1,
+      includedComments: 1,
+    },
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // generateIssueContext Tests
@@ -217,20 +127,12 @@ describe('generateIssueContext', () => {
     vi.clearAllMocks();
   });
 
-  it('should fetch GitHub issue and write context file', async () => {
-    const ghResponse = JSON.stringify({
-      number: 42,
-      title: 'Add feature X',
-      body: 'Feature description here.',
-      state: 'OPEN',
-      url: 'https://github.com/owner/repo/issues/42',
-      labels: [{ name: 'feature' }],
-      assignees: [{ login: 'alice' }],
-      comments: [{ author: { login: 'bob' }, body: 'LGTM', createdAt: '2026-01-10T00:00:00Z' }],
-      milestone: { title: 'v2.0' },
-      closedByPullRequests: [{ number: 55, state: 'MERGED' }],
-    });
-    mockExecGHAsync.mockResolvedValue(ghResponse);
+  it('should fetch GitHub issue via GitHubIssueProvider.fetchFullIssueContext and write context file', async () => {
+    const contextData = makeSampleIssueContextData();
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockResolvedValue(contextData);
+    mockGenerateIssueContextMarkdown.mockReturnValue('# Generated markdown');
 
     await generateIssueContext({
       worktreeAbsPath: '/tmp/worktree',
@@ -241,20 +143,29 @@ describe('generateIssueContext', () => {
       project: makeProject(),
     });
 
-    expect(mockExecGHAsync).toHaveBeenCalledTimes(1);
-    expect(mockExecGHAsync.mock.calls[0][0]).toContain('gh issue view 42');
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    // Verify fetchFullIssueContext was called with parsed owner/repo and issue number
+    expect(mockFetchFullIssueContext).toHaveBeenCalledWith('owner', 'repo', 42);
 
+    // Verify generateIssueContextMarkdown was called with the returned IssueContextData
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledWith(contextData);
+
+    // Verify file was written
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
     const writtenPath = mockWriteFileSync.mock.calls[0][0];
     const writtenContent = mockWriteFileSync.mock.calls[0][1];
     expect(writtenPath).toContain('.fleet-issue-context.md');
-    expect(writtenContent).toContain('# Issue 42: Add feature X');
-    expect(writtenContent).toContain('Feature description here.');
-    expect(writtenContent).toContain('LGTM');
-    expect(writtenContent).toContain('PR #55');
+    expect(writtenContent).toBe('# Generated markdown');
   });
 
-  it('should fetch Jira issue and write context file', async () => {
+  it('should fetch Jira issue and write context file using generateIssueContextMarkdown', async () => {
+    const jiraProvider = {
+      name: 'jira',
+      getIssue: mockGetIssue,
+      getLinkedPRs: mockGetLinkedPRs,
+      getDependencies: mockGetDependencies,
+    };
+    mockGetIssueProvider.mockReturnValue(jiraProvider);
+
     mockGetIssue.mockResolvedValue({
       key: 'PROJ-123',
       title: 'Jira task',
@@ -284,17 +195,23 @@ describe('generateIssueContext', () => {
     });
 
     expect(mockGetIssue).toHaveBeenCalledWith('PROJ-123');
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
 
-    const writtenContent = mockWriteFileSync.mock.calls[0][1];
-    expect(writtenContent).toContain('# Issue PROJ-123: Jira task');
-    expect(writtenContent).toContain('In Progress');
-    expect(writtenContent).toContain('PR #10');
-    expect(writtenContent).toContain('PROJ-100: Setup DB');
+    // Verify generateIssueContextMarkdown was called with IssueContextData (not formatContextMarkdown)
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.title).toBe('Jira task');
+    expect(passedData.state).toBe('In Progress');
+    expect(passedData.linkedPRs).toEqual([{ number: 10, state: 'open' }]);
+    expect(passedData.blockedBy).toEqual([{ number: 100, title: 'Setup DB', state: 'closed' }]);
+    expect(passedData.body).toBe(''); // Jira body is ADF, set to empty
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('should generate minimal context on GitHub fetch failure', async () => {
-    mockExecGHAsync.mockResolvedValue(null);
+  it('should generate fallback context on GitHub fetch failure', async () => {
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockResolvedValue(null);
 
     await generateIssueContext({
       worktreeAbsPath: '/tmp/worktree',
@@ -305,13 +222,25 @@ describe('generateIssueContext', () => {
       project: makeProject(),
     });
 
+    // Verify generateIssueContextMarkdown was called with fallback data
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.number).toBe(99);
+    expect(passedData.title).toBe('Fallback test');
+    expect(passedData.state).toBe('unknown');
+    expect(passedData.body).toBe('');
+    expect(passedData.comments).toEqual([]);
+
     expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-    const writtenContent = mockWriteFileSync.mock.calls[0][1];
-    expect(writtenContent).toContain('# Issue 99: Fallback test');
-    expect(writtenContent).toContain('| **State** | unknown |');
   });
 
-  it('should generate minimal context for unknown provider', async () => {
+  it('should generate fallback context for unknown provider', async () => {
+    // For an unknown provider, getIssueProvider may throw or return a non-GitHub provider.
+    // The generator should NOT call fetchFullIssueContext for non-GitHub providers.
+    mockGetIssueProvider.mockImplementation(() => {
+      throw new Error('Unsupported issue provider: "linear"');
+    });
+
     await generateIssueContext({
       worktreeAbsPath: '/tmp/worktree',
       issueKey: 'LIN-50',
@@ -321,17 +250,23 @@ describe('generateIssueContext', () => {
       project: makeProject({ issueProvider: 'linear', githubRepo: null }),
     });
 
-    // Should not call GitHub or Jira APIs
-    expect(mockExecGHAsync).not.toHaveBeenCalled();
-    expect(mockGetIssue).not.toHaveBeenCalled();
+    // Should not call fetchFullIssueContext
+    expect(mockFetchFullIssueContext).not.toHaveBeenCalled();
+
+    // Should still write a context file via fallback
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.number).toBe(50);
+    expect(passedData.title).toBe('Linear issue');
+    expect(passedData.state).toBe('unknown');
 
     expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-    const writtenContent = mockWriteFileSync.mock.calls[0][1];
-    expect(writtenContent).toContain('# Issue LIN-50: Linear issue');
   });
 
   it('should not throw when context generation fails', async () => {
-    mockExecGHAsync.mockRejectedValue(new Error('Network error'));
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockRejectedValue(new Error('Network error'));
 
     // Should NOT throw
     await expect(generateIssueContext({
@@ -345,6 +280,13 @@ describe('generateIssueContext', () => {
   });
 
   it('should handle Jira provider error gracefully', async () => {
+    const jiraProvider = {
+      name: 'jira',
+      getIssue: mockGetIssue,
+      getLinkedPRs: mockGetLinkedPRs,
+      getDependencies: mockGetDependencies,
+    };
+    mockGetIssueProvider.mockReturnValue(jiraProvider);
     mockGetIssue.mockRejectedValue(new Error('Jira auth failed'));
 
     await generateIssueContext({
@@ -356,27 +298,62 @@ describe('generateIssueContext', () => {
       project: makeProject({ issueProvider: 'jira', githubRepo: null }),
     });
 
-    // Should still write a minimal context file
+    // Should still write a minimal context file via fallback
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.number).toBe(999);
+    expect(passedData.title).toBe('Jira fail');
+    expect(passedData.state).toBe('unknown');
+
     expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-    const writtenContent = mockWriteFileSync.mock.calls[0][1];
-    expect(writtenContent).toContain('# Issue PROJ-999: Jira fail');
   });
 
-  it('should handle invalid GitHub repo slug', async () => {
-    mockIsValidGithubRepo.mockReturnValue(false);
+  it('should use instanceof GitHubIssueProvider to detect GitHub provider', async () => {
+    // Return a non-GitHub provider object for a github project
+    const nonGitHubProvider = {
+      name: 'custom',
+      getIssue: vi.fn(),
+      getLinkedPRs: vi.fn(),
+      getDependencies: vi.fn(),
+    };
+    mockGetIssueProvider.mockReturnValue(nonGitHubProvider);
 
     await generateIssueContext({
       worktreeAbsPath: '/tmp/worktree',
-      issueKey: '5',
-      issueNumber: 5,
-      issueTitle: 'Bad repo',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'Test',
       issueProvider: 'github',
-      project: makeProject({ githubRepo: 'invalid repo!' }),
+      project: makeProject(),
     });
 
-    // Should not call gh CLI
-    expect(mockExecGHAsync).not.toHaveBeenCalled();
-    // Should still write minimal context
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    // fetchFullIssueContext should NOT be called because provider is not instanceof GitHubIssueProvider
+    expect(mockFetchFullIssueContext).not.toHaveBeenCalled();
+
+    // Should fall through to fallback
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.state).toBe('unknown');
+  });
+
+  it('should fall back when project.githubRepo is missing for GitHub provider', async () => {
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'No repo',
+      issueProvider: 'github',
+      project: makeProject({ githubRepo: null }),
+    });
+
+    // Should not call fetchFullIssueContext because githubRepo is null
+    expect(mockFetchFullIssueContext).not.toHaveBeenCalled();
+    expect(mockGetIssueProvider).not.toHaveBeenCalled();
+
+    // Should use fallback
+    expect(mockGenerateIssueContextMarkdown).toHaveBeenCalledTimes(1);
+    const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
+    expect(passedData.title).toBe('No repo');
+    expect(passedData.state).toBe('unknown');
   });
 });


### PR DESCRIPTION
Closes #616

## Summary
- Replace `gh issue view` REST CLI calls with `GitHubIssueProvider.fetchFullIssueContext()` (GraphQL) for richer data (dependencies, bot filtering, hierarchy)
- Switch from local `formatContextMarkdown()` to shared `generateIssueContextMarkdown()` which implements spec correctly: YAML frontmatter, 8KB body limit, 10-comment limit, 16KB total cap
- Remove dead code: local `formatContextMarkdown`, `IssueContext`, `IssueComment`, `IssueLinkedPR`, `IssueDependency` types, `execGHAsync`/`isValidGithubRepo` imports
- Add `.fleet-issue-context.md` to root `.gitignore`
- Rewrite tests to mock new provider-based architecture

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 8 issue-context-generator tests pass
- [x] GitHub path uses `GitHubIssueProvider.fetchFullIssueContext()`
- [x] Jira path adapted to `IssueContextData` format
- [x] Fallback produces valid YAML frontmatter context file