### PR TITLE
Issue #644: Call processQueue immediately on team done transition

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -482,6 +482,16 @@ class GitHubPoller {
           const { getTeamManager } = await import('./team-manager.js');
           const manager = getTeamManager();
           manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
+
+          // Immediately advance the queue — the slot is already free (status=done)
+          if (team.projectId) {
+            manager.processQueue(team.projectId).catch((err) => {
+              console.error(
+                `[GitHubPoller] processQueue error after PR merge for team ${teamId}:`,
+                err instanceof Error ? err.message : err,
+              );
+            });
+          }
         } catch (err) {
           console.error(`[GitHubPoller] Failed to initiate graceful shutdown for team ${teamId}:`, err);
         }

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -215,6 +215,9 @@ describe('PR state transitions', () => {
 
     // Graceful shutdown should be initiated
     expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
+
+    // Queue should be processed immediately to advance queued teams
+    expect(mockManager.processQueue).toHaveBeenCalledWith(1);
   });
 
   it('does not call gracefulShutdown again when team is already done', async () => {
@@ -244,11 +247,43 @@ describe('PR state transitions', () => {
 
     // gracefulShutdown should NOT be called since team is already done
     expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
+    // processQueue should NOT be called since team is already done
+    expect(mockManager.processQueue).not.toHaveBeenCalled();
     // mergedAt should NOT be written again either
     expect(mockDb.updatePullRequest).not.toHaveBeenCalledWith(
       42,
       expect.objectContaining({ mergedAt: expect.any(String) }),
     );
+  });
+
+  it('calls processQueue immediately on PR merge to advance queued teams', async () => {
+    const project = makeProject({ id: 7 });
+    const team = makeTeam({ id: 5, prNumber: 99, status: 'running', projectId: 7 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 99,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-06-15T12:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // processQueue should be called with the team's projectId immediately
+    expect(mockManager.processQueue).toHaveBeenCalledWith(7);
+    // And it should be called exactly once (not duplicated)
+    expect(mockManager.processQueue).toHaveBeenCalledTimes(1);
   });
 
   it('detects new PR state (no existing PR record) and inserts it', async () => {


### PR DESCRIPTION
Closes #644

## Summary
- Added immediate `processQueue(projectId)` call in github-poller.ts when a team transitions to `done` after PR merge, eliminating the 2+ minute delay (grace period + force kill timeout) before the queue advances
- Guarded with `if (team.projectId)` and fire-and-forget `.catch()` error logging, matching the existing pattern used for dependency resolution in the same file
- Added 1 new test + 2 new assertions verifying processQueue is called on merge and NOT called when team is already done

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/server/github-poller.test.ts` — 44 passed
- [x] `npm run test:server` — 1603 passed (3 pre-existing failures in cc-spawn.test.ts, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)