### PR TITLE
Issue #630: Persist collapse/expand state for project rows and groups

### DIFF
--- a/src/client/hooks/useExpandState.ts
+++ b/src/client/hooks/useExpandState.ts
@@ -1,0 +1,126 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const STORAGE_KEY = 'fleet-projects-expanded';
+
+interface UseExpandStateReturn {
+  /** Set of item IDs that are currently expanded */
+  expandedIds: Set<string>;
+  /** Toggle a single item's expanded state */
+  toggle: (id: string) => void;
+  /** Check if a specific item is expanded */
+  isExpanded: (id: string) => boolean;
+  /** Whether localStorage had prior state on mount */
+  hasStoredData: boolean;
+  /**
+   * Seed default expanded items on first load (when localStorage is empty).
+   * Call this after the data is available. Only applies once and only if no
+   * prior expand state was persisted.
+   */
+  seedExpanded: (ids: string[]) => void;
+}
+
+/** Check if localStorage has a persisted expand state */
+function hasStoredState(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Read expanded item IDs from localStorage */
+function readFromStorage(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((v): v is string => typeof v === 'string'));
+    }
+  } catch {
+    // Ignore corrupt data
+  }
+  return new Set();
+}
+
+/** Write expanded item IDs to localStorage */
+function writeToStorage(set: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+/**
+ * Custom hook to manage expand/collapse state for the Projects page.
+ * Persists expanded item IDs to localStorage so state survives navigation
+ * and page refreshes.
+ *
+ * Items are keyed by prefixed IDs:
+ * - `project:{id}` for project cards
+ * - `group:{id}` for group sections
+ * - `group:ungrouped` for the ungrouped section
+ *
+ * On first visit (no localStorage data), all items start collapsed. Call
+ * `seedExpanded()` with default-expanded IDs after data is available to
+ * expand groups by default.
+ */
+export function useExpandState(): UseExpandStateReturn {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => readFromStorage());
+
+  // Track whether localStorage had prior state (used by seedExpanded)
+  const hadStoredState = useRef(hasStoredState());
+
+  // Expose the stored-data flag as a stable value
+  const hasStoredData = hadStoredState.current;
+
+  // Use a ref to track whether the initial load from storage has happened,
+  // so we don't write back to storage on mount.
+  const initialized = useRef(false);
+
+  // Track whether default seeding has already been attempted
+  const seeded = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      return;
+    }
+    writeToStorage(expandedIds);
+  }, [expandedIds]);
+
+  const toggle = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const isExpanded = useCallback(
+    (id: string) => expandedIds.has(id),
+    [expandedIds],
+  );
+
+  const seedExpanded = useCallback((ids: string[]) => {
+    // Only seed on first load when localStorage was empty
+    if (seeded.current || hadStoredState.current) return;
+    seeded.current = true;
+    if (ids.length > 0) {
+      setExpandedIds(new Set(ids));
+    }
+  }, []);
+
+  return {
+    expandedIds,
+    toggle,
+    isExpanded,
+    hasStoredData,
+    seedExpanded,
+  };
+}

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useApi } from '../hooks/useApi';
 import { useInlineEdit } from '../hooks/useInlineEdit';
+import { useExpandState } from '../hooks/useExpandState';
 import { AddProjectDialog } from '../components/AddProjectDialog';
 import { CleanupModal } from '../components/CleanupModal';
 import { JiraSourceDialog } from '../components/JiraSourceDialog';
@@ -580,6 +581,8 @@ function ProjectCard({
   groups,
   reinstalling,
   reinstallResult,
+  expanded,
+  onToggleExpand,
   onSaveLimit,
   onSaveModel,
   onReinstall,
@@ -594,6 +597,8 @@ function ProjectCard({
   groups: ProjectGroupWithCount[];
   reinstalling: number | null;
   reinstallResult: { id: number; ok: boolean; error?: string } | null;
+  expanded: boolean;
+  onToggleExpand: () => void;
   onSaveLimit: (projectId: number, value: number) => void;
   onSaveModel: (projectId: number, value: string) => void;
   onReinstall: (p: ProjectSummary) => void;
@@ -604,7 +609,6 @@ function ProjectCard({
   fetchRepoSettings: (projectId: number) => Promise<RepoSettings | null>;
   onCommitClaudeFiles: (projectId: number, options?: { reinstall?: boolean }) => Promise<{ ok: boolean; error?: string; message?: string }>;
 }) {
-  const [expanded, setExpanded] = useState(false);
   const [repoSettings, setRepoSettings] = useState<RepoSettings | null | undefined>(undefined);
   const [committing, setCommitting] = useState(false);
   const [commitResult, setCommitResult] = useState<{ ok: boolean; error?: string; message?: string } | null>(null);
@@ -647,7 +651,7 @@ function ProjectCard({
       {/* ── Tier 1: Compact summary line ── */}
       <div
         className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-dark-border/10 transition-colors"
-        onClick={() => setExpanded(!expanded)}
+        onClick={onToggleExpand}
       >
         {/* Chevron */}
         <ChevronRightIcon
@@ -960,7 +964,8 @@ function GroupSection({
   title,
   description,
   projectCount,
-  defaultExpanded,
+  expanded,
+  onToggleExpand,
   onEdit,
   onDelete,
   children,
@@ -968,17 +973,16 @@ function GroupSection({
   title: string;
   description?: string | null;
   projectCount: number;
-  defaultExpanded?: boolean;
+  expanded: boolean;
+  onToggleExpand: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
   children: React.ReactNode;
 }) {
-  const [expanded, setExpanded] = useState(defaultExpanded ?? true);
-
   return (
     <div className="mb-4">
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={onToggleExpand}
         className="flex items-center gap-2 w-full text-left py-2 group"
       >
         <svg
@@ -1145,6 +1149,9 @@ export function ProjectsPage() {
   const [groups, setGroups] = useState<ProjectGroupWithCount[]>([]);
   const [loading, setLoading] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
+
+  // Expand/collapse persistence
+  const expandState = useExpandState();
 
   // Group dialog state
   const [groupDialogOpen, setGroupDialogOpen] = useState(false);
@@ -1440,6 +1447,16 @@ export function ProjectsPage() {
     return { groupedSections: sections, ungroupedProjects: ungrouped };
   }, [projects, groups]);
 
+  // Seed default expanded state for groups on first load (all groups expanded)
+  useEffect(() => {
+    if (groups.length === 0 && ungroupedProjects.length === 0) return;
+    const defaultExpanded = [
+      ...groups.map((g) => `group:${g.id}`),
+      ...(ungroupedProjects.length > 0 ? ['group:ungrouped'] : []),
+    ];
+    expandState.seedExpanded(defaultExpanded);
+  }, [groups, ungroupedProjects.length, expandState.seedExpanded]);
+
   // Shared card props
   const cardProps = {
     groups,
@@ -1518,6 +1535,8 @@ export function ProjectsPage() {
                 title={group.name}
                 description={group.description}
                 projectCount={groupProjects.length}
+                expanded={expandState.isExpanded(`group:${group.id}`)}
+                onToggleExpand={() => expandState.toggle(`group:${group.id}`)}
                 onEdit={() => handleEditGroup(group)}
                 onDelete={() => handleDeleteGroup(group)}
               >
@@ -1528,6 +1547,8 @@ export function ProjectsPage() {
                     <ProjectCard
                       key={project.id}
                       project={project}
+                      expanded={expandState.isExpanded(`project:${project.id}`)}
+                      onToggleExpand={() => expandState.toggle(`project:${project.id}`)}
                       {...cardProps}
                     />
                   ))
@@ -1540,12 +1561,15 @@ export function ProjectsPage() {
               <GroupSection
                 title="Ungrouped"
                 projectCount={ungroupedProjects.length}
-                defaultExpanded={true}
+                expanded={expandState.isExpanded('group:ungrouped')}
+                onToggleExpand={() => expandState.toggle('group:ungrouped')}
               >
                 {ungroupedProjects.map((project) => (
                   <ProjectCard
                     key={project.id}
                     project={project}
+                    expanded={expandState.isExpanded(`project:${project.id}`)}
+                    onToggleExpand={() => expandState.toggle(`project:${project.id}`)}
                     {...cardProps}
                   />
                 ))}

--- a/tests/client/ProjectsPage.test.tsx
+++ b/tests/client/ProjectsPage.test.tsx
@@ -99,6 +99,8 @@ describe('ProjectsPage', () => {
     mockPost.mockReset();
     mockPut.mockReset();
     mockDel.mockReset();
+    // Clear persisted expand state between tests to prevent cross-contamination
+    localStorage.removeItem('fleet-projects-expanded');
   });
 
   afterEach(() => {
@@ -333,5 +335,84 @@ describe('ProjectsPage', () => {
     await screen.findByText('test-project');
     expect(mockGet).toHaveBeenCalledWith('projects');
     expect(mockGet).toHaveBeenCalledWith('project-groups');
+  });
+
+  // -----------------------------------------------------------------------
+  // Expand/collapse persistence (issue #630)
+  // -----------------------------------------------------------------------
+
+  it('persists project card expand state to localStorage', async () => {
+    setupDefaultMocks([makeProject({ id: 1, name: 'persist-proj' })]);
+    render(<ProjectsPage />);
+    const projectName = await screen.findByText('persist-proj');
+    const row = projectName.closest('[class*="cursor-pointer"]');
+    expect(row).not.toBeNull();
+
+    // Expand the project card
+    fireEvent.click(row!);
+    await screen.findByText('Repository');
+
+    // Verify localStorage was written with the project key
+    const stored = JSON.parse(localStorage.getItem('fleet-projects-expanded') || '[]');
+    expect(stored).toContain('project:1');
+  });
+
+  it('restores expanded project state from localStorage on mount', async () => {
+    // Pre-populate localStorage with an expanded project
+    localStorage.setItem('fleet-projects-expanded', JSON.stringify(['project:1', 'group:ungrouped']));
+
+    setupDefaultMocks([makeProject({ id: 1, name: 'restored-proj' })]);
+    render(<ProjectsPage />);
+
+    // Project details should be visible without clicking (restored from storage)
+    expect(await screen.findByText('Repository')).toBeInTheDocument();
+    expect(await screen.findByText('Configuration')).toBeInTheDocument();
+  });
+
+  it('persists group collapse state to localStorage', async () => {
+    const group = makeGroup({ id: 5, name: 'Collapsible Group' });
+    setupDefaultMocks(
+      [makeProject({ id: 1, name: 'group-proj', groupId: 5 })],
+      [group],
+    );
+    render(<ProjectsPage />);
+
+    // Group should start expanded (default behavior)
+    expect(await screen.findByText('group-proj')).toBeInTheDocument();
+
+    // Collapse the group by clicking its header
+    const groupButton = screen.getByText('Collapsible Group').closest('button');
+    expect(groupButton).not.toBeNull();
+    fireEvent.click(groupButton!);
+
+    // Project inside group should no longer be visible
+    await waitFor(() => {
+      expect(screen.queryByText('group-proj')).not.toBeInTheDocument();
+    });
+
+    // Verify localStorage reflects the collapsed state (group:5 removed from expanded set)
+    const stored = JSON.parse(localStorage.getItem('fleet-projects-expanded') || '[]');
+    expect(stored).not.toContain('group:5');
+  });
+
+  it('survives page refresh by restoring from localStorage', async () => {
+    const group = makeGroup({ id: 3, name: 'Persistent Group' });
+    // Pre-populate localStorage: group:3 expanded, project:2 expanded
+    localStorage.setItem(
+      'fleet-projects-expanded',
+      JSON.stringify(['group:3', 'project:2']),
+    );
+
+    setupDefaultMocks(
+      [makeProject({ id: 2, name: 'expanded-proj', groupId: 3 })],
+      [group],
+    );
+    render(<ProjectsPage />);
+
+    // Group should be expanded (from localStorage)
+    expect(await screen.findByText('expanded-proj')).toBeInTheDocument();
+
+    // Project should be expanded (from localStorage) — check for detail content
+    expect(await screen.findByText('Repository')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #630

## Summary
- Add `useExpandState` hook to persist expand/collapse state in `localStorage` under `fleet-projects-expanded` key
- Lift expand state from internal `ProjectCard`/`GroupSection` `useState` to controlled props driven by the new hook
- Groups default to expanded on first visit, projects default to collapsed — matching existing behavior
- 4 new tests verify persistence across navigation and page refresh

## Changed Files
- `src/client/hooks/useExpandState.ts` (new) — Custom hook managing a `Set<string>` of expanded item IDs
- `src/client/views/ProjectsPage.tsx` — Controlled expand props replace internal state
- `tests/client/ProjectsPage.test.tsx` — 4 new localStorage persistence tests

## Test plan
- [ ] Expand a project row, navigate away, return — should still be expanded
- [ ] Collapse a group, refresh page — should still be collapsed
- [ ] Clear localStorage, visit page — groups expanded, projects collapsed (defaults)
- [ ] All 21 ProjectsPage tests pass
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)