### PR TITLE
Issue #687: Kill self-polling waits with early shutdown and poll detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ The SSE broker emits 18 event types:
 | `FLEET_MAX_CI_FAILURES` | `3` | Unique CI failures before blocking |
 | `FLEET_EARLY_CRASH_THRESHOLD_SEC` | `120` | Seconds before a SubagentStop is considered an early crash |
 | `FLEET_EARLY_CRASH_MIN_TOOLS` | `5` | Minimum tool-use events for a subagent to be considered healthy |
+| `FLEET_MAX_PR_POLL_CALLS` | `5` | Max gh pr view/checks calls per team per 10-minute window before sending a poll_warning |
 | `FLEET_MERGE_SHUTDOWN_GRACE_MS` | `120000` | Grace period (ms) after PR merge before stopping the team |
 | `FLEET_DEFAULT_MODEL` | `opus` | Default model name shown when neither the team nor the project specifies a model |
 | `FLEET_CC_QUERY_MODEL` | `sonnet` | Claude model for CC query operations (e.g. `sonnet`, `opus`) |

--- a/prompts/default-prompt.md
+++ b/prompts/default-prompt.md
@@ -16,4 +16,6 @@ You are the Team Lead (TL). Your job:
 10. Respond to FC messages (ci_green, ci_red, pr_merged, nudges) promptly
 11. On pr_merged: close issue, shut down agents, finish
 
+**IMPORTANT: After setting auto-merge, do NOT poll CI with gh pr view or ScheduleWakeup. FC delivers ci_green/ci_red/pr_merged directly via stdin.**
+
 Issue: #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -131,6 +131,9 @@ const config = Object.freeze({
   /** Minimum tool-use events for a subagent session to be considered healthy */
   earlyCrashMinTools: safeParseInt(process.env['FLEET_EARLY_CRASH_MIN_TOOLS'] || '5', 'FLEET_EARLY_CRASH_MIN_TOOLS'),
 
+  /** Maximum gh pr view/checks calls per team per 10-minute window before sending a poll_warning */
+  maxPrPollCalls: safeParseInt(process.env['FLEET_MAX_PR_POLL_CALLS'] || '5', 'FLEET_MAX_PR_POLL_CALLS'),
+
   eventsRetentionDays: safeParseInt(process.env['FLEET_EVENTS_RETENTION_DAYS'] || '90', 'FLEET_EVENTS_RETENTION_DAYS'),
   usageRetentionDays: safeParseInt(process.env['FLEET_USAGE_RETENTION_DAYS'] || '30', 'FLEET_USAGE_RETENTION_DAYS'),
 
@@ -215,6 +218,7 @@ export function validateConfig(): void {
     ['mergeShutdownGraceMs', config.mergeShutdownGraceMs],
     ['earlyCrashThresholdSec', config.earlyCrashThresholdSec],
     ['earlyCrashMinTools', config.earlyCrashMinTools],
+    ['maxPrPollCalls', config.maxPrPollCalls],
     ['ccQueryMaxTurns', config.ccQueryMaxTurns],
     ['eventsRetentionDays', config.eventsRetentionDays],
     ['usageRetentionDays', config.usageRetentionDays],

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -129,6 +129,19 @@ export interface TeamMessageSender {
 const lastToolUseByTeam = new Map<string, number>();
 
 // ---------------------------------------------------------------------------
+// PR polling detection state — module-level, persists across requests
+// ---------------------------------------------------------------------------
+
+/** Window duration for counting PR poll calls (10 minutes) */
+const POLL_WINDOW_MS = 10 * 60 * 1000;
+
+/** Track gh pr view/checks calls per team within a 10-minute window */
+const prPollCountByTeam = new Map<string, { count: number; windowStart: number }>();
+
+/** Track teams that have already received a poll warning in the current window */
+const prPollWarned = new Set<string>();
+
+// ---------------------------------------------------------------------------
 // Subagent tracking for early crash detection
 // ---------------------------------------------------------------------------
 
@@ -532,6 +545,46 @@ export function processEvent(
     timestamp: payload.timestamp || nowIso,
   });
 
+  // ── PR polling frequency detection ──────────────────────────────
+  // Detect teams that excessively call `gh pr view` or `gh pr checks`
+  // via Bash tool_use events. When the count exceeds the configured
+  // threshold within a 10-minute window, send a one-time warning.
+  if (
+    eventType === 'ToolUse' &&
+    payload.tool_name === 'Bash' &&
+    messageSender
+  ) {
+    const toolInput = payload.tool_input || payload.message || '';
+    if (toolInput.includes('gh pr view') || toolInput.includes('gh pr checks')) {
+      const teamKey = payload.team;
+      const entry = prPollCountByTeam.get(teamKey);
+
+      if (!entry || now - entry.windowStart > POLL_WINDOW_MS) {
+        // Start a new window
+        prPollCountByTeam.set(teamKey, { count: 1, windowStart: now });
+        // New window also resets the warned flag
+        prPollWarned.delete(teamKey);
+      } else {
+        entry.count++;
+        if (entry.count > config.maxPrPollCalls && !prPollWarned.has(teamKey)) {
+          // Exceeded threshold — send one-time warning (inline message,
+          // matching the crash-detection pattern — no resolveMessage to
+          // avoid circular import with db.ts).
+          const warnMsg =
+            'Stop polling GitHub with gh pr view / gh pr checks. FC monitors CI and PR status ' +
+            'automatically and will notify you via stdin (ci_green, ci_red, pr_merged). Wait for these events instead of polling.';
+          try {
+            messageSender.sendMessage(teamId, warnMsg, 'fc', 'poll_warning');
+            console.log(`[EventCollector] Poll warning sent to team ${teamId} (${entry.count} gh pr calls in window)`);
+          } catch {
+            // Non-critical — silently ignore send failures
+          }
+          prPollWarned.add(teamKey);
+        }
+      }
+    }
+  }
+
   // ── Task extraction from TaskCreated events ─────────────────────
   // Parse TaskCreated hook events and upsert task data into team_tasks.
   if (eventType === 'TaskCreated' && db.upsertTeamTask) {
@@ -704,6 +757,12 @@ export function resetThrottleState(): void {
 /** Reset subagent tracking state. Intended for use in tests only. */
 export function resetSubagentTrackers(): void {
   subagentTrackers.clear();
+}
+
+/** Reset PR polling detection state. Intended for use in tests only. */
+export function resetPrPollState(): void {
+  prPollCountByTeam.clear();
+  prPollWarned.clear();
 }
 
 /** Return current size of subagent tracker map. Intended for use in tests only. */

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -411,6 +411,74 @@ class GitHubPoller {
 
         // Merge notification is now handled by gracefulShutdown below
         // (sends pr_merged_shutdown instead of pr_merged to avoid duplicates)
+
+        // ── Early shutdown on CI green + auto-merge happy path ────────
+        // When CI turns green, auto-merge is enabled, and merge state is
+        // clean, the team can shut down immediately — GitHub will handle
+        // the actual merge. This avoids the 2-minute grace period wait
+        // that normally follows pr_merged detection.
+        if (
+          existing.ciStatus !== ciStatus &&
+          ciStatus === 'passing' &&
+          autoMerge &&
+          mergeState !== 'dirty'
+        ) {
+          const team = db.getTeam(teamId);
+          if (team && team.status !== 'done') {
+            try {
+              const { getTeamManager } = await import('./team-manager.js');
+              const manager = getTeamManager();
+
+              // Send the early shutdown message
+              const shutdownMsg = resolveMessage('ci_green_auto_shutdown', {
+                PR_NUMBER: String(prNumber),
+              });
+              if (shutdownMsg) manager.sendMessage(teamId, shutdownMsg, 'fc', 'ci_green_auto_shutdown');
+
+              // Transition team to done
+              const previousStatus = team.status;
+              db.insertTransition({
+                teamId,
+                fromStatus: previousStatus,
+                toStatus: 'done',
+                trigger: 'poller',
+                reason: `CI green + auto-merge on PR #${prNumber} — early shutdown`,
+              });
+              db.updateTeamSilent(teamId, { status: 'done', phase: 'done', stoppedAt: new Date().toISOString() });
+
+              sseBroker.broadcast(
+                'team_status_changed',
+                {
+                  team_id: teamId,
+                  status: 'done',
+                  previous_status: previousStatus,
+                },
+                teamId,
+              );
+
+              console.log(
+                `[GitHubPoller] Team ${teamId} early shutdown — CI green + auto-merge on PR #${prNumber}`,
+              );
+
+              // Initiate graceful shutdown (notify TL, grace period, then kill)
+              manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
+
+              // Advance the queue immediately — the slot is free
+              if (team.projectId) {
+                manager.processQueue(team.projectId).catch((err) => {
+                  console.error(
+                    `[GitHubPoller] processQueue error after early shutdown for team ${teamId}:`,
+                    err instanceof Error ? err.message : err,
+                  );
+                });
+              }
+            } catch (err) {
+              console.error(`[GitHubPoller] Failed to initiate early shutdown for team ${teamId}:`, err);
+            }
+
+            return { ciStatus, state };
+          }
+        }
       }
     } else {
       // First time we see this PR — insert it

--- a/src/shared/message-templates.ts
+++ b/src/shared/message-templates.ts
@@ -153,4 +153,19 @@ export const DEFAULT_MESSAGE_TEMPLATES: DefaultMessageTemplate[] = [
     description: 'Sent to TL when the issue body/description is edited',
     placeholders: ['ISSUE_KEY', 'BODY_DIFF_SUMMARY'],
   },
+  {
+    id: 'ci_green_auto_shutdown',
+    template:
+      'CI passed on PR #{{PR_NUMBER}}, all checks green. Auto-merge is enabled and no conflicts — GitHub will merge automatically. Shut down all subagents immediately and exit. Do not start new work.',
+    description:
+      'Sent to TL when CI is green, auto-merge is enabled, and no merge conflicts — triggers early shutdown without waiting for actual merge.',
+    placeholders: ['PR_NUMBER'],
+  },
+  {
+    id: 'poll_warning',
+    template:
+      'Stop polling GitHub with gh pr view / gh pr checks. FC monitors CI and PR status automatically and will notify you via stdin (ci_green, ci_red, pr_merged). Wait for these events instead of polling.',
+    description: 'Sent to TL when excessive gh pr view/checks polling is detected.',
+    placeholders: [],
+  },
 ];

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -270,6 +270,18 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     hookEvent: null,
   },
   {
+    id: 'ci_green_auto_shutdown',
+    from: 'running',
+    to: 'done',
+    trigger: 'poller',
+    triggerLabel: 'CI green + auto-merge → early shutdown',
+    description:
+      'CI passes, auto-merge is enabled, and no merge conflicts. Team shuts down ' +
+      'immediately without waiting for the actual merge event — GitHub handles the merge.',
+    condition: 'CI status = passing AND autoMerge = true AND mergeStatus != dirty',
+    hookEvent: null,
+  },
+  {
     id: 'ci_green_but_dirty',
     from: 'running',
     to: 'running',

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -327,11 +327,13 @@ After TL reads `review.md` with `Status: APPROVE`:
    gh pr merge {PR} --auto --squash --delete-branch
    ```
 
-4. Wait for FC to send CI status via stdin:
-   - `ci_green` → auto-merge handles merge → wait for `pr_merged`
-   - `ci_red` → TL forwards failure details to dev → dev fixes and pushes
-   - After 3 unique CI failure types → state Blocked (FC sends `ci_blocked`)
-   - `pr_merged` → state Done
+4. **STOP and wait for FC events via stdin** (MANDATORY — do NOT poll):
+   After setting auto-merge, **stop all activity**. Do NOT run `gh pr view`, `gh pr checks`, or `ScheduleWakeup` to poll CI status. FC monitors CI every 30 seconds and delivers results directly to you via stdin:
+   - `ci_green` or `ci_green_auto_shutdown` → merge is handled automatically → team shuts down
+   - `ci_red` → forward failure details to dev → dev fixes and pushes → wait again
+   - `ci_blocked` → too many CI failure types → state Blocked
+   - `pr_merged` → state Done → close issue, shut down agents
+   FC already polls GitHub every 30s. If you also poll, you burn tokens on redundant `gh` calls.
 
 ---
 
@@ -364,6 +366,7 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 | Message ID | When | Content |
 |------------|------|---------|
 | `ci_green` | CI passes on PR | "CI passed on PR #{PR}. All checks green. Auto-merge is {status}." |
+| `ci_green_auto_shutdown` | CI green + auto-merge + clean | "CI passed, auto-merge enabled, no conflicts. Shut down immediately." |
 | `ci_red` | CI fails on PR | "CI failed on PR #{PR}. Failing checks: {details}. Fix count: {N}/{max}." |
 | `ci_blocked` | Too many CI failures | "STOP. {N} unique CI failure types on PR #{PR}. Wait for instructions." |
 | `pr_merged` | PR is merged | "PR #{PR} merged. Close the issue, clean up, and finish." |
@@ -376,7 +379,8 @@ Fleet Commander sends these messages directly to the TL via stdin. They arrive a
 
 ### TL Response to FC Messages
 
-**On `ci_green`**: Acknowledge and wait for `pr_merged` (auto-merge handles it).
+**On `ci_green`**: Acknowledge and wait for `pr_merged` or `ci_green_auto_shutdown` (auto-merge handles it).
+**On `ci_green_auto_shutdown`**: Shut down all subagents immediately and exit. GitHub will merge the PR automatically.
 **On `ci_red`**: Forward failure details to dev. Counts toward failure limit.
 **On `ci_blocked`**: STOP all work. Wait for PM instructions.
 **On `pr_merged`**: Close issue, shut down all agents (`shutdown_request`), finish.

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -7,6 +7,7 @@ import {
   processEvent,
   resetThrottleState,
   resetSubagentTrackers,
+  resetPrPollState,
   getSubagentTrackerSize,
   cleanSubagentTrackersForTeam,
   normalizeAgentName,
@@ -127,6 +128,7 @@ function createMockMessageSender(): TeamMessageSender & { sendMessage: ReturnTyp
 beforeEach(() => {
   resetThrottleState();
   resetSubagentTrackers();
+  resetPrPollState();
 });
 
 // =============================================================================
@@ -3225,5 +3227,126 @@ describe('handoff file capture', () => {
 
       expect(insertHandoffFile).toHaveBeenCalledOnce();
     }
+  });
+});
+
+// =============================================================================
+// PR polling frequency detection
+// =============================================================================
+
+describe('PR polling frequency detection', () => {
+  it('sends poll_warning when team exceeds maxPrPollCalls', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Default maxPrPollCalls = 5, so we need 6 calls to trigger
+    for (let i = 0; i < 6; i++) {
+      const payload = makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        tool_input: 'gh pr view 42 --json state',
+      });
+      processEvent(payload, db, sse, sender);
+      // Reset throttle so each tool_use goes through
+      resetThrottleState();
+    }
+
+    // The 6th call should trigger the warning
+    expect(sender.sendMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('Stop polling GitHub'),
+      'fc',
+      'poll_warning',
+    );
+  });
+
+  it('does not warn when calls are below threshold', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Send 5 calls (at the threshold, not exceeding)
+    for (let i = 0; i < 5; i++) {
+      const payload = makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        tool_input: 'gh pr view 42 --json state',
+      });
+      processEvent(payload, db, sse, sender);
+      resetThrottleState();
+    }
+
+    // Should NOT have sent a poll_warning
+    const pollWarningCalls = sender.sendMessage.mock.calls.filter(
+      (call: unknown[]) => call[3] === 'poll_warning',
+    );
+    expect(pollWarningCalls).toHaveLength(0);
+  });
+
+  it('resets counter after 10-minute window expires', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Use real timers with Date.now mocking
+    const baseTime = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now');
+
+    // Send 4 calls in the first window
+    dateSpy.mockReturnValue(baseTime);
+    for (let i = 0; i < 4; i++) {
+      const payload = makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        tool_input: 'gh pr view 42 --json state',
+      });
+      processEvent(payload, db, sse, sender);
+      resetThrottleState();
+    }
+
+    // Jump forward 11 minutes (past the 10-minute window)
+    dateSpy.mockReturnValue(baseTime + 11 * 60 * 1000);
+
+    // Send 4 more calls in the new window — should NOT trigger warning
+    for (let i = 0; i < 4; i++) {
+      const payload = makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        tool_input: 'gh pr view 42 --json state',
+      });
+      processEvent(payload, db, sse, sender);
+      resetThrottleState();
+    }
+
+    const pollWarningCalls = sender.sendMessage.mock.calls.filter(
+      (call: unknown[]) => call[3] === 'poll_warning',
+    );
+    expect(pollWarningCalls).toHaveLength(0);
+
+    dateSpy.mockRestore();
+  });
+
+  it('only warns once per window', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sender = createMockMessageSender();
+
+    // Send 10 calls — should only trigger one warning
+    for (let i = 0; i < 10; i++) {
+      const payload = makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        tool_input: 'gh pr checks 42',
+      });
+      processEvent(payload, db, sse, sender);
+      resetThrottleState();
+    }
+
+    // Should have sent exactly 1 poll_warning
+    const pollWarningCalls = sender.sendMessage.mock.calls.filter(
+      (call: unknown[]) => call[3] === 'poll_warning',
+    );
+    expect(pollWarningCalls).toHaveLength(1);
   });
 });

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -1558,3 +1558,151 @@ describe('Surgical cache update on PR merge', () => {
     consoleSpy.mockRestore();
   });
 });
+
+// =============================================================================
+// CI green + auto-merge early shutdown
+// =============================================================================
+
+describe('CI green + auto-merge early shutdown', () => {
+  it('triggers early shutdown when CI turns green with auto-merge and clean merge state', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: true,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // CI turns green, auto-merge enabled, merge state clean
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
+        autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
+      }),
+    );
+
+    // resolveMessage returns a non-null message so sendMessage fires
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('CI green auto shutdown msg');
+
+    await githubPoller.poll();
+
+    // Team should be transitioned to done
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        toStatus: 'done',
+        trigger: 'poller',
+        reason: expect.stringContaining('early shutdown'),
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        status: 'done',
+        phase: 'done',
+      }),
+    );
+
+    // Graceful shutdown should be initiated
+    expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
+
+    // Queue should be processed immediately
+    expect(mockManager.processQueue).toHaveBeenCalledWith(1);
+
+    // ci_green_auto_shutdown message should be sent
+    expect(mockManager.sendMessage).toHaveBeenCalledWith(
+      1,
+      'CI green auto shutdown msg',
+      'fc',
+      'ci_green_auto_shutdown',
+    );
+  });
+
+  it('does NOT trigger early shutdown when merge state is dirty', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'dirty',
+      autoMerge: true,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // CI turns green, auto-merge enabled, but merge state is dirty
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergeStateStatus: 'DIRTY',
+        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
+        autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
+      }),
+    );
+
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
+
+    await githubPoller.poll();
+
+    // Should NOT have transitioned to done via early shutdown
+    const transitionCalls = mockDb.insertTransition.mock.calls;
+    const earlyShutdownTransition = transitionCalls.find(
+      (call: unknown[]) => {
+        const arg = call[0] as { reason?: string };
+        return arg.reason?.includes('early shutdown');
+      },
+    );
+    expect(earlyShutdownTransition).toBeUndefined();
+  });
+
+  it('does NOT trigger early shutdown when auto-merge is NOT enabled', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // CI turns green, merge state clean, but auto-merge NOT enabled
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
+        autoMergeRequest: null,
+      }),
+    );
+
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
+
+    await githubPoller.poll();
+
+    // Should NOT have transitioned to done via early shutdown
+    const transitionCalls = mockDb.insertTransition.mock.calls;
+    const earlyShutdownTransition = transitionCalls.find(
+      (call: unknown[]) => {
+        const arg = call[0] as { reason?: string };
+        return arg.reason?.includes('early shutdown');
+      },
+    );
+    expect(earlyShutdownTransition).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #687

## Summary
- **Fix A**: Updated `templates/workflow.md` Phase 4 with explicit MANDATORY anti-polling instructions — bans `gh pr view`, `gh pr checks`, and `ScheduleWakeup` polling after auto-merge is set. Added reinforcement line in `prompts/default-prompt.md`.
- **Fix B**: Added early shutdown in `github-poller.ts` — when CI turns green + auto-merge enabled + no merge conflicts, team transitions to `done` immediately via `gracefulShutdown()` instead of waiting for the actual merge event. New `ci_green_auto_shutdown` message template and state machine transition.
- **Fix C**: Added poll frequency detection in `event-collector.ts` — tracks `gh pr view`/`gh pr checks` calls per team in a 10-minute sliding window, sends one-time `poll_warning` message when threshold exceeded (default 5 calls, configurable via `FLEET_MAX_PR_POLL_CALLS`).

## Test plan
- [ ] 3 new tests in `github-poller.test.ts`: early shutdown happy path, dirty merge guard, no auto-merge guard
- [ ] 4 new tests in `event-collector.test.ts`: exceeds threshold, below threshold, window reset, warn-once-per-window
- [ ] `workflow-size.test.ts` passes (30,089 chars, under 35,000 limit)
- [ ] `state-machine.test.ts` passes with new `ci_green_auto_shutdown` transition
- [ ] `npm run test:server` passes (all new tests green)
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)