### PR TITLE
Issue #667: Deduplicate handoff file captures within 5-second window

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -3060,16 +3060,53 @@ export class FleetDatabase {
   // -------------------------------------------------------------------------
 
   /**
+   * Dedup window in seconds: skip insert when the same team_id + file_type +
+   * content was inserted within this window (prevents duplicate captures from
+   * PostToolUse and SubagentStop firing within ~1 second of each other).
+   */
+  private static readonly HANDOFF_DEDUP_WINDOW_SEC = 5;
+
+  /**
    * Insert a captured handoff file. Content is capped at 50KB server-side.
-   * Each call creates a new row (multiple versions are tracked).
+   * Deduplicates when the same team_id + file_type + content was inserted
+   * within the last HANDOFF_DEDUP_WINDOW_SEC seconds.
+   *
+   * Returns `{ file, deduplicated }` so callers can skip SSE broadcasts on dedup.
    */
   insertHandoffFile(data: {
     teamId: number;
     fileType: HandoffFileType;
     content: string;
     agentName?: string | null;
-  }): HandoffFile {
+  }): { file: HandoffFile; deduplicated: boolean } {
     const cappedContent = data.content.slice(0, 51200); // 50KB cap
+
+    // ── Dedup check: look for a recent row with the same team_id + file_type ──
+    const recent = this.stmt(`
+      SELECT * FROM handoff_files
+       WHERE team_id = @teamId
+         AND file_type = @fileType
+         AND captured_at >= datetime('now', '-' || @windowSec || ' seconds')
+       ORDER BY id DESC
+       LIMIT 1
+    `).get({
+      teamId: data.teamId,
+      fileType: data.fileType,
+      windowSec: FleetDatabase.HANDOFF_DEDUP_WINDOW_SEC,
+    }) as Record<string, unknown> | undefined;
+
+    if (recent) {
+      const existingContent = recent.content as string;
+      // Fast-path: compare length first, then full string
+      if (
+        existingContent.length === cappedContent.length &&
+        existingContent === cappedContent
+      ) {
+        return { file: this.mapHandoffFileRow(recent), deduplicated: true };
+      }
+    }
+
+    // ── Normal insert ─────────────────────────────────────────────────
     const stmt = this.stmt(`
       INSERT INTO handoff_files (team_id, file_type, content, agent_name)
       VALUES (@teamId, @fileType, @content, @agentName)
@@ -3086,7 +3123,7 @@ export class FleetDatabase {
       'SELECT * FROM handoff_files WHERE id = ?'
     ).get(result.lastInsertRowid) as Record<string, unknown>;
 
-    return this.mapHandoffFileRow(row);
+    return { file: this.mapHandoffFileRow(row), deduplicated: false };
   }
 
   /**

--- a/src/server/routes/handoff.ts
+++ b/src/server/routes/handoff.ts
@@ -93,21 +93,24 @@ const handoffRoutes: FastifyPluginCallback = (
           });
         }
 
-        // Insert handoff file
-        const handoffFile = db.insertHandoffFile({
+        // Insert handoff file (with dedup — skips if identical content
+        // was captured for the same team + file_type within 5 seconds)
+        const { file: handoffFile, deduplicated } = db.insertHandoffFile({
           teamId: teamRecord.id,
           fileType: fileType as HandoffFileType,
           content: fileContent,
           agentName: null, // multipart upload doesn't carry agent name
         });
 
-        // Broadcast SSE event
-        sseBroker.broadcast('team_handoff_file', {
-          team_id: teamRecord.id,
-          file_type: handoffFile.fileType,
-          agent_name: handoffFile.agentName,
-          captured_at: handoffFile.capturedAt,
-        }, teamRecord.id);
+        // Only broadcast SSE when this is a genuinely new capture
+        if (!deduplicated) {
+          sseBroker.broadcast('team_handoff_file', {
+            team_id: teamRecord.id,
+            file_type: handoffFile.fileType,
+            agent_name: handoffFile.agentName,
+            captured_at: handoffFile.capturedAt,
+          }, teamRecord.id);
+        }
 
         return reply.code(200).send({ ok: true });
       } catch (err: unknown) {

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -108,7 +108,7 @@ export interface EventCollectorDb {
     fileType: HandoffFileType;
     content: string;
     agentName?: string | null;
-  }): HandoffFile;
+  }): { file: HandoffFile; deduplicated: boolean };
 }
 
 /** SSE broker interface for broadcasting events */
@@ -603,19 +603,22 @@ export function processEvent(
       // Validate: require both file_type and content
       const validTypes = new Set(['plan.md', 'changes.md', 'review.md']);
       if (fileType && validTypes.has(fileType) && content && content.length > 0) {
-        const handoffFile = db.insertHandoffFile({
+        const { file: handoffFile, deduplicated } = db.insertHandoffFile({
           teamId,
           fileType: fileType as HandoffFileType,
           content: content.slice(0, 51200), // 50KB cap
           agentName: agentName !== 'team-lead' ? agentName : null,
         });
 
-        sse.broadcast('team_handoff_file', {
-          team_id: teamId,
-          file_type: handoffFile.fileType,
-          agent_name: handoffFile.agentName,
-          captured_at: handoffFile.capturedAt,
-        }, teamId);
+        // Only broadcast SSE when this is a genuinely new capture
+        if (!deduplicated) {
+          sse.broadcast('team_handoff_file', {
+            team_id: teamId,
+            file_type: handoffFile.fileType,
+            agent_name: handoffFile.agentName,
+            captured_at: handoffFile.capturedAt,
+          }, teamId);
+        }
       }
     } catch {
       // Non-critical — handoff file capture failure should not break event processing

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -2997,12 +2997,15 @@ describe('TaskCreated event processing', () => {
 describe('handoff file capture', () => {
   it('should insert handoff file when handoff_file event has valid cc_stdin', () => {
     const insertHandoffFile = vi.fn().mockReturnValue({
-      id: 1,
-      teamId: 1,
-      fileType: 'plan.md',
-      content: '# Plan\nSome content',
-      agentName: 'planner',
-      capturedAt: '2024-01-01T00:00:00.000Z',
+      file: {
+        id: 1,
+        teamId: 1,
+        fileType: 'plan.md',
+        content: '# Plan\nSome content',
+        agentName: 'planner',
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      },
+      deduplicated: false,
     });
     const db = createMockDb({ insertHandoffFile });
     const sse = createMockSse();
@@ -3027,12 +3030,15 @@ describe('handoff file capture', () => {
 
   it('should broadcast team_handoff_file SSE event on capture', () => {
     const insertHandoffFile = vi.fn().mockReturnValue({
-      id: 1,
-      teamId: 1,
-      fileType: 'changes.md',
-      content: '# Changes',
-      agentName: 'dev',
-      capturedAt: '2024-01-01T00:00:00.000Z',
+      file: {
+        id: 1,
+        teamId: 1,
+        fileType: 'changes.md',
+        content: '# Changes',
+        agentName: 'dev',
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      },
+      deduplicated: false,
     });
     const db = createMockDb({ insertHandoffFile });
     const sse = createMockSse();
@@ -3052,6 +3058,37 @@ describe('handoff file capture', () => {
         agent_name: 'dev',
       }),
       1,
+    );
+  });
+
+  it('should skip SSE broadcast when handoff file is deduplicated', () => {
+    const insertHandoffFile = vi.fn().mockReturnValue({
+      file: {
+        id: 1,
+        teamId: 1,
+        fileType: 'plan.md',
+        content: '# Plan',
+        agentName: 'planner',
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      },
+      deduplicated: true,
+    });
+    const db = createMockDb({ insertHandoffFile });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'handoff_file',
+      cc_stdin: JSON.stringify({ file_type: 'plan.md', content: '# Plan' }),
+      agent_type: 'planner',
+    });
+    processEvent(payload, db, sse);
+
+    // insertHandoffFile was called, but SSE broadcast should be skipped
+    expect(insertHandoffFile).toHaveBeenCalledOnce();
+    expect(sse.broadcast).not.toHaveBeenCalledWith(
+      'team_handoff_file',
+      expect.anything(),
+      expect.anything(),
     );
   });
 
@@ -3109,12 +3146,15 @@ describe('handoff file capture', () => {
 
   it('should set agentName to null for team-lead agent', () => {
     const insertHandoffFile = vi.fn().mockReturnValue({
-      id: 1,
-      teamId: 1,
-      fileType: 'review.md',
-      content: '# Review',
-      agentName: null,
-      capturedAt: '2024-01-01T00:00:00.000Z',
+      file: {
+        id: 1,
+        teamId: 1,
+        fileType: 'review.md',
+        content: '# Review',
+        agentName: null,
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      },
+      deduplicated: false,
     });
     const db = createMockDb({ insertHandoffFile });
     const sse = createMockSse();
@@ -3136,12 +3176,15 @@ describe('handoff file capture', () => {
 
   it('should cap content at 50KB', () => {
     const insertHandoffFile = vi.fn().mockReturnValue({
-      id: 1,
-      teamId: 1,
-      fileType: 'plan.md',
-      content: 'x'.repeat(51200),
-      agentName: null,
-      capturedAt: '2024-01-01T00:00:00.000Z',
+      file: {
+        id: 1,
+        teamId: 1,
+        fileType: 'plan.md',
+        content: 'x'.repeat(51200),
+        agentName: null,
+        capturedAt: '2024-01-01T00:00:00.000Z',
+      },
+      deduplicated: false,
     });
     const db = createMockDb({ insertHandoffFile });
     const sse = createMockSse();
@@ -3161,12 +3204,15 @@ describe('handoff file capture', () => {
   it('should accept all three valid handoff file types', () => {
     for (const fileType of ['plan.md', 'changes.md', 'review.md']) {
       const insertHandoffFile = vi.fn().mockReturnValue({
-        id: 1,
-        teamId: 1,
-        fileType,
-        content: `# ${fileType}`,
-        agentName: null,
-        capturedAt: '2024-01-01T00:00:00.000Z',
+        file: {
+          id: 1,
+          teamId: 1,
+          fileType,
+          content: `# ${fileType}`,
+          agentName: null,
+          capturedAt: '2024-01-01T00:00:00.000Z',
+        },
+        deduplicated: false,
       });
       const db = createMockDb({ insertHandoffFile });
       const sse = createMockSse();

--- a/tests/server/routes/handoff-routes.test.ts
+++ b/tests/server/routes/handoff-routes.test.ts
@@ -326,4 +326,169 @@ describe('POST /api/handoff', () => {
     expect(latest.content.length).toBeLessThanOrEqual(51200);
     expect(latest.content.length).toBe(50000);
   });
+
+  // ── Deduplication tests ──────────────────────────────────────────
+
+  it('should deduplicate same content uploaded twice within 5 seconds', async () => {
+    const team = seedTeam({ worktreeName: `handoff-dedup-same-${Date.now()}` });
+    const content = '# Plan\n\nIdentical content for dedup test';
+
+    // First upload
+    const mp1 = buildMultipart(
+      { team: team.worktreeName, fileType: 'plan.md' },
+      { name: 'plan.md', content },
+    );
+    const r1 = await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp1.contentType },
+      payload: mp1.body,
+    });
+    expect(r1.statusCode).toBe(200);
+
+    // Second upload — same content, same file type, immediate
+    const mp2 = buildMultipart(
+      { team: team.worktreeName, fileType: 'plan.md' },
+      { name: 'plan.md', content },
+    );
+    const r2 = await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp2.contentType },
+      payload: mp2.body,
+    });
+    expect(r2.statusCode).toBe(200);
+
+    // Only 1 entry should exist — the duplicate was deduplicated
+    const db = getDatabase();
+    const files = db.getHandoffFiles(team.id);
+    const planFiles = files.filter((f) => f.fileType === 'plan.md');
+    expect(planFiles).toHaveLength(1);
+  });
+
+  it('should preserve both entries when content differs within 5 seconds', async () => {
+    const team = seedTeam({ worktreeName: `handoff-dedup-diff-${Date.now()}` });
+
+    // First upload
+    const mp1 = buildMultipart(
+      { team: team.worktreeName, fileType: 'changes.md' },
+      { name: 'changes.md', content: '# Changes v1' },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp1.contentType },
+      payload: mp1.body,
+    });
+
+    // Second upload — different content
+    const mp2 = buildMultipart(
+      { team: team.worktreeName, fileType: 'changes.md' },
+      { name: 'changes.md', content: '# Changes v2 — updated' },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp2.contentType },
+      payload: mp2.body,
+    });
+
+    const db = getDatabase();
+    const files = db.getHandoffFiles(team.id);
+    const changesFiles = files.filter((f) => f.fileType === 'changes.md');
+    expect(changesFiles).toHaveLength(2);
+    expect(changesFiles[0].content).toBe('# Changes v1');
+    expect(changesFiles[1].content).toBe('# Changes v2 — updated');
+  });
+
+  it('should preserve both entries when same content is uploaded 30+ seconds apart', async () => {
+    const team = seedTeam({ worktreeName: `handoff-dedup-stale-${Date.now()}` });
+    const content = '# Review\n\nSame content but old timestamp';
+
+    // First upload via normal route
+    const mp1 = buildMultipart(
+      { team: team.worktreeName, fileType: 'review.md' },
+      { name: 'review.md', content },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp1.contentType },
+      payload: mp1.body,
+    });
+
+    // Backdate the first entry by 30 seconds using raw SQL
+    const db = getDatabase();
+    db.raw.exec(`
+      UPDATE handoff_files
+         SET captured_at = datetime('now', '-30 seconds')
+       WHERE team_id = ${team.id} AND file_type = 'review.md'
+    `);
+
+    // Second upload — same content, but now 30s has elapsed
+    const mp2 = buildMultipart(
+      { team: team.worktreeName, fileType: 'review.md' },
+      { name: 'review.md', content },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp2.contentType },
+      payload: mp2.body,
+    });
+
+    const files = db.getHandoffFiles(team.id);
+    const reviewFiles = files.filter((f) => f.fileType === 'review.md');
+    expect(reviewFiles).toHaveLength(2);
+  });
+
+  it('should deduplicate independently across file types', async () => {
+    const team = seedTeam({ worktreeName: `handoff-dedup-types-${Date.now()}` });
+    const content = '# Same content for different types';
+
+    // Upload plan.md
+    const mp1 = buildMultipart(
+      { team: team.worktreeName, fileType: 'plan.md' },
+      { name: 'plan.md', content },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp1.contentType },
+      payload: mp1.body,
+    });
+
+    // Upload changes.md with same content — should NOT be deduplicated
+    const mp2 = buildMultipart(
+      { team: team.worktreeName, fileType: 'changes.md' },
+      { name: 'changes.md', content },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp2.contentType },
+      payload: mp2.body,
+    });
+
+    // Upload plan.md again with same content — SHOULD be deduplicated
+    const mp3 = buildMultipart(
+      { team: team.worktreeName, fileType: 'plan.md' },
+      { name: 'plan.md', content },
+    );
+    await server.inject({
+      method: 'POST',
+      url: '/api/handoff',
+      headers: { 'content-type': mp3.contentType },
+      payload: mp3.body,
+    });
+
+    const db = getDatabase();
+    const files = db.getHandoffFiles(team.id);
+    const planFiles = files.filter((f) => f.fileType === 'plan.md');
+    const changesFiles = files.filter((f) => f.fileType === 'changes.md');
+
+    // plan.md: 1 (second was deduped), changes.md: 1
+    expect(planFiles).toHaveLength(1);
+    expect(changesFiles).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Closes #667

## Summary
- Added server-side deduplication to `db.insertHandoffFile()` — query-before-insert with 5-second window, content comparison (length fast-path + full string equality)
- Updated handoff route and event-collector to skip SSE broadcast on deduplicated uploads
- Added 4 integration tests + 1 unit test covering all acceptance criteria

## Changed Files
- `src/server/db.ts` — Dedup logic with `HANDOFF_DEDUP_WINDOW_SEC = 5` constant
- `src/server/routes/handoff.ts` — Destructure new return type, gate SSE broadcast
- `src/server/services/event-collector.ts` — Updated interface + conditional SSE skip
- `tests/server/event-collector.test.ts` — Updated mocks + new dedup-skips-SSE test
- `tests/server/routes/handoff-routes.test.ts` — 4 new integration tests

## Test plan
- [x] Same file captured twice within 5s with same content → only 1 DB entry
- [x] Same file captured twice with different content → both preserved
- [x] Same file captured 30+ seconds apart → both preserved
- [x] Independent dedup across file types
- [x] SSE broadcast skipped on dedup
- [x] All existing handoff-routes tests pass
- [x] `npm run test:server` passes (1683/1686, 3 pre-existing failures unrelated)