### PR TITLE
Issue #682: Enable 1h prompt cache TTL for spawned teams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ The SSE broker emits 18 event types:
 | `FLEET_CLAUDE_CMD` | `claude` | Claude Code CLI command |
 | `FLEET_SKIP_PERMISSIONS` | `true` | Skip CC permission prompts (`true`/`false`) |
 | `FLEET_ENABLE_AGENT_TEAMS` | `true` | Enable agent teams feature (`true`/`false`) |
+| `FLEET_PROMPT_CACHE_1H` | `true` | When `true`, set `ENABLE_PROMPT_CACHING_1H=1` on spawned CC processes for 1-hour prompt cache TTL. Set to `false` to use the default 5-minute TTL. |
 | `LOG_LEVEL` | `info` | Server log level |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub PR/CI/merge poll interval (ms) |
 | `FLEET_ISSUE_POLL_MS` | `300000` | Issue list poll interval (ms, default 5min) |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -143,6 +143,7 @@ const config = Object.freeze({
   claudeCmd: process.env['FLEET_CLAUDE_CMD'] || 'claude',
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',
   enableAgentTeams: process.env['FLEET_ENABLE_AGENT_TEAMS'] !== 'false',
+  promptCache1h: process.env['FLEET_PROMPT_CACHE_1H'] !== 'false',
 
   dbPath: process.env['FLEET_DB_PATH'] || defaultDbPath(),
   hookLogPath: process.env['FLEET_HOOK_LOG'] || defaultHookLogPath(),

--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -85,6 +85,14 @@ export function buildEnv(fleetContext?: FleetEnvContext): SpawnEnv {
     env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = undefined;
   }
 
+  // Explicitly set or clear the 1-hour prompt cache TTL flag so it is never
+  // accidentally inherited from the outer server process with a stale value.
+  if (config.promptCache1h) {
+    env['ENABLE_PROMPT_CACHING_1H'] = '1';
+  } else {
+    env['ENABLE_PROMPT_CACHING_1H'] = undefined;
+  }
+
   // Absolute path to the shared hooks.log file. Hook scripts read this env
   // var instead of computing a fragile relative path from their own location.
   env['FLEET_HOOK_LOG'] = config.hookLogPath;

--- a/tests/server/cc-spawn.test.ts
+++ b/tests/server/cc-spawn.test.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from 'events';
 const mockConfig = vi.hoisted(() => ({
   skipPermissions: true,
   enableAgentTeams: true,
+  promptCache1h: true,
   terminalCmd: 'auto' as 'auto' | 'wt' | 'cmd',
   ccQueryModel: 'sonnet',
   ccQueryTimeoutMs: 30000,
@@ -131,6 +132,7 @@ describe('cc-spawn', () => {
     // Reset config to defaults
     mockConfig.skipPermissions = true;
     mockConfig.enableAgentTeams = true;
+    mockConfig.promptCache1h = true;
     mockConfig.terminalCmd = 'auto';
     mockConfig.ccQueryModel = 'sonnet';
     mockConfig.ccQueryTimeoutMs = 30000;
@@ -208,6 +210,20 @@ describe('cc-spawn', () => {
 
       expect(env['FLEET_PROJECT_ID']).toBe('99');
       expect(typeof env['FLEET_PROJECT_ID']).toBe('string');
+    });
+
+    it('includes ENABLE_PROMPT_CACHING_1H when promptCache1h is true', () => {
+      mockConfig.promptCache1h = true;
+      const env = buildEnv(makeFleetContext());
+
+      expect(env['ENABLE_PROMPT_CACHING_1H']).toBe('1');
+    });
+
+    it('sets ENABLE_PROMPT_CACHING_1H to undefined when promptCache1h is false', () => {
+      mockConfig.promptCache1h = false;
+      const env = buildEnv(makeFleetContext());
+
+      expect(env['ENABLE_PROMPT_CACHING_1H']).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Closes #682

## Summary
- Add `FLEET_PROMPT_CACHE_1H` config flag (default `true`) that passes `ENABLE_PROMPT_CACHING_1H=1` to all spawned CC processes via the centralized `buildEnv()` function
- When set to `false`, the env var is explicitly cleared to prevent accidental inheritance from the server process
- All spawn paths (new, resume, dequeue, interactive, query) go through `buildEnv()` — no changes needed in `team-manager.ts`

## Changed files
- `src/server/config.ts` — new `promptCache1h` boolean using `!== 'false'` pattern
- `src/server/utils/cc-spawn.ts` — set/clear `ENABLE_PROMPT_CACHING_1H` in `buildEnv()`
- `tests/server/cc-spawn.test.ts` — 2 new tests (flag on → `'1'`, flag off → `undefined`)
- `CLAUDE.md` — documented in Environment Variables table

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] New tests pass: flag on sets `'1'`, flag off sets `undefined`
- [x] `npm test` — 1722 passed (3 pre-existing failures unrelated to this change)