### PR TITLE
Issue #640: Add MCP tools for project CRUD and issue relations

### DIFF
--- a/src/server/mcp/index.ts
+++ b/src/server/mcp/index.ts
@@ -26,6 +26,8 @@ import { registerGetTeamTimelineTool } from './tools/get-team-timeline.js';
 import { registerListIssuesTool } from './tools/list-issues.js';
 import { registerListProjectsTool } from './tools/list-projects.js';
 import { registerAddProjectTool } from './tools/add-project.js';
+import { registerRemoveProjectTool } from './tools/remove-project.js';
+import { registerInstallProjectTool } from './tools/install-project.js';
 import { registerGetUsageTool } from './tools/get-usage.js';
 import { registerListTeamsTool } from './tools/list-teams.js';
 import { registerGetTeamTool } from './tools/get-team.js';
@@ -33,6 +35,13 @@ import { registerStopTeamTool } from './tools/stop-team.js';
 import { registerRestartTeamTool } from './tools/restart-team.js';
 import { registerSendMessageTool } from './tools/send-message.js';
 import { registerLaunchTeamTool } from './tools/launch-team.js';
+import { registerGetRelationsTool } from './tools/get-relations.js';
+import { registerAddBlockedByTool } from './tools/add-blocked-by.js';
+import { registerRemoveBlockedByTool } from './tools/remove-blocked-by.js';
+import { registerSetParentTool } from './tools/set-parent.js';
+import { registerRemoveParentTool } from './tools/remove-parent.js';
+import { registerAddChildTool } from './tools/add-child.js';
+import { registerRemoveChildTool } from './tools/remove-child.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,6 +71,8 @@ export async function startMcpServer(): Promise<void> {
   registerListIssuesTool(mcpServer);
   registerListProjectsTool(mcpServer);
   registerAddProjectTool(mcpServer);
+  registerRemoveProjectTool(mcpServer);
+  registerInstallProjectTool(mcpServer);
   registerGetUsageTool(mcpServer);
   registerListTeamsTool(mcpServer);
   registerGetTeamTool(mcpServer);
@@ -69,6 +80,13 @@ export async function startMcpServer(): Promise<void> {
   registerRestartTeamTool(mcpServer);
   registerSendMessageTool(mcpServer);
   registerLaunchTeamTool(mcpServer);
+  registerGetRelationsTool(mcpServer);
+  registerAddBlockedByTool(mcpServer);
+  registerRemoveBlockedByTool(mcpServer);
+  registerSetParentTool(mcpServer);
+  registerRemoveParentTool(mcpServer);
+  registerAddChildTool(mcpServer);
+  registerRemoveChildTool(mcpServer);
 
   // Initialize database
   const db = getDatabase(config.dbPath);

--- a/src/server/mcp/tools/add-blocked-by.ts
+++ b/src/server/mcp/tools/add-blocked-by.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// MCP Tool: fleet_add_blocked_by
+// =============================================================================
+// Adds a blockedBy relation between two issues.
+//
+// Input:  { projectId: number, issueKey: string, blockerKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.addBlockedBy(projectId, issueKey, blockerKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_add_blocked_by` tool on the given MCP server.
+ *
+ * This tool adds a blockedBy relation, indicating that the given issue
+ * is blocked by the specified blocker issue.
+ */
+export function registerAddBlockedByTool(server: McpServer): void {
+  server.tool(
+    'fleet_add_blocked_by',
+    'Adds a blockedBy relation between two issues',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      issueKey: z.string().describe('Issue key of the blocked issue'),
+      blockerKey: z.string().describe('Issue key of the blocker'),
+    },
+    async ({ projectId, issueKey, blockerKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.addBlockedBy(projectId, issueKey, blockerKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/add-child.ts
+++ b/src/server/mcp/tools/add-child.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_add_child
+// =============================================================================
+// Adds a child (sub-issue) to a parent issue.
+//
+// Input:  { projectId: number, parentKey: string, childKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.addChild(projectId, parentKey, childKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_add_child` tool on the given MCP server.
+ *
+ * This tool adds a child (sub-issue) to the specified parent issue.
+ */
+export function registerAddChildTool(server: McpServer): void {
+  server.tool(
+    'fleet_add_child',
+    'Adds a child (sub-issue) to a parent issue',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      parentKey: z.string().describe('Issue key of the parent'),
+      childKey: z.string().describe('Issue key of the child to add'),
+    },
+    async ({ projectId, parentKey, childKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.addChild(projectId, parentKey, childKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/get-relations.ts
+++ b/src/server/mcp/tools/get-relations.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_get_relations
+// =============================================================================
+// Gets all relations (parent, children, blockedBy, blocking) for an issue.
+//
+// Input:  { projectId: number, issueKey: string }
+// Output: JSON IssueRelations object
+//
+// Service method: IssueRelationsService.getRelations(projectId, issueKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_get_relations` tool on the given MCP server.
+ *
+ * This tool retrieves all issue relations (parent, children, blockedBy,
+ * blocking) for a specific issue within a project.
+ */
+export function registerGetRelationsTool(server: McpServer): void {
+  server.tool(
+    'fleet_get_relations',
+    'Gets all relations (parent, children, blockedBy, blocking) for an issue',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      issueKey: z.string().describe('Issue key (e.g. "42" for GitHub, "PROJ-123" for Jira)'),
+    },
+    async ({ projectId, issueKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        const relations = await service.getRelations(projectId, issueKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(relations, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/install-project.ts
+++ b/src/server/mcp/tools/install-project.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// MCP Tool: fleet_install_project
+// =============================================================================
+// Installs (or reinstalls) Fleet Commander hooks for a project.
+//
+// Input:  { projectId: number }
+// Output: JSON { ok, output, error?, installStatus }
+//
+// Service method: ProjectService.installHooksForProject(projectId)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getProjectService } from '../../services/project-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_install_project` tool on the given MCP server.
+ *
+ * This tool installs or reinstalls Fleet Commander hooks and prompt
+ * files for the project identified by its numeric ID.
+ */
+export function registerInstallProjectTool(server: McpServer): void {
+  server.tool(
+    'fleet_install_project',
+    'Installs or reinstalls Fleet Commander hooks for a project',
+    {
+      projectId: z.number().describe('Numeric ID of the project to install/reinstall hooks for'),
+    },
+    async ({ projectId }) => {
+      try {
+        const service = getProjectService();
+        const result = service.installHooksForProject(projectId);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/remove-blocked-by.ts
+++ b/src/server/mcp/tools/remove-blocked-by.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_remove_blocked_by
+// =============================================================================
+// Removes a blockedBy relation between two issues.
+//
+// Input:  { projectId: number, issueKey: string, blockerKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.removeBlockedBy(projectId, issueKey, blockerKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_remove_blocked_by` tool on the given MCP server.
+ *
+ * This tool removes a blockedBy relation between two issues.
+ */
+export function registerRemoveBlockedByTool(server: McpServer): void {
+  server.tool(
+    'fleet_remove_blocked_by',
+    'Removes a blockedBy relation between two issues',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      issueKey: z.string().describe('Issue key of the blocked issue'),
+      blockerKey: z.string().describe('Issue key of the blocker to remove'),
+    },
+    async ({ projectId, issueKey, blockerKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.removeBlockedBy(projectId, issueKey, blockerKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/remove-child.ts
+++ b/src/server/mcp/tools/remove-child.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_remove_child
+// =============================================================================
+// Removes a child (sub-issue) from a parent issue.
+//
+// Input:  { projectId: number, parentKey: string, childKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.removeChild(projectId, parentKey, childKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_remove_child` tool on the given MCP server.
+ *
+ * This tool removes a child (sub-issue) from the specified parent issue.
+ */
+export function registerRemoveChildTool(server: McpServer): void {
+  server.tool(
+    'fleet_remove_child',
+    'Removes a child (sub-issue) from a parent issue',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      parentKey: z.string().describe('Issue key of the parent'),
+      childKey: z.string().describe('Issue key of the child to remove'),
+    },
+    async ({ projectId, parentKey, childKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.removeChild(projectId, parentKey, childKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/remove-parent.ts
+++ b/src/server/mcp/tools/remove-parent.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// MCP Tool: fleet_remove_parent
+// =============================================================================
+// Removes the parent from an issue.
+//
+// Input:  { projectId: number, issueKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.removeParent(projectId, issueKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_remove_parent` tool on the given MCP server.
+ *
+ * This tool removes the parent (super-issue) from the specified issue.
+ */
+export function registerRemoveParentTool(server: McpServer): void {
+  server.tool(
+    'fleet_remove_parent',
+    'Removes the parent from an issue',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      issueKey: z.string().describe('Issue key to remove the parent from'),
+    },
+    async ({ projectId, issueKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.removeParent(projectId, issueKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/remove-project.ts
+++ b/src/server/mcp/tools/remove-project.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// MCP Tool: fleet_remove_project
+// =============================================================================
+// Removes a project (git repository) from Fleet Commander.
+//
+// Input:  { projectId: number }
+// Output: JSON { ok: true, projectId }
+//
+// Service method: ProjectService.deleteProject(projectId)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getProjectService } from '../../services/project-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_remove_project` tool on the given MCP server.
+ *
+ * This tool removes a project identified by its numeric ID, including
+ * uninstalling hooks and cleaning up associated teams.
+ */
+export function registerRemoveProjectTool(server: McpServer): void {
+  server.tool(
+    'fleet_remove_project',
+    'Removes a project from Fleet Commander by its numeric ID',
+    {
+      projectId: z.number().describe('Numeric ID of the project to remove'),
+    },
+    async ({ projectId }) => {
+      try {
+        const service = getProjectService();
+        await service.deleteProject(projectId);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true, projectId }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/src/server/mcp/tools/set-parent.ts
+++ b/src/server/mcp/tools/set-parent.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// MCP Tool: fleet_set_parent
+// =============================================================================
+// Sets the parent issue for a given issue.
+//
+// Input:  { projectId: number, issueKey: string, parentKey: string }
+// Output: JSON { ok: true }
+//
+// Service method: IssueRelationsService.setParent(projectId, issueKey, parentKey)
+// =============================================================================
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getIssueRelationsService } from '../../services/issue-relations-service.js';
+import { ServiceError } from '../../services/service-error.js';
+
+/**
+ * Registers the `fleet_set_parent` tool on the given MCP server.
+ *
+ * This tool sets the parent (super-issue) for the specified issue.
+ */
+export function registerSetParentTool(server: McpServer): void {
+  server.tool(
+    'fleet_set_parent',
+    'Sets the parent issue for a given issue',
+    {
+      projectId: z.number().describe('Numeric project ID'),
+      issueKey: z.string().describe('Issue key of the child issue'),
+      parentKey: z.string().describe('Issue key of the parent'),
+    },
+    async ({ projectId, issueKey, parentKey }) => {
+      try {
+        const service = getIssueRelationsService();
+        await service.setParent(projectId, issueKey, parentKey);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        if (err instanceof ServiceError) {
+          return {
+            content: [{ type: 'text' as const, text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/tests/server/mcp/add-blocked-by.test.ts
+++ b/tests/server/mcp/add-blocked-by.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP add-blocked-by Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_add_blocked_by MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockAddBlockedBy = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    addBlockedBy: mockAddBlockedBy,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerAddBlockedByTool } = await import(
+  '../../../src/server/mcp/tools/add-blocked-by.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_add_blocked_by MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_add_blocked_by');
+  });
+
+  it('registers with a description', () => {
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42', blockerKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to addBlockedBy', async () => {
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42', blockerKey: '10' });
+
+    expect(mockAddBlockedBy).toHaveBeenCalledWith(1, '42', '10');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockAddBlockedBy.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, issueKey: '42', blockerKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockAddBlockedBy.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerAddBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueKey: '42', blockerKey: '10' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/add-child.test.ts
+++ b/tests/server/mcp/add-child.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP add-child Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_add_child MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockAddChild = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    addChild: mockAddChild,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerAddChildTool } = await import(
+  '../../../src/server/mcp/tools/add-child.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_add_child MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerAddChildTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_add_child');
+  });
+
+  it('registers with a description', () => {
+    registerAddChildTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerAddChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, parentKey: '10', childKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to addChild', async () => {
+    registerAddChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, parentKey: '10', childKey: '42' });
+
+    expect(mockAddChild).toHaveBeenCalledWith(1, '10', '42');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockAddChild.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerAddChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, parentKey: '10', childKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockAddChild.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerAddChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, parentKey: '10', childKey: '42' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/get-relations.test.ts
+++ b/tests/server/mcp/get-relations.test.ts
@@ -1,0 +1,136 @@
+// =============================================================================
+// Fleet Commander — MCP get-relations Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_get_relations MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockRelations = {
+  parent: { key: '10', title: 'Parent issue' },
+  children: [{ key: '20', title: 'Child issue' }],
+  blockedBy: [{ key: '30', title: 'Blocker issue' }],
+  blocking: [],
+};
+
+const mockGetRelations = vi.fn().mockResolvedValue(mockRelations);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    getRelations: mockGetRelations,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerGetRelationsTool } = await import(
+  '../../../src/server/mcp/tools/get-relations.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_get_relations MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerGetRelationsTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_get_relations');
+  });
+
+  it('registers with a description', () => {
+    registerGetRelationsTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns relations JSON', async () => {
+    registerGetRelationsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockRelations);
+  });
+
+  it('handler passes projectId and issueKey to getRelations', async () => {
+    registerGetRelationsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42' });
+
+    expect(mockGetRelations).toHaveBeenCalledWith(1, '42');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockGetRelations.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerGetRelationsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, issueKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockGetRelations.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerGetRelationsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueKey: '42' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/install-project.test.ts
+++ b/tests/server/mcp/install-project.test.ts
@@ -1,0 +1,140 @@
+// =============================================================================
+// Fleet Commander — MCP install-project Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_install_project MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockInstallResult = {
+  ok: true,
+  output: 'Hooks installed successfully',
+  installStatus: {
+    hooks: { installed: true },
+    prompt: { installed: true },
+  },
+};
+
+const mockInstallHooksForProject = vi.fn().mockReturnValue(mockInstallResult);
+
+vi.mock('../../../src/server/services/project-service.js', () => ({
+  getProjectService: () => ({
+    installHooksForProject: mockInstallHooksForProject,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerInstallProjectTool } = await import(
+  '../../../src/server/mcp/tools/install-project.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_install_project MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerInstallProjectTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_install_project');
+  });
+
+  it('registers with a description', () => {
+    registerInstallProjectTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns install result JSON', async () => {
+    registerInstallProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 3 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(mockInstallResult);
+  });
+
+  it('handler passes projectId to installHooksForProject', async () => {
+    registerInstallProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 3 });
+
+    expect(mockInstallHooksForProject).toHaveBeenCalledWith(3);
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockInstallHooksForProject.mockImplementationOnce(() => {
+      throw new ServiceError('Project 999 not found', 'NOT_FOUND', 404);
+    });
+
+    registerInstallProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockInstallHooksForProject.mockImplementationOnce(() => {
+      throw new Error('unexpected');
+    });
+
+    registerInstallProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 3 })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/remove-blocked-by.test.ts
+++ b/tests/server/mcp/remove-blocked-by.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP remove-blocked-by Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_remove_blocked_by MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockRemoveBlockedBy = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    removeBlockedBy: mockRemoveBlockedBy,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerRemoveBlockedByTool } = await import(
+  '../../../src/server/mcp/tools/remove-blocked-by.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_remove_blocked_by MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_remove_blocked_by');
+  });
+
+  it('registers with a description', () => {
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42', blockerKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to removeBlockedBy', async () => {
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42', blockerKey: '10' });
+
+    expect(mockRemoveBlockedBy).toHaveBeenCalledWith(1, '42', '10');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockRemoveBlockedBy.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, issueKey: '42', blockerKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockRemoveBlockedBy.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerRemoveBlockedByTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueKey: '42', blockerKey: '10' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/remove-child.test.ts
+++ b/tests/server/mcp/remove-child.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP remove-child Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_remove_child MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockRemoveChild = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    removeChild: mockRemoveChild,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerRemoveChildTool } = await import(
+  '../../../src/server/mcp/tools/remove-child.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_remove_child MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerRemoveChildTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_remove_child');
+  });
+
+  it('registers with a description', () => {
+    registerRemoveChildTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerRemoveChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, parentKey: '10', childKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to removeChild', async () => {
+    registerRemoveChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, parentKey: '10', childKey: '42' });
+
+    expect(mockRemoveChild).toHaveBeenCalledWith(1, '10', '42');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockRemoveChild.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerRemoveChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, parentKey: '10', childKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockRemoveChild.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerRemoveChildTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, parentKey: '10', childKey: '42' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/remove-parent.test.ts
+++ b/tests/server/mcp/remove-parent.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP remove-parent Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_remove_parent MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockRemoveParent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    removeParent: mockRemoveParent,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerRemoveParentTool } = await import(
+  '../../../src/server/mcp/tools/remove-parent.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_remove_parent MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerRemoveParentTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_remove_parent');
+  });
+
+  it('registers with a description', () => {
+    registerRemoveParentTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerRemoveParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to removeParent', async () => {
+    registerRemoveParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42' });
+
+    expect(mockRemoveParent).toHaveBeenCalledWith(1, '42');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockRemoveParent.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerRemoveParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, issueKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockRemoveParent.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerRemoveParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueKey: '42' })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/remove-project.test.ts
+++ b/tests/server/mcp/remove-project.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP remove-project Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_remove_project MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockDeleteProject = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/project-service.js', () => ({
+  getProjectService: () => ({
+    deleteProject: mockDeleteProject,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerRemoveProjectTool } = await import(
+  '../../../src/server/mcp/tools/remove-project.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_remove_project MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_remove_project');
+  });
+
+  it('registers with a description', () => {
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 7 })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true, projectId: 7 });
+  });
+
+  it('handler passes projectId to deleteProject', async () => {
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 7 });
+
+    expect(mockDeleteProject).toHaveBeenCalledWith(7);
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockDeleteProject.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999 })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockDeleteProject.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerRemoveProjectTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 7 })).rejects.toThrow('unexpected');
+  });
+});

--- a/tests/server/mcp/set-parent.test.ts
+++ b/tests/server/mcp/set-parent.test.ts
@@ -1,0 +1,129 @@
+// =============================================================================
+// Fleet Commander — MCP set-parent Tool Tests
+// =============================================================================
+// Smoke tests for the fleet_set_parent MCP tool registration and handler.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ServiceError } from '../../../src/server/services/service-error.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports
+// ---------------------------------------------------------------------------
+
+const mockSetParent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
+  getIssueRelationsService: () => ({
+    setParent: mockSetParent,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture tool registrations via a mock McpServer
+// ---------------------------------------------------------------------------
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (...args: unknown[]) => Promise<unknown>;
+}
+
+const registeredTools: RegisteredTool[] = [];
+
+const mockMcpServer = {
+  tool: vi.fn((...args: unknown[]) => {
+    // server.tool(name, description, schema, handler) — 4-arg form
+    const name = args[0] as string;
+    const description = args[1] as string;
+    const schema = args[2];
+    const handler = args[3] as (...a: unknown[]) => Promise<unknown>;
+    registeredTools.push({ name, description, schema, handler });
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerSetParentTool } = await import(
+  '../../../src/server/mcp/tools/set-parent.js'
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fleet_set_parent MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredTools.length = 0;
+  });
+
+  it('registers with the correct tool name', () => {
+    registerSetParentTool(mockMcpServer as any);
+
+    expect(mockMcpServer.tool).toHaveBeenCalledOnce();
+    expect(registeredTools).toHaveLength(1);
+    expect(registeredTools[0]!.name).toBe('fleet_set_parent');
+  });
+
+  it('registers with a description', () => {
+    registerSetParentTool(mockMcpServer as any);
+
+    expect(registeredTools[0]!.description).toBeTruthy();
+    expect(typeof registeredTools[0]!.description).toBe('string');
+  });
+
+  it('handler returns ok result on success', async () => {
+    registerSetParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42', parentKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it('handler passes correct args to setParent', async () => {
+    registerSetParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await handler({ projectId: 1, issueKey: '42', parentKey: '10' });
+
+    expect(mockSetParent).toHaveBeenCalledWith(1, '42', '10');
+  });
+
+  it('handler returns isError on ServiceError', async () => {
+    mockSetParent.mockRejectedValueOnce(
+      new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
+    );
+
+    registerSetParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 999, issueKey: '42', parentKey: '10' })) as {
+      content: Array<{ type: string; text: string }>;
+      isError: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Project 999 not found');
+  });
+
+  it('handler re-throws non-ServiceError exceptions', async () => {
+    mockSetParent.mockRejectedValueOnce(new Error('unexpected'));
+
+    registerSetParentTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    await expect(handler({ projectId: 1, issueKey: '42', parentKey: '10' })).rejects.toThrow('unexpected');
+  });
+});


### PR DESCRIPTION
Closes #640

## Summary
- Added 9 new MCP tools: `fleet_remove_project`, `fleet_install_project`, `fleet_get_relations`, `fleet_add_blocked_by`, `fleet_remove_blocked_by`, `fleet_set_parent`, `fleet_remove_parent`, `fleet_add_child`, `fleet_remove_child`
- All tools are thin wrappers over existing service methods (ProjectService, IssueRelationsService) with Zod parameter schemas and ServiceError handling
- 54 new tests (6 per tool) in `tests/server/mcp/`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] New MCP tests: 54 passed, 0 failed
- [x] All tools follow `fleet_` naming convention and established patterns