### PR TITLE
Issue #646: Increase issue cache TTL to 5min; surgical cache update on issue close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ fleet-commander/
         team-manager.ts     # child_process.spawn, stdin/stdout pipes, lifecycle
         event-collector.ts  # Hook event processing -> DB -> SSE broadcast
         github-poller.ts    # gh CLI polling (PRs, CI, merges) every 30s
-        issue-fetcher.ts    # GraphQL issue fetch with 60s cache
+        issue-fetcher.ts    # GraphQL issue fetch with 5min cache
         stuck-detector.ts   # Idle (5min) and stuck (10min) detection
         sse-broker.ts       # SSE connection management, 17 event types, 30s heartbeat
         usage-tracker.ts    # Usage percentage polling
@@ -228,7 +228,7 @@ The SSE broker emits 17 event types:
 | `FLEET_ENABLE_AGENT_TEAMS` | `true` | Enable agent teams feature (`true`/`false`) |
 | `LOG_LEVEL` | `info` | Server log level |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub PR/CI/merge poll interval (ms) |
-| `FLEET_ISSUE_POLL_MS` | `60000` | Issue list poll interval (ms) |
+| `FLEET_ISSUE_POLL_MS` | `300000` | Issue list poll interval (ms, default 5min) |
 | `FLEET_ISSUE_UPDATE_POLL_MS` | `30000` | Issue update (comments, labels, body) poll interval (ms) |
 | `FLEET_STUCK_CHECK_MS` | `60000` | Stuck/idle detection check interval (ms) |
 | `FLEET_USAGE_POLL_MS` | `900000` | Usage percentage poll interval (ms, default 15min) |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -114,7 +114,7 @@ const config = Object.freeze({
   fleetCommanderRoot,
 
   githubPollIntervalMs: safeParseInt(process.env['FLEET_GITHUB_POLL_MS'] || '30000', 'FLEET_GITHUB_POLL_MS'),
-  issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '60000', 'FLEET_ISSUE_POLL_MS'),
+  issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '300000', 'FLEET_ISSUE_POLL_MS'),
   issueUpdatePollMs: safeParseInt(process.env['FLEET_ISSUE_UPDATE_POLL_MS'] || '30000', 'FLEET_ISSUE_UPDATE_POLL_MS'),
   stuckCheckIntervalMs: safeParseInt(process.env['FLEET_STUCK_CHECK_MS'] || '60000', 'FLEET_STUCK_CHECK_MS'),
   usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '900000', 'FLEET_USAGE_POLL_MS'),

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -495,6 +495,38 @@ class GitHubPoller {
         } catch (err) {
           console.error(`[GitHubPoller] Failed to initiate graceful shutdown for team ${teamId}:`, err);
         }
+
+        // Surgical cache update: check if the merged PR closed the issue,
+        // and if so, update the cached issue tree without a full refresh.
+        try {
+          if (team.projectId && team.issueNumber) {
+            const [owner, repo] = githubRepo.split('/');
+            const issueState = await execGHAsync(
+              `gh api "/repos/${owner}/${repo}/issues/${team.issueNumber}" --jq ".state"`,
+            );
+            if (issueState && issueState.trim() === 'closed') {
+              const { getIssueFetcher } = await import('./issue-fetcher.js');
+              const fetcher = getIssueFetcher();
+              fetcher.markIssueClosed(team.projectId, team.issueNumber);
+
+              sseBroker.broadcast('project_updated', {
+                project_id: team.projectId,
+                reason: 'issue_closed',
+                issue_number: team.issueNumber,
+              });
+
+              console.log(
+                `[GitHubPoller] Issue #${team.issueNumber} confirmed closed after PR #${prNumber} merge — cache updated`
+              );
+            }
+          }
+        } catch (err) {
+          // Non-fatal: the next full cache refresh will pick up the state change
+          console.error(
+            `[GitHubPoller] Failed to check/update issue state after PR #${prNumber} merge:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
       }
     }
 
@@ -580,7 +612,11 @@ class GitHubPoller {
       // Check in-memory blocked issues
       for (const [key, entry] of this.previouslyBlocked) {
         try {
-          const deps = await fetcher.fetchDependenciesForIssue(entry.projectId, entry.issueNumber);
+          // Try cache first to avoid unnecessary API calls
+          let deps = fetcher.getDependenciesFromCache(entry.projectId, entry.issueNumber);
+          if (deps === null) {
+            deps = await fetcher.fetchDependenciesForIssue(entry.projectId, entry.issueNumber);
+          }
           if (deps && deps.resolved) {
             // All blockers are now closed — broadcast resolution event
             sseBroker.broadcast('dependency_resolved', {
@@ -613,7 +649,11 @@ class GitHubPoller {
         if (!team.projectId) continue;
 
         try {
-          const deps = await fetcher.fetchDependenciesForIssue(team.projectId, team.issueNumber);
+          // Try cache first to avoid unnecessary API calls
+          let deps = fetcher.getDependenciesFromCache(team.projectId, team.issueNumber);
+          if (deps === null) {
+            deps = await fetcher.fetchDependenciesForIssue(team.projectId, team.issueNumber);
+          }
           if (deps && deps.resolved) {
             // All blockers resolved — clear blocked_by_json and broadcast
             db.updateTeamSilent(team.id, { blockedByJson: null });

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -893,6 +893,90 @@ export class IssueFetcher {
   }
 
   /**
+   * Surgically mark an issue as closed in the cache without a full refresh.
+   * Also updates any blockedBy references to this issue across the entire tree,
+   * recalculating openCount and resolved status.
+   *
+   * Synchronous — no network calls; operates on cached data in place.
+   * Called after GitHub API confirms the issue is closed (e.g. after PR merge).
+   *
+   * @param projectId - The project owning the issue
+   * @param issueNumber - The issue number to mark as closed
+   */
+  markIssueClosed(projectId: number, issueNumber: number): void {
+    const cache = this.cacheByProject.get(projectId);
+    if (!cache) return;
+
+    // Mark the issue node itself as closed
+    const node = this.findInTree(cache.issues, issueNumber);
+    if (node) {
+      node.state = 'closed';
+    }
+
+    // Walk the entire tree and update any blockedBy references to this issue
+    const allNodes = this.flattenTree(cache.issues);
+    for (const n of allNodes) {
+      if (!n.dependencies || !n.dependencies.blockedBy) continue;
+
+      let updated = false;
+      for (const dep of n.dependencies.blockedBy) {
+        if (dep.number === issueNumber && dep.state === 'open') {
+          // Only update same-repo deps, or deps without owner/repo (body-parsed same-repo)
+          if (!dep.owner || !dep.repo || this.isSameProjectRepo(projectId, dep.owner, dep.repo)) {
+            dep.state = 'closed';
+            updated = true;
+          }
+        }
+      }
+
+      if (updated) {
+        n.dependencies.openCount = n.dependencies.blockedBy.filter((d) => d.state === 'open').length;
+        n.dependencies.resolved = n.dependencies.openCount === 0;
+      }
+    }
+  }
+
+  /**
+   * Look up dependencies for a specific issue from the in-memory cache.
+   * Returns the cached IssueDependencyInfo if the issue is found in the cache,
+   * or null if the cache does not contain this issue (caller should fall back
+   * to a live API call).
+   *
+   * @param projectId - The project to search in
+   * @param issueNumber - The issue number to look up
+   * @returns Cached dependency info, or null if not in cache
+   */
+  getDependenciesFromCache(projectId: number, issueNumber: number): IssueDependencyInfo | null {
+    const cache = this.cacheByProject.get(projectId);
+    if (!cache || !cache.cachedAt) return null;
+
+    const node = this.findInTree(cache.issues, issueNumber);
+    if (!node) return null;
+
+    if (node.dependencies) {
+      return node.dependencies;
+    }
+
+    // Issue exists in cache but has no dependencies — return empty/resolved info
+    return this.buildEmptyDependencyInfo(issueNumber);
+  }
+
+  /**
+   * Check whether an owner/repo pair matches the project's GitHub repo.
+   */
+  private isSameProjectRepo(projectId: number, owner: string, repo: string): boolean {
+    try {
+      const db = getDatabase();
+      const project = db.getProject(projectId);
+      if (!project || !project.githubRepo) return false;
+      const [projOwner, projRepo] = project.githubRepo.split('/');
+      return projOwner === owner && projRepo === repo;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Force a re-fetch from the issue provider for a specific project.
    */
   async refresh(projectId?: number): Promise<IssueNode[]> {

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -48,7 +48,7 @@ export interface SSEEventPayloads {
   team_stopped: { team_id: number };
   usage_updated: { daily_percent: number; weekly_percent: number; sonnet_percent: number; extra_percent: number; zone: UsageZone };
   project_added: { project_id: number; name: string; repo_path: string };
-  project_updated: { project_id: number; name: string; status: string };
+  project_updated: { project_id: number; name?: string; status?: string; reason?: string; issue_number?: number };
   project_removed: { project_id: number };
   project_cleanup: { project_id: number; removed_count: number; failed_count: number };
   snapshot: { teams: unknown[] };

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1134,7 +1134,11 @@ export class TeamManager {
       if (unblocked.length >= available) break;
 
       try {
-        const deps = await fetcher.fetchDependenciesForIssue(projectId, team.issueNumber);
+        // Try cache first to avoid unnecessary API calls
+        let deps = fetcher.getDependenciesFromCache(projectId, team.issueNumber);
+        if (deps === null) {
+          deps = await fetcher.fetchDependenciesForIssue(projectId, team.issueNumber);
+        }
 
         // Permissive fallback: if fetch returns null, treat as unblocked
         if (!deps || deps.resolved) {
@@ -1153,7 +1157,11 @@ export class TeamManager {
           // Add the open deps' own dependencies (if we can fetch them)
           for (const dep of openDeps) {
             try {
-              const subDeps = await fetcher.fetchDependenciesForIssue(projectId, dep.number);
+              // Try cache first to avoid unnecessary API calls
+              let subDeps = fetcher.getDependenciesFromCache(projectId, dep.number);
+              if (subDeps === null) {
+                subDeps = await fetcher.fetchDependenciesForIssue(projectId, dep.number);
+              }
               if (subDeps && subDeps.blockedBy.length > 0) {
                 depGraph.set(dep.number, subDeps.blockedBy.filter((d) => d.state === 'open').map((d) => d.number));
               }

--- a/tests/client/SettingsPage.test.tsx
+++ b/tests/client/SettingsPage.test.tsx
@@ -43,7 +43,7 @@ function makeSettings() {
     earlyCrashThresholdSec: 120,
     earlyCrashMinTools: 5,
     githubPollIntervalMs: 30000,
-    issuePollIntervalMs: 60000,
+    issuePollIntervalMs: 300000,
     stuckCheckIntervalMs: 60000,
     usagePollIntervalMs: 30000,
     sseHeartbeatMs: 30000,

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -65,6 +65,8 @@ vi.mock('../../src/server/services/team-manager.js', () => ({
 
 const mockFetcher = {
   fetchDependenciesForIssue: vi.fn().mockResolvedValue(null),
+  getDependenciesFromCache: vi.fn().mockReturnValue(null),
+  markIssueClosed: vi.fn(),
 };
 vi.mock('../../src/server/services/issue-fetcher.js', () => ({
   getIssueFetcher: () => mockFetcher,
@@ -1366,6 +1368,117 @@ describe('Input validation guards', () => {
 
     // gh CLI should never be called for an invalid repo slug
     expect(mockExecGHAsync).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+// =============================================================================
+// Surgical cache update on PR merge (Issue #646)
+// =============================================================================
+
+describe('Surgical cache update on PR merge', () => {
+  it('calls markIssueClosed when issue is confirmed closed after merge', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1, issueNumber: 10 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // First call: pollPR gh pr view -> merged
+    // Second call: issue state check -> closed
+    mockExecGHAsync
+      .mockResolvedValueOnce(
+        makeGHPRViewResult({
+          state: 'CLOSED',
+          mergedAt: '2025-01-01T00:00:00Z',
+        }),
+      )
+      .mockResolvedValueOnce('closed\n');
+
+    await githubPoller.poll();
+
+    expect(mockFetcher.markIssueClosed).toHaveBeenCalledWith(1, 10);
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'project_updated',
+      expect.objectContaining({
+        project_id: 1,
+        reason: 'issue_closed',
+        issue_number: 10,
+      }),
+    );
+  });
+
+  it('does NOT call markIssueClosed when issue is still open after merge', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1, issueNumber: 10 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // First call: pollPR gh pr view -> merged
+    // Second call: issue state check -> open (not auto-closed)
+    mockExecGHAsync
+      .mockResolvedValueOnce(
+        makeGHPRViewResult({
+          state: 'CLOSED',
+          mergedAt: '2025-01-01T00:00:00Z',
+        }),
+      )
+      .mockResolvedValueOnce('open\n');
+
+    await githubPoller.poll();
+
+    expect(mockFetcher.markIssueClosed).not.toHaveBeenCalled();
+  });
+
+  it('handles issue state check failure gracefully', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1, issueNumber: 10 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // First call: pollPR gh pr view -> merged
+    // Second call: issue state check -> failure
+    mockExecGHAsync
+      .mockResolvedValueOnce(
+        makeGHPRViewResult({
+          state: 'CLOSED',
+          mergedAt: '2025-01-01T00:00:00Z',
+        }),
+      )
+      .mockRejectedValueOnce(new Error('API rate limit exceeded'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Should not throw
+    await githubPoller.poll();
+
+    expect(mockFetcher.markIssueClosed).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 });

--- a/tests/server/issue-fetcher-archived-deps.test.ts
+++ b/tests/server/issue-fetcher-archived-deps.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../src/server/db.js', () => ({
 
 vi.mock('../../src/server/config.js', () => ({
   default: {
-    issuePollIntervalMs: 60000,
+    issuePollIntervalMs: 300000,
   },
 }));
 

--- a/tests/server/issue-fetcher-blockedby-recovery.test.ts
+++ b/tests/server/issue-fetcher-blockedby-recovery.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../src/server/db.js', () => ({
 
 vi.mock('../../src/server/config.js', () => ({
   default: {
-    issuePollIntervalMs: 60000,
+    issuePollIntervalMs: 300000,
   },
 }));
 

--- a/tests/server/issue-fetcher-cache-update.test.ts
+++ b/tests/server/issue-fetcher-cache-update.test.ts
@@ -1,0 +1,441 @@
+// =============================================================================
+// Fleet Commander -- Issue Fetcher Cache Update Tests (Issue #646)
+// =============================================================================
+// Tests for the two new IssueFetcher methods:
+//   - markIssueClosed: surgically mark an issue as closed in the cache and
+//     update any blockedBy references across the tree
+//   - getDependenciesFromCache: look up dependencies from the in-memory cache
+//     without making API calls
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IssueNode } from '../../src/server/services/issue-fetcher.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import. vi.mock calls are hoisted.
+// ---------------------------------------------------------------------------
+
+const {
+  mockFetchRawIssueHierarchy,
+  mockFetchMissingParents,
+  mockFetchSingleIssueDeps,
+  mockResolveIssueStates,
+  mockDb,
+} = vi.hoisted(() => ({
+  mockFetchRawIssueHierarchy: vi.fn(),
+  mockFetchMissingParents: vi.fn(),
+  mockFetchSingleIssueDeps: vi.fn(),
+  mockResolveIssueStates: vi.fn(),
+  mockDb: {
+    getProject: vi.fn().mockReturnValue({
+      id: 1,
+      name: 'test-repo',
+      githubRepo: 'owner/repo',
+      issueProvider: null,
+      projectKey: null,
+      providerConfig: null,
+    }),
+    getProjects: vi.fn().mockReturnValue([]),
+    getIssueSources: vi.fn().mockReturnValue([]),
+    getActiveTeams: vi.fn().mockReturnValue([]),
+    getActiveTeamsByProject: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    issuePollIntervalMs: 300000,
+  },
+}));
+
+vi.mock('../../src/server/providers/github-issue-provider.js', () => {
+  class GitHubIssueProvider {
+    name = 'github';
+    capabilities = {
+      dependencies: true,
+      subIssues: true,
+      labels: true,
+      boardStatuses: false,
+      priorities: false,
+      assignees: true,
+      linkedPRs: true,
+    };
+    fetchRawIssueHierarchy = mockFetchRawIssueHierarchy;
+    fetchMissingParents = mockFetchMissingParents;
+    fetchSingleIssueDeps = mockFetchSingleIssueDeps;
+    resolveIssueStates = mockResolveIssueStates;
+    getIssue = vi.fn().mockResolvedValue(null);
+    queryIssues = vi.fn().mockResolvedValue({ issues: [], cursor: null, hasMore: false });
+    getDependencies = vi.fn().mockResolvedValue([]);
+    getLinkedPRs = vi.fn().mockResolvedValue([]);
+    mapToGenericIssue = vi.fn();
+  }
+
+  return {
+    GitHubIssueProvider,
+    parseDependenciesFromBody: vi.fn().mockReturnValue([]),
+    runWithConcurrency: async <T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> => {
+      const results: T[] = new Array(tasks.length);
+      let nextIndex = 0;
+      async function worker(): Promise<void> {
+        while (nextIndex < tasks.length) {
+          const idx = nextIndex++;
+          results[idx] = await tasks[idx]();
+        }
+      }
+      const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
+      await Promise.all(workers);
+      return results;
+    },
+    parseRepo: (githubRepo: string): [string, string] => {
+      const parts = githubRepo.split('/');
+      return [parts[0] || 'unknown', parts[1] || 'unknown'];
+    },
+    GITHUB_STATUS_MAP: { OPEN: 'open', CLOSED: 'closed' },
+    MAX_CONCURRENT_RESOLVE: 5,
+    ISSUES_QUERY_FULL: '',
+    SINGLE_ISSUE_DEPS_QUERY_FULL: '',
+  };
+});
+
+vi.mock('../../src/server/providers/index.js', async () => {
+  const { GitHubIssueProvider } = await import('../../src/server/providers/github-issue-provider.js');
+  const instance = new GitHubIssueProvider();
+  return {
+    getIssueProvider: () => instance,
+    resetProviders: vi.fn(),
+  };
+});
+
+vi.mock('../../src/server/providers/jira-issue-provider.js', () => ({
+  JiraIssueProvider: class JiraIssueProvider {},
+}));
+
+// Import after mocks
+const { IssueFetcher } = await import('../../src/server/services/issue-fetcher.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIssueNode(overrides: Partial<IssueNode> & { number: number }): IssueNode {
+  return {
+    title: `Issue #${overrides.number}`,
+    state: 'open',
+    labels: [],
+    url: `https://github.com/owner/repo/issues/${overrides.number}`,
+    children: [],
+    activeTeam: null,
+    issueKey: String(overrides.number),
+    issueProvider: 'github',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let fetcher: InstanceType<typeof IssueFetcher>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetcher = new IssueFetcher();
+});
+
+// =============================================================================
+// markIssueClosed
+// =============================================================================
+
+describe('markIssueClosed', () => {
+  it('marks a root issue as closed', () => {
+    // Populate cache directly via the internal cacheByProject map
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+        makeIssueNode({ number: 20, state: 'open' }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    expect(cache.issues[0].state).toBe('closed');
+    expect(cache.issues[1].state).toBe('open'); // unchanged
+  });
+
+  it('marks a nested child issue as closed', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({
+          number: 1,
+          state: 'open',
+          children: [
+            makeIssueNode({ number: 10, state: 'open' }),
+          ],
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    expect(cache.issues[0].children[0].state).toBe('closed');
+    expect(cache.issues[0].state).toBe('open'); // parent unchanged
+  });
+
+  it('updates blockedBy references to the closed issue', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+        makeIssueNode({
+          number: 20,
+          state: 'open',
+          dependencies: {
+            issueNumber: 20,
+            blockedBy: [
+              { number: 10, owner: 'owner', repo: 'repo', state: 'open' as const, title: 'Blocker' },
+              { number: 30, owner: 'owner', repo: 'repo', state: 'open' as const, title: 'Other blocker' },
+            ],
+            resolved: false,
+            openCount: 2,
+          },
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    const deps = cache.issues[1].dependencies!;
+    expect(deps.blockedBy[0].state).toBe('closed');
+    expect(deps.blockedBy[1].state).toBe('open'); // unchanged
+    expect(deps.openCount).toBe(1);
+    expect(deps.resolved).toBe(false);
+  });
+
+  it('sets resolved to true when the last blocker is closed', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+        makeIssueNode({
+          number: 20,
+          state: 'open',
+          dependencies: {
+            issueNumber: 20,
+            blockedBy: [
+              { number: 10, owner: 'owner', repo: 'repo', state: 'open' as const, title: 'Blocker' },
+            ],
+            resolved: false,
+            openCount: 1,
+          },
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    const deps = cache.issues[1].dependencies!;
+    expect(deps.blockedBy[0].state).toBe('closed');
+    expect(deps.openCount).toBe(0);
+    expect(deps.resolved).toBe(true);
+  });
+
+  it('does not update cross-repo blockers with different owner/repo', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({
+          number: 20,
+          state: 'open',
+          dependencies: {
+            issueNumber: 20,
+            blockedBy: [
+              { number: 10, owner: 'other-owner', repo: 'other-repo', state: 'open' as const, title: 'Cross-repo blocker' },
+            ],
+            resolved: false,
+            openCount: 1,
+          },
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    // Cross-repo blocker should not be updated
+    const deps = cache.issues[0].dependencies!;
+    expect(deps.blockedBy[0].state).toBe('open');
+    expect(deps.openCount).toBe(1);
+    expect(deps.resolved).toBe(false);
+  });
+
+  it('updates blockers without owner/repo (body-parsed same-repo)', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({
+          number: 20,
+          state: 'open',
+          dependencies: {
+            issueNumber: 20,
+            blockedBy: [
+              { number: 10, owner: '', repo: '', state: 'open' as const, title: 'Body-parsed blocker' },
+            ],
+            resolved: false,
+            openCount: 1,
+          },
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    fetcher.markIssueClosed(1, 10);
+
+    const deps = cache.issues[0].dependencies!;
+    expect(deps.blockedBy[0].state).toBe('closed');
+    expect(deps.openCount).toBe(0);
+    expect(deps.resolved).toBe(true);
+  });
+
+  it('is a no-op if the project has no cache', () => {
+    // No cache set for project 999 — should not throw
+    expect(() => fetcher.markIssueClosed(999, 10)).not.toThrow();
+  });
+
+  it('is a no-op if the issue is not in the cache', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    // Issue 999 does not exist — should not throw, and issue 10 stays unchanged
+    fetcher.markIssueClosed(1, 999);
+    expect(cache.issues[0].state).toBe('open');
+  });
+});
+
+// =============================================================================
+// getDependenciesFromCache
+// =============================================================================
+
+describe('getDependenciesFromCache', () => {
+  it('returns cached dependencies when issue has them', () => {
+    const expectedDeps = {
+      issueNumber: 10,
+      blockedBy: [
+        { number: 5, owner: 'owner', repo: 'repo', state: 'open' as const, title: 'Blocker' },
+      ],
+      resolved: false,
+      openCount: 1,
+    };
+
+    const cache = {
+      issues: [
+        makeIssueNode({
+          number: 10,
+          state: 'open',
+          dependencies: expectedDeps,
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    const result = fetcher.getDependenciesFromCache(1, 10);
+    expect(result).toBe(expectedDeps);
+  });
+
+  it('returns empty dependency info when issue exists but has no dependencies', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    const result = fetcher.getDependenciesFromCache(1, 10);
+    expect(result).toEqual({
+      issueNumber: 10,
+      blockedBy: [],
+      resolved: true,
+      openCount: 0,
+    });
+  });
+
+  it('returns null when no cache exists for the project', () => {
+    const result = fetcher.getDependenciesFromCache(999, 10);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cache has no cachedAt (stale/partial)', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+      ],
+      cachedAt: null,
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    const result = fetcher.getDependenciesFromCache(1, 10);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the issue is not in the cache', () => {
+    const cache = {
+      issues: [
+        makeIssueNode({ number: 10, state: 'open' }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    const result = fetcher.getDependenciesFromCache(1, 999);
+    expect(result).toBeNull();
+  });
+
+  it('finds issue in nested children', () => {
+    const expectedDeps = {
+      issueNumber: 20,
+      blockedBy: [
+        { number: 5, owner: 'owner', repo: 'repo', state: 'closed' as const, title: 'Resolved blocker' },
+      ],
+      resolved: true,
+      openCount: 0,
+    };
+
+    const cache = {
+      issues: [
+        makeIssueNode({
+          number: 1,
+          state: 'open',
+          children: [
+            makeIssueNode({
+              number: 20,
+              state: 'open',
+              dependencies: expectedDeps,
+            }),
+          ],
+        }),
+      ],
+      cachedAt: new Date().toISOString(),
+    };
+    (fetcher as unknown as { cacheByProject: Map<number, unknown> }).cacheByProject.set(1, cache);
+
+    const result = fetcher.getDependenciesFromCache(1, 20);
+    expect(result).toBe(expectedDeps);
+  });
+});

--- a/tests/server/issue-fetcher-orphan.test.ts
+++ b/tests/server/issue-fetcher-orphan.test.ts
@@ -51,7 +51,7 @@ vi.mock('../../src/server/db.js', () => ({
 
 vi.mock('../../src/server/config.js', () => ({
   default: {
-    issuePollIntervalMs: 60000,
+    issuePollIntervalMs: 300000,
   },
 }));
 

--- a/tests/server/issue-fetcher-performance.test.ts
+++ b/tests/server/issue-fetcher-performance.test.ts
@@ -32,7 +32,7 @@ vi.mock('../../src/server/db.js', () => ({
 
 vi.mock('../../src/server/config.js', () => ({
   default: {
-    issuePollIntervalMs: 60000,
+    issuePollIntervalMs: 300000,
   },
 }));
 

--- a/tests/server/team-manager-process-queue.test.ts
+++ b/tests/server/team-manager-process-queue.test.ts
@@ -52,9 +52,12 @@ vi.mock('../../src/server/utils/find-git-bash.js', () => ({
 // Mock issue-fetcher for dependency checks in processQueue
 const mockFetchDependenciesForIssue = vi.fn();
 
+const mockGetDependenciesFromCache = vi.fn().mockReturnValue(null);
+
 vi.mock('../../src/server/services/issue-fetcher.js', () => ({
   getIssueFetcher: () => ({
     fetchDependenciesForIssue: mockFetchDependenciesForIssue,
+    getDependenciesFromCache: mockGetDependenciesFromCache,
   }),
   detectCircularDependencies: vi.fn().mockReturnValue(null),
 }));


### PR DESCRIPTION
Closes #646

## Summary
- Increased `FLEET_ISSUE_POLL_MS` default from 60s to 5min to reduce GitHub API load for large projects
- Added surgical cache update when PR merge triggers issue closure (confirmed via `gh api` — no optimistic updates)
- Dependency checker (`checkDependencyResolution`, `filterUnblockedTeams`) now uses cache-first lookup, falling back to live API only on cache miss
- Cross-repo blocker guard prevents false positives on same-number issues from different repos

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1619 passed (3 pre-existing failures in cc-spawn.test.ts)
- [x] Client tests — 15 passed
- [x] 14 new tests for `markIssueClosed` and `getDependenciesFromCache`
- [x] 3 new github-poller tests for surgical cache update (confirmed closed, still open, API failure)
- [x] Mock config values updated across 5 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)