### PR TITLE
Issue #665: Capture handoff files (plan.md, changes.md, review.md) via PostToolUse hook

### DIFF
--- a/hooks/on_post_tool_use.sh
+++ b/hooks/on_post_tool_use.sh
@@ -10,4 +10,32 @@ _LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | tool_use | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
 input=$(cat)
 echo "$input" | "$HOOK_DIR/send_event.sh" "tool_use"
+
+# ── Handoff file detection ───────────────────────────────────────
+# If the tool was Write or Edit and the file is plan.md, changes.md, or
+# review.md, capture the file content and send a handoff_file event.
+# Runs in background so the hook returns immediately (fire-and-forget).
+TOOL_NAME=""
+FILE_PATH=""
+
+# Try jq first for reliable extraction
+if command -v jq >/dev/null 2>&1; then
+    TOOL_NAME=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+    FILE_PATH=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || true)
+fi
+
+# Check if this is a Write or Edit of a handoff file
+if [ -n "$TOOL_NAME" ] && [ -n "$FILE_PATH" ]; then
+    case "$TOOL_NAME" in
+        Write|Edit)
+            BASENAME=$(basename "$FILE_PATH" 2>/dev/null || true)
+            case "$BASENAME" in
+                plan.md|changes.md|review.md)
+                    "$HOOK_DIR/send_handoff.sh" "$BASENAME" "$FILE_PATH" "$input" &
+                    ;;
+            esac
+            ;;
+    esac
+fi
+
 exit 0

--- a/hooks/send_handoff.sh
+++ b/hooks/send_handoff.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# fleet-commander v0.0.15
+# Fleet Commander: Sends a handoff_file event when an agent writes
+# plan.md, changes.md, or review.md.
+#
+# Usage: send_handoff.sh <file_type> <file_path> <cc_stdin_json>
+#
+# Called from on_post_tool_use.sh in background (fire-and-forget).
+# Reads the file content (capped at 50KB) and POSTs a handoff_file
+# event to the Fleet Commander server.
+#
+# Design principles:
+#   - NEVER block Claude Code. Timeout is 2 seconds, errors are swallowed.
+#   - Content capped at 50KB (head -c 51200) to prevent DB bloat.
+#   - Always exits 0 — failures must not propagate.
+
+# ── Configuration ──────────────────────────────────────────────────
+FLEET_URL="${FLEET_SERVER_URL:-http://localhost:4680/api/events}"
+FILE_TYPE="${1:-}"
+FILE_PATH="${2:-}"
+CC_STDIN="${3:-}"
+
+# Kill switch
+if [ "${FLEET_COMMANDER_OFF:-0}" = "1" ]; then
+    exit 0
+fi
+
+# Validate inputs
+if [ -z "$FILE_TYPE" ] || [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# ── Read file content (capped at 50KB) ───────────────────────────
+if [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+CONTENT=$(head -c 51200 "$FILE_PATH" 2>/dev/null || true)
+if [ -z "$CONTENT" ]; then
+    exit 0
+fi
+
+# ── Identify worktree / team ─────────────────────────────────────
+TEAM_NAME=""
+
+if [ -n "${FLEET_TEAM_ID:-}" ]; then
+    TEAM_NAME="$FLEET_TEAM_ID"
+fi
+
+if [ -z "$TEAM_NAME" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    case "$CLAUDE_PROJECT_DIR" in
+        */worktrees/*)
+            TEAM_NAME=$(printf '%s' "$CLAUDE_PROJECT_DIR" | sed 's|.*/worktrees/||' | sed 's|/.*||')
+            ;;
+        *)
+            TEAM_NAME=$(basename "$CLAUDE_PROJECT_DIR")
+            ;;
+    esac
+fi
+
+if [ -z "$TEAM_NAME" ]; then
+    WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+    case "$WORKTREE_ROOT" in
+        */worktrees/*)
+            TEAM_NAME=$(printf '%s' "$WORKTREE_ROOT" | sed 's|.*/worktrees/||' | sed 's|/.*||')
+            ;;
+        *)
+            TEAM_NAME=$(basename "$WORKTREE_ROOT")
+            ;;
+    esac
+fi
+
+# ── Build timestamp ───────────────────────────────────────────────
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+
+# ── JSON string encoder ──────────────────────────────────────────
+json_encode_string() {
+    if command -v jq >/dev/null 2>&1; then
+        jq -Rs .
+    else
+        local raw
+        raw="$(cat; printf .)"
+        raw="${raw%.}"
+        printf '%s' "$raw" | tr '\015' '\001' | awk '
+        BEGIN { ORS=""; printf "\"" }
+        {
+            gsub(/\\/, "\\\\")
+            gsub(/"/, "\\\"")
+            gsub(/\t/, "\\t")
+            gsub(/\001/, "\\r")
+            gsub(/\x08/, "\\b")
+            gsub(/\x0c/, "\\f")
+            if (NR > 1) printf "\\n"
+            printf "%s", $0
+        }
+        END { printf "\"" }
+        '
+    fi
+}
+
+# ── Compose JSON payload ─────────────────────────────────────────
+# Build a cc_stdin-style payload with file_type and content fields
+# so the server can extract them via JSON.parse().
+ENCODED_CONTENT=$(printf '%s' "$CONTENT" | json_encode_string)
+ENCODED_FILE_TYPE=$(printf '%s' "$FILE_TYPE" | json_encode_string)
+ENCODED_TEAM=$(printf '%s' "$TEAM_NAME" | json_encode_string)
+ENCODED_TIMESTAMP=$(printf '%s' "$TIMESTAMP" | json_encode_string)
+
+# Build inner cc_stdin object with file_type and content
+CC_STDIN_OBJ="{\"file_type\":${ENCODED_FILE_TYPE},\"content\":${ENCODED_CONTENT}}"
+ENCODED_CC_STDIN=$(printf '%s' "$CC_STDIN_OBJ" | json_encode_string)
+
+PAYLOAD="{\"event\":\"handoff_file\",\"team\":${ENCODED_TEAM},\"timestamp\":${ENCODED_TIMESTAMP},\"cc_stdin\":${ENCODED_CC_STDIN}}"
+
+# ── Fire and forget ───────────────────────────────────────────────
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+if command -v curl >/dev/null 2>&1; then
+    curl -s -S --max-time 2 --connect-timeout 1 \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d "$PAYLOAD" \
+        "$FLEET_URL" >/dev/null 2>&1
+    CURL_RESULT=$?
+    if [ "$CURL_RESULT" -eq 0 ]; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | handoff_file | $TEAM_NAME | type=$FILE_TYPE curl=ok" >> "$_LOG" 2>/dev/null || true
+    else
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | handoff_file | $TEAM_NAME | type=$FILE_TYPE curl=fail($CURL_RESULT)" >> "$_LOG" 2>/dev/null || true
+    fi
+else
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | SEND  | handoff_file | $TEAM_NAME | type=$FILE_TYPE curl=missing" >> "$_LOG" 2>/dev/null || true
+fi
+
+# Always exit 0 — hooks must never fail
+exit 0

--- a/src/client/components/HandoffFileCard.tsx
+++ b/src/client/components/HandoffFileCard.tsx
@@ -1,0 +1,134 @@
+import { useState, useCallback } from 'react';
+import type { HandoffFile } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Label and color for each file type */
+const FILE_TYPE_META: Record<string, { label: string; color: string }> = {
+  'plan.md': { label: 'Plan', color: '#58A6FF' },
+  'changes.md': { label: 'Changes', color: '#3FB950' },
+  'review.md': { label: 'Review', color: '#D29922' },
+};
+
+/** Format ISO timestamp to a readable relative or absolute time */
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HandoffFileCardProps {
+  file: HandoffFile;
+  defaultExpanded?: boolean;
+}
+
+export function HandoffFileCard({ file, defaultExpanded = false }: HandoffFileCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [copied, setCopied] = useState(false);
+
+  const meta = FILE_TYPE_META[file.fileType] || { label: file.fileType, color: '#8B949E' };
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(file.content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard API may not be available
+    });
+  }, [file.content]);
+
+  return (
+    <div className="border border-dark-border/50 rounded-md overflow-hidden">
+      {/* Header */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-dark-border/10 transition-colors text-left"
+      >
+        {/* Expand/collapse chevron */}
+        <svg
+          className={`w-3.5 h-3.5 text-dark-muted transition-transform ${expanded ? 'rotate-90' : ''}`}
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z" />
+        </svg>
+
+        {/* File type badge */}
+        <span
+          className="text-xs font-medium px-1.5 py-0.5 rounded"
+          style={{ backgroundColor: meta.color + '20', color: meta.color }}
+        >
+          {meta.label}
+        </span>
+
+        {/* File name */}
+        <span className="text-sm text-dark-text font-mono">{file.fileType}</span>
+
+        {/* Agent name */}
+        {file.agentName && (
+          <span className="text-[10px] text-dark-muted px-1.5 py-0.5 rounded bg-dark-border/20">
+            {file.agentName}
+          </span>
+        )}
+
+        {/* Spacer */}
+        <span className="flex-1" />
+
+        {/* Timestamp */}
+        <span className="text-xs text-dark-muted">
+          {formatTimestamp(file.capturedAt)}
+        </span>
+      </button>
+
+      {/* Content */}
+      {expanded && (
+        <div className="border-t border-dark-border/30">
+          {/* Toolbar */}
+          <div className="flex items-center justify-end px-3 py-1 bg-dark-surface/30">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleCopy();
+              }}
+              className="text-xs text-dark-muted hover:text-dark-text transition-colors flex items-center gap-1"
+            >
+              {copied ? (
+                <>
+                  <svg className="w-3 h-3 text-[#3FB950]" viewBox="0 0 16 16" fill="currentColor">
+                    <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+                  </svg>
+                  Copied
+                </>
+              ) : (
+                <>
+                  <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+                    <path fillRule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z" clipRule="evenodd" />
+                    <path fillRule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z" clipRule="evenodd" />
+                  </svg>
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Pre-formatted content */}
+          <pre className="px-3 py-2 text-xs text-dark-text/90 whitespace-pre-wrap break-words max-h-96 overflow-y-auto custom-scrollbar font-mono leading-relaxed">
+            {file.content}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -8,9 +8,10 @@ import { CIChecks } from './CIChecks';
 import { UnifiedTimeline } from './UnifiedTimeline';
 import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
+import { HandoffFileCard } from './HandoffFileCard';
 import { STATUS_COLORS } from '../utils/constants';
 import { formatIssueKey } from '../../shared/issue-provider';
-import type { TeamTask } from '../../shared/types';
+import type { TeamTask, HandoffFile } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -43,9 +44,11 @@ export function TeamDetail() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [quickActionLoading, setQuickActionLoading] = useState<string | null>(null);
   const [quickActionSent, setQuickActionSent] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'session-log' | 'tasks' | 'team'>('session-log');
+  const [activeTab, setActiveTab] = useState<'session-log' | 'tasks' | 'files' | 'team'>('session-log');
   const [tasks, setTasks] = useState<TeamTask[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
+  const [handoffFiles, setHandoffFiles] = useState<HandoffFile[]>([]);
+  const [handoffFilesLoading, setHandoffFilesLoading] = useState(false);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const [agentFilters, setAgentFilters] = useState<Set<string>>(new Set());
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
@@ -110,6 +113,37 @@ export function TeamDetail() {
   }, [api]);
 
   useFleetSSE('task_updated', handleTaskUpdated);
+
+  // Fetch handoff files when the Files tab is selected
+  useEffect(() => {
+    if (activeTab !== 'files' || !selectedTeamId) return;
+    let cancelled = false;
+    setHandoffFilesLoading(true);
+    api.get<HandoffFile[]>(`teams/${selectedTeamId}/handoff-files`)
+      .then((data) => {
+        if (!cancelled) setHandoffFiles(data);
+      })
+      .catch(() => {
+        if (!cancelled) setHandoffFiles([]);
+      })
+      .finally(() => {
+        if (!cancelled) setHandoffFilesLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [activeTab, selectedTeamId, api]);
+
+  // Refresh handoff files on SSE team_handoff_file events
+  const handleHandoffFile = useCallback((_type: string, data: unknown) => {
+    const payload = data as { team_id: number };
+    const teamId = selectedTeamIdRef.current;
+    if (activeTabRef.current !== 'files' || !teamId) return;
+    if (payload.team_id !== teamId) return;
+    api.get<HandoffFile[]>(`teams/${teamId}/handoff-files`)
+      .then((files) => setHandoffFiles(files))
+      .catch(() => { /* SSE refresh is best-effort */ });
+  }, [api]);
+
+  useFleetSSE('team_handoff_file', handleHandoffFile);
 
   // Close panel handler
   const handleClose = useCallback(() => {
@@ -522,6 +556,21 @@ export function TeamDetail() {
                     )}
                   </button>
                   <button
+                    onClick={() => setActiveTab('files')}
+                    className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab === 'files'
+                        ? 'border-dark-accent text-dark-text'
+                        : 'border-transparent text-dark-muted hover:text-dark-text'
+                    }`}
+                  >
+                    Files
+                    {handoffFiles.length > 0 && (
+                      <span className="ml-1.5 text-xs text-dark-muted">
+                        ({handoffFiles.length})
+                      </span>
+                    )}
+                  </button>
+                  <button
                     onClick={() => setActiveTab('team')}
                     className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
                       activeTab === 'team'
@@ -617,6 +666,38 @@ export function TeamDetail() {
                               {task.owner}
                             </span>
                           </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {activeTab === 'files' && (
+                  <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-5 py-3">
+                    {handoffFilesLoading && handoffFiles.length === 0 && (
+                      <div className="flex items-center justify-center py-8">
+                        <span className="text-dark-muted">Loading files...</span>
+                      </div>
+                    )}
+
+                    {!handoffFilesLoading && handoffFiles.length === 0 && (
+                      <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <svg className="w-10 h-10 text-dark-muted/40 mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                        <p className="text-sm text-dark-muted">No handoff files yet.</p>
+                        <p className="text-xs text-dark-muted/60 mt-1">Files appear when agents write plan.md, changes.md, or review.md.</p>
+                      </div>
+                    )}
+
+                    {handoffFiles.length > 0 && (
+                      <div className="space-y-2">
+                        {handoffFiles.map((file) => (
+                          <HandoffFileCard
+                            key={file.id}
+                            file={file}
+                            defaultExpanded={handoffFiles.length <= 3}
+                          />
                         ))}
                       </div>
                     )}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -29,6 +29,8 @@ import type {
   AgentMessage,
   MessageEdge,
   TeamTask,
+  HandoffFile,
+  HandoffFileType,
 } from '../shared/types.js';
 import { encrypt, decrypt, isEncrypted, decryptWithKey } from './utils/crypto.js';
 import config from './config.js';
@@ -405,6 +407,9 @@ export class FleetDatabase {
 
     // Add pending_children_json column to teams if missing (v15 migration — parent waits for children)
     this.addPendingChildrenJsonColumn();
+
+    // Add handoff_files table if missing (v16 migration — captured plan/changes/review files)
+    this.addHandoffFilesTable();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1078,6 +1083,29 @@ export class FleetDatabase {
       console.log('[DB] Migrated to v15: added pending_children_json column to teams');
     } catch {
       // Table may not exist yet (fresh database) — schema.sql will create it
+    }
+  }
+
+  /**
+   * Add handoff_files table if it doesn't exist.
+   * v16 migration — stores captured plan.md, changes.md, review.md files.
+   */
+  private addHandoffFilesTable(): void {
+    try {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS handoff_files (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          team_id         INTEGER NOT NULL REFERENCES teams(id),
+          file_type       TEXT NOT NULL,
+          content         TEXT NOT NULL,
+          agent_name      TEXT,
+          captured_at     TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_handoff_files_team ON handoff_files(team_id);
+      `);
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (16)');
+    } catch {
+      // Table may already exist — safe to ignore
     }
   }
 
@@ -3024,6 +3052,62 @@ export class FleetDatabase {
       owner: row.owner as string,
       createdAt: utcify(row.created_at as string),
       updatedAt: utcify(row.updated_at as string),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Handoff Files
+  // -------------------------------------------------------------------------
+
+  /**
+   * Insert a captured handoff file. Content is capped at 50KB server-side.
+   * Each call creates a new row (multiple versions are tracked).
+   */
+  insertHandoffFile(data: {
+    teamId: number;
+    fileType: HandoffFileType;
+    content: string;
+    agentName?: string | null;
+  }): HandoffFile {
+    const cappedContent = data.content.slice(0, 51200); // 50KB cap
+    const stmt = this.stmt(`
+      INSERT INTO handoff_files (team_id, file_type, content, agent_name)
+      VALUES (@teamId, @fileType, @content, @agentName)
+    `);
+
+    const result = stmt.run({
+      teamId: data.teamId,
+      fileType: data.fileType,
+      content: cappedContent,
+      agentName: data.agentName ?? null,
+    });
+
+    const row = this.stmt(
+      'SELECT * FROM handoff_files WHERE id = ?'
+    ).get(result.lastInsertRowid) as Record<string, unknown>;
+
+    return this.mapHandoffFileRow(row);
+  }
+
+  /**
+   * Get all handoff files for a team, ordered by id ascending (oldest first).
+   */
+  getHandoffFiles(teamId: number): HandoffFile[] {
+    const rows = this.stmt(
+      'SELECT * FROM handoff_files WHERE team_id = ? ORDER BY id ASC'
+    ).all(teamId) as Record<string, unknown>[];
+
+    return rows.map((r) => this.mapHandoffFileRow(r));
+  }
+
+  private mapHandoffFileRow(row: Record<string, unknown>): HandoffFile {
+    return {
+      id: row.id as number,
+      teamId: row.team_id as number,
+      fileType: row.file_type as HandoffFileType,
+      content: row.content as string,
+      agentName: (row.agent_name as string | null) ?? null,
+      capturedAt: utcify(row.captured_at as string),
     };
   }
 

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -773,6 +773,34 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // GET /api/teams/:id/handoff-files — captured handoff files for this team
+  // -------------------------------------------------------------------------
+  fastify.get(
+    '/api/teams/:id/handoff-files',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseIdParam(request.params.id, 'id');
+
+        const service = getTeamService();
+        const files = service.getHandoffFiles(teamId);
+        return reply.code(200).send(files);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to get team handoff files');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // GET /api/teams/:id/messages — agent messages for this team
   // -------------------------------------------------------------------------
   fastify.get(

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -341,6 +341,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_team_tasks_team_task ON team_tasks(team_id
 CREATE INDEX IF NOT EXISTS idx_team_tasks_team ON team_tasks(team_id);
 
 -- ---------------------------------------------------------------------------
+-- HANDOFF FILES — captured plan.md, changes.md, review.md from agent worktrees
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS handoff_files (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  team_id         INTEGER NOT NULL REFERENCES teams(id),
+  file_type       TEXT NOT NULL,
+  content         TEXT NOT NULL,
+  agent_name      TEXT,
+  captured_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoff_files_team ON handoff_files(team_id);
+
+-- ---------------------------------------------------------------------------
 -- PROVIDER STATE — key-value persistence for issue provider runtime state
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS provider_state (

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -15,7 +15,7 @@
  *   Non-tool_use events are NEVER throttled.
  */
 
-import type { TeamStatus, TeamPhase } from '../../shared/types.js';
+import type { TeamStatus, TeamPhase, HandoffFile, HandoffFileType } from '../../shared/types.js';
 import { TERMINAL_STATUSES } from '../../shared/types.js';
 import type { SSEEventType, SSEEventPayloads } from './sse-broker.js';
 import config from '../config.js';
@@ -103,6 +103,12 @@ export interface EventCollectorDb {
     status: string;
     owner: string;
   }): { id: number; teamId: number; taskId: string; subject: string; status: string; owner: string };
+  insertHandoffFile?(data: {
+    teamId: number;
+    fileType: HandoffFileType;
+    content: string;
+    agentName?: string | null;
+  }): HandoffFile;
 }
 
 /** SSE broker interface for broadcasting events */
@@ -245,6 +251,7 @@ function normalizeEventType(raw: string): string {
     'worktree_create': 'WorktreeCreate',
     'worktree_remove': 'WorktreeRemove',
     'task_created': 'TaskCreated',
+    'handoff_file': 'HandoffFile',
   };
   return map[raw.toLowerCase()] || raw;
 }
@@ -568,6 +575,50 @@ export function processEvent(
       }, teamId);
     } catch {
       // Non-critical — task extraction failure should not break event processing
+    }
+  }
+
+  // ── Handoff file capture from HandoffFile events ────────────────
+  // Parse HandoffFile events sent by on_post_tool_use.sh when agents
+  // Write/Edit plan.md, changes.md, or review.md. Content is stored
+  // in a dedicated handoff_files table for display in TeamDetail.
+  if (eventType === 'HandoffFile' && db.insertHandoffFile) {
+    try {
+      let fileType: string | undefined;
+      let content: string | undefined;
+
+      // Parse cc_stdin for handoff file fields
+      let ccData: Record<string, unknown> = {};
+      if (payload.cc_stdin) {
+        try {
+          ccData = JSON.parse(payload.cc_stdin) as Record<string, unknown>;
+        } catch {
+          // Malformed cc_stdin — try direct payload fields
+        }
+      }
+
+      fileType = (ccData.file_type ?? payload.message) as string | undefined;
+      content = (ccData.content as string | undefined);
+
+      // Validate: require both file_type and content
+      const validTypes = new Set(['plan.md', 'changes.md', 'review.md']);
+      if (fileType && validTypes.has(fileType) && content && content.length > 0) {
+        const handoffFile = db.insertHandoffFile({
+          teamId,
+          fileType: fileType as HandoffFileType,
+          content: content.slice(0, 51200), // 50KB cap
+          agentName: agentName !== 'team-lead' ? agentName : null,
+        });
+
+        sse.broadcast('team_handoff_file', {
+          team_id: teamId,
+          file_type: handoffFile.fileType,
+          agent_name: handoffFile.agentName,
+          captured_at: handoffFile.capturedAt,
+        }, teamId);
+      }
+    } catch {
+      // Non-critical — handoff file capture failure should not break event processing
     }
   }
 

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -36,7 +36,8 @@ export type SSEEventType =
   | 'team_thinking_start'
   | 'team_thinking_stop'
   | 'task_updated'
-  | 'relations_updated';
+  | 'relations_updated'
+  | 'team_handoff_file';
 
 /** Payload shapes for each event type */
 export interface SSEEventPayloads {
@@ -58,6 +59,7 @@ export interface SSEEventPayloads {
   team_thinking_stop: { team_id: number; duration_ms: number };
   task_updated: { team_id: number; task_id: string; subject: string; status: string; owner: string };
   relations_updated: { project_id: number; issue_key: string; relations: IssueRelations };
+  team_handoff_file: { team_id: number; file_type: string; agent_name: string | null; captured_at: string };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -1008,6 +1008,26 @@ export class TeamService {
 
     return db.getTeamTasks(teamId);
   }
+
+  /**
+   * Get all captured handoff files for a team.
+   *
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getHandoffFiles(teamId: number): unknown[] {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    return db.getHandoffFiles(teamId);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -442,6 +442,19 @@ export interface TeamTask {
   updatedAt: string;
 }
 
+/** Valid handoff file types captured from agent Write/Edit operations */
+export type HandoffFileType = 'plan.md' | 'changes.md' | 'review.md';
+
+/** A captured handoff file from an agent's worktree */
+export interface HandoffFile {
+  id: number;
+  teamId: number;
+  fileType: HandoffFileType;
+  content: string;
+  agentName: string | null;
+  capturedAt: string;
+}
+
 /** Aggregated edge for the communication graph (sender -> recipient) */
 export interface MessageEdge {
   sender: string;

--- a/tests/client/HandoffFileCard.test.tsx
+++ b/tests/client/HandoffFileCard.test.tsx
@@ -1,0 +1,91 @@
+// =============================================================================
+// Fleet Commander — HandoffFileCard Component Tests
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HandoffFileCard } from '../../src/client/components/HandoffFileCard';
+import type { HandoffFile } from '../../src/shared/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeFile(overrides?: Partial<HandoffFile>): HandoffFile {
+  return {
+    id: 1,
+    teamId: 1,
+    fileType: 'plan.md',
+    content: '# Plan\n\nThis is the implementation plan.',
+    agentName: 'planner',
+    capturedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HandoffFileCard', () => {
+  it('should render the file type badge', () => {
+    render(<HandoffFileCard file={makeFile()} />);
+    expect(screen.getByText('Plan')).toBeInTheDocument();
+  });
+
+  it('should render the file name', () => {
+    render(<HandoffFileCard file={makeFile()} />);
+    expect(screen.getByText('plan.md')).toBeInTheDocument();
+  });
+
+  it('should render the agent name when present', () => {
+    render(<HandoffFileCard file={makeFile({ agentName: 'dev' })} />);
+    expect(screen.getByText('dev')).toBeInTheDocument();
+  });
+
+  it('should not render agent name when null', () => {
+    render(<HandoffFileCard file={makeFile({ agentName: null })} />);
+    expect(screen.queryByText('planner')).not.toBeInTheDocument();
+  });
+
+  it('should show content when expanded by default', () => {
+    render(<HandoffFileCard file={makeFile()} defaultExpanded={true} />);
+    expect(screen.getByText(/This is the implementation plan/)).toBeInTheDocument();
+  });
+
+  it('should hide content when collapsed by default', () => {
+    render(<HandoffFileCard file={makeFile()} defaultExpanded={false} />);
+    expect(screen.queryByText(/This is the implementation plan/)).not.toBeInTheDocument();
+  });
+
+  it('should toggle content visibility on header click', () => {
+    render(<HandoffFileCard file={makeFile()} defaultExpanded={false} />);
+
+    // Content should be hidden initially
+    expect(screen.queryByText(/This is the implementation plan/)).not.toBeInTheDocument();
+
+    // Click the header button to expand
+    const header = screen.getByText('plan.md').closest('button');
+    expect(header).toBeTruthy();
+    fireEvent.click(header!);
+
+    // Content should now be visible
+    expect(screen.getByText(/This is the implementation plan/)).toBeInTheDocument();
+  });
+
+  it('should render correct badge label for changes.md', () => {
+    render(<HandoffFileCard file={makeFile({ fileType: 'changes.md' })} />);
+    expect(screen.getByText('Changes')).toBeInTheDocument();
+  });
+
+  it('should render correct badge label for review.md', () => {
+    render(<HandoffFileCard file={makeFile({ fileType: 'review.md' })} />);
+    expect(screen.getByText('Review')).toBeInTheDocument();
+  });
+
+  it('should show Copy button when expanded', () => {
+    render(<HandoffFileCard file={makeFile()} defaultExpanded={true} />);
+    expect(screen.getByText('Copy')).toBeInTheDocument();
+  });
+});

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -2989,3 +2989,195 @@ describe('TaskCreated event processing', () => {
     expect(insertCall.eventInsert.eventType).toBe('TaskCreated');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Handoff File Capture
+// ---------------------------------------------------------------------------
+
+describe('handoff file capture', () => {
+  it('should insert handoff file when handoff_file event has valid cc_stdin', () => {
+    const insertHandoffFile = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      fileType: 'plan.md',
+      content: '# Plan\nSome content',
+      agentName: 'planner',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'plan.md', content: '# Plan\nSome content' }),
+      agent_type: 'planner',
+    });
+    processEvent(payload, db, sse);
+
+    expect(insertHandoffFile).toHaveBeenCalledOnce();
+    expect(insertHandoffFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fileType: 'plan.md',
+        content: '# Plan\nSome content',
+        agentName: 'planner',
+      }),
+    );
+  });
+
+  it('should broadcast team_handoff_file SSE event on capture', () => {
+    const insertHandoffFile = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      fileType: 'changes.md',
+      content: '# Changes',
+      agentName: 'dev',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'changes.md', content: '# Changes' }),
+      agent_type: 'dev',
+    });
+    processEvent(payload, db, sse);
+
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_handoff_file',
+      expect.objectContaining({
+        team_id: 1,
+        file_type: 'changes.md',
+        agent_name: 'dev',
+      }),
+      1,
+    );
+  });
+
+  it('should skip handoff file with invalid file_type', () => {
+    const insertHandoffFile = vi.fn();
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'unknown.md', content: '# Unknown' }),
+    });
+    processEvent(payload, db, sse);
+
+    expect(insertHandoffFile).not.toHaveBeenCalled();
+  });
+
+  it('should skip handoff file with empty content', () => {
+    const insertHandoffFile = vi.fn();
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'plan.md', content: '' }),
+    });
+    processEvent(payload, db, sse);
+
+    expect(insertHandoffFile).not.toHaveBeenCalled();
+  });
+
+  it('should skip handoff file when insertHandoffFile is not available', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'plan.md', content: '# Plan' }),
+    });
+    // Should not throw
+    const result = processEvent(payload, db, sse);
+    expect(result.processed).toBe(true);
+  });
+
+  it('should normalize handoff_file event type to HandoffFile', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const payload = makePayload({ event: 'handoff_file' });
+    processEvent(payload, db, sse);
+
+    const insertCall = db.processEventTransaction.mock.calls[0][0];
+    expect(insertCall.eventInsert.eventType).toBe('HandoffFile');
+  });
+
+  it('should set agentName to null for team-lead agent', () => {
+    const insertHandoffFile = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      fileType: 'review.md',
+      content: '# Review',
+      agentName: null,
+      capturedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    // No agent_type = team-lead after normalization
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'review.md', content: '# Review' }),
+      agent_type: undefined,
+    });
+    processEvent(payload, db, sse);
+
+    expect(insertHandoffFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: null, // team-lead is mapped to null
+      }),
+    );
+  });
+
+  it('should cap content at 50KB', () => {
+    const insertHandoffFile = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      fileType: 'plan.md',
+      content: 'x'.repeat(51200),
+      agentName: null,
+      capturedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const oversizedContent = 'x'.repeat(100000);
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'plan.md', content: oversizedContent }),
+    });
+    processEvent(payload, db, sse);
+
+    expect(insertHandoffFile).toHaveBeenCalledOnce();
+    const callArgs = insertHandoffFile.mock.calls[0][0];
+    expect(callArgs.content.length).toBeLessThanOrEqual(51200);
+  });
+
+  it('should accept all three valid handoff file types', () => {
+    for (const fileType of ['plan.md', 'changes.md', 'review.md']) {
+      const insertHandoffFile = vi.fn().mockReturnValue({
+        id: 1,
+        teamId: 1,
+        fileType,
+        content: `# ${fileType}`,
+        agentName: null,
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      });
+      const db = createMockDb({ insertHandoffFile });
+      const sse = createMockSse();
+
+      const payload = makePayload({
+        event: 'handoff_file',
+        cc_stdin: JSON.stringify({ file_type: fileType, content: `# ${fileType}` }),
+      });
+      processEvent(payload, db, sse);
+
+      expect(insertHandoffFile).toHaveBeenCalledOnce();
+    }
+  });
+});


### PR DESCRIPTION
Closes #665

## Summary
- PostToolUse hook detects Write/Edit of plan.md, changes.md, review.md and sends file content to FC via new `send_handoff.sh` helper (fire-and-forget, 50KB cap)
- New `handoff_files` DB table stores captured files per team with versioning
- SSE broadcast (`team_handoff_file`) notifies dashboard on capture
- New "Files" tab in TeamDetail shows captured handoff files with collapsible cards, type badges, timestamps, and copy button

## Test plan
- [x] Server tests: 8 new event-collector tests for handoff file processing (valid capture, SSE broadcast, invalid type, empty content, missing method, normalization, agent name, content cap)
- [x] Client tests: 10 new HandoffFileCard tests (badge rendering, expand/collapse, all file types, copy button)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: install hooks on a target repo, trigger a team, verify plan.md/changes.md/review.md appear in Files tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)