### PR TITLE
Issue #645: Add Retry/Restart buttons for failed teams in FleetGrid

### DIFF
--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -91,6 +91,8 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
   const api = useApi();
   const [stopping, setStopping] = useState(false);
   const [forceLaunching, setForceLaunching] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  const [restarting, setRestarting] = useState(false);
 
   const handleStop = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -115,6 +117,32 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
       // Ignore — the SSE stream will reflect actual state
     } finally {
       setForceLaunching(false);
+    }
+  };
+
+  const handleRetry = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (retrying) return;
+    setRetrying(true);
+    try {
+      await api.post(`teams/${team.id}/resume`);
+    } catch {
+      // Ignore — the SSE stream will reflect actual state
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const handleRestart = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (restarting) return;
+    setRestarting(true);
+    try {
+      await api.post(`teams/${team.id}/restart`);
+    } catch {
+      // Ignore — the SSE stream will reflect actual state
+    } finally {
+      setRestarting(false);
     }
   };
 
@@ -245,6 +273,26 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
             >
               {stopping ? 'Stopping\u2026' : 'Stop'}
             </button>
+          )}
+          {team.status === 'failed' && (
+            <>
+              <button
+                onClick={handleRetry}
+                disabled={retrying}
+                className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-[#3FB950] hover:border-[#3FB950]/50 transition-colors disabled:opacity-50"
+                title="Re-queue team (respects queue order)"
+              >
+                {retrying ? 'Retrying\u2026' : 'Retry'}
+              </button>
+              <button
+                onClick={handleRestart}
+                disabled={restarting}
+                className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors disabled:opacity-50"
+                title="Restart team (bypasses queue)"
+              >
+                {restarting ? 'Restarting\u2026' : 'Restart'}
+              </button>
+            </>
           )}
         </span>
       </td>

--- a/tests/client/TeamRow.test.tsx
+++ b/tests/client/TeamRow.test.tsx
@@ -198,6 +198,77 @@ describe('TeamRow', () => {
     expect(screen.getByText('thinking...')).toBeInTheDocument();
   });
 
+  // -------------------------------------------------------------------------
+  // Retry / Restart buttons for failed teams
+  // -------------------------------------------------------------------------
+
+  it('shows Retry button for failed teams', () => {
+    renderRow(fullTeam({ status: 'failed' }));
+    expect(screen.getByTitle('Re-queue team (respects queue order)')).toBeInTheDocument();
+  });
+
+  it('shows Restart button for failed teams', () => {
+    renderRow(fullTeam({ status: 'failed' }));
+    expect(screen.getByTitle('Restart team (bypasses queue)')).toBeInTheDocument();
+  });
+
+  it('does not show Retry button for running teams', () => {
+    renderRow(fullTeam({ status: 'running' }));
+    expect(screen.queryByTitle('Re-queue team (respects queue order)')).not.toBeInTheDocument();
+  });
+
+  it('does not show Restart button for done teams', () => {
+    renderRow(fullTeam({ status: 'done' }));
+    expect(screen.queryByTitle('Restart team (bypasses queue)')).not.toBeInTheDocument();
+  });
+
+  it('calls resume API when Retry is clicked', async () => {
+    const team = fullTeam({ id: 99, status: 'failed' });
+    renderRow(team);
+    const retryBtn = screen.getByTitle('Re-queue team (respects queue order)');
+    await fireEvent.click(retryBtn);
+    expect(mockPost).toHaveBeenCalledWith('teams/99/resume');
+  });
+
+  it('calls restart API when Restart is clicked', async () => {
+    const team = fullTeam({ id: 77, status: 'failed' });
+    renderRow(team);
+    const restartBtn = screen.getByTitle('Restart team (bypasses queue)');
+    await fireEvent.click(restartBtn);
+    expect(mockPost).toHaveBeenCalledWith('teams/77/restart');
+  });
+
+  it('shows loading state on Retry button while retrying', async () => {
+    // Make the post hang indefinitely so we can observe the loading state
+    let resolvePost!: () => void;
+    mockPost.mockImplementation(() => new Promise<void>(r => { resolvePost = r; }));
+    const team = fullTeam({ id: 10, status: 'failed' });
+    renderRow(team);
+    const retryBtn = screen.getByTitle('Re-queue team (respects queue order)');
+    expect(retryBtn.textContent).toBe('Retry');
+    fireEvent.click(retryBtn);
+    // Wait for the state update to propagate
+    await vi.waitFor(() => {
+      expect(retryBtn.textContent).toBe('Retrying\u2026');
+    });
+    // Resolve the pending post to clean up
+    resolvePost();
+  });
+
+  it('shows loading state on Restart button while restarting', async () => {
+    let resolvePost!: () => void;
+    mockPost.mockImplementation(() => new Promise<void>(r => { resolvePost = r; }));
+    const team = fullTeam({ id: 11, status: 'failed' });
+    renderRow(team);
+    const restartBtn = screen.getByTitle('Restart team (bypasses queue)');
+    expect(restartBtn.textContent).toBe('Restart');
+    fireEvent.click(restartBtn);
+    await vi.waitFor(() => {
+      expect(restartBtn.textContent).toBe('Restarting\u2026');
+    });
+    resolvePost();
+  });
+
   it('does not re-render when props are reference-equal', () => {
     const team = fullTeam();
     const onSelect = vi.fn();

--- a/tests/client/test-utils.tsx
+++ b/tests/client/test-utils.tsx
@@ -52,6 +52,7 @@ export function makeTeam(overrides: Partial<TeamDashboardRow> = {}): TeamDashboa
     totalCacheCreationTokens: 0,
     totalCacheReadTokens: 0,
     totalCostUsd: 0,
+    retryCount: 0,
     prState: null,
     ciStatus: null,
     mergeStatus: null,


### PR DESCRIPTION
Closes #645

## Summary
- Add **Retry** button (calls `POST /api/teams/:id/resume`) — re-queues via normal queue logic, respects queue order and dependency checks
- Add **Restart** button (calls `POST /api/teams/:id/restart`) — force launches, bypasses queue
- Both buttons shown only for failed teams, with loading states and double-click prevention
- 8 new tests covering visibility, API calls, and loading states (30/30 pass)

## Test plan
- [ ] Verify Retry and Restart buttons appear on failed team rows in FleetGrid
- [ ] Verify buttons do NOT appear on running/done/queued teams
- [ ] Click Retry → team re-queues (status changes to queued or launching)
- [ ] Click Restart → team force-launches (status changes to launching)
- [ ] Verify loading state shows "Retrying..."/"Restarting..." during API call
- [ ] `npm run test:client` passes
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)