### PR TITLE
Issue #621: Fix dependency lookup for non-active projects and persist blockedBySupported

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -393,6 +393,9 @@ export class FleetDatabase {
     // Add project_issue_sources table and backfill from projects (v13 migration)
     this.addProjectIssueSourcesTable();
 
+    // Add provider_state table if missing (for persisting provider runtime state)
+    this.addProviderStateTable();
+
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
 
@@ -1013,6 +1016,24 @@ export class FleetDatabase {
       console.log(`[DB] Migrated to v13: project_issue_sources table created, backfilled ${projects.length} project(s)`);
     } catch {
       // Tables may not exist yet (fresh database) — schema.sql will create them
+    }
+  }
+
+  /**
+   * Add provider_state table for persisting issue provider runtime state
+   * (e.g. blockedBySupported flag for GitHubIssueProvider).
+   */
+  private addProviderStateTable(): void {
+    try {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS provider_state (
+          key         TEXT PRIMARY KEY,
+          value       TEXT NOT NULL,
+          updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+    } catch {
+      // Table may already exist — safe to ignore
     }
   }
 
@@ -2932,6 +2953,32 @@ export class FleetDatabase {
       createdAt: utcify(row.created_at as string),
       updatedAt: utcify(row.updated_at as string),
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Provider State
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get a persisted provider state value by key.
+   * Returns undefined if the key has not been set.
+   */
+  getProviderState(key: string): string | undefined {
+    const row = this.db.prepare(
+      'SELECT value FROM provider_state WHERE key = ?'
+    ).get(key) as { value: string } | undefined;
+    return row?.value;
+  }
+
+  /**
+   * Set (upsert) a provider state value by key.
+   */
+  setProviderState(key: string, value: string): void {
+    this.db.prepare(
+      `INSERT INTO provider_state (key, value, updated_at)
+       VALUES (?, ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+    ).run(key, value);
   }
 }
 

--- a/src/server/providers/github-issue-provider.ts
+++ b/src/server/providers/github-issue-provider.ts
@@ -488,6 +488,12 @@ export class GitHubIssueProvider implements IssueProvider {
   // When this reaches 0, the next fetchRawIssueHierarchy() call re-enables blockedBySupported.
   private blockedByRetryCountdown = 0;
 
+  /**
+   * Optional callback invoked when `blockedBySupported` changes value.
+   * Set by the provider registry to persist state changes to the database.
+   */
+  onBlockedBySupportedChanged?: (supported: boolean) => void;
+
   // -------------------------------------------------------------------------
   // IssueProvider interface methods
   // -------------------------------------------------------------------------
@@ -828,6 +834,15 @@ export class GitHubIssueProvider implements IssueProvider {
   }
 
   /**
+   * Set the blockedBySupported flag directly (e.g. to inject persisted state
+   * on startup). Resets the retry countdown to 0.
+   */
+  setBlockedBySupported(value: boolean): void {
+    this.blockedBySupported = value;
+    this.blockedByRetryCountdown = 0;
+  }
+
+  /**
    * Decrement the retry countdown and re-enable blockedBy if it reaches 0.
    * Called by IssueFetcher at the start of each poll cycle.
    */
@@ -836,6 +851,7 @@ export class GitHubIssueProvider implements IssueProvider {
       this.blockedByRetryCountdown--;
       if (this.blockedByRetryCountdown === 0) {
         this.blockedBySupported = true;
+        this.onBlockedBySupportedChanged?.(true);
         console.info(
           '[GitHubIssueProvider] blockedBySupported changed: false -> true (retry countdown reached 0)'
         );
@@ -872,6 +888,7 @@ export class GitHubIssueProvider implements IssueProvider {
     if (this.blockedBySupported) {
       this.blockedBySupported = false;
       this.blockedByRetryCountdown = 5;
+      this.onBlockedBySupportedChanged?.(false);
       console.warn(
         '[GitHubIssueProvider] blockedBySupported changed: true -> false ' +
         '(batch query field error; will retry after 5 poll cycles)'

--- a/src/server/providers/index.ts
+++ b/src/server/providers/index.ts
@@ -8,6 +8,7 @@
 
 import type { IssueProvider, NormalizedStatus } from '../../shared/issue-provider.js';
 import type { Project } from '../../shared/types.js';
+import { getDatabase } from '../db.js';
 import { GitHubIssueProvider } from './github-issue-provider.js';
 import { JiraIssueProvider, type JiraConfig } from './jira-issue-provider.js';
 
@@ -41,9 +42,32 @@ export function getIssueProvider(project: Project): IssueProvider {
   let provider: IssueProvider;
 
   switch (providerName) {
-    case 'github':
-      provider = new GitHubIssueProvider();
+    case 'github': {
+      const ghProvider = new GitHubIssueProvider();
+
+      // Restore persisted blockedBySupported state from the database
+      try {
+        const db = getDatabase();
+        const persisted = db.getProviderState('github:blockedBySupported');
+        if (persisted === 'false') {
+          ghProvider.setBlockedBySupported(false);
+        }
+      } catch {
+        // DB may not be ready during tests — ignore
+      }
+
+      // Persist blockedBySupported changes to the database
+      ghProvider.onBlockedBySupportedChanged = (supported) => {
+        try {
+          getDatabase().setProviderState('github:blockedBySupported', String(supported));
+        } catch {
+          // DB may not be ready during tests — ignore
+        }
+      };
+
+      provider = ghProvider;
       break;
+    }
     case 'jira': {
       const jiraConfig = parseJiraConfig(project);
       provider = new JiraIssueProvider(jiraConfig);

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -334,5 +334,14 @@ CREATE TABLE IF NOT EXISTS team_tasks (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_team_tasks_team_task ON team_tasks(team_id, task_id);
 CREATE INDEX IF NOT EXISTS idx_team_tasks_team ON team_tasks(team_id);
 
+-- ---------------------------------------------------------------------------
+-- PROVIDER STATE — key-value persistence for issue provider runtime state
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS provider_state (
+  key         TEXT PRIMARY KEY,
+  value       TEXT NOT NULL,
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- Insert schema version 9 (or upgrade from earlier versions)
 INSERT OR IGNORE INTO schema_version (version) VALUES (13);

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -12,7 +12,7 @@
 
 import config from '../config.js';
 import { getDatabase } from '../db.js';
-import type { DependencyRef, IssueDependencyInfo } from '../../shared/types.js';
+import type { DependencyRef, IssueDependencyInfo, Project } from '../../shared/types.js';
 import type { GenericIssue, GenericDependencyRef } from '../../shared/issue-provider.js';
 import { getIssueProvider, resetProviders } from '../providers/index.js';
 import {
@@ -970,8 +970,8 @@ export class IssueFetcher {
    *
    * Returns null if the API call fails (e.g. gh CLI too old).
    */
-  async fetchDependencies(owner: string, repo: string, issueNumber: number): Promise<IssueDependencyInfo | null> {
-    return this.fetchDependenciesFromProvider(owner, repo, issueNumber);
+  async fetchDependencies(owner: string, repo: string, issueNumber: number, project: Project): Promise<IssueDependencyInfo | null> {
+    return this.fetchDependenciesFromProvider(owner, repo, issueNumber, project);
   }
 
   /**
@@ -1015,7 +1015,7 @@ export class IssueFetcher {
       try {
         const config = JSON.parse(ghSource.configJson) as { owner: string; repo: string };
         if (config.owner && config.repo) {
-          return this.fetchDependencies(config.owner, config.repo, issueNumber);
+          return this.fetchDependencies(config.owner, config.repo, issueNumber, project);
         }
       } catch {
         // Fall through to project.githubRepo
@@ -1024,7 +1024,7 @@ export class IssueFetcher {
 
     if (!project.githubRepo) return null;
     const [owner, repo] = parseRepo(project.githubRepo);
-    return this.fetchDependencies(owner, repo, issueNumber);
+    return this.fetchDependencies(owner, repo, issueNumber, project);
   }
 
   // -------------------------------------------------------------------------
@@ -1036,22 +1036,16 @@ export class IssueFetcher {
    * Used for single-issue dependency fetching (e.g. launch-time check).
    *
    * Delegates GraphQL execution to the GitHubIssueProvider.
+   * Receives the project directly from the caller to avoid a redundant
+   * `getProjects({ status: 'active' })` lookup that would miss non-active projects.
    */
   private async fetchDependenciesFromProvider(
     owner: string,
     repo: string,
     issueNumber: number,
+    project: Project,
   ): Promise<IssueDependencyInfo | null> {
     try {
-      // Look up the project to get the provider
-      const db = getDatabase();
-      const projects = db.getProjects({ status: 'active' });
-      const project = projects.find((p) => p.githubRepo === `${owner}/${repo}`);
-      if (!project) {
-        console.error(`[IssueFetcher] No project found for ${owner}/${repo}`);
-        return null;
-      }
-
       const provider = getIssueProvider(project);
       if (!(provider instanceof GitHubIssueProvider)) {
         console.error(`[IssueFetcher] Provider for ${owner}/${repo} is not a GitHubIssueProvider`);

--- a/tests/server/issue-dependencies.test.ts
+++ b/tests/server/issue-dependencies.test.ts
@@ -1152,3 +1152,4 @@ describe('batch launch dependency gate categorization', () => {
     expect(result.queueable.map((q) => q.issue.number)).toEqual([11, 12]);
   });
 });
+

--- a/tests/server/issue-fetcher-archived-deps.test.ts
+++ b/tests/server/issue-fetcher-archived-deps.test.ts
@@ -1,0 +1,176 @@
+// =============================================================================
+// Fleet Commander -- Archived Project Dependency Fetch Tests (Bug #621)
+// =============================================================================
+// Tests that fetchDependenciesForIssue works correctly when the project has
+// a non-active status (e.g. 'archived'). Previously, fetchDependenciesFromProvider
+// called db.getProjects({ status: 'active' }) which would miss archived projects,
+// causing a perpetual fail-closed for dependencies. The fix passes the project
+// directly through the call chain from fetchDependenciesForIssue.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks -- must be declared before import
+// ---------------------------------------------------------------------------
+
+const archivedProject = {
+  id: 1,
+  name: 'test-repo',
+  repoPath: '/path/to/repo',
+  githubRepo: 'owner/repo',
+  status: 'archived',
+  hooksInstalled: false,
+  maxActiveTeams: 5,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockDb = {
+  getProject: vi.fn().mockReturnValue(archivedProject),
+  getProjects: vi.fn().mockReturnValue([]),  // Empty: archived project not in active list
+  getIssueSources: vi.fn().mockReturnValue([]),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamsByProject: vi.fn().mockReturnValue([]),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    issuePollIntervalMs: 60000,
+  },
+}));
+
+// Mock child_process — exec callback must be invoked for resolveIssueStates to resolve
+const mockExec = vi.fn((_cmd: string, _opts: unknown, cb: Function) => {
+  // Return a plausible gh CLI response for resolveIssueStates
+  cb(null, { stdout: 'open\nBlocker issue', stderr: '' });
+});
+vi.mock('child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+  spawn: vi.fn(),
+}));
+
+// Mock util.promisify so that execAsync uses our mockExec
+vi.mock('util', () => ({
+  promisify: (fn: unknown) => {
+    return (...args: unknown[]) => {
+      return new Promise((resolve, reject) => {
+        (fn as Function)(...args, (err: Error | null, result: unknown) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      });
+    };
+  },
+}));
+
+// Import after mocks
+import { GitHubIssueProvider } from '../../src/server/providers/github-issue-provider.js';
+import { IssueFetcher } from '../../src/server/services/issue-fetcher.js';
+import * as providerRegistry from '../../src/server/providers/index.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fetchDependenciesForIssue with archived project (Bug #621)', () => {
+  let fetcher: IssueFetcher;
+  let provider: GitHubIssueProvider;
+  let getProviderSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSingleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDb.getProject.mockReturnValue(archivedProject);
+    mockDb.getProjects.mockReturnValue([]);
+    mockDb.getIssueSources.mockReturnValue([]);
+
+    provider = new GitHubIssueProvider();
+    getProviderSpy = vi.spyOn(providerRegistry, 'getIssueProvider').mockReturnValue(provider);
+
+    // Mock the provider's fetchSingleIssueDeps to return dependency data
+    // Use body: null to avoid triggering resolveIssueStates for the simple cases
+    fetchSingleSpy = vi.spyOn(provider, 'fetchSingleIssueDeps').mockResolvedValue({
+      body: null,
+      blockedBy: {
+        nodes: [{
+          number: 10,
+          title: 'Blocker issue',
+          state: 'OPEN',
+          repository: { owner: { login: 'owner' }, name: 'repo' },
+        }],
+      },
+      trackedInIssues: { nodes: [] },
+    });
+
+    fetcher = new IssueFetcher();
+  });
+
+  it('should successfully fetch dependencies for an archived project', async () => {
+    const result = await fetcher.fetchDependenciesForIssue(1, 42);
+
+    // Critical: result should NOT be null. Before the fix, this returned null
+    // because fetchDependenciesFromProvider called getProjects({ status: 'active' })
+    // which returned an empty array (archived project not included).
+    expect(result).not.toBeNull();
+    expect(result!.blockedBy).toHaveLength(1);
+    expect(result!.blockedBy[0].number).toBe(10);
+    expect(result!.resolved).toBe(false);
+    expect(result!.openCount).toBe(1);
+
+    // Verify the project was looked up by ID (no status filter)
+    expect(mockDb.getProject).toHaveBeenCalledWith(1);
+    // Verify fetchSingleIssueDeps was called
+    expect(fetchSingleSpy).toHaveBeenCalledWith('owner', 'repo', 42);
+  });
+
+  it('should pass project with status archived to the provider', async () => {
+    await fetcher.fetchDependenciesForIssue(1, 42);
+
+    // getIssueProvider should have been called with the archived project
+    expect(getProviderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, status: 'archived' })
+    );
+  });
+
+  it('should handle body-based dependencies with resolveIssueStates for archived project', async () => {
+    // Use body text that triggers parseDependenciesFromBody + resolveIssueStates
+    fetchSingleSpy.mockResolvedValue({
+      body: 'blocked by #20',
+      blockedBy: { nodes: [] },
+      trackedInIssues: { nodes: [] },
+    });
+
+    const result = await fetcher.fetchDependenciesForIssue(1, 42);
+
+    // Should succeed even with body parsing + resolveIssueStates
+    expect(result).not.toBeNull();
+    expect(result!.blockedBy).toHaveLength(1);
+    expect(result!.blockedBy[0].number).toBe(20);
+  });
+
+  it('should return null when project does not exist at all', async () => {
+    mockDb.getProject.mockReturnValue(undefined);
+
+    const result = await fetcher.fetchDependenciesForIssue(999, 42);
+
+    expect(result).toBeNull();
+    expect(fetchSingleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return null when archived project has no githubRepo and no issue sources', async () => {
+    mockDb.getProject.mockReturnValue({
+      ...archivedProject,
+      githubRepo: null,
+    });
+
+    const result = await fetcher.fetchDependenciesForIssue(1, 42);
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/server/providers/github-issue-provider.test.ts
+++ b/tests/server/providers/github-issue-provider.test.ts
@@ -370,4 +370,86 @@ describe('GitHubIssueProvider', () => {
 
     spy.mockRestore();
   });
+
+  // -----------------------------------------------------------------------
+  // setBlockedBySupported
+  // -----------------------------------------------------------------------
+
+  describe('setBlockedBySupported', () => {
+    it('should set blockedBySupported to false', () => {
+      provider.setBlockedBySupported(false);
+      expect(provider.isBlockedBySupported).toBe(false);
+    });
+
+    it('should set blockedBySupported to true', () => {
+      // Start by setting to false, then back to true
+      provider.setBlockedBySupported(false);
+      provider.setBlockedBySupported(true);
+      expect(provider.isBlockedBySupported).toBe(true);
+    });
+
+    it('should reset retry countdown when setting blockedBySupported', () => {
+      // Simulate a downgrade with countdown
+      (provider as any).blockedBySupported = false;
+      (provider as any).blockedByRetryCountdown = 3;
+
+      // setBlockedBySupported should reset the countdown
+      provider.setBlockedBySupported(false);
+      expect((provider as any).blockedByRetryCountdown).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // onBlockedBySupportedChanged callback
+  // -----------------------------------------------------------------------
+
+  describe('onBlockedBySupportedChanged callback', () => {
+    it('should invoke callback when executeGraphQL downgrades blockedBySupported', async () => {
+      const callback = vi.fn();
+      provider.onBlockedBySupportedChanged = callback;
+
+      // Mock runGHGraphQL to fail with a field error so executeGraphQL downgrades
+      const ghSpy = vi.spyOn(provider as any, 'runGHGraphQL')
+        .mockResolvedValue(JSON.stringify({
+          data: null,
+          errors: [{ message: "Field 'blockedBy' doesn't exist on type 'Issue'" }],
+        }));
+
+      await (provider as any).executeGraphQL('owner', 'repo', null);
+
+      expect(callback).toHaveBeenCalledWith(false);
+
+      ghSpy.mockRestore();
+    });
+
+    it('should invoke callback when tickRetryCountdown re-enables blockedBySupported', () => {
+      const callback = vi.fn();
+      provider.onBlockedBySupportedChanged = callback;
+
+      // Set up state as if blockedBy was downgraded with 1 tick left
+      (provider as any).blockedBySupported = false;
+      (provider as any).blockedByRetryCountdown = 1;
+
+      provider.tickRetryCountdown();
+
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+
+    it('should not invoke callback when callback is not set', async () => {
+      // Ensure no callback is set
+      provider.onBlockedBySupportedChanged = undefined;
+
+      // This should not throw even without a callback
+      const ghSpy = vi.spyOn(provider as any, 'runGHGraphQL')
+        .mockResolvedValue(JSON.stringify({
+          data: null,
+          errors: [{ message: "Field 'blockedBy' doesn't exist on type 'Issue'" }],
+        }));
+
+      await (provider as any).executeGraphQL('owner', 'repo', null);
+      expect(provider.isBlockedBySupported).toBe(false);
+
+      ghSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
Closes #621

## Summary
- **Bug 1**: `fetchDependenciesFromProvider` no longer calls `db.getProjects({ status: 'active' })` — the `Project` object is now passed directly through the call chain, fixing perpetual fail-closed for archived/inactive projects with queued teams.
- **Bug 2**: `blockedBySupported` flag in `GitHubIssueProvider` is now persisted to a new `provider_state` table. On server restart, the persisted value is restored, eliminating the wasted failed GraphQL query per project.

## Changes
- `src/server/services/issue-fetcher.ts` — Thread `Project` parameter through `fetchDependencies` and `fetchDependenciesFromProvider`
- `src/server/providers/github-issue-provider.ts` — Add `setBlockedBySupported()` setter and `onBlockedBySupportedChanged` callback
- `src/server/providers/index.ts` — Wire up DB persistence for `blockedBySupported` state
- `src/server/db.ts` — Add `provider_state` table migration, `getProviderState()` and `setProviderState()` methods
- `src/server/schema.sql` — Add `provider_state` table definition
- New tests for setter/callback behavior and archived-project dependency fetch

## Test plan
- [x] `npm test` — all tests pass (3 pre-existing failures in `cc-spawn.test.ts` unrelated)
- [x] `npx tsc --noEmit` — no type errors
- [x] New tests cover: `setBlockedBySupported` setter, `onBlockedBySupportedChanged` callback firing, archived-project dependency fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)