### PR TITLE
Issue #614: Fix Jira issueKey→issueNumber collision across 7+ code paths

### DIFF
--- a/src/client/components/LaunchDialog.tsx
+++ b/src/client/components/LaunchDialog.tsx
@@ -14,6 +14,8 @@ interface IssueItem {
   state: 'open' | 'closed';
   labels: string[];
   activeTeam?: { id: number; status: string } | null;
+  issueKey?: string;
+  issueProvider?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -27,6 +29,8 @@ interface IssueTreeNode {
   labels: string[];
   children: IssueTreeNode[];
   activeTeam?: { id: number; status: string } | null;
+  issueKey?: string;
+  issueProvider?: string;
 }
 
 /** Flatten an issue tree into a single-level array */
@@ -40,6 +44,8 @@ function flattenIssueTree(nodes: IssueTreeNode[]): IssueItem[] {
         state: node.state,
         labels: node.labels,
         activeTeam: node.activeTeam,
+        issueKey: node.issueKey,
+        issueProvider: node.issueProvider,
       });
       if (node.children.length > 0) {
         walk(node.children);
@@ -202,10 +208,11 @@ function summarizeStreamEvent(event: StreamEvent): string {
 interface LaunchLogProps {
   teamId: number;
   issueKey: string;
+  issueProvider: string | null;
   onClose: () => void;
 }
 
-function LaunchLog({ teamId, issueKey, onClose }: LaunchLogProps) {
+function LaunchLog({ teamId, issueKey, issueProvider, onClose }: LaunchLogProps) {
   const api = useApi();
   const [teamStatus, setTeamStatus] = useState<TeamStatus>('queued');
   const [outputLines, setOutputLines] = useState<string[]>([]);
@@ -329,7 +336,7 @@ function LaunchLog({ teamId, issueKey, onClose }: LaunchLogProps) {
           {statusLabel(teamStatus)}
         </span>
         <span className="text-xs text-dark-muted ml-auto">
-          {formatIssueKey(issueKey, null)} &middot; Team #{teamId}
+          {formatIssueKey(issueKey, issueProvider)} &middot; Team #{teamId}
         </span>
       </div>
 
@@ -461,6 +468,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
   // --- Launch log state ---
   const [launchedTeamId, setLaunchedTeamId] = useState<number | null>(null);
   const [launchedIssueKey, setLaunchedIssueKey] = useState<string | null>(null);
+  const [launchedIssueProvider, setLaunchedIssueProvider] = useState<string | null>(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -543,6 +551,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
       setSelectedProjectId('');
       setLaunchedTeamId(null);
       setLaunchedIssueKey(null);
+      setLaunchedIssueProvider(null);
       setZone('green');
       setIssues([]);
       setIssuesError(null);
@@ -580,7 +589,8 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
     return issues.filter((issue) =>
       (!isNaN(numMatch) && issue.number === numMatch) ||
       issue.title.toLowerCase().includes(q) ||
-      String(issue.number).includes(q),
+      String(issue.number).includes(q) ||
+      (issue.issueKey && issue.issueKey.toLowerCase().includes(q)),
     );
   }, [issues, issueSearch]);
 
@@ -604,7 +614,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
 
   // --- Select an issue from the picker ---
   const handleSelectIssue = useCallback((issue: IssueItem) => {
-    setIssueNumber(String(issue.number));
+    setIssueNumber(issue.issueKey ?? String(issue.number));
     setIssueSearch('');
   }, []);
 
@@ -643,13 +653,16 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
       // Switch to launch log view instead of closing
       setLaunchedTeamId(team.id);
       setLaunchedIssueKey(trimmed);
+      // Determine issueProvider from the matched issue in the picker
+      const matchedIssue = issues.find((i) => i.issueKey === trimmed || String(i.number) === trimmed);
+      setLaunchedIssueProvider(matchedIssue?.issueProvider ?? (isNumeric ? 'github' : null));
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message || 'Failed to launch team');
     } finally {
       setLoading(false);
     }
-  }, [issueNumber, prompt, api, projects, selectedProjectId, headless]);
+  }, [issueNumber, prompt, api, projects, selectedProjectId, headless, issues]);
 
   // --- Batch launch ---
   const handleLaunchBatch = useCallback(async () => {
@@ -661,19 +674,13 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
       return;
     }
 
-    const numbers = raw
+    const keys = raw
       .split(/[,\s]+/)
       .map((s) => s.trim())
-      .filter(Boolean)
-      .map((s) => parseInt(s, 10));
+      .filter(Boolean);
 
-    if (numbers.some((n) => isNaN(n) || n < 1)) {
-      setError('All issue numbers must be positive integers');
-      return;
-    }
-
-    if (numbers.length === 0) {
-      setError('Enter at least one issue number');
+    if (keys.length === 0) {
+      setError('Enter at least one issue key');
       return;
     }
 
@@ -688,7 +695,15 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
       return;
     }
 
-    const batchIssueList = numbers.map((n) => ({ number: n }));
+    // Build batch issue list: parse each key as numeric or non-numeric
+    const batchIssueList = keys.map((key) => {
+      const num = parseInt(key, 10);
+      const isNumeric = !isNaN(num) && num > 0 && String(num) === key;
+      return {
+        number: isNumeric ? num : 0,
+        issueKey: key,
+      };
+    });
     const effectivePrompt = prompt.trim() || undefined;
     const projectId = selectedProjectId ? parseInt(selectedProjectId, 10) : undefined;
 
@@ -701,7 +716,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
         projectId,
         headless,
       });
-      setToast(`Launched ${numbers.length} team${numbers.length > 1 ? 's' : ''}`);
+      setToast(`Launched ${keys.length} team${keys.length > 1 ? 's' : ''}`);
       onClose();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -773,6 +788,7 @@ export function LaunchDialog({ open, onClose }: LaunchDialogProps) {
               <LaunchLog
                 teamId={launchedTeamId}
                 issueKey={launchedIssueKey}
+                issueProvider={launchedIssueProvider}
                 onClose={onClose}
               />
             ) : (

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -867,12 +867,14 @@ function RunAllConfirmDialog({ issues, skippedActive, blockedIssues, projectId, 
           number: n.number,
           title: n.title,
           issueKey: n.issueKey,
+          issueProvider: n.issueProvider,
         })),
         blockedIssues: blockedIssues.length > 0
           ? blockedIssues.map((n) => ({
               number: n.number,
               title: n.title,
               issueKey: n.issueKey,
+              issueProvider: n.issueProvider,
               blockedBy: n.dependencies?.blockedBy
                 ?.filter((b) => b.state === 'open')
                 .map((b) => b.number) ?? [],

--- a/src/server/mcp/tools/launch-team.ts
+++ b/src/server/mcp/tools/launch-team.ts
@@ -34,8 +34,11 @@ export function registerLaunchTeamTool(server: McpServer): void {
     },
     async ({ projectId, issueNumber, issueKey, headless, force }) => {
       try {
-        // Derive issueNumber from issueKey if not provided
-        const effectiveIssueNumber = issueNumber ?? (issueKey ? parseInt(issueKey, 10) || 0 : 0);
+        // Derive issueNumber from issueKey if not provided.
+        // For Jira keys like "PROJ-123", parseInt yields NaN -- use 0 instead.
+        // For purely numeric keys like "42", derive the number normally.
+        const numericKey = issueKey ? Number(issueKey) : NaN;
+        const effectiveIssueNumber = issueNumber ?? (Number.isInteger(numericKey) && numericKey > 0 ? numericKey : 0);
         if (!effectiveIssueNumber && !issueKey) {
           return {
             content: [{ type: 'text' as const, text: 'Either issueNumber or issueKey must be provided' }],

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -35,8 +35,8 @@ interface LaunchBody {
 
 interface LaunchBatchBody {
   projectId: number;
-  issues: Array<{ number: number; title?: string; issueKey?: string }>;
-  blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; blockedBy?: number[] }>;
+  issues: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string }>;
+  blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string; blockedBy?: number[] }>;
   prompt?: string;
   delayMs?: number;
   headless?: boolean;

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -730,12 +730,48 @@ export class IssueFetcher {
   }
 
   /**
+   * Get a single issue by issueKey (string) from the cache.
+   * Searches by node.issueKey via findInTreeByKey. Falls back to numeric
+   * lookup if the key is a purely numeric string (backward compat for GitHub).
+   * Searches across all project caches if projectId is not specified.
+   */
+  getIssueByKey(key: string, projectId?: number): IssueNode | undefined {
+    if (projectId !== undefined) {
+      const cached = this.cacheByProject.get(projectId);
+      if (!cached) return undefined;
+      const found = this.findInTreeByKey(cached.issues, key);
+      if (found) return found;
+      // Fallback: try numeric lookup for backward compat
+      const num = Number(key);
+      if (Number.isInteger(num) && num > 0) {
+        return this.findInTree(cached.issues, num);
+      }
+      return undefined;
+    }
+
+    // Search all project caches
+    for (const cache of this.cacheByProject.values()) {
+      const found = this.findInTreeByKey(cache.issues, key);
+      if (found) return found;
+    }
+    // Fallback: try numeric lookup across all caches
+    const num = Number(key);
+    if (Number.isInteger(num) && num > 0) {
+      for (const cache of this.cacheByProject.values()) {
+        const found = this.findInTree(cache.issues, num);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Suggest the next issue to work on for a specific project.
    * Criteria: Ready status, no active team, not in activeTeamIssues list.
    * Returns the highest priority issue (P0 > P1 > P2 > unlabeled).
    */
-  getNextIssue(activeTeamIssues: number[], projectId?: number): IssueNode | null {
-    const available = this.getAvailableIssues(activeTeamIssues, projectId);
+  getNextIssue(activeTeamIssues: number[], projectId?: number, activeTeamIssueKeys: string[] = []): IssueNode | null {
+    const available = this.getAvailableIssues(activeTeamIssues, projectId, activeTeamIssueKeys);
 
     if (available.length === 0) return null;
 
@@ -753,9 +789,14 @@ export class IssueFetcher {
    * Get all issues that have no active team assigned.
    * Filters by Ready board status and excludes issues in activeTeamIssues.
    * Uses cached issues synchronously -- does not trigger a fetch.
+   *
+   * @param activeTeamIssues - Issue numbers with active teams
+   * @param projectId - Optional project ID to filter by
+   * @param activeTeamIssueKeys - Issue keys (strings) with active teams, for Jira/Linear dedup
    */
-  getAvailableIssues(activeTeamIssues: number[], projectId?: number): IssueNode[] {
-    const activeSet = new Set(activeTeamIssues);
+  getAvailableIssues(activeTeamIssues: number[], projectId?: number, activeTeamIssueKeys: string[] = []): IssueNode[] {
+    const activeNumberSet = new Set(activeTeamIssues);
+    const activeKeySet = new Set(activeTeamIssueKeys);
     const issues = this.getIssuesCached(projectId);
     const allIssues = this.flattenTree(issues);
 
@@ -763,8 +804,9 @@ export class IssueFetcher {
       // Must be open
       if (issue.state !== 'open') return false;
 
-      // Must not already have an active team
-      if (activeSet.has(issue.number)) return false;
+      // Must not already have an active team (check by issueKey first, then by number)
+      if (issue.issueKey && activeKeySet.has(issue.issueKey)) return false;
+      if (activeNumberSet.has(issue.number)) return false;
 
       // Prefer "Ready" board status, but include issues without board status
       // (they might not be on the project board yet)
@@ -883,18 +925,24 @@ export class IssueFetcher {
         ? db.getActiveTeamsByProject(projectId)
         : db.getActiveTeams();
 
-      // Build a map of issue number -> active team
-      const teamByIssue = new Map<number, { id: number; status: string }>();
+      // Build dual maps: issueKey (string) -> team and issueNumber (number) -> team.
+      // The issueKey map is the primary lookup to avoid collisions between
+      // Jira issues with the same trailing number (e.g. FRONTEND-42 vs BACKEND-42).
+      const teamByIssueKey = new Map<string, { id: number; status: string }>();
+      const teamByIssueNumber = new Map<number, { id: number; status: string }>();
       for (const team of activeTeams) {
-        teamByIssue.set(team.issueNumber, {
-          id: team.id,
-          status: team.status,
-        });
+        const teamInfo = { id: team.id, status: team.status };
+        if (team.issueKey) {
+          teamByIssueKey.set(team.issueKey, teamInfo);
+        }
+        teamByIssueNumber.set(team.issueNumber, teamInfo);
       }
 
-      // Recursively create shallow copies with team info set
+      // Recursively create shallow copies with team info set.
+      // Look up by issueKey first (if available), then fall back to number.
       const enrichNode = (node: IssueNode): IssueNode => {
-        const team = teamByIssue.get(node.number);
+        const team = (node.issueKey ? teamByIssueKey.get(node.issueKey) : undefined)
+          ?? teamByIssueNumber.get(node.number);
         return {
           ...node,
           labels: [...node.labels],
@@ -1101,6 +1149,20 @@ export class IssueFetcher {
     for (const node of nodes) {
       if (node.number === number) return node;
       const found = this.findInTree(node.children, number);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  /**
+   * Recursively search for an issue by issueKey (string) in the tree.
+   * Used for Jira/Linear-style keys like "PROJ-123" that cannot be
+   * uniquely identified by numeric issue number alone.
+   */
+  private findInTreeByKey(nodes: IssueNode[], key: string): IssueNode | undefined {
+    for (const node of nodes) {
+      if (node.issueKey === key) return node;
+      const found = this.findInTreeByKey(node.children, key);
       if (found) return found;
     }
     return undefined;

--- a/src/server/services/issue-service.ts
+++ b/src/server/services/issue-service.ts
@@ -81,6 +81,24 @@ function getActiveTeamIssueNumbers(projectId?: number): number[] {
   }
 }
 
+/**
+ * Get issue keys (strings) for all active teams from the database.
+ * Filters out null keys (old teams that predate issueKey tracking).
+ */
+function getActiveTeamIssueKeys(projectId?: number): string[] {
+  try {
+    const db = getDatabase();
+    const activeTeams = projectId !== undefined
+      ? db.getActiveTeamsByProject(projectId)
+      : db.getActiveTeams();
+    return activeTeams
+      .map((t) => t.issueKey)
+      .filter((k): k is string => k !== null);
+  } catch {
+    return [];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -186,7 +204,8 @@ export class IssueService {
   getNextIssue(): { issue: IssueNode | null; reason: string } {
     const fetcher = getIssueFetcher();
     const activeIssues = getActiveTeamIssueNumbers();
-    const nextIssue = fetcher.getNextIssue(activeIssues);
+    const activeKeys = getActiveTeamIssueKeys();
+    const nextIssue = fetcher.getNextIssue(activeIssues, undefined, activeKeys);
 
     if (!nextIssue) {
       return {
@@ -211,7 +230,8 @@ export class IssueService {
   getAvailableIssues(): { issues: IssueNode[]; count: number } {
     const fetcher = getIssueFetcher();
     const activeIssues = getActiveTeamIssueNumbers();
-    const available = fetcher.getAvailableIssues(activeIssues);
+    const activeKeys = getActiveTeamIssueKeys();
+    const available = fetcher.getAvailableIssues(activeIssues, undefined, activeKeys);
 
     const enriched = fetcher.enrichWithTeamInfo(available);
 
@@ -240,6 +260,34 @@ export class IssueService {
     if (!issue) {
       throw notFoundError(
         `Issue #${issueNumber} not found in cache. Try POST /api/issues/refresh first.`,
+      );
+    }
+
+    const [enriched] = fetcher.enrichWithTeamInfo([issue]);
+
+    return enriched;
+  }
+
+  /**
+   * Get a single issue by its string key (e.g. "42" for GitHub, "PROJ-123" for Jira).
+   * Falls back to numeric lookup if the key is a purely numeric string.
+   *
+   * @param key - The issue key string
+   * @returns The enriched issue
+   * @throws ServiceError with code VALIDATION if key is empty
+   * @throws ServiceError with code NOT_FOUND if issue not in cache
+   */
+  getIssueByKey(key: string): IssueNode {
+    if (!key || typeof key !== 'string' || !key.trim()) {
+      throw validationError('Issue key must be a non-empty string');
+    }
+
+    const fetcher = getIssueFetcher();
+    const issue = fetcher.getIssueByKey(key.trim());
+
+    if (!issue) {
+      throw notFoundError(
+        `Issue "${key}" not found in cache. Try POST /api/issues/refresh first.`,
       );
     }
 

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1613,7 +1613,7 @@ export class TeamManager {
 
   async launchBatch(
     projectId: number,
-    issues: Array<{ number: number; title?: string; issueKey?: string }>,
+    issues: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string }>,
     prompt?: string,
     delayMs?: number,
     headless?: boolean,

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -159,8 +159,8 @@ export class TeamService {
    */
   async launchBatch(params: {
     projectId: number;
-    issues: Array<{ number: number; title?: string; issueKey?: string }>;
-    blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; blockedBy?: number[] }>;
+    issues: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string }>;
+    blockedIssues?: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string; blockedBy?: number[] }>;
     prompt?: string;
     delayMs?: number;
     headless?: boolean;
@@ -179,8 +179,11 @@ export class TeamService {
 
     if (hasIssues) {
       for (const issue of issues) {
-        if (!issue.number || typeof issue.number !== 'number' || issue.number < 1) {
-          throw validationError(`Invalid issue number: ${JSON.stringify(issue)}`);
+        // Allow number=0 when issueKey is present (e.g. Jira keys like "PROJ-123")
+        const hasValidNumber = typeof issue.number === 'number' && issue.number >= 1;
+        const hasValidKey = typeof issue.issueKey === 'string' && issue.issueKey.trim().length > 0;
+        if (!hasValidNumber && !hasValidKey) {
+          throw validationError(`Invalid issue: must have a positive number or a non-empty issueKey: ${JSON.stringify(issue)}`);
         }
       }
     }
@@ -195,8 +198,8 @@ export class TeamService {
     }
 
     // Dependency check for batch launch — separate launchable from queueable
-    const launchable: Array<{ number: number; title?: string; issueKey?: string }> = [];
-    const queueable: Array<{ issue: { number: number; title?: string; issueKey?: string }; blockerNumbers: number[] }> = [];
+    const launchable: Array<{ number: number; title?: string; issueKey?: string; issueProvider?: string }> = [];
+    const queueable: Array<{ issue: { number: number; title?: string; issueKey?: string; issueProvider?: string }; blockerNumbers: number[] }> = [];
 
     for (const issue of (issues ?? [])) {
       const depInfo = await checkDependencies(projectId, issue.number);

--- a/tests/server/mcp/launch-team.test.ts
+++ b/tests/server/mcp/launch-team.test.ts
@@ -155,4 +155,62 @@ describe('fleet_launch_team MCP tool', () => {
     const handler = registeredTools[0]!.handler;
     await expect(handler({ projectId: 1, issueNumber: 42 })).rejects.toThrow('unexpected');
   });
+
+  it('handler derives issueNumber=0 from non-numeric Jira issueKey', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: 'PROJ-123' });
+
+    expect(mockLaunchTeam).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 1,
+        issueNumber: 0,
+        issueKey: 'PROJ-123',
+      }),
+    );
+  });
+
+  it('handler derives issueNumber from purely numeric issueKey', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42' });
+
+    expect(mockLaunchTeam).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 1,
+        issueNumber: 42,
+        issueKey: '42',
+      }),
+    );
+  });
+
+  it('handler returns error when neither issueNumber nor issueKey provided', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Either issueNumber or issueKey');
+  });
+
+  it('handler prefers explicit issueNumber over issueKey derivation', async () => {
+    registerLaunchTeamTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueNumber: 99, issueKey: 'PROJ-123' });
+
+    expect(mockLaunchTeam).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 1,
+        issueNumber: 99,
+        issueKey: 'PROJ-123',
+      }),
+    );
+  });
 });

--- a/tests/server/services/issue-fetcher-jira-collision.test.ts
+++ b/tests/server/services/issue-fetcher-jira-collision.test.ts
@@ -1,0 +1,303 @@
+// =============================================================================
+// Fleet Commander -- Jira Issue Key Collision Tests
+// =============================================================================
+// Focused tests for the Jira collision bug (#614): two Jira teams with
+// different project prefixes but same trailing number (e.g. FRONTEND-42 and
+// BACKEND-42) should be correctly distinguished in enrichWithTeamInfo,
+// getIssueByKey, getAvailableIssues, and findInTreeByKey.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// ---------------------------------------------------------------------------
+// Mock the issue provider and GitHub provider to avoid real network calls
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/providers/index.js', () => ({
+  getIssueProvider: vi.fn(() => ({
+    fetchIssues: vi.fn().mockResolvedValue([]),
+    getDependencies: vi.fn().mockResolvedValue([]),
+  })),
+  resetProviders: vi.fn(),
+}));
+
+vi.mock('../../../src/server/providers/github-issue-provider.js', () => ({
+  GitHubIssueProvider: class MockGitHubProvider {},
+  parseDependenciesFromBody: vi.fn().mockReturnValue([]),
+  runWithConcurrency: vi.fn(),
+  parseRepo: vi.fn().mockReturnValue(['owner', 'repo']),
+}));
+
+vi.mock('../../../src/server/providers/jira-issue-provider.js', () => ({
+  JiraIssueProvider: class MockJiraProvider {},
+}));
+
+// Import after mocks
+import { IssueFetcher } from '../../../src/server/services/issue-fetcher.js';
+import type { IssueNode } from '../../../src/server/services/issue-fetcher.js';
+
+// ---------------------------------------------------------------------------
+// Test state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// DB lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-jira-collision-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+});
+
+afterAll(() => {
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIssueNode(overrides: Partial<IssueNode> & { number: number }): IssueNode {
+  return {
+    title: `Issue ${overrides.number}`,
+    state: 'open',
+    labels: [],
+    url: `https://example.com/issue/${overrides.number}`,
+    children: [],
+    activeTeam: null,
+    ...overrides,
+  };
+}
+
+function seedProject(name: string): { id: number } {
+  const db = getDatabase();
+  return db.insertProject({
+    name,
+    repoPath: `C:/fake/${name}-${Date.now()}`,
+    githubRepo: null,
+  });
+}
+
+function seedTeam(projectId: number, issueNumber: number, issueKey: string, status = 'running'): number {
+  const db = getDatabase();
+  const team = db.insertTeam({
+    projectId,
+    issueNumber,
+    issueTitle: `Team for ${issueKey}`,
+    worktreeName: `${issueKey.toLowerCase().replace(/[^a-z0-9]/g, '-')}`,
+    headless: true,
+    issueKey,
+    issueProvider: 'jira',
+  });
+  db.updateTeamSilent(team.id, { status });
+  return team.id;
+}
+
+// =============================================================================
+// Tests: enrichWithTeamInfo — dual-keyed map
+// =============================================================================
+
+describe('enrichWithTeamInfo with Jira collision scenario', () => {
+  let fetcher: IssueFetcher;
+
+  beforeEach(() => {
+    fetcher = new IssueFetcher();
+  });
+
+  it('should distinguish FRONTEND-42 from BACKEND-42 by issueKey', () => {
+    const project = seedProject('collision-test-a');
+
+    // Create two teams with same issueNumber (42) but different issueKeys
+    seedTeam(project.id, 42, 'FRONTEND-42', 'running');
+    seedTeam(project.id, 42, 'BACKEND-42', 'idle');
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, issueKey: 'FRONTEND-42', issueProvider: 'jira', title: 'Frontend fix' }),
+      makeIssueNode({ number: 42, issueKey: 'BACKEND-42', issueProvider: 'jira', title: 'Backend fix' }),
+    ];
+
+    const enriched = fetcher.enrichWithTeamInfo(issues, project.id);
+
+    // Both should have activeTeam set, and they should be DIFFERENT teams
+    expect(enriched[0]!.activeTeam).not.toBeNull();
+    expect(enriched[1]!.activeTeam).not.toBeNull();
+
+    // They should be different teams (different ids)
+    expect(enriched[0]!.activeTeam!.id).not.toBe(enriched[1]!.activeTeam!.id);
+
+    // Verify the correct team is matched to the correct issue
+    const frontendTeam = enriched.find((i) => i.issueKey === 'FRONTEND-42');
+    const backendTeam = enriched.find((i) => i.issueKey === 'BACKEND-42');
+    expect(frontendTeam?.activeTeam?.status).toBe('running');
+    expect(backendTeam?.activeTeam?.status).toBe('idle');
+  });
+
+  it('should fall back to issueNumber for nodes without issueKey', () => {
+    const project = seedProject('collision-test-b');
+    seedTeam(project.id, 99, 'PROJ-99', 'running');
+
+    const issues: IssueNode[] = [
+      // Node without issueKey — should match by number
+      makeIssueNode({ number: 99, title: 'Legacy issue without key' }),
+    ];
+
+    const enriched = fetcher.enrichWithTeamInfo(issues, project.id);
+
+    expect(enriched[0]!.activeTeam).not.toBeNull();
+    expect(enriched[0]!.activeTeam!.status).toBe('running');
+  });
+
+  it('should return null activeTeam for nodes with no matching team', () => {
+    const project = seedProject('collision-test-c');
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 777, issueKey: 'NOPE-777', issueProvider: 'jira', title: 'No team' }),
+    ];
+
+    const enriched = fetcher.enrichWithTeamInfo(issues, project.id);
+
+    expect(enriched[0]!.activeTeam).toBeNull();
+  });
+});
+
+// =============================================================================
+// Tests: getIssueByKey
+// =============================================================================
+
+describe('IssueFetcher.getIssueByKey', () => {
+  it('should find an issue by its Jira-style issueKey', () => {
+    const fetcher = new IssueFetcher();
+
+    // Inject issues into the cache via the private cacheByProject map
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, issueKey: 'PROJ-42', issueProvider: 'jira', title: 'Jira issue' }),
+      makeIssueNode({ number: 43, issueKey: 'PROJ-43', issueProvider: 'jira', title: 'Another Jira issue' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues, cachedAt: new Date().toISOString() });
+
+    const found = fetcher.getIssueByKey('PROJ-42', 1);
+    expect(found).toBeDefined();
+    expect(found!.issueKey).toBe('PROJ-42');
+    expect(found!.title).toBe('Jira issue');
+  });
+
+  it('should return undefined for a non-existent key', () => {
+    const fetcher = new IssueFetcher();
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, issueKey: 'PROJ-42', issueProvider: 'jira' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues, cachedAt: new Date().toISOString() });
+
+    const found = fetcher.getIssueByKey('NONEXIST-999', 1);
+    expect(found).toBeUndefined();
+  });
+
+  it('should search all projects when projectId is not specified', () => {
+    const fetcher = new IssueFetcher();
+
+    const issuesA: IssueNode[] = [
+      makeIssueNode({ number: 10, issueKey: 'ALPHA-10', issueProvider: 'jira' }),
+    ];
+    const issuesB: IssueNode[] = [
+      makeIssueNode({ number: 20, issueKey: 'BETA-20', issueProvider: 'jira' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues: issuesA, cachedAt: new Date().toISOString() });
+    (fetcher as any).cacheByProject.set(2, { issues: issuesB, cachedAt: new Date().toISOString() });
+
+    const found = fetcher.getIssueByKey('BETA-20');
+    expect(found).toBeDefined();
+    expect(found!.issueKey).toBe('BETA-20');
+  });
+
+  it('should fall back to numeric lookup for numeric string keys', () => {
+    const fetcher = new IssueFetcher();
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, issueKey: '42', issueProvider: 'github' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues, cachedAt: new Date().toISOString() });
+
+    const found = fetcher.getIssueByKey('42', 1);
+    expect(found).toBeDefined();
+    expect(found!.number).toBe(42);
+  });
+
+  it('should find issues nested in children by key', () => {
+    const fetcher = new IssueFetcher();
+
+    const child = makeIssueNode({ number: 99, issueKey: 'PROJ-99', issueProvider: 'jira', title: 'Nested' });
+    const parent = makeIssueNode({ number: 100, issueKey: 'PROJ-100', issueProvider: 'jira', title: 'Parent', children: [child] });
+    (fetcher as any).cacheByProject.set(1, { issues: [parent], cachedAt: new Date().toISOString() });
+
+    const found = fetcher.getIssueByKey('PROJ-99', 1);
+    expect(found).toBeDefined();
+    expect(found!.title).toBe('Nested');
+  });
+});
+
+// =============================================================================
+// Tests: getAvailableIssues — dual-keyed filtering
+// =============================================================================
+
+describe('getAvailableIssues with issueKey filtering', () => {
+  it('should filter by issueKey when available', () => {
+    const fetcher = new IssueFetcher();
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, issueKey: 'FRONTEND-42', issueProvider: 'jira', title: 'Frontend' }),
+      makeIssueNode({ number: 42, issueKey: 'BACKEND-42', issueProvider: 'jira', title: 'Backend' }),
+      makeIssueNode({ number: 43, issueKey: 'FRONTEND-43', issueProvider: 'jira', title: 'Available' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues, cachedAt: new Date().toISOString() });
+
+    // Only FRONTEND-42 has an active team (by key)
+    const available = fetcher.getAvailableIssues([], 1, ['FRONTEND-42']);
+
+    // BACKEND-42 and FRONTEND-43 should be available; FRONTEND-42 should be filtered out
+    expect(available).toHaveLength(2);
+    expect(available.find((i) => i.issueKey === 'FRONTEND-42')).toBeUndefined();
+    expect(available.find((i) => i.issueKey === 'BACKEND-42')).toBeDefined();
+    expect(available.find((i) => i.issueKey === 'FRONTEND-43')).toBeDefined();
+  });
+
+  it('should still filter by number for backward compatibility', () => {
+    const fetcher = new IssueFetcher();
+
+    const issues: IssueNode[] = [
+      makeIssueNode({ number: 42, title: 'GitHub issue' }),
+      makeIssueNode({ number: 43, title: 'Another issue' }),
+    ];
+    (fetcher as any).cacheByProject.set(1, { issues, cachedAt: new Date().toISOString() });
+
+    const available = fetcher.getAvailableIssues([42], 1);
+
+    expect(available).toHaveLength(1);
+    expect(available[0]!.number).toBe(43);
+  });
+});

--- a/tests/server/services/issue-service.test.ts
+++ b/tests/server/services/issue-service.test.ts
@@ -60,6 +60,7 @@ const mockGetIssuesByProject = vi.fn().mockReturnValue([]);
 const mockGetCachedAt = vi.fn().mockReturnValue('2026-03-25T12:00:00Z');
 const mockGetAvailableIssues = vi.fn().mockReturnValue(mockFlatIssues);
 const mockGetIssue = vi.fn().mockReturnValue(null);
+const mockGetIssueByKey = vi.fn().mockReturnValue(undefined);
 const mockRefresh = vi.fn().mockResolvedValue(mockIssueTree);
 const mockStart = vi.fn();
 const mockStop = vi.fn();
@@ -75,6 +76,7 @@ vi.mock('../../../src/server/services/issue-fetcher.js', () => ({
     getCachedAt: mockGetCachedAt,
     getAvailableIssues: mockGetAvailableIssues,
     getIssue: mockGetIssue,
+    getIssueByKey: mockGetIssueByKey,
     start: mockStart,
     stop: mockStop,
     refresh: mockRefresh,
@@ -133,6 +135,7 @@ beforeEach(() => {
   mockGetCachedAt.mockReturnValue('2026-03-25T12:00:00Z');
   mockGetAvailableIssues.mockReturnValue(mockFlatIssues);
   mockGetIssue.mockReturnValue(null);
+  mockGetIssueByKey.mockReturnValue(undefined);
   mockGetNextIssue.mockReturnValue(null);
   mockRefresh.mockResolvedValue(mockIssueTree);
 });
@@ -389,6 +392,63 @@ describe('IssueService.getIssue', () => {
 
     expect(result.number).toBe(42);
     expect(result.title).toBe('Test issue');
+  });
+});
+
+// =============================================================================
+// Tests: getIssueByKey
+// =============================================================================
+
+describe('IssueService.getIssueByKey', () => {
+  it('should throw VALIDATION for empty key', () => {
+    try {
+      service.getIssueByKey('');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for whitespace-only key', () => {
+    try {
+      service.getIssueByKey('   ');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND when issue not in cache', () => {
+    try {
+      service.getIssueByKey('NONEXIST-999');
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+      expect((err as ServiceError).message).toContain('NONEXIST-999');
+    }
+  });
+
+  it('should return enriched issue when found by key', () => {
+    const mockIssue = {
+      number: 42,
+      title: 'Jira issue',
+      state: 'open',
+      labels: [],
+      children: [],
+      issueKey: 'PROJ-42',
+      issueProvider: 'jira',
+    };
+    mockGetIssueByKey.mockReturnValue(mockIssue);
+    mockEnrichWithTeamInfo.mockReturnValue([mockIssue]);
+
+    const result = service.getIssueByKey('PROJ-42');
+
+    expect(result.number).toBe(42);
+    expect(result.title).toBe('Jira issue');
+    expect(mockGetIssueByKey).toHaveBeenCalledWith('PROJ-42');
   });
 });
 


### PR DESCRIPTION
Closes #614

## Summary
- Fix all 7 code paths that used `issueNumber` (integer) as sole lookup key, causing collisions for Jira issues with the same trailing number (e.g. `FRONTEND-42` vs `BACKEND-42`)
- Add dual-keyed lookup strategy: `issueKey` (string) as primary, `issueNumber` as fallback for backward compatibility
- Add `getIssueByKey()` methods to `IssueFetcher` and `IssueService` for key-based lookups
- Fix MCP `fleet_launch_team` to handle non-numeric Jira keys without `parseInt` → `NaN` → `0`
- Propagate `issueKey`/`issueProvider` through `LaunchDialog` picker, batch payload, and launch log
- Add `issueProvider` to `IssueTreeView` Run All batch payload
- Relax `LaunchBatchBody` validation to accept `number: 0` when `issueKey` is present

## Test plan
- [ ] New `issue-fetcher-jira-collision.test.ts` covers dual-key enrichment with colliding trailing numbers
- [ ] New `getIssueByKey` tests in `issue-service.test.ts` (validation, not-found, success)
- [ ] New MCP `launch-team.test.ts` tests for Jira key derivation and numeric key
- [ ] All existing server tests pass (backward compat preserved)
- [ ] `npm run build` succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)