### PR TITLE
Issue #671: Add Cancel/Remove action for queued teams

### DIFF
--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -96,6 +96,7 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
   const api = useApi();
   const [stopping, setStopping] = useState(false);
   const [forceLaunching, setForceLaunching] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
   const [retrying, setRetrying] = useState(false);
   const [restarting, setRestarting] = useState(false);
 
@@ -122,6 +123,21 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
       // Ignore — the SSE stream will reflect actual state
     } finally {
       setForceLaunching(false);
+    }
+  };
+
+  const handleCancel = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (cancelling) return;
+    const issueLabel = team.issueKey ?? String(team.issueNumber);
+    if (!window.confirm(`Remove queued team for ${issueLabel}? This will permanently delete the team record.`)) return;
+    setCancelling(true);
+    try {
+      await api.del(`teams/${team.id}`);
+    } catch {
+      // Ignore — the SSE stream will reflect actual state
+    } finally {
+      setCancelling(false);
     }
   };
 
@@ -264,14 +280,24 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
       <td className="px-4 whitespace-nowrap">
         <span className="inline-flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
           {team.status === 'queued' && (
-            <button
-              onClick={handleForceLaunch}
-              disabled={forceLaunching}
-              className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-[#D29922] hover:border-[#D29922]/50 transition-colors disabled:opacity-50"
-              title="Launch immediately despite usage limit"
-            >
-              {forceLaunching ? 'Launching\u2026' : 'Force Launch'}
-            </button>
+            <>
+              <button
+                onClick={handleForceLaunch}
+                disabled={forceLaunching}
+                className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-[#D29922] hover:border-[#D29922]/50 transition-colors disabled:opacity-50"
+                title="Launch immediately despite usage limit"
+              >
+                {forceLaunching ? 'Launching\u2026' : 'Force Launch'}
+              </button>
+              <button
+                onClick={handleCancel}
+                disabled={cancelling}
+                className="px-2 py-1 text-xs rounded border border-dark-border text-dark-muted hover:text-[#F85149] hover:border-[#F85149]/50 transition-colors disabled:opacity-50"
+                title="Remove queued team"
+              >
+                {cancelling ? 'Removing\u2026' : 'Cancel'}
+              </button>
+            </>
           )}
           {isActive && (
             <button

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -2600,6 +2600,8 @@ export class FleetDatabase {
       this.stmt('DELETE FROM events WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM commands WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM usage_snapshots WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM team_tasks WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM handoff_files WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM pull_requests WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM teams WHERE id = ?').run(id);
     })(teamId);

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -222,6 +222,42 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // DELETE /api/teams/:id — cancel a queued team (remove from DB)
+  // -------------------------------------------------------------------------
+  fastify.delete(
+    '/api/teams/:id',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseIdParam(request.params.id, 'id');
+        const service = getTeamService();
+        service.cancelQueuedTeam(teamId);
+        return reply.code(200).send({ success: true });
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('not found')) {
+          return reply.code(404).send({ error: 'Not Found', message });
+        }
+        if (message.includes('not queued')) {
+          return reply.code(409).send({ error: 'Conflict', message });
+        }
+
+        request.log.error(err, 'Failed to cancel queued team');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message,
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // POST /api/teams/:id/force-launch — force-launch a queued team
   // -------------------------------------------------------------------------
   fastify.post(

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1004,6 +1004,35 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // cancelQueued — remove a queued team from DB and re-evaluate the queue
+  // -------------------------------------------------------------------------
+
+  cancelQueued(teamId: number): void {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw new Error(`Team ${teamId} not found`);
+    }
+
+    if (team.status !== 'queued') {
+      throw new Error(`Team ${teamId} is not queued (current status: ${team.status})`);
+    }
+
+    const projectId = team.projectId;
+
+    db.deleteTeamAndRelated(teamId);
+
+    sseBroker.broadcast('team_stopped', { team_id: teamId }, teamId);
+    this.broadcastSnapshot();
+
+    if (projectId) {
+      this.processQueue(projectId).catch((err) => {
+        console.error(`[TeamManager] processQueue failed after cancel:`, err);
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // processQueue — dequeue and launch teams when slots free up
   // -------------------------------------------------------------------------
 

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -747,6 +747,22 @@ export class TeamService {
   }
 
   /**
+   * Cancel a queued team — removes it from DB and re-evaluates the queue.
+   *
+   * @param teamId - The team ID
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws Error if team doesn't exist or is not queued
+   */
+  cancelQueuedTeam(teamId: number): void {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const manager = getTeamManager();
+    manager.cancelQueued(teamId);
+  }
+
+  /**
    * Resume a stopped team.
    *
    * @param teamId - The team ID

--- a/tests/server/routes/teams-routes.test.ts
+++ b/tests/server/routes/teams-routes.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../src/server/services/team-manager.js', () => {
   const mockRestart = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
   const mockLaunchBatch = vi.fn().mockResolvedValue([]);
   const mockQueueTeamWithBlockers = vi.fn().mockResolvedValue({ id: 1, status: 'queued' });
+  const mockCancelQueued = vi.fn();
 
   return {
     getTeamManager: vi.fn(() => ({
@@ -41,6 +42,7 @@ vi.mock('../../../src/server/services/team-manager.js', () => {
       stop: mockStop,
       stopAll: mockStopAll,
       forceLaunch: mockForceLaunch,
+      cancelQueued: mockCancelQueued,
       resume: mockResume,
       restart: mockRestart,
       launchBatch: mockLaunchBatch,
@@ -848,6 +850,65 @@ describe('GET /api/teams/:id/tasks', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Tests: DELETE /api/teams/:id (cancel queued team)
+// =============================================================================
+
+describe('DELETE /api/teams/:id', () => {
+  it('should return 200 on successful cancel', async () => {
+    const team = seedTeam({ status: 'queued' });
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `/api/teams/${team.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true });
+  });
+
+  it('should return 404 when team does not exist', async () => {
+    const manager = getTeamManager() as ReturnType<typeof getTeamManager>;
+    (manager.cancelQueued as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('Team 99999 not found');
+    });
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/teams/99999',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toContain('not found');
+  });
+
+  it('should return 409 when team is not queued', async () => {
+    const team = seedTeam({ status: 'running' });
+    const manager = getTeamManager() as ReturnType<typeof getTeamManager>;
+    (manager.cancelQueued as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error(`Team ${team.id} is not queued (current status: running)`);
+    });
+
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `/api/teams/${team.id}`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().message).toContain('not queued');
+  });
+
+  it('should return 400 for invalid ID', async () => {
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/teams/abc',
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain('positive integer');
   });
 });
 

--- a/tests/server/services/team-service.test.ts
+++ b/tests/server/services/team-service.test.ts
@@ -29,6 +29,7 @@ const mockResume = vi.fn().mockResolvedValue({ id: 1, status: 'running' });
 const mockRestart = vi.fn().mockResolvedValue({ id: 1, status: 'launching' });
 const mockLaunchBatch = vi.fn().mockResolvedValue([]);
 const mockQueueTeamWithBlockers = vi.fn().mockResolvedValue({ id: 1, status: 'queued' });
+const mockCancelQueued = vi.fn();
 
 vi.mock('../../../src/server/services/team-manager.js', () => ({
   getTeamManager: vi.fn(() => ({
@@ -39,6 +40,7 @@ vi.mock('../../../src/server/services/team-manager.js', () => ({
     stop: mockStop,
     stopAll: mockStopAll,
     forceLaunch: mockForceLaunch,
+    cancelQueued: mockCancelQueued,
     resume: mockResume,
     restart: mockRestart,
     launchBatch: mockLaunchBatch,
@@ -1132,6 +1134,37 @@ describe('TeamService.exportTeam', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(ServiceError);
       expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+});
+
+// =============================================================================
+// Tests: cancelQueuedTeam
+// =============================================================================
+
+describe('TeamService.cancelQueuedTeam', () => {
+  it('should delegate to manager.cancelQueued', () => {
+    service.cancelQueuedTeam(42);
+    expect(mockCancelQueued).toHaveBeenCalledWith(42);
+  });
+
+  it('should throw VALIDATION for invalid team ID (0)', () => {
+    try {
+      service.cancelQueuedTeam(0);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for NaN team ID', () => {
+    try {
+      service.cancelQueuedTeam(NaN);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
     }
   });
 });


### PR DESCRIPTION
Closes #671

## Summary
- Add Cancel button on queued team rows in FleetGrid (next to Force Launch)
- New `DELETE /api/teams/:id` endpoint removes team from DB and re-evaluates queue
- Fix pre-existing bug: `deleteTeamAndRelated` now cleans up `team_tasks` and `handoff_files` tables
- Confirmation dialog before deletion using `window.confirm()` (consistent with existing patterns)

## Changed Files
- `src/server/db.ts` — Fixed `deleteTeamAndRelated` to include `team_tasks` and `handoff_files`
- `src/server/services/team-manager.ts` — Added `cancelQueued()` method
- `src/server/services/team-service.ts` — Added `cancelQueuedTeam()` with validation
- `src/server/routes/teams.ts` — Added `DELETE /api/teams/:id` route
- `src/client/components/TeamRow.tsx` — Added Cancel button for queued teams
- `tests/server/routes/teams-routes.test.ts` — 4 new route tests
- `tests/server/services/team-service.test.ts` — 3 new service tests

## Test plan
- [ ] Cancel button visible only on queued team rows
- [ ] Clicking Cancel shows confirmation dialog
- [ ] Confirming removes team from DB and updates FleetGrid via SSE
- [ ] Other queued teams advance after cancellation
- [ ] 409 returned if team status changed between dialog and API call
- [ ] All new tests pass (`npm run test:server`)