### PR TITLE
Issue #686: Disambiguate mergeStatus=blocked + stop stale CI data polluting merged PRs

### DIFF
--- a/src/client/components/PRDetail.tsx
+++ b/src/client/components/PRDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useApi } from '../hooks/useApi';
 import { CIChecks } from './CIChecks';
+import { getMergeStatusColor, getMergeStatusLabel } from '../utils/merge-status';
 import type { TeamDetail } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
@@ -12,17 +13,6 @@ const STATE_COLORS: Record<string, { color: string; label: string }> = {
   merged: { color: '#A371F7', label: 'MERGED' },
   closed: { color: '#8B949E', label: 'CLOSED' },
   draft: { color: '#8B949E', label: 'DRAFT' },
-};
-
-const MERGE_STATUS_COLORS: Record<string, string> = {
-  clean: '#3FB950',
-  behind: '#D29922',
-  blocked: '#F85149',
-  dirty: '#F85149',
-  unstable: '#D29922',
-  has_hooks: '#D29922',
-  draft: '#8B949E',
-  unknown: '#8B949E',
 };
 
 // ---------------------------------------------------------------------------
@@ -142,7 +132,8 @@ export function PRDetail({ prNumber, teamId, onClose, githubRepo }: PRDetailProp
   const effectiveGithubRepo = githubRepo ?? detail?.githubRepo ?? null;
   const prUrl = effectiveGithubRepo && pr ? `https://github.com/${effectiveGithubRepo}/pull/${pr.number}` : null;
   const stateInfo = STATE_COLORS[pr?.state ?? ''] ?? { color: '#8B949E', label: 'UNKNOWN' };
-  const mergeStatusColor = MERGE_STATUS_COLORS[(pr?.mergeStatus ?? 'unknown').toLowerCase()] ?? '#8B949E';
+  const mergeStatusColor = getMergeStatusColor(pr?.mergeStatus);
+  const mergeStatusLabel = getMergeStatusLabel(pr?.mergeStatus);
   const isOpen = pr?.state === 'open';
 
   return (
@@ -224,7 +215,7 @@ export function PRDetail({ prNumber, teamId, onClose, githubRepo }: PRDetailProp
                   backgroundColor: mergeStatusColor + '10',
                 }}
               >
-                {pr.mergeStatus.toUpperCase()}
+                {mergeStatusLabel}
               </span>
             )}
 

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -10,6 +10,7 @@ import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
 import { HandoffFileCard } from './HandoffFileCard';
 import { STATUS_COLORS } from '../utils/constants';
+import { getMergeStatusLabel } from '../utils/merge-status';
 import { formatIssueKey } from '../../shared/issue-provider';
 import type { TeamTask, HandoffFile } from '../../shared/types';
 
@@ -243,9 +244,9 @@ export function TeamDetail() {
 
   // PR merge status label — hide when PR is merged or closed (GitHub returns
   // "unknown" for mergeStateStatus once a PR is no longer open, which is confusing)
-  const mergeStatusLabel =
+  const mergeStatusLabelText =
     detail?.pr && detail.pr.state !== 'merged' && detail.pr.state !== 'closed'
-      ? (detail.pr.mergeStatus ?? null)
+      ? getMergeStatusLabel(detail.pr.mergeStatus)
       : null;
 
   return (
@@ -505,9 +506,9 @@ export function TeamDetail() {
                         >
                           {detail.pr.state?.toUpperCase() ?? 'UNKNOWN'}
                         </span>
-                        {mergeStatusLabel && (
+                        {mergeStatusLabelText && (
                           <span className="text-xs text-dark-muted">
-                            Merge: {mergeStatusLabel}
+                            Merge: {mergeStatusLabelText}
                           </span>
                         )}
                         {detail.pr.autoMerge && (

--- a/src/client/utils/merge-status.ts
+++ b/src/client/utils/merge-status.ts
@@ -1,0 +1,47 @@
+// =============================================================================
+// Fleet Commander — Merge Status Colors & Labels (shared by PRDetail + TeamDetail)
+// =============================================================================
+
+import type { MergeStatus } from '../../shared/types.js';
+
+/** Color map for merge status badge rendering */
+export const MERGE_STATUS_COLORS: Record<MergeStatus, string> = {
+  clean: '#3FB950',
+  behind: '#D29922',
+  blocked: '#F85149',
+  blocked_ci_pending: '#D29922',
+  blocked_ci_failed: '#F85149',
+  blocked_review: '#D29922',
+  blocked_unknown: '#F85149',
+  dirty: '#F85149',
+  unstable: '#D29922',
+  has_hooks: '#D29922',
+  draft: '#8B949E',
+  unknown: '#8B949E',
+};
+
+/** Human-readable labels for merge status badge rendering */
+export const MERGE_STATUS_LABELS: Record<MergeStatus, string> = {
+  clean: 'CLEAN',
+  behind: 'BEHIND',
+  blocked: 'BLOCKED',
+  blocked_ci_pending: 'CI PENDING',
+  blocked_ci_failed: 'CI FAILED',
+  blocked_review: 'REVIEW REQUIRED',
+  blocked_unknown: 'BLOCKED',
+  dirty: 'DIRTY',
+  unstable: 'UNSTABLE',
+  has_hooks: 'HAS HOOKS',
+  draft: 'DRAFT',
+  unknown: 'UNKNOWN',
+};
+
+/** Get the color for a merge status string, with fallback */
+export function getMergeStatusColor(status: string | null | undefined): string {
+  return MERGE_STATUS_COLORS[status as MergeStatus] ?? '#8B949E';
+}
+
+/** Get the human-readable label for a merge status string, with fallback */
+export function getMergeStatusLabel(status: string | null | undefined): string {
+  return MERGE_STATUS_LABELS[status as MergeStatus] ?? (status?.toUpperCase() ?? 'UNKNOWN');
+}

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS pull_requests (
   title           TEXT,
   state           TEXT,                           -- OPEN|MERGED|CLOSED|draft
   ci_status       TEXT,                           -- none|pending|passing|failing
-  merge_status    TEXT,                           -- unknown|clean|behind|blocked|dirty
+  merge_status    TEXT,                           -- unknown|clean|behind|blocked|blocked_ci_pending|blocked_ci_failed|blocked_review|blocked_unknown|dirty|unstable|has_hooks|draft
   auto_merge      INTEGER NOT NULL DEFAULT 0,     -- 0|1
   ci_fail_count   INTEGER NOT NULL DEFAULT 0,     -- unique failure types; >= 3 means blocked
   checks_json     TEXT,                           -- JSON array: [{name, status, conclusion}]

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -43,6 +43,7 @@ interface GHPRViewResult {
   autoMergeRequest?: { enabledAt?: string } | null;
   headRefName?: string;
   baseRefName?: string;
+  reviewDecision?: string | null;
 }
 
 interface GHPRListItem {
@@ -245,7 +246,7 @@ class GitHubPoller {
     // Use gh pr view to get PR status, CI checks, merge state, and auto-merge
     const result = await execGHAsync(
       `gh pr view ${prNumber} --repo "${githubRepo}" ` +
-        `--json number,title,state,mergeStateStatus,statusCheckRollup,autoMergeRequest,headRefName,baseRefName,mergedAt`
+        `--json number,title,state,mergeStateStatus,statusCheckRollup,autoMergeRequest,headRefName,baseRefName,mergedAt,reviewDecision`
     );
     if (!result) return null; // gh CLI failed — skip this cycle
 
@@ -264,20 +265,33 @@ class GitHubPoller {
     const isMerged = !!data.mergedAt;
     const rawState = data.state?.toLowerCase() ?? 'open';
     const state: PRState = isMerged ? 'merged' : (['draft', 'open', 'merged', 'closed'].includes(rawState) ? rawState as PRState : 'open');
-    const rawMerge = data.mergeStateStatus?.toLowerCase() ?? 'unknown';
-    const mergeState: MergeStatus = (['clean', 'behind', 'blocked', 'dirty', 'unstable', 'has_hooks', 'draft', 'unknown'].includes(rawMerge) ? rawMerge as MergeStatus : 'unknown');
-
-    // Derive CI status from statusCheckRollup
-    const checks: GHCheckRun[] = data.statusCheckRollup ?? [];
+    // Derive CI status from statusCheckRollup, filtering post-merge checks for merged PRs
+    const rawChecks: GHCheckRun[] = data.statusCheckRollup ?? [];
+    const checks = isMerged ? this.filterPostMergeChecks(rawChecks, data.mergedAt ?? null) : rawChecks;
     const ciStatus = this.deriveCIStatus(checks);
 
+    // Map GitHub mergeStateStatus to our MergeStatus, disambiguating 'blocked'
+    const rawMerge = data.mergeStateStatus?.toLowerCase() ?? 'unknown';
+    let mergeState: MergeStatus;
+    if (isMerged) {
+      // Merged PRs have no merge blockers
+      mergeState = 'clean';
+    } else if (rawMerge === 'blocked') {
+      mergeState = this.disambiguateBlocked(checks, ciStatus, data.reviewDecision);
+    } else {
+      mergeState = (['clean', 'behind', 'dirty', 'unstable', 'has_hooks', 'draft', 'unknown'].includes(rawMerge) ? rawMerge as MergeStatus : 'unknown');
+    }
+
     const autoMerge = !!data.autoMergeRequest;
-    const checksJson = JSON.stringify(checks);
+    const checksJson = JSON.stringify(rawChecks);
     const title = data.title ?? `PR #${prNumber}`;
 
-    // Count unique CI failures — cumulative (only goes up or resets to 0 on green)
+    // Count unique CI failures — cumulative (only goes up or resets to 0 on green/merge)
     let ciFailCount = existing?.ciFailCount ?? 0;
-    if (ciStatus === 'passing') {
+    if (isMerged) {
+      // Reset failure count on merge — stale CI data should not pollute merged PRs
+      ciFailCount = 0;
+    } else if (ciStatus === 'passing') {
       // Reset failure count when CI is green
       ciFailCount = 0;
     } else if (ciStatus === 'failing') {
@@ -949,6 +963,77 @@ class GitHubPoller {
         `[GitHubPoller] Detected PR #${prs[0]!.number} for branch "${branchName}" (team ${teamId}, repo: ${githubRepo})`
       );
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public: reconcile a single team's PR (final poll on team done)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Trigger a single PR poll for a team. Called when a team transitions to
+   * `done` so that stale mergeStatus/ciFailCount is reconciled even if
+   * the normal poll cycle hasn't caught the merge yet.
+   */
+  async reconcilePR(teamId: number): Promise<void> {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team?.prNumber || !team.projectId) return;
+
+    const projects = db.getProjects({ status: 'active' });
+    const project = projects.find((p) => p.id === team.projectId);
+    const githubRepo = project?.githubRepo;
+    if (!githubRepo) return;
+
+    await this.pollPR(team.prNumber, teamId, githubRepo);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: disambiguate GitHub's generic BLOCKED merge state
+  // -------------------------------------------------------------------------
+
+  /**
+   * When GitHub reports `mergeStateStatus: 'BLOCKED'`, inspect CI status and
+   * review decision to determine the specific reason. Returns a disambiguated
+   * `MergeStatus` sub-state.
+   */
+  private disambiguateBlocked(
+    _checks: GHCheckRun[],
+    ciStatus: CIStatus,
+    reviewDecision: string | null | undefined,
+  ): MergeStatus {
+    if (ciStatus === 'pending') return 'blocked_ci_pending';
+    if (ciStatus === 'failing') return 'blocked_ci_failed';
+    if (
+      reviewDecision === 'REVIEW_REQUIRED' ||
+      reviewDecision === 'CHANGES_REQUESTED'
+    ) {
+      return 'blocked_review';
+    }
+    return 'blocked_unknown';
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: filter post-merge cleanup workflows from check runs
+  // -------------------------------------------------------------------------
+
+  /**
+   * For merged PRs, filter out check runs that are still IN_PROGRESS with no
+   * conclusion. These are post-merge cleanup workflows (deploy, release, etc.)
+   * that should not influence the stored CI status of a merged PR.
+   *
+   * For non-merged PRs (mergedAt is null), returns all checks unmodified.
+   */
+  private filterPostMergeChecks(checks: GHCheckRun[], mergedAt: string | null): GHCheckRun[] {
+    if (!mergedAt) return checks;
+    return checks.filter((c) => {
+      // Keep checks that have a conclusion (they completed before or after merge)
+      if (c.conclusion) return true;
+      // Filter out still-running checks (no conclusion + IN_PROGRESS) — these are
+      // post-merge workflows that would otherwise make ciStatus stay "pending"
+      if (c.status === 'IN_PROGRESS') return false;
+      // Keep all other checks (e.g. queued but not yet started)
+      return true;
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -1777,6 +1777,15 @@ export class TeamManager {
 
         sseBroker.broadcast('team_stopped', { team_id: teamId }, teamId);
         this.broadcastSnapshot();
+
+        // Final PR reconciliation on team done — clear stale CI/merge data
+        if (exitStatus === 'done' && currentTeam.prNumber) {
+          import('./github-poller.js').then(({ githubPoller }) => {
+            githubPoller.reconcilePR(teamId).catch((err) => {
+              console.error(`[TeamManager] reconcilePR error for team ${teamId}:`, err instanceof Error ? err.message : err);
+            });
+          }).catch(() => { /* ignore import failure */ });
+        }
       }
 
       if (currentTeam.projectId) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,7 +22,7 @@ export type PRState = 'draft' | 'open' | 'merged' | 'closed';
 export type CIStatus = 'none' | 'pending' | 'passing' | 'failing';
 
 /** PR merge readiness status (from GitHub mergeStateStatus) */
-export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'dirty' | 'unstable' | 'has_hooks' | 'draft';
+export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'blocked_ci_pending' | 'blocked_ci_failed' | 'blocked_review' | 'blocked_unknown' | 'dirty' | 'unstable' | 'has_hooks' | 'draft';
 
 /** Project status */
 export type ProjectStatus = 'active' | 'archived';

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -150,6 +150,7 @@ function makeGHPRViewResult(overrides?: Record<string, unknown>) {
     headRefName: 'feat/10-test',
     baseRefName: 'main',
     mergedAt: null,
+    reviewDecision: null,
     ...overrides,
   });
 }
@@ -1559,7 +1560,7 @@ describe('Surgical cache update on PR merge', () => {
   });
 });
 
-// =============================================================================
+
 // CI green + auto-merge early shutdown
 // =============================================================================
 
@@ -1704,5 +1705,310 @@ describe('CI green + auto-merge early shutdown', () => {
       },
     );
     expect(earlyShutdownTransition).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Merge status disambiguation (issue #686)
+// =============================================================================
+
+describe('Merge status disambiguation', () => {
+  it('disambiguates blocked with pending CI as blocked_ci_pending', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'unknown',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'build', conclusion: null, status: 'IN_PROGRESS' },
+        ],
+        reviewDecision: null,
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'blocked_ci_pending' }),
+    );
+  });
+
+  it('disambiguates blocked with failing CI as blocked_ci_failed', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'unknown',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'FAILURE', status: 'COMPLETED' },
+        ],
+        reviewDecision: null,
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'blocked_ci_failed' }),
+    );
+  });
+
+  it('disambiguates blocked with review required as blocked_review', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'unknown',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+        reviewDecision: 'REVIEW_REQUIRED',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'blocked_review' }),
+    );
+  });
+
+  it('disambiguates blocked with CHANGES_REQUESTED as blocked_review', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'unknown',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+        reviewDecision: 'CHANGES_REQUESTED',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'blocked_review' }),
+    );
+  });
+
+  it('disambiguates blocked with unknown reason as blocked_unknown', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'none',
+      mergeStatus: 'unknown',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        mergeStateStatus: 'BLOCKED',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        ],
+        reviewDecision: null,
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'blocked_unknown' }),
+    );
+  });
+});
+
+// =============================================================================
+// Post-merge CI filtering and cleanup (issue #686)
+// =============================================================================
+
+describe('Post-merge CI filtering and cleanup', () => {
+  it('resets ciFailCount to 0 when PR is merged', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'failing',
+      mergeStatus: 'blocked',
+      autoMerge: false,
+      ciFailCount: 2,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'FAILURE', status: 'COMPLETED' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciFailCount: 0 }),
+    );
+  });
+
+  it('sets mergeStatus to clean on merge', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'blocked',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergeStatus: 'clean' }),
+    );
+  });
+
+  it('filters post-merge IN_PROGRESS checks from ciStatus derivation', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'passing',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // Merged PR with one passing pre-merge check and one IN_PROGRESS post-merge check
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+        statusCheckRollup: [
+          { name: 'build', conclusion: 'SUCCESS', status: 'COMPLETED' },
+          { name: 'deploy', conclusion: null, status: 'IN_PROGRESS' },
+        ],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // ciStatus should be 'passing' (post-merge IN_PROGRESS check filtered out)
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciStatus: 'passing' }),
+    );
+  });
+
+  it('reconcilePR triggers a single PR poll for a team', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, projectId: 1, status: 'done' });
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'blocked',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-01-01T00:00:00Z',
+      }),
+    );
+
+    await githubPoller.reconcilePR(1);
+
+    // Should have called gh pr view for the team's PR
+    expect(mockExecGHAsync).toHaveBeenCalledWith(
+      expect.stringContaining('gh pr view 42'),
+    );
+    // ciFailCount should be 0 and mergeStatus should be clean
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ ciFailCount: 0, mergeStatus: 'clean' }),
+    );
   });
 });


### PR DESCRIPTION
Closes #686

## Summary

- **Disambiguated `mergeStatus`**: Replaced single `blocked` value with four explicit sub-states: `blocked_ci_pending`, `blocked_ci_failed`, `blocked_review`, `blocked_unknown`. Cross-references CI status and `reviewDecision` from GitHub.
- **Filtered post-merge cleanup workflows**: IN_PROGRESS checks without conclusion are excluded from CI rollup on merged PRs, preventing stale `ciStatus: 'pending'`.
- **Reset stale CI data on merge**: `ciFailCount` reset to 0 and `mergeStatus` set to `clean` when a PR is merged.
- **Final PR reconciliation on team done**: `reconcilePR()` called fire-and-forget when a team transitions to `done`, clearing stale data even if the poller hasn't caught up.
- **UI updates**: Shared `merge-status.ts` utility provides human-readable labels ("CI PENDING", "CI FAILED", "REVIEW REQUIRED") with semantically correct colors (amber for waiting, red for failure).

## Changed files (8)

| File | Change |
|------|--------|
| `src/shared/types.ts` | Expanded `MergeStatus` type with 4 new sub-states |
| `src/server/services/github-poller.ts` | Core disambiguation, filtering, reconciliation logic |
| `src/server/services/team-manager.ts` | Fire-and-forget `reconcilePR()` on team done |
| `src/server/schema.sql` | Updated comment documenting valid values |
| `src/client/utils/merge-status.ts` | New shared color/label utility |
| `src/client/components/PRDetail.tsx` | Uses shared utility for merge status badge |
| `src/client/components/TeamDetail.tsx` | Uses shared utility for merge status label |
| `tests/server/github-poller.test.ts` | 9 new tests (58 total, all passing) |

## Test plan

- [x] `npx vitest run tests/server/github-poller.test.ts` — 58 passed (9 new)
- [x] `npm run test:server` — 1738 passed
- [x] `npm run test:client` — all passed
- [x] `npx tsc --noEmit` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)