### PR TITLE
Issue #631: Fix issue sources UX — provider-aware dialogs, status badges, GitHub auth

### DIFF
--- a/src/client/components/GitHubSourceDialog.tsx
+++ b/src/client/components/GitHubSourceDialog.tsx
@@ -1,0 +1,370 @@
+// =============================================================================
+// Fleet Commander -- GitHubSourceDialog (modal for adding/editing GitHub issue source)
+// =============================================================================
+// Follows the JiraSourceDialog pattern: modal overlay, dark theme, form fields,
+// Test Connection + Save buttons.
+// =============================================================================
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ProjectIssueSourceResponse, GitHubSourceConfig, GitHubSourceCredentials, GitHubAuthMode } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GitHubSourceDialogProps {
+  open: boolean;
+  projectId: number;
+  source?: ProjectIssueSourceResponse | null;
+  onClose: () => void;
+  onSave: (data: {
+    provider: string;
+    label: string | null;
+    configJson: string;
+    credentialsJson: string;
+    enabled: boolean;
+  }) => Promise<void>;
+}
+
+interface TestResult {
+  ok: boolean;
+  repoName?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// GitHubSourceDialog
+// ---------------------------------------------------------------------------
+
+export function GitHubSourceDialog({ open, projectId, source, onClose, onSave }: GitHubSourceDialogProps) {
+  const [owner, setOwner] = useState('');
+  const [repo, setRepo] = useState('');
+  const [authMode, setAuthMode] = useState<GitHubAuthMode>('gh-cli');
+  const [pat, setPat] = useState('');
+  const [label, setLabel] = useState('');
+  const [enabled, setEnabled] = useState(true);
+
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  const ownerInputRef = useRef<HTMLInputElement>(null);
+
+  // Populate fields when opening (create vs edit)
+  useEffect(() => {
+    if (open) {
+      if (source) {
+        // Edit mode: parse existing config
+        try {
+          const config: GitHubSourceConfig = JSON.parse(source.configJson);
+          setOwner(config.owner || '');
+          setRepo(config.repo || '');
+          setAuthMode(config.authMode || 'gh-cli');
+        } catch {
+          setOwner('');
+          setRepo('');
+          setAuthMode('gh-cli');
+        }
+        // Fetch credentials from the dedicated endpoint
+        setPat('');
+        if (source.hasCredentials) {
+          fetch(`/api/projects/${projectId}/issue-sources/${source.id}/credentials`)
+            .then((res) => res.json())
+            .then((data: { credentialsJson: string | null }) => {
+              if (data.credentialsJson) {
+                try {
+                  const creds: GitHubSourceCredentials = JSON.parse(data.credentialsJson);
+                  setPat(creds.pat || '');
+                } catch {
+                  // Invalid credentials JSON -- leave fields empty
+                }
+              }
+            })
+            .catch(() => {
+              // Failed to fetch credentials -- leave fields empty
+            });
+        }
+        setLabel(source.label || '');
+        setEnabled(source.enabled);
+      } else {
+        // Create mode: reset all fields
+        setOwner('');
+        setRepo('');
+        setAuthMode('gh-cli');
+        setPat('');
+        setLabel('');
+        setEnabled(true);
+      }
+      setError(null);
+      setTestResult(null);
+      setSaving(false);
+      setTesting(false);
+      setTimeout(() => ownerInputRef.current?.focus(), 50);
+    }
+  }, [open, source, projectId]);
+
+  const validate = useCallback((): string | null => {
+    if (!owner.trim()) return 'Owner is required';
+    if (!repo.trim()) return 'Repository is required';
+    if (authMode === 'pat' && !pat.trim()) return 'Personal Access Token is required';
+    return null;
+  }, [owner, repo, authMode, pat]);
+
+  const handleTestConnection = useCallback(async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setTestResult(null);
+    setTesting(true);
+    try {
+      const resp = await fetch(`/api/projects/${projectId}/issue-sources/test-connection`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'github',
+          owner: owner.trim(),
+          repo: repo.trim(),
+          authMode,
+          ...(authMode === 'pat' ? { pat: pat.trim() } : {}),
+        }),
+      });
+      const data = await resp.json() as TestResult;
+      setTestResult(data);
+    } catch (err) {
+      setTestResult({ ok: false, error: err instanceof Error ? err.message : 'Unknown error' });
+    } finally {
+      setTesting(false);
+    }
+  }, [validate, projectId, owner, repo, authMode, pat]);
+
+  const handleSubmit = useCallback(async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      const configJson = JSON.stringify({
+        owner: owner.trim(),
+        repo: repo.trim(),
+        authMode,
+      } satisfies GitHubSourceConfig);
+      const credentialsJson = authMode === 'pat'
+        ? JSON.stringify({ pat: pat.trim() } satisfies GitHubSourceCredentials)
+        : '';
+
+      await onSave({
+        provider: 'github',
+        label: label.trim() || null,
+        configJson,
+        credentialsJson,
+        enabled,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+      setSaving(false);
+    }
+  }, [validate, owner, repo, authMode, pat, label, enabled, onSave]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="w-[480px] max-w-[95vw] bg-dark-surface border border-dark-border rounded-lg shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-dark-border">
+          <h2 className="text-base font-semibold text-dark-text">
+            {source ? 'Edit GitHub Source' : 'Add GitHub Source'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-dark-muted hover:text-dark-text transition-colors p-1 rounded hover:bg-dark-border/30"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          {/* Label (optional) */}
+          <div>
+            <label className="block text-xs text-dark-muted mb-1">Label (optional)</label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+              className="w-full px-3 py-1.5 text-sm rounded border border-dark-border bg-dark-base text-dark-text focus:outline-none focus:border-dark-accent"
+              placeholder="e.g. My GitHub Repo"
+            />
+          </div>
+
+          {/* Owner */}
+          <div>
+            <label className="block text-xs text-dark-muted mb-1">Owner</label>
+            <input
+              ref={ownerInputRef}
+              type="text"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+              className="w-full px-3 py-1.5 text-sm rounded border border-dark-border bg-dark-base text-dark-text focus:outline-none focus:border-dark-accent"
+              placeholder="e.g. octocat"
+            />
+          </div>
+
+          {/* Repository */}
+          <div>
+            <label className="block text-xs text-dark-muted mb-1">Repository</label>
+            <input
+              type="text"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+              className="w-full px-3 py-1.5 text-sm rounded border border-dark-border bg-dark-base text-dark-text focus:outline-none focus:border-dark-accent"
+              placeholder="e.g. hello-world"
+            />
+          </div>
+
+          {/* Auth Mode */}
+          <div>
+            <label className="block text-xs text-dark-muted mb-1">Authentication</label>
+            <div className="flex items-center gap-4 mt-1">
+              <label className="flex items-center gap-1.5 text-sm text-dark-text cursor-pointer">
+                <input
+                  type="radio"
+                  name="authMode"
+                  value="gh-cli"
+                  checked={authMode === 'gh-cli'}
+                  onChange={() => setAuthMode('gh-cli')}
+                  className="accent-[#3FB950]"
+                />
+                gh CLI (default)
+              </label>
+              <label className="flex items-center gap-1.5 text-sm text-dark-text cursor-pointer">
+                <input
+                  type="radio"
+                  name="authMode"
+                  value="pat"
+                  checked={authMode === 'pat'}
+                  onChange={() => setAuthMode('pat')}
+                  className="accent-[#3FB950]"
+                />
+                Personal Access Token
+              </label>
+            </div>
+          </div>
+
+          {/* gh CLI note */}
+          {authMode === 'gh-cli' && (
+            <div className="text-xs text-dark-muted/70 bg-dark-base/50 rounded px-3 py-2 border border-dark-border/50">
+              Uses local <code className="text-dark-accent/80">gh auth</code> session -- no credentials needed.
+            </div>
+          )}
+
+          {/* PAT input */}
+          {authMode === 'pat' && (
+            <div>
+              <label className="block text-xs text-dark-muted mb-1">Personal Access Token</label>
+              <input
+                type="password"
+                value={pat}
+                onChange={(e) => setPat(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+                className="w-full px-3 py-1.5 text-sm rounded border border-dark-border bg-dark-base text-dark-text focus:outline-none focus:border-dark-accent"
+                placeholder="ghp_xxxxxxxxxxxx"
+                autoComplete="off"
+              />
+            </div>
+          )}
+
+          {/* Enabled toggle (edit mode only) */}
+          {source && (
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-dark-muted">Enabled</label>
+              <button
+                type="button"
+                onClick={() => setEnabled(!enabled)}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                  enabled ? 'bg-[#3FB950]' : 'bg-dark-border'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                    enabled ? 'translate-x-4' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </div>
+          )}
+
+          {/* Test Connection result */}
+          {testResult && (
+            <div
+              className="text-xs rounded px-3 py-2 border"
+              style={{
+                color: testResult.ok ? '#3FB950' : '#F85149',
+                borderColor: testResult.ok ? '#3FB95040' : '#F8514940',
+                backgroundColor: testResult.ok ? '#3FB95010' : '#F8514910',
+              }}
+            >
+              {testResult.ok
+                ? `Connected successfully${testResult.repoName ? ` -- repo: ${testResult.repoName}` : ''}`
+                : testResult.error || 'Connection failed'}
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="text-xs text-[#F85149]">{error}</div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-4 border-t border-dark-border">
+          <button
+            onClick={handleTestConnection}
+            disabled={testing}
+            className="px-3 py-1.5 text-sm rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted transition-colors disabled:opacity-50"
+          >
+            {testing ? 'Testing...' : 'Test Connection'}
+          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-muted transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={saving}
+              className="px-4 py-1.5 text-sm font-medium rounded border border-dark-accent/40 text-dark-accent bg-dark-accent/10 hover:bg-dark-accent/20 transition-colors disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : (source ? 'Save' : 'Create')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -5,8 +5,9 @@ import { useExpandState } from '../hooks/useExpandState';
 import { AddProjectDialog } from '../components/AddProjectDialog';
 import { CleanupModal } from '../components/CleanupModal';
 import { JiraSourceDialog } from '../components/JiraSourceDialog';
+import { GitHubSourceDialog } from '../components/GitHubSourceDialog';
 import { OverflowMenu } from '../components/OverflowMenu';
-import { ChevronRightIcon, PencilIcon } from '../components/Icons';
+import { ChevronRightIcon, PencilIcon, ProviderIcon } from '../components/Icons';
 import type { ProjectSummary, ProjectStatus, ProjectGroup, ProjectIssueSourceResponse, RepoSettings } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -362,14 +363,32 @@ function InstallHealthDetail({ project, repoSettings }: { project: ProjectSummar
 // IssueSourcesSection — lists configured issue sources with status badges
 // ---------------------------------------------------------------------------
 
+/** Parse GitHub auth mode from configJson, defaulting to 'gh-cli' for backward compat */
+function getGitHubAuthMode(configJson: string): string {
+  try {
+    const config = JSON.parse(configJson) as Record<string, unknown>;
+    return typeof config.authMode === 'string' ? config.authMode : 'gh-cli';
+  } catch {
+    return 'gh-cli';
+  }
+}
+
 /** Status badge color: green=enabled+credentials, red=enabled+no credentials, gray=disabled */
 function sourceStatusColor(source: ProjectIssueSourceResponse): string {
   if (!source.enabled) return '#8B949E';
+  // GitHub sources in gh-cli mode are always green when enabled (no credentials needed)
+  if (source.provider === 'github' && getGitHubAuthMode(source.configJson) === 'gh-cli') {
+    return '#3FB950';
+  }
   return source.hasCredentials ? '#3FB950' : '#F85149';
 }
 
 function sourceStatusLabel(source: ProjectIssueSourceResponse): string {
   if (!source.enabled) return 'Disabled';
+  // GitHub sources in gh-cli mode show "Ready (gh CLI)" when enabled
+  if (source.provider === 'github' && getGitHubAuthMode(source.configJson) === 'gh-cli') {
+    return 'Ready (gh CLI)';
+  }
   return source.hasCredentials ? 'Connected' : 'No credentials';
 }
 
@@ -381,7 +400,7 @@ function IssueSourcesSection({
   const api = useApi();
   const [sources, setSources] = useState<ProjectIssueSourceResponse[]>([]);
   const [loading, setLoading] = useState(true);
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogState, setDialogState] = useState<'closed' | 'pick-provider' | 'github' | 'jira'>('closed');
   const [editingSource, setEditingSource] = useState<ProjectIssueSourceResponse | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
 
@@ -412,7 +431,7 @@ function IssueSourcesSection({
     } else {
       await api.post(`projects/${projectId}/issue-sources`, data);
     }
-    setDialogOpen(false);
+    setDialogState('closed');
     setEditingSource(null);
     await fetchSources();
   }, [api, projectId, editingSource, fetchSources]);
@@ -448,10 +467,10 @@ function IssueSourcesSection({
           Issue Sources
         </div>
         <button
-          onClick={() => { setEditingSource(null); setDialogOpen(true); }}
+          onClick={() => { setEditingSource(null); setDialogState('pick-provider'); }}
           className="text-[10px] text-dark-accent/70 hover:text-dark-accent transition-colors"
         >
-          + Add Jira Source
+          + Add Issue Source
         </button>
       </div>
 
@@ -473,6 +492,8 @@ function IssueSourcesSection({
               const config = JSON.parse(source.configJson) as Record<string, unknown>;
               if (config.projectKey) {
                 sourceLabel = source.label || `${source.provider} — ${config.projectKey}`;
+              } else if (config.owner && config.repo) {
+                sourceLabel = source.label || `${config.owner}/${config.repo}`;
               }
             } catch {
               // Use default label
@@ -489,6 +510,9 @@ function IssueSourcesSection({
                   style={{ backgroundColor: statusColor }}
                   title={statusText}
                 />
+
+                {/* Provider icon */}
+                <ProviderIcon provider={source.provider} size={12} className="shrink-0 text-dark-muted" />
 
                 {/* Label */}
                 <span className="text-dark-text/80 truncate flex-1" title={sourceLabel}>
@@ -517,7 +541,7 @@ function IssueSourcesSection({
 
                 {/* Edit button */}
                 <button
-                  onClick={() => { setEditingSource(source); setDialogOpen(true); }}
+                  onClick={() => { setEditingSource(source); setDialogState(source.provider === 'github' ? 'github' : 'jira'); }}
                   className="text-dark-muted/50 hover:text-dark-text transition-colors shrink-0"
                   title="Edit"
                 >
@@ -561,11 +585,62 @@ function IssueSourcesSection({
         </div>
       )}
 
-      <JiraSourceDialog
-        open={dialogOpen}
+      {/* Provider picker modal */}
+      {dialogState === 'pick-provider' && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={(e) => { if (e.target === e.currentTarget) setDialogState('closed'); }}
+        >
+          <div className="w-[320px] max-w-[95vw] bg-dark-surface border border-dark-border rounded-lg shadow-2xl" role="dialog" aria-modal="true">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-dark-border">
+              <h2 className="text-base font-semibold text-dark-text">Choose Provider</h2>
+              <button
+                onClick={() => setDialogState('closed')}
+                className="text-dark-muted hover:text-dark-text transition-colors p-1 rounded hover:bg-dark-border/30"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className="px-5 py-4 space-y-2">
+              <button
+                onClick={() => setDialogState('github')}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-dark-text rounded border border-dark-border hover:border-dark-accent/50 hover:bg-dark-accent/5 transition-colors"
+              >
+                <ProviderIcon provider="github" size={18} />
+                GitHub
+              </button>
+              <button
+                onClick={() => setDialogState('jira')}
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-dark-text rounded border border-dark-border hover:border-dark-accent/50 hover:bg-dark-accent/5 transition-colors"
+              >
+                <ProviderIcon provider="jira" size={18} />
+                Jira
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Provider-specific dialogs */}
+      <GitHubSourceDialog
+        open={dialogState === 'github'}
         projectId={projectId}
         source={editingSource}
-        onClose={() => { setDialogOpen(false); setEditingSource(null); }}
+        onClose={() => { setDialogState('closed'); setEditingSource(null); }}
+        onSave={handleSave}
+      />
+
+      <JiraSourceDialog
+        open={dialogState === 'jira'}
+        projectId={projectId}
+        source={editingSource}
+        onClose={() => { setDialogState('closed'); setEditingSource(null); }}
         onSave={handleSave}
       />
     </div>

--- a/src/server/routes/issue-sources.ts
+++ b/src/server/routes/issue-sources.ts
@@ -281,10 +281,12 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
   );
 
   /**
-   * POST /api/projects/:projectId/issue-sources/test-connection — Test Jira connection
+   * POST /api/projects/:projectId/issue-sources/test-connection — Test provider connection
    *
-   * Accepts Jira credential fields and validates them against the Jira REST API.
-   * Always returns 200 with { ok, projectName?, error? }.
+   * Provider-aware: accepts a `provider` field to dispatch to the correct handler.
+   * - `provider === 'github'`: validates gh CLI auth or PAT against GitHub API.
+   * - `provider === 'jira'` (or omitted): validates Jira REST API credentials.
+   * Always returns 200 with { ok, projectName?/repoName?, error? }.
    */
   server.post<{ Params: { projectId: string } }>(
     '/api/projects/:projectId/issue-sources/test-connection',
@@ -303,6 +305,107 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
           throw validationError('Request body is required');
         }
 
+        const provider = typeof body.provider === 'string' ? body.provider : 'jira';
+
+        // --- GitHub provider ---
+        if (provider === 'github') {
+          const owner = body.owner;
+          const repo = body.repo;
+          const authMode = typeof body.authMode === 'string' ? body.authMode : 'gh-cli';
+
+          if (!owner || typeof owner !== 'string') {
+            throw validationError('owner is required and must be a string');
+          }
+          if (!repo || typeof repo !== 'string') {
+            throw validationError('repo is required and must be a string');
+          }
+
+          if (authMode === 'gh-cli') {
+            // Validate gh CLI is authenticated
+            const { execFileSync } = await import('child_process');
+            try {
+              execFileSync('gh', ['auth', 'status'], { timeout: 10000, stdio: 'pipe' });
+            } catch (ghErr: unknown) {
+              const errMsg = ghErr instanceof Error && 'code' in ghErr && (ghErr as NodeJS.ErrnoException).code === 'ENOENT'
+                ? 'gh CLI is not installed or not in PATH'
+                : 'gh CLI is not authenticated. Run "gh auth login" first.';
+              return reply.code(200).send({ ok: false, error: errMsg });
+            }
+
+            // Validate repo exists
+            try {
+              const result = execFileSync('gh', ['api', `repos/${owner}/${repo}`, '--jq', '.full_name'], {
+                timeout: 10000,
+                stdio: 'pipe',
+                encoding: 'utf-8',
+              });
+              return reply.code(200).send({ ok: true, repoName: result.trim() });
+            } catch {
+              return reply.code(200).send({
+                ok: false,
+                error: `Repository "${owner}/${repo}" not found or not accessible via gh CLI`,
+              });
+            }
+          }
+
+          // authMode === 'pat'
+          const pat = body.pat;
+          if (!pat || typeof pat !== 'string') {
+            throw validationError('pat is required for PAT auth mode');
+          }
+
+          try {
+            const response = await fetch(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, {
+              method: 'GET',
+              headers: {
+                'Authorization': `token ${pat}`,
+                'Accept': 'application/vnd.github+json',
+                'User-Agent': 'Fleet-Commander',
+              },
+              signal: AbortSignal.timeout(10000),
+            });
+
+            if (response.ok) {
+              const data = await response.json() as Record<string, unknown>;
+              return reply.code(200).send({
+                ok: true,
+                repoName: typeof data.full_name === 'string' ? data.full_name : `${owner}/${repo}`,
+              });
+            }
+
+            if (response.status === 401) {
+              return reply.code(200).send({
+                ok: false,
+                error: 'Authentication failed: invalid Personal Access Token',
+              });
+            }
+
+            if (response.status === 404) {
+              return reply.code(200).send({
+                ok: false,
+                error: `Repository "${owner}/${repo}" not found or not accessible`,
+              });
+            }
+
+            return reply.code(200).send({
+              ok: false,
+              error: `GitHub API returned ${response.status}: ${response.statusText}`,
+            });
+          } catch (fetchErr: unknown) {
+            if (fetchErr instanceof Error && fetchErr.name === 'TimeoutError') {
+              return reply.code(200).send({
+                ok: false,
+                error: 'Connection timed out after 10 seconds',
+              });
+            }
+            return reply.code(200).send({
+              ok: false,
+              error: `Connection failed: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
+            });
+          }
+        }
+
+        // --- Jira provider (default) ---
         const jiraUrl = body.jiraUrl;
         const projectKey = body.projectKey;
         const email = body.email;
@@ -386,7 +489,7 @@ async function issueSourcesRoutes(server: FastifyInstance): Promise<void> {
         if (err instanceof ServiceError) {
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
         }
-        request.log.error(err, 'Failed to test Jira connection');
+        request.log.error(err, 'Failed to test connection');
         return reply.code(500).send({
           error: 'Internal Server Error',
           message: err instanceof Error ? err.message : String(err),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -98,6 +98,21 @@ export interface JiraSourceCredentials {
   apiToken: string;
 }
 
+/** GitHub auth mode: gh CLI (default, no credentials needed) or PAT */
+export type GitHubAuthMode = 'gh-cli' | 'pat';
+
+/** GitHub source configuration stored in configJson */
+export interface GitHubSourceConfig {
+  owner: string;
+  repo: string;
+  authMode: GitHubAuthMode;
+}
+
+/** GitHub source credentials stored in credentialsJson (encrypted at rest) */
+export interface GitHubSourceCredentials {
+  pat: string;
+}
+
 /** Detailed file-level info for a single install artifact */
 export interface InstallFileStatus {
   name: string;

--- a/tests/client/GitHubSourceDialog.test.tsx
+++ b/tests/client/GitHubSourceDialog.test.tsx
@@ -1,0 +1,305 @@
+// =============================================================================
+// Fleet Commander -- GitHubSourceDialog Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ---------------------------------------------------------------------------
+// Mock fetch for test-connection and credentials
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// Import component
+import { GitHubSourceDialog } from '../../src/client/components/GitHubSourceDialog';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSource(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    projectId: 1,
+    provider: 'github',
+    label: 'My GitHub',
+    configJson: JSON.stringify({ owner: 'octocat', repo: 'hello-world', authMode: 'gh-cli' }),
+    hasCredentials: false,
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHubSourceDialog', () => {
+  it('does not render when open is false', () => {
+    const { container } = render(
+      <GitHubSourceDialog open={false} projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  it('renders create mode with empty fields and correct title', () => {
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText('Add GitHub Source')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g. octocat')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g. hello-world')).toBeInTheDocument();
+  });
+
+  it('renders edit mode with pre-populated fields and correct title', () => {
+    const source = makeSource();
+    render(
+      <GitHubSourceDialog open projectId={1} source={source} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText('Edit GitHub Source')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('octocat')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('hello-world')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('My GitHub')).toBeInTheDocument();
+  });
+
+  it('auth mode toggle switches between gh-cli and PAT modes', () => {
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+
+    // Default is gh-cli - PAT field should not be visible
+    expect(screen.queryByPlaceholderText('ghp_xxxxxxxxxxxx')).not.toBeInTheDocument();
+    expect(screen.getByText(/no credentials needed/i)).toBeInTheDocument();
+
+    // Switch to PAT
+    fireEvent.click(screen.getByLabelText('Personal Access Token'));
+    expect(screen.getByPlaceholderText('ghp_xxxxxxxxxxxx')).toBeInTheDocument();
+    expect(screen.queryByText(/no credentials needed/i)).not.toBeInTheDocument();
+
+    // Switch back to gh-cli
+    fireEvent.click(screen.getByLabelText('gh CLI (default)'));
+    expect(screen.queryByPlaceholderText('ghp_xxxxxxxxxxxx')).not.toBeInTheDocument();
+    expect(screen.getByText(/no credentials needed/i)).toBeInTheDocument();
+  });
+
+  it('gh-cli mode hides PAT field and shows no credentials note', () => {
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(screen.queryByPlaceholderText('ghp_xxxxxxxxxxxx')).not.toBeInTheDocument();
+    expect(screen.getByText(/no credentials needed/i)).toBeInTheDocument();
+  });
+
+  it('PAT mode shows PAT field', () => {
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByLabelText('Personal Access Token'));
+    expect(screen.getByPlaceholderText('ghp_xxxxxxxxxxxx')).toBeInTheDocument();
+  });
+
+  it('shows validation error when owner is empty on save', async () => {
+    const onSave = vi.fn();
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={onSave} />,
+    );
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => {
+      expect(screen.getByText('Owner is required')).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when repo is empty on save', async () => {
+    const onSave = vi.fn();
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'myowner' },
+    });
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => {
+      expect(screen.getByText('Repository is required')).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when PAT is empty in PAT mode', async () => {
+    const onSave = vi.fn();
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'myowner' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. hello-world'), {
+      target: { value: 'myrepo' },
+    });
+    fireEvent.click(screen.getByLabelText('Personal Access Token'));
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => {
+      expect(screen.getByText('Personal Access Token is required')).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onSave with correct payload in gh-cli mode', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'myowner' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. hello-world'), {
+      target: { value: 'myrepo' },
+    });
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        provider: 'github',
+        label: null,
+        configJson: JSON.stringify({ owner: 'myowner', repo: 'myrepo', authMode: 'gh-cli' }),
+        credentialsJson: '',
+        enabled: true,
+      });
+    });
+  });
+
+  it('calls onSave with correct payload in PAT mode', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'myowner' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. hello-world'), {
+      target: { value: 'myrepo' },
+    });
+    fireEvent.click(screen.getByLabelText('Personal Access Token'));
+    fireEvent.change(screen.getByPlaceholderText('ghp_xxxxxxxxxxxx'), {
+      target: { value: 'ghp_abc123' },
+    });
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        provider: 'github',
+        label: null,
+        configJson: JSON.stringify({ owner: 'myowner', repo: 'myrepo', authMode: 'pat' }),
+        credentialsJson: JSON.stringify({ pat: 'ghp_abc123' }),
+        enabled: true,
+      });
+    });
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={onClose} onSave={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows test connection success result', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, repoName: 'octocat/hello-world' }),
+    });
+    globalThis.fetch = mockFetch;
+
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'octocat' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. hello-world'), {
+      target: { value: 'hello-world' },
+    });
+
+    fireEvent.click(screen.getByText('Test Connection'));
+    await waitFor(() => {
+      expect(screen.getByText(/Connected successfully/)).toBeInTheDocument();
+      expect(screen.getByText(/octocat\/hello-world/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows test connection error result', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: false, error: 'Repository not found' }),
+    });
+    globalThis.fetch = mockFetch;
+
+    render(
+      <GitHubSourceDialog open projectId={1} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. octocat'), {
+      target: { value: 'octocat' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. hello-world'), {
+      target: { value: 'nonexistent' },
+    });
+
+    fireEvent.click(screen.getByText('Test Connection'));
+    await waitFor(() => {
+      expect(screen.getByText('Repository not found')).toBeInTheDocument();
+    });
+  });
+
+  it('renders edit mode with PAT auth and fetches credentials', async () => {
+    const source = makeSource({
+      configJson: JSON.stringify({ owner: 'myorg', repo: 'myrepo', authMode: 'pat' }),
+      hasCredentials: true,
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ credentialsJson: JSON.stringify({ pat: 'ghp_fetched' }) }),
+    });
+    globalThis.fetch = mockFetch;
+
+    render(
+      <GitHubSourceDialog open projectId={1} source={source} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Edit GitHub Source')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('myorg')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('myrepo')).toBeInTheDocument();
+
+    // Credentials should be fetched
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/projects/1/issue-sources/1/credentials');
+    });
+  });
+
+  it('defaults authMode to gh-cli when configJson has no authMode', () => {
+    const source = makeSource({
+      configJson: JSON.stringify({ owner: 'legacy-owner', repo: 'legacy-repo' }),
+    });
+    render(
+      <GitHubSourceDialog open projectId={1} source={source} onClose={vi.fn()} onSave={vi.fn()} />,
+    );
+    // Should show gh-cli mode (no credentials needed note visible)
+    expect(screen.getByText(/no credentials needed/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('legacy-owner')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('legacy-repo')).toBeInTheDocument();
+  });
+});

--- a/tests/client/ProjectsPage.test.tsx
+++ b/tests/client/ProjectsPage.test.tsx
@@ -415,4 +415,23 @@ describe('ProjectsPage', () => {
     // Project should be expanded (from localStorage) — check for detail content
     expect(await screen.findByText('Repository')).toBeInTheDocument();
   });
+
+  // -----------------------------------------------------------------------
+  // Issue Sources — provider-aware status badges (#631)
+  // -----------------------------------------------------------------------
+
+  it('shows "+ Add Issue Source" button text (not "+ Add Jira Source")', async () => {
+    setupDefaultMocks();
+    render(<ProjectsPage />);
+    // Expand a project card first
+    const projectName = await screen.findByText('test-project');
+    const row = projectName.closest('[class*="cursor-pointer"]');
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+
+    await waitFor(() => {
+      expect(screen.getByText('+ Add Issue Source')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('+ Add Jira Source')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #631

## Summary
- **Provider-aware dialogs**: Edit button now opens the correct dialog (GitHub or Jira) based on `source.provider`. New `GitHubSourceDialog` component with gh CLI / PAT auth mode toggle.
- **Status badges**: GitHub sources in gh-cli mode show green "Ready (gh CLI)" without requiring credentials. PAT mode uses standard credential check.
- **Add Source flow**: Replaced hardcoded "+ Add Jira Source" with "+ Add Issue Source" button that shows a provider picker (GitHub / Jira).
- **Provider icons**: `ProviderIcon` displayed next to each source label for visual clarity.
- **API extension**: Test-connection endpoint now supports `provider: 'github'` with gh-cli auth status and PAT validation.

## Changed Files
- `src/shared/types.ts` — `GitHubAuthMode`, `GitHubSourceConfig`, `GitHubSourceCredentials` types
- `src/client/components/GitHubSourceDialog.tsx` — New GitHub source dialog component
- `src/client/views/ProjectsPage.tsx` — Provider-aware status, dialogs, icons, picker
- `src/server/routes/issue-sources.ts` — GitHub test-connection support
- `tests/client/GitHubSourceDialog.test.tsx` — 16 new tests
- `tests/client/ProjectsPage.test.tsx` — 1 new test

## Test plan
- [ ] Verify GitHub source edit opens GitHub dialog (not Jira)
- [ ] Verify gh-cli mode shows green status without credentials
- [ ] Verify PAT mode shows credential status correctly
- [ ] Verify Jira sources work unchanged
- [ ] Verify "+ Add Issue Source" shows provider picker
- [ ] Verify provider icons render next to each source
- [ ] Run `npm run test:client` — all tests pass
- [ ] Run `npm run test:server` — all tests pass
- [ ] Run `npx tsc --noEmit` — clean