### PR TITLE
Issue #620: Fix getIssue() returning null, use real createdAt, remove dead code

### DIFF
--- a/src/server/providers/github-issue-provider.ts
+++ b/src/server/providers/github-issue-provider.ts
@@ -42,6 +42,7 @@ export interface GraphQLIssueNode {
   title: string;
   state: string;
   url: string;
+  createdAt?: string;
   body?: string | null;
   labels?: { nodes?: Array<{ name: string }> };
   parent?: { number: number; title: string } | null;
@@ -135,6 +136,7 @@ query GetIssues($owner: String!, $repo: String!, $cursor: String) {
         parent { number title }
         subIssuesSummary { total completed percentCompleted }
         body
+        createdAt
         closedByPullRequestsReferences(first: 3, includeClosedPrs: true) {
           nodes { number state }
         }
@@ -162,6 +164,7 @@ query GetIssues($owner: String!, $repo: String!, $cursor: String) {
         parent { number title }
         subIssuesSummary { total completed percentCompleted }
         body
+        createdAt
         closedByPullRequestsReferences(first: 3, includeClosedPrs: true) {
           nodes { number state }
         }
@@ -491,13 +494,16 @@ export class GitHubIssueProvider implements IssueProvider {
 
   /**
    * Fetch a single issue by key (issue number as string).
-   * Uses GitHub GraphQL aliased query.
+   *
+   * @throws Error - always throws because this method requires owner/repo
+   * context that is not available from the issue key alone. Use
+   * fetchFullIssueContext() or fetchRawIssueHierarchy() instead.
    */
-  async getIssue(key: string): Promise<GenericIssue | null> {
-    // This method requires owner/repo context that is not available from
-    // the key alone. For now, return null -- the IssueFetcher uses
-    // fetchRawIssueHierarchy for batch fetches instead.
-    return null;
+  async getIssue(_key: string): Promise<GenericIssue | null> {
+    throw new Error(
+      'GitHubIssueProvider.getIssue() requires owner/repo context that is not available ' +
+      'from the issue key alone. Use fetchFullIssueContext() or fetchRawIssueHierarchy() instead.'
+    );
   }
 
   /**
@@ -589,7 +595,7 @@ export class GitHubIssueProvider implements IssueProvider {
       assignee: null,
       priority: null,
       parentKey: node.parent?.number ? String(node.parent.number) : null,
-      createdAt: new Date().toISOString(), // GitHub GraphQL does not include createdAt in this query
+      createdAt: node.createdAt ?? new Date().toISOString(), // Fallback for cached responses without createdAt
       updatedAt: null,
       provider: 'github',
     };

--- a/src/server/providers/jira-issue-provider.ts
+++ b/src/server/providers/jira-issue-provider.ts
@@ -521,21 +521,6 @@ export class JiraIssueProvider implements IssueProvider {
         }
       }
 
-      // Also handle outward direction: if outward says "blocks" and we have an outwardIssue,
-      // that means THIS issue blocks the outward issue -- skip (not a dependency OF this issue)
-
-      // Handle reverse: if inward says "blocks" (not "blocked by"), then outwardIssue is the blocker
-      const isBlocksDirection = !isBlockedByDirection && inwardDesc.includes('block');
-      if (isBlocksDirection && link.outwardIssue) {
-        // This means the outward issue blocks this one through the "blocks" inward link
-        // Actually, let's be more precise: if inward = "blocks" and we have outwardIssue,
-        // that doesn't make this issue blocked. Let's check the outward description too.
-        const outwardDesc = link.type.outward.toLowerCase();
-        if (outwardDesc.includes('blocked by') && link.outwardIssue) {
-          // outwardIssue is blocked by this issue -- not a dep of this issue
-          // skip
-        }
-      }
     }
 
     return deps;

--- a/tests/server/providers/github-issue-provider.test.ts
+++ b/tests/server/providers/github-issue-provider.test.ts
@@ -190,9 +190,8 @@ describe('GitHubIssueProvider', () => {
   // IssueProvider interface methods (stub implementations)
   // -----------------------------------------------------------------------
 
-  it('should return null from getIssue (requires owner/repo context)', async () => {
-    const result = await provider.getIssue('123');
-    expect(result).toBeNull();
+  it('should throw from getIssue (requires owner/repo context)', async () => {
+    await expect(provider.getIssue('123')).rejects.toThrow(/requires owner\/repo context/);
   });
 
   it('should return empty result from queryIssues', async () => {
@@ -221,6 +220,7 @@ describe('GitHubIssueProvider', () => {
         title: 'Fix the bug',
         state: 'OPEN',
         url: 'https://github.com/org/repo/issues/42',
+        createdAt: '2026-01-15T10:00:00Z',
         labels: { nodes: [{ name: 'bug' }, { name: 'P1' }] },
       };
 
@@ -234,6 +234,25 @@ describe('GitHubIssueProvider', () => {
       expect(result.labels).toEqual(['bug', 'P1']);
       expect(result.provider).toBe('github');
       expect(result.parentKey).toBeNull();
+      expect(result.createdAt).toBe('2026-01-15T10:00:00Z');
+    });
+
+    it('should fall back to current time when createdAt is missing', () => {
+      const before = new Date().toISOString();
+      const node: GraphQLIssueNode = {
+        number: 99,
+        title: 'No createdAt',
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/issues/99',
+      };
+
+      const result = provider.mapToGenericIssue(node);
+      const after = new Date().toISOString();
+
+      // createdAt should be a valid ISO 8601 string between before and after
+      expect(result.createdAt).toBeDefined();
+      expect(result.createdAt! >= before).toBe(true);
+      expect(result.createdAt! <= after).toBe(true);
     });
 
     it('should map CLOSED state to closed normalized status', () => {

--- a/tests/server/providers/jira-issue-provider.test.ts
+++ b/tests/server/providers/jira-issue-provider.test.ts
@@ -366,6 +366,33 @@ describe('JiraIssueProvider.getDependencies', () => {
     expect(deps).toHaveLength(0);
   });
 
+  it('should not treat outward "blocks" links as dependencies of this issue', async () => {
+    const provider = new JiraIssueProvider(makeConfig());
+
+    // This issue blocks TEST-99 (outward direction) -- TEST-99 is NOT a dependency of this issue
+    const issue = makeJiraIssue({
+      fields: {
+        issuelinks: [
+          {
+            id: '2',
+            type: { name: 'Blocks', inward: 'is blocked by', outward: 'blocks' },
+            outwardIssue: {
+              key: 'TEST-99',
+              fields: {
+                summary: 'Issue blocked by us',
+                status: { name: 'Open', statusCategory: { key: 'new', name: 'To Do' } },
+              },
+            },
+          },
+        ],
+      },
+    });
+    mockFetchResponse(issue);
+
+    const deps = await provider.getDependencies('TEST-42');
+    expect(deps).toHaveLength(0);
+  });
+
   it('should return empty array on error', async () => {
     const provider = new JiraIssueProvider(makeConfig());
     fetchMock.mockRejectedValueOnce(new Error('API error'));


### PR DESCRIPTION
Closes #620

## Summary
- **`GitHubIssueProvider.getIssue()`** now throws an error with a descriptive message instead of silently returning `null`, since it lacks the owner/repo context needed to fetch a single issue
- **`mapToGenericIssue()`** now uses the real `createdAt` from GitHub's GraphQL API instead of `new Date().toISOString()` — added `createdAt` to both `ISSUES_QUERY_FULL` and `ISSUES_QUERY_BASIC`
- **Removed dead code** in `JiraIssueProvider.extractBlockingDependencies()` — the `isBlocksDirection` branch that computed values but never pushed to the results array
- Updated and added tests covering all three fixes