### PR TITLE
Issue #617: Fix VirtualizedTreeList zero-height bug in SingleProjectTree

### DIFF
--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -1603,7 +1603,7 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
         prioritizing={prioritization.loading}
         collapsedNodes={collapsedNodes}
         onToggleCollapse={onToggleCollapse}
-        className="flex-1"
+        className="max-h-[70vh]"
       />
 
       {/* Run All confirmation dialog */}


### PR DESCRIPTION
Closes #617

## Summary
- Fix zero-height bug in `SingleProjectTree` by changing `VirtualizedTreeList` className from `flex-1` to `max-h-[70vh]`
- Aligns with existing pattern used by `ProjectGroup` (`max-h-[70vh]`) and `ProviderSubGroup` (`max-h-[60vh]`) paths

## Changes
- `src/client/views/IssueTreeView.tsx` line 1604: `className="flex-1"` → `className="max-h-[70vh]"`

## Test plan
- [x] `tsc --noEmit` passes
- [x] Client tests pass (`npm run test:client`)
- [ ] Verify issue tree is visible and scrollable when single project is selected