### PR TITLE
Issue #657: Add pagination to FleetGrid

### DIFF
--- a/src/client/components/PaginationBar.tsx
+++ b/src/client/components/PaginationBar.tsx
@@ -1,0 +1,78 @@
+import { PAGE_SIZE_OPTIONS } from '../hooks/usePagination';
+import type { PageSize } from '../hooks/usePagination';
+
+// ---------------------------------------------------------------------------
+// PaginationBar — page size selector, prev/next buttons, page indicator
+// ---------------------------------------------------------------------------
+
+interface PaginationBarProps {
+  page: number;
+  totalPages: number;
+  pageSize: PageSize;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: PageSize) => void;
+}
+
+export function PaginationBar({
+  page,
+  totalPages,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: PaginationBarProps) {
+  const isFirstPage = page <= 1;
+  const isLastPage = page >= totalPages;
+
+  return (
+    <div
+      className="flex items-center justify-between px-4 py-2 text-xs border-t border-dark-border"
+      data-testid="pagination-bar"
+    >
+      {/* Page size selector */}
+      <div className="flex items-center gap-2">
+        <label htmlFor="pagination-page-size" className="text-dark-muted">
+          Show
+        </label>
+        <select
+          id="pagination-page-size"
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value) as PageSize)}
+          className="bg-dark-surface border border-dark-border text-dark-text text-xs rounded px-2 py-1 focus:outline-none focus:border-dark-accent"
+          data-testid="pagination-page-size"
+        >
+          {PAGE_SIZE_OPTIONS.map((size) => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+        </select>
+        <span className="text-dark-muted">per page</span>
+      </div>
+
+      {/* Page indicator */}
+      <span className="text-dark-muted" data-testid="pagination-indicator">
+        Page {page} of {totalPages}
+      </span>
+
+      {/* Prev / Next buttons */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(page - 1)}
+          disabled={isFirstPage}
+          className="px-2 py-1 rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-dark-muted disabled:hover:border-dark-border"
+          data-testid="pagination-prev"
+        >
+          Prev
+        </button>
+        <button
+          onClick={() => onPageChange(page + 1)}
+          disabled={isLastPage}
+          className="px-2 py-1 rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-dark-muted disabled:hover:border-dark-border"
+          data-testid="pagination-next"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/hooks/usePagination.ts
+++ b/src/client/hooks/usePagination.ts
@@ -1,0 +1,119 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+const DEFAULT_PAGE_SIZE: PageSize = 25;
+const STORAGE_KEY = 'fleet-grid-page-size';
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+function readPageSize(): PageSize {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_PAGE_SIZE;
+    const parsed = Number(raw);
+    if ((PAGE_SIZE_OPTIONS as readonly number[]).includes(parsed)) {
+      return parsed as PageSize;
+    }
+  } catch {
+    // Ignore corrupt data
+  }
+  return DEFAULT_PAGE_SIZE;
+}
+
+function writePageSize(size: PageSize): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(size));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure pagination function (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Paginate an array of items.
+ * - Clamps page to [1, totalPages].
+ * - Returns the slice for the current page and the total number of pages.
+ */
+export function paginateItems<T>(
+  items: T[],
+  page: number,
+  pageSize: number,
+): { pageItems: T[]; totalPages: number } {
+  if (items.length === 0) {
+    return { pageItems: [], totalPages: 1 };
+  }
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const clampedPage = Math.max(1, Math.min(page, totalPages));
+  const start = (clampedPage - 1) * pageSize;
+  const end = start + pageSize;
+  return { pageItems: items.slice(start, end), totalPages };
+}
+
+// ---------------------------------------------------------------------------
+// Hook return type
+// ---------------------------------------------------------------------------
+
+export interface Pagination {
+  page: number;
+  pageSize: PageSize;
+  setPage: (page: number) => void;
+  setPageSize: (size: PageSize) => void;
+  resetPage: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom hook to manage pagination state with localStorage persistence
+ * for page size. Follows the same initialized-ref pattern as useGridFilters
+ * to avoid writing to localStorage on mount.
+ */
+export function usePagination(): Pagination {
+  const [page, setPageRaw] = useState(1);
+  const [pageSize, setPageSizeRaw] = useState<PageSize>(readPageSize);
+
+  // Track initialization to avoid writing back on mount
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true;
+      return;
+    }
+    writePageSize(pageSize);
+  }, [pageSize]);
+
+  const setPage = useCallback((p: number) => {
+    setPageRaw(p);
+  }, []);
+
+  const setPageSize = useCallback((size: PageSize) => {
+    setPageSizeRaw(size);
+    setPageRaw(1);
+  }, []);
+
+  const resetPage = useCallback(() => {
+    setPageRaw(1);
+  }, []);
+
+  return {
+    page,
+    pageSize,
+    setPage,
+    setPageSize,
+    resetPage,
+  };
+}

--- a/src/client/views/FleetGridView.tsx
+++ b/src/client/views/FleetGridView.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTeams, useSelection } from '../context/FleetContext';
 import { FleetGrid } from '../components/FleetGrid';
 import { TeamTimeline } from '../components/TeamTimeline';
 import { GridFilterBar } from '../components/GridFilterBar';
+import { PaginationBar } from '../components/PaginationBar';
 import { useGridFilters, applyGridFilters } from '../hooks/useGridFilters';
+import { usePagination, paginateItems } from '../hooks/usePagination';
 import type { TeamDashboardRow, TeamStatus } from '../../shared/types';
 
 type ViewMode = 'grid' | 'timeline';
@@ -41,6 +43,12 @@ export function FleetGridView() {
   const { selectedTeamId, setSelectedTeamId } = useSelection();
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const { selectedProject, selectedStatuses, setProject, setStatuses } = useGridFilters();
+  const { page, pageSize, setPage, setPageSize, resetPage } = usePagination();
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    resetPage();
+  }, [selectedProject, selectedStatuses, resetPage]);
 
   // Unique project names sorted alphabetically (derived from unfiltered teams)
   const projectNames = useMemo(() => {
@@ -55,6 +63,12 @@ export function FleetGridView() {
   const filteredTeams = useMemo(
     () => sortTeams(applyGridFilters(teams, selectedProject, selectedStatuses)),
     [teams, selectedProject, selectedStatuses],
+  );
+
+  // Paginate filtered teams (grid view only)
+  const { pageItems: paginatedTeams, totalPages } = useMemo(
+    () => paginateItems(filteredTeams, page, pageSize),
+    [filteredTeams, page, pageSize],
   );
 
   const hasActiveFilters = selectedProject !== null || selectedStatuses.size > 0;
@@ -116,11 +130,22 @@ export function FleetGridView() {
 
       {/* View content */}
       {viewMode === 'grid' ? (
-        <FleetGrid
-          teams={filteredTeams}
-          selectedTeamId={selectedTeamId}
-          onSelectTeam={setSelectedTeamId}
-        />
+        <>
+          <FleetGrid
+            teams={paginatedTeams}
+            selectedTeamId={selectedTeamId}
+            onSelectTeam={setSelectedTeamId}
+          />
+          {filteredTeams.length > 0 && (
+            <PaginationBar
+              page={page}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+            />
+          )}
+        </>
       ) : (
         <TeamTimeline teams={filteredTeams} />
       )}

--- a/tests/client/FleetGridView.test.tsx
+++ b/tests/client/FleetGridView.test.tsx
@@ -15,9 +15,14 @@ let mockSelectedTeamId: number | null = null;
 const mockSetSelectedTeamId = vi.fn();
 const mockSetProject = vi.fn();
 const mockSetStatuses = vi.fn();
+const mockSetPage = vi.fn();
+const mockSetPageSize = vi.fn();
+const mockResetPage = vi.fn();
 
 let mockSelectedProject: string | null = null;
 let mockSelectedStatuses = new Set<string>();
+let mockPage = 1;
+let mockPageSize = 25;
 
 vi.mock('../../src/client/context/FleetContext', () => ({
   useTeams: () => ({
@@ -45,6 +50,25 @@ vi.mock('../../src/client/hooks/useGridFilters', () => ({
       return true;
     });
   },
+}));
+
+// Mock the pagination hook
+vi.mock('../../src/client/hooks/usePagination', () => ({
+  usePagination: () => ({
+    page: mockPage,
+    pageSize: mockPageSize,
+    setPage: mockSetPage,
+    setPageSize: mockSetPageSize,
+    resetPage: mockResetPage,
+  }),
+  paginateItems: (items: unknown[], page: number, pageSize: number) => {
+    const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+    const clampedPage = Math.max(1, Math.min(page, totalPages));
+    const start = (clampedPage - 1) * pageSize;
+    const end = start + pageSize;
+    return { pageItems: items.slice(start, end), totalPages };
+  },
+  PAGE_SIZE_OPTIONS: [25, 50, 100] as const,
 }));
 
 // Mock child components to keep rendering lightweight
@@ -79,6 +103,22 @@ vi.mock('../../src/client/components/GridFilterBar', () => ({
   ),
 }));
 
+vi.mock('../../src/client/components/PaginationBar', () => ({
+  PaginationBar: (props: {
+    page: number;
+    totalPages: number;
+    pageSize: number;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (size: number) => void;
+  }) => (
+    <div data-testid="pagination-bar">
+      PaginationBar (page {props.page} of {props.totalPages}, size {props.pageSize})
+      <button data-testid="page-next" onClick={() => props.onPageChange(props.page + 1)}>Next</button>
+      <button data-testid="page-size-50" onClick={() => props.onPageSizeChange(50)}>Size 50</button>
+    </div>
+  ),
+}));
+
 // Import after mocks
 import { FleetGridView } from '../../src/client/views/FleetGridView';
 
@@ -107,9 +147,14 @@ describe('FleetGridView', () => {
     mockSelectedTeamId = null;
     mockSelectedProject = null;
     mockSelectedStatuses = new Set();
+    mockPage = 1;
+    mockPageSize = 25;
     mockSetSelectedTeamId.mockReset();
     mockSetProject.mockReset();
     mockSetStatuses.mockReset();
+    mockSetPage.mockReset();
+    mockSetPageSize.mockReset();
+    mockResetPage.mockReset();
   });
 
   afterEach(() => {
@@ -247,5 +292,74 @@ describe('FleetGridView', () => {
     render(<FleetGridView />);
     // GridFilterBar mock renders project names joined
     expect(screen.getByText('GridFilterBar (projects: alpha,beta)')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pagination integration tests
+  // -------------------------------------------------------------------------
+
+  it('renders PaginationBar in grid view when teams exist', () => {
+    mockTeams = [makeTeam()];
+    render(<FleetGridView />);
+    expect(screen.getByTestId('pagination-bar')).toBeInTheDocument();
+  });
+
+  it('does not render PaginationBar in timeline view', () => {
+    mockTeams = [makeTeam()];
+    render(<FleetGridView />);
+    fireEvent.click(screen.getByText('Timeline'));
+    expect(screen.queryByTestId('pagination-bar')).not.toBeInTheDocument();
+  });
+
+  it('does not render PaginationBar in empty state', () => {
+    mockTeams = [];
+    render(<FleetGridView />);
+    expect(screen.queryByTestId('pagination-bar')).not.toBeInTheDocument();
+  });
+
+  it('passes paginated teams to FleetGrid', () => {
+    // Create 30 teams, with page size 25 only 25 should be passed
+    mockTeams = Array.from({ length: 30 }, (_, i) =>
+      makeTeam({ id: i + 1, issueNumber: 100 + i }),
+    );
+    mockPageSize = 25;
+    mockPage = 1;
+    render(<FleetGridView />);
+    expect(screen.getByText('FleetGrid (25 teams)')).toBeInTheDocument();
+  });
+
+  it('passes all filtered teams to TeamTimeline (not paginated)', () => {
+    mockTeams = Array.from({ length: 30 }, (_, i) =>
+      makeTeam({ id: i + 1, issueNumber: 100 + i }),
+    );
+    mockPageSize = 25;
+    mockPage = 1;
+    render(<FleetGridView />);
+    fireEvent.click(screen.getByText('Timeline'));
+    expect(screen.getByText('TeamTimeline (30 teams)')).toBeInTheDocument();
+  });
+
+  it('forwards onPageChange to setPage', () => {
+    mockTeams = [makeTeam()];
+    render(<FleetGridView />);
+    fireEvent.click(screen.getByTestId('page-next'));
+    expect(mockSetPage).toHaveBeenCalledWith(2);
+  });
+
+  it('forwards onPageSizeChange to setPageSize', () => {
+    mockTeams = [makeTeam()];
+    render(<FleetGridView />);
+    fireEvent.click(screen.getByTestId('page-size-50'));
+    expect(mockSetPageSize).toHaveBeenCalledWith(50);
+  });
+
+  it('shows PaginationBar with page and totalPages info', () => {
+    mockTeams = Array.from({ length: 60 }, (_, i) =>
+      makeTeam({ id: i + 1, issueNumber: 100 + i }),
+    );
+    mockPage = 2;
+    mockPageSize = 25;
+    render(<FleetGridView />);
+    expect(screen.getByText('PaginationBar (page 2 of 3, size 25)')).toBeInTheDocument();
   });
 });

--- a/tests/client/PaginationBar.test.tsx
+++ b/tests/client/PaginationBar.test.tsx
@@ -1,0 +1,145 @@
+// =============================================================================
+// Fleet Commander — PaginationBar Component Tests
+// =============================================================================
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PaginationBar } from '../../src/client/components/PaginationBar';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOOP = () => {};
+
+const DEFAULT_PROPS = {
+  page: 1,
+  totalPages: 5,
+  pageSize: 25 as const,
+  onPageChange: NOOP,
+  onPageSizeChange: NOOP,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PaginationBar', () => {
+  // -------------------------------------------------------------------------
+  // Rendering
+  // -------------------------------------------------------------------------
+
+  describe('rendering', () => {
+    it('renders the pagination bar container', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId('pagination-bar')).toBeInTheDocument();
+    });
+
+    it('renders page indicator with current page and total', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={2} totalPages={5} />);
+      expect(screen.getByTestId('pagination-indicator')).toHaveTextContent('Page 2 of 5');
+    });
+
+    it('renders page size selector with all options', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} />);
+      const select = screen.getByTestId('pagination-page-size') as HTMLSelectElement;
+      const options = select.querySelectorAll('option');
+      expect(options).toHaveLength(3);
+      expect(options[0].textContent).toBe('25');
+      expect(options[1].textContent).toBe('50');
+      expect(options[2].textContent).toBe('100');
+    });
+
+    it('shows selected page size in the dropdown', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} pageSize={50} />);
+      const select = screen.getByTestId('pagination-page-size') as HTMLSelectElement;
+      expect(select.value).toBe('50');
+    });
+
+    it('renders Prev and Next buttons', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId('pagination-prev')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-next')).toBeInTheDocument();
+    });
+
+    it('renders "Show" and "per page" labels', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} />);
+      expect(screen.getByText('Show')).toBeInTheDocument();
+      expect(screen.getByText('per page')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Button disabled states
+  // -------------------------------------------------------------------------
+
+  describe('button disabled states', () => {
+    it('disables Prev button on page 1', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={1} />);
+      expect(screen.getByTestId('pagination-prev')).toBeDisabled();
+    });
+
+    it('enables Prev button on page 2+', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={2} />);
+      expect(screen.getByTestId('pagination-prev')).not.toBeDisabled();
+    });
+
+    it('disables Next button on last page', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={5} totalPages={5} />);
+      expect(screen.getByTestId('pagination-next')).toBeDisabled();
+    });
+
+    it('enables Next button when not on last page', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={1} totalPages={5} />);
+      expect(screen.getByTestId('pagination-next')).not.toBeDisabled();
+    });
+
+    it('disables both buttons when totalPages is 1', () => {
+      render(<PaginationBar {...DEFAULT_PROPS} page={1} totalPages={1} />);
+      expect(screen.getByTestId('pagination-prev')).toBeDisabled();
+      expect(screen.getByTestId('pagination-next')).toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Interaction
+  // -------------------------------------------------------------------------
+
+  describe('interaction', () => {
+    it('calls onPageChange(page - 1) when Prev is clicked', () => {
+      const onChange = vi.fn();
+      render(<PaginationBar {...DEFAULT_PROPS} page={3} onPageChange={onChange} />);
+      fireEvent.click(screen.getByTestId('pagination-prev'));
+      expect(onChange).toHaveBeenCalledWith(2);
+    });
+
+    it('calls onPageChange(page + 1) when Next is clicked', () => {
+      const onChange = vi.fn();
+      render(<PaginationBar {...DEFAULT_PROPS} page={3} onPageChange={onChange} />);
+      fireEvent.click(screen.getByTestId('pagination-next'));
+      expect(onChange).toHaveBeenCalledWith(4);
+    });
+
+    it('calls onPageSizeChange when page size is changed', () => {
+      const onSizeChange = vi.fn();
+      render(<PaginationBar {...DEFAULT_PROPS} onPageSizeChange={onSizeChange} />);
+      fireEvent.change(screen.getByTestId('pagination-page-size'), { target: { value: '50' } });
+      expect(onSizeChange).toHaveBeenCalledWith(50);
+    });
+
+    it('does not call onPageChange when disabled Prev is clicked', () => {
+      const onChange = vi.fn();
+      render(<PaginationBar {...DEFAULT_PROPS} page={1} onPageChange={onChange} />);
+      fireEvent.click(screen.getByTestId('pagination-prev'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onPageChange when disabled Next is clicked', () => {
+      const onChange = vi.fn();
+      render(<PaginationBar {...DEFAULT_PROPS} page={5} totalPages={5} onPageChange={onChange} />);
+      fireEvent.click(screen.getByTestId('pagination-next'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/client/usePagination.test.ts
+++ b/tests/client/usePagination.test.ts
@@ -1,0 +1,200 @@
+// =============================================================================
+// Fleet Commander — usePagination Hook & paginateItems Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePagination, paginateItems, PAGE_SIZE_OPTIONS } from '../../src/client/hooks/usePagination';
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const storageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((_index: number) => null),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', { value: storageMock });
+
+// ---------------------------------------------------------------------------
+// paginateItems — Pure function tests
+// ---------------------------------------------------------------------------
+
+describe('paginateItems', () => {
+  const items = Array.from({ length: 60 }, (_, i) => i + 1);
+
+  it('returns first page slice with correct total pages', () => {
+    const result = paginateItems(items, 1, 25);
+    expect(result.pageItems).toHaveLength(25);
+    expect(result.pageItems[0]).toBe(1);
+    expect(result.pageItems[24]).toBe(25);
+    expect(result.totalPages).toBe(3);
+  });
+
+  it('returns second page slice', () => {
+    const result = paginateItems(items, 2, 25);
+    expect(result.pageItems).toHaveLength(25);
+    expect(result.pageItems[0]).toBe(26);
+    expect(result.pageItems[24]).toBe(50);
+  });
+
+  it('returns last page with remaining items', () => {
+    const result = paginateItems(items, 3, 25);
+    expect(result.pageItems).toHaveLength(10);
+    expect(result.pageItems[0]).toBe(51);
+    expect(result.pageItems[9]).toBe(60);
+  });
+
+  it('clamps page below 1 to page 1', () => {
+    const result = paginateItems(items, 0, 25);
+    expect(result.pageItems[0]).toBe(1);
+    expect(result.pageItems).toHaveLength(25);
+  });
+
+  it('clamps page above totalPages to last page', () => {
+    const result = paginateItems(items, 100, 25);
+    expect(result.pageItems[0]).toBe(51);
+    expect(result.pageItems).toHaveLength(10);
+    expect(result.totalPages).toBe(3);
+  });
+
+  it('returns all items when page size exceeds total', () => {
+    const result = paginateItems(items, 1, 100);
+    expect(result.pageItems).toHaveLength(60);
+    expect(result.totalPages).toBe(1);
+  });
+
+  it('handles empty array', () => {
+    const result = paginateItems([], 1, 25);
+    expect(result.pageItems).toHaveLength(0);
+    expect(result.totalPages).toBe(1);
+  });
+
+  it('handles single item', () => {
+    const result = paginateItems(['a'], 1, 25);
+    expect(result.pageItems).toEqual(['a']);
+    expect(result.totalPages).toBe(1);
+  });
+
+  it('handles exact page boundary', () => {
+    const exactItems = Array.from({ length: 50 }, (_, i) => i + 1);
+    const result = paginateItems(exactItems, 2, 25);
+    expect(result.pageItems).toHaveLength(25);
+    expect(result.pageItems[0]).toBe(26);
+    expect(result.totalPages).toBe(2);
+  });
+
+  it('works with page size 50', () => {
+    const result = paginateItems(items, 1, 50);
+    expect(result.pageItems).toHaveLength(50);
+    expect(result.totalPages).toBe(2);
+  });
+
+  it('works with page size 100', () => {
+    const result = paginateItems(items, 1, 100);
+    expect(result.pageItems).toHaveLength(60);
+    expect(result.totalPages).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PAGE_SIZE_OPTIONS constant
+// ---------------------------------------------------------------------------
+
+describe('PAGE_SIZE_OPTIONS', () => {
+  it('contains 25, 50, 100', () => {
+    expect([...PAGE_SIZE_OPTIONS]).toEqual([25, 50, 100]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePagination — Hook tests
+// ---------------------------------------------------------------------------
+
+describe('usePagination', () => {
+  beforeEach(() => {
+    storageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('starts on page 1 with default page size 25', () => {
+    const { result } = renderHook(() => usePagination());
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it('rehydrates page size from localStorage', () => {
+    storageMock.setItem('fleet-grid-page-size', '50');
+    const { result } = renderHook(() => usePagination());
+    expect(result.current.pageSize).toBe(50);
+  });
+
+  it('falls back to default for invalid localStorage value', () => {
+    storageMock.setItem('fleet-grid-page-size', '42');
+    const { result } = renderHook(() => usePagination());
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it('falls back to default for non-numeric localStorage value', () => {
+    storageMock.setItem('fleet-grid-page-size', 'abc');
+    const { result } = renderHook(() => usePagination());
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it('setPage updates the current page', () => {
+    const { result } = renderHook(() => usePagination());
+    act(() => {
+      result.current.setPage(3);
+    });
+    expect(result.current.page).toBe(3);
+  });
+
+  it('setPageSize updates page size and resets to page 1', () => {
+    const { result } = renderHook(() => usePagination());
+    act(() => {
+      result.current.setPage(3);
+    });
+    expect(result.current.page).toBe(3);
+    act(() => {
+      result.current.setPageSize(50);
+    });
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.page).toBe(1);
+  });
+
+  it('resetPage sets page back to 1', () => {
+    const { result } = renderHook(() => usePagination());
+    act(() => {
+      result.current.setPage(5);
+    });
+    expect(result.current.page).toBe(5);
+    act(() => {
+      result.current.resetPage();
+    });
+    expect(result.current.page).toBe(1);
+  });
+
+  it('persists page size to localStorage on setPageSize', () => {
+    const { result } = renderHook(() => usePagination());
+    act(() => {
+      result.current.setPageSize(100);
+    });
+    expect(storageMock.getItem('fleet-grid-page-size')).toBe('100');
+  });
+
+  it('does not write to localStorage on initial mount', () => {
+    storageMock.setItem('fleet-grid-page-size', '50');
+    vi.clearAllMocks();
+    renderHook(() => usePagination());
+    // setItem should not have been called during mount
+    expect(storageMock.setItem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #657

## Summary
- Add `usePagination` hook with localStorage persistence and `paginateItems` pure helper
- Add `PaginationBar` component with page size selector (25/50/100), prev/next navigation, and page indicator
- Integrate pagination into `FleetGridView` — grid view shows paginated teams, timeline view shows all filtered teams
- Pagination resets to page 1 on filter or page size change

## Test plan
- [x] 21 unit tests for `paginateItems` and `usePagination` hook
- [x] 16 component tests for `PaginationBar`
- [x] 8 integration tests for `FleetGridView` pagination
- [x] All existing tests pass unmodified
- [x] TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)