### PR TITLE
Issue #618: Fix double timer and leaked initialTimer in IssueUpdatePoller

### DIFF
--- a/src/server/services/issue-update-poller.ts
+++ b/src/server/services/issue-update-poller.ts
@@ -97,14 +97,11 @@ class IssueUpdatePoller {
   private snapshots = new Map<number, IssueSnapshot>();
 
   /**
-   * Start the polling loop. First poll fires after 10s delay, then
-   * every `config.issueUpdatePollMs` milliseconds.
+   * Start the polling loop. First poll fires after `config.issueUpdatePollMs`
+   * milliseconds, then repeats at the same interval.
    */
   start(): void {
     if (this.timer) return; // already running
-
-    const initialTimer = setTimeout(() => this.poll(), 10_000);
-    if (initialTimer.unref) initialTimer.unref();
 
     this.scheduleNextPoll();
     console.log(

--- a/tests/server/issue-update-poller.test.ts
+++ b/tests/server/issue-update-poller.test.ts
@@ -577,4 +577,30 @@ describe('IssueUpdatePoller', () => {
     // Should NOT send a message — this is a re-initialization
     expect(mockManager.sendMessage).not.toHaveBeenCalled();
   });
+
+  it('stop() cancels pending poll so no poll fires after stop', async () => {
+    issueUpdatePoller.start();
+    issueUpdatePoller.stop();
+
+    // Advance well past the poll interval — no poll should fire
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockDb.getActiveTeams).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent — calling twice does not create duplicate timers', async () => {
+    const team = makeTeam({ status: 'running' });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+    mockExecGHAsync.mockResolvedValue(makeGHIssueView());
+
+    issueUpdatePoller.start();
+    issueUpdatePoller.start(); // second call should be no-op
+
+    // Advance past one poll interval — only one poll should fire
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(mockExecGHAsync).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Closes #618

## Summary
- Remove leaked `initialTimer` local variable from `IssueUpdatePoller.start()` that created a double-poll on first cycle and fired even after `stop()`
- Consolidate all timing through the existing `scheduleNextPoll()` mechanism which `stop()` properly clears
- Add tests verifying `stop()` fully cancels pending polls and `start()` idempotency

## Changes
- `src/server/services/issue-update-poller.ts` — 2-line deletion removing `initialTimer` and its `unref()` call
- `tests/server/issue-update-poller.test.ts` — 2 new tests for timer lifecycle