### PR TITLE
Issue #637: Add dependency graph visualization per project

### DIFF
--- a/src/client/components/DependencyGraph.tsx
+++ b/src/client/components/DependencyGraph.tsx
@@ -1,0 +1,386 @@
+// ---------------------------------------------------------------------------
+// DependencyGraph — Force-directed graph of issue dependencies per project
+// ---------------------------------------------------------------------------
+
+import { useEffect, useMemo, useRef, useCallback, useState } from 'react';
+import ForceGraph from 'react-force-graph-2d';
+import type { ForceGraphMethods } from 'react-force-graph-2d';
+// d3-force-3d is a transitive dep of react-force-graph-2d (no type declarations)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error — d3-force-3d has no type declarations
+import { forceCollide } from 'd3-force-3d';
+import type { IssueNode } from './TreeNode';
+
+// ---------------------------------------------------------------------------
+// Graph node and link types
+// ---------------------------------------------------------------------------
+
+interface DependencyGraphNode {
+  id: string;
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  isBlocked: boolean;
+  color: string;
+  x?: number;
+  y?: number;
+  url: string;
+  issueKey?: string;
+  issueProvider?: string;
+}
+
+interface DependencyGraphLink {
+  source: string;
+  target: string;
+  type: 'blockedBy' | 'parent';
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface DependencyGraphProps {
+  issues: IssueNode[];
+  projectName: string;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NODE_RADIUS = 20;
+const FONT_SIZE_NUMBER = 14;
+const FONT_SIZE_LABEL = 10;
+
+const COLOR_RESOLVED = '#3FB950';
+const COLOR_OPEN_UNBLOCKED = '#D29922';
+const COLOR_OPEN_BLOCKED = '#F85149';
+const COLOR_BORDER = '#484F58';
+const COLOR_LABEL = '#8B949E';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively flatten an issue tree into a flat list */
+function flattenTree(nodes: IssueNode[]): IssueNode[] {
+  const result: IssueNode[] = [];
+  function walk(items: IssueNode[]) {
+    for (const item of items) {
+      result.push(item);
+      if (item.children.length > 0) walk(item.children);
+    }
+  }
+  walk(nodes);
+  return result;
+}
+
+/** Truncate text to a maximum number of characters */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '\u2026';
+}
+
+/** Collect parent-child edges from the tree structure */
+function collectParentChildEdges(nodes: IssueNode[], issueSet: Set<string>): DependencyGraphLink[] {
+  const edges: DependencyGraphLink[] = [];
+  function walk(items: IssueNode[]) {
+    for (const item of items) {
+      for (const child of item.children) {
+        const parentId = String(item.number);
+        const childId = String(child.number);
+        if (issueSet.has(parentId) && issueSet.has(childId)) {
+          edges.push({ source: parentId, target: childId, type: 'parent' });
+        }
+      }
+      if (item.children.length > 0) walk(item.children);
+    }
+  }
+  walk(nodes);
+  return edges;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DependencyGraph({ issues, projectName }: DependencyGraphProps) {
+  const graphRef = useRef<ForceGraphMethods<DependencyGraphNode, DependencyGraphLink>>(undefined);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 500 });
+
+  // Track container size with ResizeObserver
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          setDimensions({ width: Math.floor(width), height: Math.floor(height) });
+        }
+      }
+    });
+
+    observer.observe(container);
+    const rect = container.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      setDimensions({ width: Math.floor(rect.width), height: Math.floor(rect.height) });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  // Build graph data from issues
+  const graphData = useMemo(() => {
+    const flat = flattenTree(issues);
+    const issueMap = new Map<number, IssueNode>();
+    for (const issue of flat) {
+      // Avoid duplicates — first occurrence wins
+      if (!issueMap.has(issue.number)) {
+        issueMap.set(issue.number, issue);
+      }
+    }
+
+    const issueIdSet = new Set<string>(
+      [...issueMap.keys()].map(String),
+    );
+
+    // Create nodes
+    const nodes: DependencyGraphNode[] = [...issueMap.values()].map((issue) => {
+      const hasOpenBlockers = issue.dependencies
+        ? issue.dependencies.openCount > 0
+        : false;
+
+      let color: string;
+      if (issue.state === 'closed') {
+        color = COLOR_RESOLVED;
+      } else if (hasOpenBlockers) {
+        color = COLOR_OPEN_BLOCKED;
+      } else {
+        color = COLOR_OPEN_UNBLOCKED;
+      }
+
+      return {
+        id: String(issue.number),
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        isBlocked: hasOpenBlockers,
+        color,
+        url: issue.url,
+        issueKey: issue.issueKey,
+        issueProvider: issue.issueProvider,
+      };
+    });
+
+    // Create blockedBy edges (only where both endpoints exist in the graph)
+    const links: DependencyGraphLink[] = [];
+    const edgeKeys = new Set<string>();
+
+    for (const issue of issueMap.values()) {
+      if (!issue.dependencies) continue;
+      for (const blocker of issue.dependencies.blockedBy) {
+        const blockerId = String(blocker.number);
+        const blockedId = String(issue.number);
+        if (issueIdSet.has(blockerId) && issueIdSet.has(blockedId)) {
+          const key = `blockedBy:${blockerId}->${blockedId}`;
+          if (!edgeKeys.has(key)) {
+            edgeKeys.add(key);
+            links.push({ source: blockerId, target: blockedId, type: 'blockedBy' });
+          }
+        }
+      }
+    }
+
+    // Create parent-child edges
+    const parentChildEdges = collectParentChildEdges(issues, issueIdSet);
+    for (const edge of parentChildEdges) {
+      const key = `parent:${edge.source}->${edge.target}`;
+      if (!edgeKeys.has(key)) {
+        edgeKeys.add(key);
+        links.push(edge);
+      }
+    }
+
+    return { nodes, links };
+  }, [issues]);
+
+  // Configure d3 forces
+  useEffect(() => {
+    const fg = graphRef.current;
+    if (!fg || graphData.nodes.length === 0) return;
+
+    const charge = fg.d3Force('charge');
+    if (charge && typeof charge.strength === 'function') {
+      charge.strength(-300);
+    }
+
+    fg.d3Force('collide', forceCollide(NODE_RADIUS + 25));
+    fg.d3ReheatSimulation();
+  }, [graphData.nodes.length]);
+
+  // Zoom to fit after initial render
+  useEffect(() => {
+    const fg = graphRef.current;
+    if (!fg || graphData.nodes.length === 0) return;
+    const timer = setTimeout(() => {
+      fg.zoomToFit(400, 60);
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [graphData.nodes.length]);
+
+  // Custom node rendering
+  const nodeCanvasObject = useCallback(
+    (node: DependencyGraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+      const x = node.x ?? 0;
+      const y = node.y ?? 0;
+      const r = NODE_RADIUS;
+      const fontSize = FONT_SIZE_NUMBER / globalScale;
+      const labelFontSize = FONT_SIZE_LABEL / globalScale;
+
+      // Filled circle with 40% opacity
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, 2 * Math.PI);
+      ctx.fillStyle = node.color + '66';
+      ctx.fill();
+
+      // Border
+      ctx.strokeStyle = COLOR_BORDER;
+      ctx.lineWidth = 2 / globalScale;
+      ctx.stroke();
+
+      // Issue number centered inside
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = '#E6EDF3';
+      ctx.fillText(`#${node.number}`, x, y);
+
+      // Truncated title below
+      ctx.font = `${labelFontSize}px sans-serif`;
+      ctx.fillStyle = COLOR_LABEL;
+      ctx.fillText(truncate(node.title, 22), x, y + r + 10 / globalScale);
+    },
+    [],
+  );
+
+  // Node pointer area for hover/click detection
+  const nodePointerAreaPaint = useCallback(
+    (node: DependencyGraphNode, color: string, ctx: CanvasRenderingContext2D) => {
+      const x = node.x ?? 0;
+      const y = node.y ?? 0;
+      ctx.beginPath();
+      ctx.arc(x, y, NODE_RADIUS + 4, 0, 2 * Math.PI);
+      ctx.fillStyle = color;
+      ctx.fill();
+    },
+    [],
+  );
+
+  // Node click — open issue in new tab
+  const onNodeClick = useCallback((node: DependencyGraphNode) => {
+    if (node.url) {
+      window.open(node.url, '_blank');
+    }
+  }, []);
+
+  // Link color by type
+  const linkColor = useCallback((link: DependencyGraphLink) => {
+    return link.type === 'blockedBy' ? COLOR_OPEN_BLOCKED : COLOR_BORDER;
+  }, []);
+
+  // Link width
+  const linkWidth = useCallback((_link: DependencyGraphLink) => {
+    return 1.5;
+  }, []);
+
+  // Link dashed pattern for parent/child edges
+  const linkLineDash = useCallback((link: DependencyGraphLink) => {
+    return link.type === 'parent' ? [5, 3] : null;
+  }, []);
+
+  // Directional arrows for blockedBy edges only
+  const linkDirectionalArrowLength = useCallback((link: DependencyGraphLink) => {
+    return link.type === 'blockedBy' ? 6 : 0;
+  }, []);
+
+  // Node label tooltip
+  const nodeLabel = useCallback((node: DependencyGraphNode) => {
+    const stateLabel = node.state === 'closed' ? 'Resolved' : (node.isBlocked ? 'Blocked' : 'Open');
+    return `<div style="padding:4px 8px;background:#161B22;border:1px solid #30363D;border-radius:4px;font-size:11px;color:#E6EDF3;">
+      <b>#${node.number}</b> ${node.title}<br/>
+      <span style="color:${node.color}">${stateLabel}</span>
+    </div>`;
+  }, []);
+
+  // Empty state
+  if (graphData.nodes.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-dark-muted text-sm">
+        No issues to visualize for {projectName}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full h-full min-h-[300px]">
+      <ForceGraph
+        ref={graphRef}
+        graphData={graphData}
+        width={dimensions.width}
+        height={dimensions.height}
+        backgroundColor="transparent"
+        nodeCanvasObject={nodeCanvasObject}
+        nodeCanvasObjectMode={() => 'replace'}
+        nodePointerAreaPaint={nodePointerAreaPaint}
+        nodeLabel={nodeLabel}
+        onNodeClick={onNodeClick}
+        linkWidth={linkWidth}
+        linkColor={linkColor}
+        linkLineDash={linkLineDash}
+        linkDirectionalArrowLength={linkDirectionalArrowLength}
+        linkDirectionalArrowRelPos={1}
+        linkDirectionalArrowColor={linkColor}
+        linkCurvature={0.15}
+        d3AlphaDecay={0.02}
+        d3VelocityDecay={0.3}
+        cooldownTicks={100}
+        enableZoomInteraction={true}
+        enablePanInteraction={true}
+        enableNodeDrag={true}
+        minZoom={0.3}
+        maxZoom={6}
+      />
+
+      {/* Legend overlay */}
+      <div className="absolute bottom-3 right-3 bg-dark-surface/90 border border-dark-border rounded-lg px-3 py-2 text-xs text-dark-muted">
+        <div className="font-semibold text-dark-text mb-1.5">Legend</div>
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full" style={{ backgroundColor: COLOR_RESOLVED }} />
+            <span>Resolved</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full" style={{ backgroundColor: COLOR_OPEN_UNBLOCKED }} />
+            <span>Open (unblocked)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full" style={{ backgroundColor: COLOR_OPEN_BLOCKED }} />
+            <span>Open (blocked)</span>
+          </div>
+          <div className="flex items-center gap-2 mt-1 pt-1 border-t border-dark-border/50">
+            <svg width="20" height="8"><line x1="0" y1="4" x2="20" y2="4" stroke={COLOR_OPEN_BLOCKED} strokeWidth="2" /></svg>
+            <span>Dependency (blocks)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <svg width="20" height="8"><line x1="0" y1="4" x2="20" y2="4" stroke={COLOR_BORDER} strokeWidth="2" strokeDasharray="5,3" /></svg>
+            <span>Parent / child</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/DependencyGraphModal.tsx
+++ b/src/client/components/DependencyGraphModal.tsx
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------
+// DependencyGraphModal — Full-screen modal overlay for the dependency graph
+// ---------------------------------------------------------------------------
+
+import { useEffect, useCallback } from 'react';
+import { DependencyGraph } from './DependencyGraph';
+import type { IssueNode } from './TreeNode';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface DependencyGraphModalProps {
+  issues: IssueNode[];
+  projectName: string;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DependencyGraphModal({ issues, projectName, onClose }: DependencyGraphModalProps) {
+  // Close on Escape key press
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Close on backdrop click
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  // Count issues for the header
+  const issueCount = countIssues(issues);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-[90vw] h-[80vh] max-w-[1400px] bg-dark-surface border border-dark-border rounded-lg shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-dark-border shrink-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-dark-text">
+              Dependency Graph: {projectName}
+            </h2>
+            <span className="text-xs text-dark-muted">
+              {issueCount} issue{issueCount !== 1 ? 's' : ''}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center rounded text-dark-muted hover:text-dark-text hover:bg-dark-hover transition-colors"
+            aria-label="Close dependency graph"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Graph body */}
+        <div className="flex-1 min-h-0">
+          <DependencyGraph
+            issues={issues}
+            projectName={projectName}
+            onClose={onClose}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively count all issues in the tree */
+function countIssues(nodes: IssueNode[]): number {
+  let count = 0;
+  for (const node of nodes) {
+    count += 1;
+    if (node.children.length > 0) count += countIssues(node.children);
+  }
+  return count;
+}

--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -266,6 +266,19 @@ export function LinearIcon({ size = 14, className }: IconProps) {
   );
 }
 
+export function DependencyGraphIcon({ size = 20, className }: IconProps) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="6" cy="6" r="3"/>
+      <circle cx="18" cy="6" r="3"/>
+      <circle cx="12" cy="18" r="3"/>
+      <line x1="8.7" y1="7.5" x2="9.3" y2="16.5"/>
+      <line x1="15.3" y1="7.5" x2="14.7" y2="16.5"/>
+      <line x1="9" y1="6" x2="15" y2="6"/>
+    </svg>
+  );
+}
+
 /**
  * Maps a provider name to its icon component.
  * Falls back to a generic circle icon for unknown providers.

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -5,7 +5,8 @@ import { usePrioritization, sortTreeByPriority } from '../hooks/usePrioritizatio
 import { useCollapseState } from '../hooks/useCollapseState';
 import { useFlattenedTree } from '../hooks/useVirtualizedTree';
 import { VirtualizedTreeList } from '../components/VirtualizedTreeList';
-import { ProviderIcon } from '../components/Icons';
+import { ProviderIcon, DependencyGraphIcon } from '../components/Icons';
+import { DependencyGraphModal } from '../components/DependencyGraphModal';
 import type { IssueNode } from '../components/TreeNode';
 import type { ProjectSummary } from '../../shared/types';
 
@@ -757,6 +758,7 @@ export function IssueTreeView() {
           <SingleProjectTree
             tree={filteredTree}
             projectId={launchProjectId}
+            projectName={activeProjects.length === 1 ? activeProjects[0].name : undefined}
             onLaunch={handleLaunch}
             launchingIssues={launchingIssues}
             launchErrors={launchErrors}
@@ -1228,6 +1230,7 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
   const expanded = !collapsedNodes.has(projectNodeId);
   const prioritization = usePrioritization();
   const [showRunAllDialog, setShowRunAllDialog] = useState(false);
+  const [showDepGraph, setShowDepGraph] = useState(false);
 
   // Detect distinct providers in this group's tree
   const distinctProviders = useMemo(() => {
@@ -1323,6 +1326,14 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
           </span>
         </button>
 
+        <button
+          onClick={() => setShowDepGraph(true)}
+          className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors"
+          title="View dependency graph"
+        >
+          <DependencyGraphIcon size={14} />
+        </button>
+
         <PrioritizeButtons
           prioritization={prioritization}
           tree={group.tree}
@@ -1416,6 +1427,15 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
           api={api}
           fetchTree={fetchTree}
           onClose={() => setShowRunAllDialog(false)}
+        />
+      )}
+
+      {/* Dependency graph modal */}
+      {showDepGraph && (
+        <DependencyGraphModal
+          issues={group.tree}
+          projectName={group.projectName}
+          onClose={() => setShowDepGraph(false)}
         />
       )}
     </div>
@@ -1527,6 +1547,7 @@ function ProviderSubGroup({ provider, issues, projectId, nodeKey, onLaunch, laun
 interface SingleProjectTreeProps {
   tree: IssueNode[];
   projectId: number | null;
+  projectName?: string;
   onLaunch: (issueNumber: number, title: string, projectId?: number, issueKey?: string, issueProvider?: string) => Promise<void>;
   launchingIssues: Set<number>;
   launchErrors: Map<number, string>;
@@ -1536,10 +1557,11 @@ interface SingleProjectTreeProps {
   onToggleCollapse: (nodeId: string) => void;
 }
 
-function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: SingleProjectTreeProps) {
+function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse }: SingleProjectTreeProps) {
   const api = useApi();
   const prioritization = usePrioritization();
   const [showRunAllDialog, setShowRunAllDialog] = useState(false);
+  const [showDepGraph, setShowDepGraph] = useState(false);
 
   const displayTree = useMemo(() => {
     if (!prioritization.hasPriority) return tree;
@@ -1554,6 +1576,14 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
     <div className="flex flex-col h-full">
       {/* Prioritize controls */}
       <div className="flex items-center gap-2 px-2 pb-2 shrink-0">
+        <button
+          onClick={() => setShowDepGraph(true)}
+          className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors"
+          title="View dependency graph"
+        >
+          <DependencyGraphIcon size={14} />
+        </button>
+
         <PrioritizeButtons
           prioritization={prioritization}
           tree={tree}
@@ -1616,6 +1646,15 @@ function SingleProjectTree({ tree, projectId, onLaunch, launchingIssues, launchE
           api={api}
           fetchTree={fetchTree}
           onClose={() => setShowRunAllDialog(false)}
+        />
+      )}
+
+      {/* Dependency graph modal */}
+      {showDepGraph && (
+        <DependencyGraphModal
+          issues={tree}
+          projectName={projectName ?? 'Project'}
+          onClose={() => setShowDepGraph(false)}
         />
       )}
     </div>

--- a/tests/client/DependencyGraph.test.tsx
+++ b/tests/client/DependencyGraph.test.tsx
@@ -1,0 +1,244 @@
+// =============================================================================
+// Fleet Commander -- DependencyGraph Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { IssueNode } from '../../src/client/components/TreeNode';
+
+// Polyfill ResizeObserver for jsdom (not available by default)
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class ResizeObserver {
+      private callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe() { /* noop */ }
+      unobserve() { /* noop */ }
+      disconnect() { /* noop */ }
+    };
+  }
+});
+
+// Mock react-force-graph-2d since it uses canvas (not available in jsdom)
+const mockForceGraph = vi.fn(() => null);
+vi.mock('react-force-graph-2d', () => ({
+  default: vi.fn((props: Record<string, unknown>) => {
+    mockForceGraph(props);
+    return null;
+  }),
+}));
+
+// Import after mock is set up
+import { DependencyGraph } from '../../src/client/components/DependencyGraph';
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides: Partial<IssueNode> = {}): IssueNode {
+  return {
+    number: 1,
+    title: 'Test issue',
+    state: 'open',
+    labels: [],
+    url: 'https://github.com/test/repo/issues/1',
+    children: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Graph data type for test assertions
+// ---------------------------------------------------------------------------
+
+interface TestGraphData {
+  graphData: {
+    nodes: Array<{ id: string; color: string; number: number }>;
+    links: Array<{ source: string; target: string; type: string }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DependencyGraph', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    mockForceGraph.mockClear();
+    onClose.mockClear();
+  });
+
+  it('renders empty state when no issues provided', () => {
+    render(
+      <DependencyGraph issues={[]} projectName="test-project" onClose={onClose} />,
+    );
+    expect(screen.getByText('No issues to visualize for test-project')).toBeInTheDocument();
+  });
+
+  it('renders the force graph when issues are present', () => {
+    const issues = [
+      makeIssue({ number: 1, title: 'First' }),
+      makeIssue({ number: 2, title: 'Second' }),
+      makeIssue({ number: 3, title: 'Third' }),
+    ];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    expect(screen.queryByText('No issues to visualize for test-project')).not.toBeInTheDocument();
+    expect(mockForceGraph).toHaveBeenCalled();
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+    expect(call.graphData.nodes).toHaveLength(3);
+  });
+
+  it('colors nodes correctly based on state', () => {
+    const issues = [
+      // Closed issue — should be green
+      makeIssue({ number: 1, title: 'Closed one', state: 'closed' }),
+      // Open issue with no blockers — should be yellow
+      makeIssue({ number: 2, title: 'Open unblocked', state: 'open' }),
+      // Open issue with open blockers — should be red
+      makeIssue({
+        number: 3,
+        title: 'Open blocked',
+        state: 'open',
+        dependencies: {
+          issueNumber: 3,
+          blockedBy: [{ number: 99, owner: 'other', repo: 'repo', state: 'open', title: 'ext blocker' }],
+          resolved: false,
+          openCount: 1,
+        },
+      }),
+    ];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+    const nodes = call.graphData.nodes;
+
+    const closedNode = nodes.find((n) => n.id === '1');
+    const openNode = nodes.find((n) => n.id === '2');
+    const blockedNode = nodes.find((n) => n.id === '3');
+
+    expect(closedNode?.color).toBe('#3FB950');  // green
+    expect(openNode?.color).toBe('#D29922');    // yellow
+    expect(blockedNode?.color).toBe('#F85149'); // red
+  });
+
+  it('creates blockedBy edges between issues', () => {
+    const issues = [
+      makeIssue({ number: 1, title: 'Blocker' }),
+      makeIssue({
+        number: 2,
+        title: 'Blocked',
+        dependencies: {
+          issueNumber: 2,
+          blockedBy: [{ number: 1, owner: 'test', repo: 'repo', state: 'open', title: 'Blocker' }],
+          resolved: false,
+          openCount: 1,
+        },
+      }),
+    ];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+    const links = call.graphData.links;
+
+    expect(links).toHaveLength(1);
+    expect(links[0].source).toBe('1');
+    expect(links[0].target).toBe('2');
+    expect(links[0].type).toBe('blockedBy');
+  });
+
+  it('creates parent/child edges from tree structure', () => {
+    const child1 = makeIssue({ number: 2, title: 'Child 1' });
+    const child2 = makeIssue({ number: 3, title: 'Child 2' });
+    const parent = makeIssue({ number: 1, title: 'Parent', children: [child1, child2] });
+
+    render(
+      <DependencyGraph issues={[parent]} projectName="test-project" onClose={onClose} />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+    const links = call.graphData.links;
+
+    // Should have 2 parent->child edges
+    const parentEdges = links.filter((l) => l.type === 'parent');
+    expect(parentEdges).toHaveLength(2);
+    expect(parentEdges.some((e) => e.source === '1' && e.target === '2')).toBe(true);
+    expect(parentEdges.some((e) => e.source === '1' && e.target === '3')).toBe(true);
+  });
+
+  it('only creates edges where both endpoints exist in the issue set', () => {
+    // Issue blocked by an external issue (number 99, not in the set)
+    const issues = [
+      makeIssue({
+        number: 1,
+        title: 'Blocked by external',
+        dependencies: {
+          issueNumber: 1,
+          blockedBy: [{ number: 99, owner: 'other', repo: 'repo', state: 'open', title: 'External' }],
+          resolved: false,
+          openCount: 1,
+        },
+      }),
+    ];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+
+    // Node should exist but be red (blocked)
+    expect(call.graphData.nodes).toHaveLength(1);
+    expect(call.graphData.nodes[0].color).toBe('#F85149');
+
+    // No edges should be created (external blocker is not in set)
+    expect(call.graphData.links).toHaveLength(0);
+  });
+
+  it('renders the legend overlay', () => {
+    const issues = [makeIssue({ number: 1, title: 'Test' })];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    expect(screen.getByText('Legend')).toBeInTheDocument();
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.getByText('Open (unblocked)')).toBeInTheDocument();
+    expect(screen.getByText('Open (blocked)')).toBeInTheDocument();
+    expect(screen.getByText('Dependency (blocks)')).toBeInTheDocument();
+    expect(screen.getByText('Parent / child')).toBeInTheDocument();
+  });
+
+  it('deduplicates issues when same number appears in multiple branches', () => {
+    // Same issue number appears as both a root issue and a child
+    const child = makeIssue({ number: 2, title: 'Duplicate' });
+    const issues = [
+      makeIssue({ number: 1, title: 'Parent', children: [child] }),
+      makeIssue({ number: 2, title: 'Duplicate at root' }),
+    ];
+
+    render(
+      <DependencyGraph issues={issues} projectName="test-project" onClose={onClose} />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as TestGraphData;
+    // Should deduplicate — only 2 unique nodes
+    expect(call.graphData.nodes).toHaveLength(2);
+  });
+});

--- a/tests/client/DependencyGraphModal.test.tsx
+++ b/tests/client/DependencyGraphModal.test.tsx
@@ -1,0 +1,114 @@
+// =============================================================================
+// Fleet Commander -- DependencyGraphModal Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { IssueNode } from '../../src/client/components/TreeNode';
+
+// Polyfill ResizeObserver for jsdom (not available by default)
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class ResizeObserver {
+      private callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe() { /* noop */ }
+      unobserve() { /* noop */ }
+      disconnect() { /* noop */ }
+    };
+  }
+});
+
+// Mock react-force-graph-2d since it uses canvas (not available in jsdom)
+vi.mock('react-force-graph-2d', () => ({
+  default: vi.fn(() => null),
+}));
+
+// Import after mock is set up
+import { DependencyGraphModal } from '../../src/client/components/DependencyGraphModal';
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides: Partial<IssueNode> = {}): IssueNode {
+  return {
+    number: 1,
+    title: 'Test issue',
+    state: 'open',
+    labels: [],
+    url: 'https://github.com/test/repo/issues/1',
+    children: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DependencyGraphModal', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+  });
+
+  it('renders modal with project name and close button', () => {
+    const issues = [makeIssue({ number: 1 }), makeIssue({ number: 2 })];
+
+    render(
+      <DependencyGraphModal issues={issues} projectName="my-project" onClose={onClose} />,
+    );
+
+    expect(screen.getByText('Dependency Graph: my-project')).toBeInTheDocument();
+    expect(screen.getByText('2 issues')).toBeInTheDocument();
+    expect(screen.getByLabelText('Close dependency graph')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const issues = [makeIssue({ number: 1 })];
+
+    render(
+      <DependencyGraphModal issues={issues} projectName="my-project" onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Close dependency graph'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const issues = [makeIssue({ number: 1 })];
+
+    render(
+      <DependencyGraphModal issues={issues} projectName="my-project" onClose={onClose} />,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays singular issue count for one issue', () => {
+    const issues = [makeIssue({ number: 1 })];
+
+    render(
+      <DependencyGraphModal issues={issues} projectName="my-project" onClose={onClose} />,
+    );
+
+    expect(screen.getByText('1 issue')).toBeInTheDocument();
+  });
+
+  it('counts nested children in issue count', () => {
+    const child = makeIssue({ number: 2, title: 'Child' });
+    const parent = makeIssue({ number: 1, title: 'Parent', children: [child] });
+
+    render(
+      <DependencyGraphModal issues={[parent]} projectName="my-project" onClose={onClose} />,
+    );
+
+    expect(screen.getByText('2 issues')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #637

## Summary
- Add a dependency graph visualization accessible via a graph icon on each project row in the Issue Tree view
- Issues rendered as color-coded force-directed graph nodes (green=closed, yellow=open+unblocked, red=open+blocked) using the existing `react-force-graph-2d` library
- `blockedBy` relations shown as solid red directed edges; parent/child hierarchy shown as dashed gray edges
- Full-screen modal overlay with zoom/pan support, legend, clickable nodes, and Escape/backdrop dismiss

## Test plan
- [ ] Verify graph icon appears on project rows in Issue Tree view (both multi-project and single-project modes)
- [ ] Click graph icon and verify modal opens with force-directed dependency graph
- [ ] Verify node colors: green for closed, yellow for open+unblocked, red for open+blocked issues
- [ ] Verify blockedBy edges render as solid red arrows, parent/child as dashed gray
- [ ] Verify clicking a node opens the issue URL in a new tab
- [ ] Verify zoom/pan works on the graph
- [ ] Test with a project that has 50+ issues
- [ ] Verify modal closes via X button, Escape key, and backdrop click
- [ ] Verify empty state message when project has no issues
- [ ] Run `npm run test:client` — all 13 new tests pass
- [ ] Run `npx tsc --noEmit` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)