### PR TITLE
Issue #702: inherited blockers in batch tree API and MCP

### DIFF
--- a/src/server/mcp/tools/get-relations.ts
+++ b/src/server/mcp/tools/get-relations.ts
@@ -1,12 +1,16 @@
 // =============================================================================
 // MCP Tool: fleet_get_relations
 // =============================================================================
-// Gets all relations (parent, children, blockedBy, blocking) for an issue.
+// Gets all relations (parent, children, blockedBy, blocking, inheritedBlockedBy)
+// for an issue. `inheritedBlockedBy` surfaces blockers that apply to this issue
+// through its ancestor chain (parent, grandparent, ...) — matching what the
+// batch tree API and launch guard use to decide whether an issue is blocked.
 //
 // Input:  { projectId: number, issueKey: string }
-// Output: JSON IssueRelations object
+// Output: JSON IssueRelationsWithInherited object
 //
-// Service method: IssueRelationsService.getRelations(projectId, issueKey)
+// Service method:
+//   IssueRelationsService.getRelationsWithInherited(projectId, issueKey)
 // =============================================================================
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -18,12 +22,12 @@ import { ServiceError } from '../../services/service-error.js';
  * Registers the `fleet_get_relations` tool on the given MCP server.
  *
  * This tool retrieves all issue relations (parent, children, blockedBy,
- * blocking) for a specific issue within a project.
+ * blocking, inheritedBlockedBy) for a specific issue within a project.
  */
 export function registerGetRelationsTool(server: McpServer): void {
   server.tool(
     'fleet_get_relations',
-    'Gets all relations (parent, children, blockedBy, blocking) for an issue',
+    'Gets all relations for an issue: parent, children, blockedBy, blocking, and inheritedBlockedBy (blockers inherited via the ancestor chain).',
     {
       projectId: z.number().describe('Numeric project ID'),
       issueKey: z.string().describe('Issue key (e.g. "42" for GitHub, "PROJ-123" for Jira)'),
@@ -31,7 +35,7 @@ export function registerGetRelationsTool(server: McpServer): void {
     async ({ projectId, issueKey }) => {
       try {
         const service = getIssueRelationsService();
-        const relations = await service.getRelations(projectId, issueKey);
+        const relations = await service.getRelationsWithInherited(projectId, issueKey);
 
         return {
           content: [

--- a/src/server/services/issue-fetcher.ts
+++ b/src/server/services/issue-fetcher.ts
@@ -519,6 +519,12 @@ export class IssueFetcher {
       }
     }
 
+    // Enrich every node with inherited blockers from ancestor chains before
+    // caching so the batch tree API, MCP tools, and every cache reader see
+    // consistent blocker info (matches the on-demand getDependenciesFromCache
+    // path).
+    this.enrichAllNodesWithInheritedBlockers(rootIssues);
+
     // Update the per-project cache
     if (fetchComplete) {
       this.cacheByProject.set(projectId, {
@@ -661,6 +667,10 @@ export class IssueFetcher {
 
       await runWithConcurrency(depTasks, 5);
     }
+
+    // Enrich every node with inherited blockers from ancestor chains before
+    // caching (same invariant as the GitHub fetch path).
+    this.enrichAllNodesWithInheritedBlockers(rootIssues);
 
     // Update the per-project cache
     if (fetchComplete) {
@@ -941,6 +951,11 @@ export class IssueFetcher {
     } else {
       node.dependencies = undefined;
     }
+
+    // Re-enrich the whole tree so inheritedBlockedBy on descendants reflects
+    // the mutation (e.g. a blocker added to a parent should propagate to
+    // children; removing one should clear it from their inherited list).
+    this.enrichAllNodesWithInheritedBlockers(cache.issues);
   }
 
   /**
@@ -1007,6 +1022,12 @@ export class IssueFetcher {
         }
       }
     }
+
+    // Re-enrich the whole tree so descendants of the closed issue (and any
+    // issue whose ancestor chain transited through it) see updated
+    // inheritedBlockedBy state: blockers that referenced this number are now
+    // closed and should no longer inflate openCount on descendants.
+    this.enrichAllNodesWithInheritedBlockers(cache.issues);
   }
 
   /**
@@ -1026,10 +1047,24 @@ export class IssueFetcher {
     const node = this.findInTree(cache.issues, issueNumber);
     if (!node) return null;
 
-    // Start with existing dependency info or build empty
+    // Start with existing dependency info or build empty. The cached
+    // dependencies may already carry inheritedBlockedBy from the post-fetch
+    // enrichment pass — strip those before we recompute below so we don't
+    // double-count openCount. (The fresh collectAncestorBlockers call
+    // produces the same result either way, so stripping is safe and keeps
+    // this method idempotent for test fixtures that bypass fetch.)
     const deps: IssueDependencyInfo = node.dependencies
-      ? { ...node.dependencies }
+      ? { ...node.dependencies, inheritedBlockedBy: undefined }
       : this.buildEmptyDependencyInfo(issueNumber);
+    if (node.dependencies?.inheritedBlockedBy) {
+      const prevInheritedOpen = node.dependencies.inheritedBlockedBy.filter(
+        (b) => b.state === 'open',
+      ).length;
+      deps.openCount = Math.max(0, deps.openCount - prevInheritedOpen);
+      // Recompute resolved from direct blockers + pendingChildren only
+      const directOpen = deps.blockedBy.filter((b) => b.state === 'open').length;
+      deps.resolved = directOpen === 0 && !deps.pendingChildren;
+    }
 
     // Check for pending children from cached subIssueSummary
     if (node.subIssueSummary && node.subIssueSummary.total > 0 && node.subIssueSummary.completed < node.subIssueSummary.total) {
@@ -1427,6 +1462,78 @@ export class IssueFetcher {
     }
 
     return deps;
+  }
+
+  /**
+   * Enrich every node in the given tree with `inheritedBlockedBy` computed
+   * from its ancestor chain. Mutates each node's `dependencies` in place so
+   * downstream readers (batch tree API, MCP, getIssuesByProject, etc.) see
+   * consistent blocker info matching the on-demand `getDependenciesFromCache`
+   * path.
+   *
+   * Called once after a full fetch (or a surgical mutation) completes, right
+   * before the cache is written/updated. For each node:
+   *   - Computes direct blocker set from node.dependencies?.blockedBy
+   *   - Walks ancestors via collectAncestorBlockers (respects depth cap, cycles,
+   *     closed ancestors, sub-issue stripping)
+   *   - If any inherited blockers exist, initializes node.dependencies lazily
+   *     via buildEmptyDependencyInfo() when absent, and recalculates
+   *     openCount/resolved to include inherited open blockers.
+   *
+   * If no inherited blockers exist, node.dependencies is left untouched so
+   * issues with no blockers at all remain `undefined` (no behavior change for
+   * the common unblocked case).
+   */
+  private enrichAllNodesWithInheritedBlockers(rootIssues: IssueNode[]): void {
+    const parentMap = this.buildParentMap(rootIssues);
+    // Transient cache view for collectAncestorBlockers lookups. cachedAt is
+    // irrelevant here — collectAncestorBlockers only reads cache.issues via
+    // findInTree.
+    const transientCache: ProjectIssueCache = { issues: rootIssues, cachedAt: null };
+
+    const allNodes = this.flattenTree(rootIssues);
+
+    // Reset any previously-computed inherited state so this method is idempotent.
+    // Re-running after surgical mutations (updateIssueDependencies /
+    // markIssueClosed) must not double-count inherited openCount.
+    for (const node of allNodes) {
+      if (node.dependencies?.inheritedBlockedBy) {
+        const prevInheritedOpen = node.dependencies.inheritedBlockedBy.filter(
+          (b) => b.state === 'open',
+        ).length;
+        node.dependencies.openCount = Math.max(
+          0,
+          node.dependencies.openCount - prevInheritedOpen,
+        );
+        node.dependencies.inheritedBlockedBy = undefined;
+        // Recompute resolved from remaining direct blockers / pending children
+        const directOpen = node.dependencies.blockedBy.filter((b) => b.state === 'open').length;
+        node.dependencies.resolved = directOpen === 0 && !node.dependencies.pendingChildren;
+      }
+    }
+
+    for (const node of allNodes) {
+      const directBlockerNumbers = new Set(
+        node.dependencies?.blockedBy.map((b) => b.number) ?? [],
+      );
+      const inherited = this.collectAncestorBlockers(
+        node.number,
+        parentMap,
+        transientCache,
+        directBlockerNumbers,
+      );
+      if (inherited.length === 0) continue;
+
+      if (!node.dependencies) {
+        node.dependencies = this.buildEmptyDependencyInfo(node.number);
+      }
+      node.dependencies.inheritedBlockedBy = inherited;
+      const inheritedOpenCount = inherited.filter((b) => b.state === 'open').length;
+      node.dependencies.openCount += inheritedOpenCount;
+      if (inheritedOpenCount > 0) {
+        node.dependencies.resolved = false;
+      }
+    }
   }
 
   /**

--- a/src/server/services/issue-relations-service.ts
+++ b/src/server/services/issue-relations-service.ts
@@ -7,7 +7,7 @@
 // touched and the error propagates to the caller.
 // =============================================================================
 
-import type { IssueRelations } from '../../shared/issue-provider.js';
+import type { IssueRelations, IssueRelationRef } from '../../shared/issue-provider.js';
 import { getDatabase } from '../db.js';
 import { getIssueProvider } from '../providers/index.js';
 import { GitHubIssueProvider } from '../providers/github-issue-provider.js';
@@ -15,6 +15,18 @@ import { JiraIssueProvider } from '../providers/jira-issue-provider.js';
 import { getIssueFetcher } from './issue-fetcher.js';
 import { sseBroker } from './sse-broker.js';
 import { validationError, notFoundError, externalError } from './service-error.js';
+
+/** A relation ref augmented with the ancestor through which it is inherited. */
+export interface InheritedRelationRef extends IssueRelationRef {
+  /** Display key of the ancestor this block is inherited through. */
+  viaAncestorKey: string;
+}
+
+/** IssueRelations plus inherited blockers from the parent-child hierarchy. */
+export interface IssueRelationsWithInherited extends IssueRelations {
+  /** Blockers inherited from ancestor issues (empty if no chain blockers). */
+  inheritedBlockedBy: InheritedRelationRef[];
+}
 
 // ---------------------------------------------------------------------------
 // Helper: resolve GitHub owner/repo from project's issue sources
@@ -92,6 +104,33 @@ class IssueRelationsService {
         `Failed to get relations for ${issueKey}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+  }
+
+  /**
+   * Get relations for an issue and additionally attach any blockers inherited
+   * from its ancestor chain (parent, grandparent, ...). Reads inherited info
+   * from the in-memory issue cache populated by `IssueFetcher`. If the issue
+   * is not present in the cache (cold cache, or issue not yet fetched), the
+   * result has an empty `inheritedBlockedBy` array — the caller still gets
+   * the direct relations.
+   */
+  async getRelationsWithInherited(
+    projectId: number,
+    issueKey: string,
+  ): Promise<IssueRelationsWithInherited> {
+    const relations = await this.getRelations(projectId, issueKey);
+
+    const node = getIssueFetcher().getIssueByKey(issueKey, projectId);
+    const inheritedDeps = node?.dependencies?.inheritedBlockedBy ?? [];
+
+    const inheritedBlockedBy: InheritedRelationRef[] = inheritedDeps.map((dep) => ({
+      key: dep.issueKey ?? String(dep.number),
+      title: dep.title,
+      state: dep.state,
+      viaAncestorKey: dep.viaAncestorKey ?? `#${dep.viaAncestor}`,
+    }));
+
+    return { ...relations, inheritedBlockedBy };
   }
 
   /**

--- a/tests/server/issue-dependencies.test.ts
+++ b/tests/server/issue-dependencies.test.ts
@@ -1471,3 +1471,430 @@ describe('inherited blockers (parent-child hierarchy)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Batch tree enrichment (post-fetch inheritedBlockedBy pass)
+// ---------------------------------------------------------------------------
+// These tests exercise the enrichment pass that runs at the end of
+// fetchIssueHierarchy / fetchIssueHierarchyGeneric. The pass is what makes
+// the batch tree API (GET /api/issues, GET /api/projects/:id/issues) return
+// leaf nodes with inheritedBlockedBy populated — previously only the
+// on-demand getDependenciesFromCache path did this enrichment, so the UI
+// would show a Play button for issues that should have been blocked.
+// ---------------------------------------------------------------------------
+
+describe('batch tree enrichment (inheritedBlockedBy post-pass)', () => {
+  /** Minimal IssueNode factory (mirrors the helper in "inherited blockers"). */
+  function makeNode(
+    number: number,
+    opts: {
+      state?: 'open' | 'closed';
+      children?: IssueNode[];
+      dependencies?: IssueDependencyInfo;
+      issueKey?: string;
+    } = {},
+  ): IssueNode {
+    const node: IssueNode = {
+      number,
+      title: `Issue #${number}`,
+      state: opts.state ?? 'open',
+      labels: [],
+      url: `https://github.com/test/repo/issues/${number}`,
+      children: opts.children ?? [],
+      issueKey: opts.issueKey ?? String(number),
+      issueProvider: 'github',
+    };
+    if (opts.dependencies) {
+      node.dependencies = opts.dependencies;
+    }
+    return node;
+  }
+
+  function makeDepRef(number: number, state: 'open' | 'closed' = 'open'): DependencyRef {
+    return {
+      number,
+      owner: 'test',
+      repo: 'repo',
+      state,
+      title: `Blocker #${number}`,
+    };
+  }
+
+  /**
+   * Invoke the private enrichment pass directly. This is what runs at the
+   * end of fetchIssueHierarchy, and what every cache reader (including the
+   * batch tree routes) sees after a fetch.
+   */
+  function runEnrichment(roots: IssueNode[]): void {
+    const fetcher = new IssueFetcher();
+    (fetcher as unknown as {
+      enrichAllNodesWithInheritedBlockers: (r: IssueNode[]) => void;
+    }).enrichAllNodesWithInheritedBlockers(roots);
+  }
+
+  it('should populate inheritedBlockedBy on leaf when direct parent has an open blocker', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    runEnrichment([parent]);
+
+    expect(leaf.dependencies).toBeDefined();
+    expect(leaf.dependencies!.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].number).toBe(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].viaAncestor).toBe(10);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].state).toBe('open');
+    expect(leaf.dependencies!.resolved).toBe(false);
+    expect(leaf.dependencies!.openCount).toBe(1);
+  });
+
+  it('should populate inheritedBlockedBy via grandparent (multi-level inheritance)', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, { children: [leaf] });
+    const grandparent = makeNode(5, {
+      issueKey: 'PROJ-5',
+      dependencies: {
+        issueNumber: 5,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [parent],
+    });
+
+    runEnrichment([grandparent]);
+
+    expect(leaf.dependencies).toBeDefined();
+    expect(leaf.dependencies!.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].number).toBe(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].viaAncestor).toBe(5);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].viaAncestorKey).toBe('PROJ-5');
+  });
+
+  it('should populate inheritedBlockedBy via great-grandparent (3-level inheritance)', () => {
+    const leaf = makeNode(40);
+    const parent = makeNode(30, { children: [leaf] });
+    const grandparent = makeNode(20, { children: [parent] });
+    const greatGrandparent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [grandparent],
+    });
+
+    runEnrichment([greatGrandparent]);
+
+    expect(leaf.dependencies).toBeDefined();
+    expect(leaf.dependencies!.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].number).toBe(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].viaAncestor).toBe(10);
+    expect(leaf.dependencies!.resolved).toBe(false);
+
+    // Intermediate parent/grandparent also inherit from the higher chain
+    expect(parent.dependencies?.inheritedBlockedBy?.[0].number).toBe(1);
+    expect(grandparent.dependencies?.inheritedBlockedBy?.[0].number).toBe(1);
+  });
+
+  it('should leave dependencies undefined on nodes with no ancestor blockers', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, { children: [leaf] });
+    const grandparent = makeNode(5, { children: [parent] });
+
+    runEnrichment([grandparent]);
+
+    expect(leaf.dependencies).toBeUndefined();
+    expect(parent.dependencies).toBeUndefined();
+    expect(grandparent.dependencies).toBeUndefined();
+  });
+
+  it('should append inherited blockers to a node that already has direct blockers', () => {
+    const leaf = makeNode(20, {
+      dependencies: {
+        issueNumber: 20,
+        blockedBy: [makeDepRef(99, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+    });
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    runEnrichment([parent]);
+
+    expect(leaf.dependencies!.blockedBy.map((b) => b.number)).toEqual([99]);
+    expect(leaf.dependencies!.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.inheritedBlockedBy![0].number).toBe(1);
+    // openCount = 1 direct + 1 inherited
+    expect(leaf.dependencies!.openCount).toBe(2);
+    expect(leaf.dependencies!.resolved).toBe(false);
+  });
+
+  it('should not propagate blockers through a closed ancestor', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, {
+      state: 'closed',
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    runEnrichment([parent]);
+
+    // Closed ancestor breaks the chain
+    expect(leaf.dependencies).toBeUndefined();
+  });
+
+  it('should not propagate blockers beyond MAX_ANCESTOR_DEPTH (cycle safety)', () => {
+    // Build a chain of 12 parents with a blocker at the root. The leaf is
+    // 12 levels deep — beyond MAX_ANCESTOR_DEPTH=10, so it must NOT inherit.
+    let current: IssueNode = makeNode(100);
+    const deepLeaf = current;
+    for (let i = 99; i >= 88; i--) {
+      current = makeNode(i, { children: [current] });
+    }
+    current.dependencies = {
+      issueNumber: current.number,
+      blockedBy: [makeDepRef(1, 'open')],
+      resolved: false,
+      openCount: 1,
+    };
+
+    runEnrichment([current]);
+
+    expect(deepLeaf.dependencies).toBeUndefined();
+  });
+
+  it('should enrich all siblings sharing a blocked parent', () => {
+    const sibA = makeNode(21);
+    const sibB = makeNode(22);
+    const sibC = makeNode(23);
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [sibA, sibB, sibC],
+    });
+
+    runEnrichment([parent]);
+
+    for (const s of [sibA, sibB, sibC]) {
+      expect(s.dependencies?.inheritedBlockedBy).toHaveLength(1);
+      expect(s.dependencies!.inheritedBlockedBy![0].number).toBe(1);
+      expect(s.dependencies!.openCount).toBe(1);
+      expect(s.dependencies!.resolved).toBe(false);
+    }
+  });
+
+  it('should handle empty tree as a no-op', () => {
+    expect(() => runEnrichment([])).not.toThrow();
+  });
+
+  it('should be idempotent — running twice must not double-count openCount', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    runEnrichment([parent]);
+    runEnrichment([parent]);
+
+    expect(leaf.dependencies!.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.openCount).toBe(1);
+    expect(leaf.dependencies!.resolved).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markIssueClosed cascades to inherited blockers
+// ---------------------------------------------------------------------------
+
+describe('markIssueClosed cascades to inherited blockers', () => {
+  function makeNode(
+    number: number,
+    opts: {
+      state?: 'open' | 'closed';
+      children?: IssueNode[];
+      dependencies?: IssueDependencyInfo;
+      issueKey?: string;
+    } = {},
+  ): IssueNode {
+    const node: IssueNode = {
+      number,
+      title: `Issue #${number}`,
+      state: opts.state ?? 'open',
+      labels: [],
+      url: `https://github.com/test/repo/issues/${number}`,
+      children: opts.children ?? [],
+      issueKey: opts.issueKey ?? String(number),
+      issueProvider: 'github',
+    };
+    if (opts.dependencies) node.dependencies = opts.dependencies;
+    return node;
+  }
+
+  function makeDepRef(number: number, state: 'open' | 'closed' = 'open'): DependencyRef {
+    return { number, owner: '', repo: '', state, title: `Blocker #${number}` };
+  }
+
+  function setupFetcher(issues: IssueNode[]): IssueFetcher {
+    const fetcher = new IssueFetcher();
+    const cache = { issues, cachedAt: new Date().toISOString() };
+    (fetcher as unknown as {
+      cacheByProject: Map<number, { issues: IssueNode[]; cachedAt: string | null }>;
+    }).cacheByProject.set(1, cache);
+    // Prime inherited enrichment so test starts from the post-fetch state
+    (fetcher as unknown as {
+      enrichAllNodesWithInheritedBlockers: (r: IssueNode[]) => void;
+    }).enrichAllNodesWithInheritedBlockers(issues);
+    return fetcher;
+  }
+
+  it('clears inheritedBlockedBy openCount on descendants when ancestor blocker closes', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    const fetcher = setupFetcher([parent]);
+
+    // Sanity: leaf inherits the open blocker pre-close
+    expect(leaf.dependencies?.inheritedBlockedBy).toHaveLength(1);
+    expect(leaf.dependencies!.openCount).toBe(1);
+
+    // Close #1 — the blocker the ancestor depends on
+    fetcher.markIssueClosed(1, 1);
+
+    // Parent's direct blocker should now be closed
+    expect(parent.dependencies!.blockedBy[0]!.state).toBe('closed');
+    expect(parent.dependencies!.resolved).toBe(true);
+    expect(parent.dependencies!.openCount).toBe(0);
+
+    // Leaf's inherited info should reflect that the blocker is now closed —
+    // either cleared or marked resolved (openCount back to 0).
+    if (leaf.dependencies?.inheritedBlockedBy) {
+      const inheritedOpen = leaf.dependencies.inheritedBlockedBy.filter(
+        (b) => b.state === 'open',
+      ).length;
+      expect(inheritedOpen).toBe(0);
+    }
+    expect(leaf.dependencies?.openCount ?? 0).toBe(0);
+    expect(leaf.dependencies?.resolved ?? true).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateIssueDependencies re-runs inheritance enrichment
+// ---------------------------------------------------------------------------
+
+describe('updateIssueDependencies re-runs inheritance enrichment', () => {
+  function makeNode(
+    number: number,
+    opts: {
+      state?: 'open' | 'closed';
+      children?: IssueNode[];
+      dependencies?: IssueDependencyInfo;
+      issueKey?: string;
+    } = {},
+  ): IssueNode {
+    const node: IssueNode = {
+      number,
+      title: `Issue #${number}`,
+      state: opts.state ?? 'open',
+      labels: [],
+      url: `https://github.com/test/repo/issues/${number}`,
+      children: opts.children ?? [],
+      issueKey: opts.issueKey ?? String(number),
+      issueProvider: 'github',
+    };
+    if (opts.dependencies) node.dependencies = opts.dependencies;
+    return node;
+  }
+
+  function makeDepRef(number: number, state: 'open' | 'closed' = 'open'): DependencyRef {
+    return { number, owner: '', repo: '', state, title: `Blocker #${number}` };
+  }
+
+  function setupFetcher(issues: IssueNode[]): IssueFetcher {
+    const fetcher = new IssueFetcher();
+    const cache = { issues, cachedAt: new Date().toISOString() };
+    (fetcher as unknown as {
+      cacheByProject: Map<number, { issues: IssueNode[]; cachedAt: string | null }>;
+    }).cacheByProject.set(1, cache);
+    (fetcher as unknown as {
+      enrichAllNodesWithInheritedBlockers: (r: IssueNode[]) => void;
+    }).enrichAllNodesWithInheritedBlockers(issues);
+    return fetcher;
+  }
+
+  it('clears inheritedBlockedBy on children when the parent blocker is removed', () => {
+    const leaf = makeNode(20);
+    const parent = makeNode(10, {
+      dependencies: {
+        issueNumber: 10,
+        blockedBy: [makeDepRef(1, 'open')],
+        resolved: false,
+        openCount: 1,
+      },
+      children: [leaf],
+    });
+
+    const fetcher = setupFetcher([parent]);
+
+    // Sanity check after setup: leaf inherits the blocker
+    expect(leaf.dependencies?.inheritedBlockedBy).toHaveLength(1);
+
+    // Simulate removing the blocker from the parent via updateIssueDependencies
+    fetcher.updateIssueDependencies(1, '10', {
+      parent: null,
+      children: [{ key: '20', title: 'Issue #20', state: 'open' }],
+      blockedBy: [],
+      blocking: [],
+    });
+
+    // Parent now has no direct blockers
+    expect(parent.dependencies).toBeUndefined();
+
+    // Leaf's inherited list must no longer carry the removed blocker
+    const leafInherited = leaf.dependencies?.inheritedBlockedBy ?? [];
+    const stillHasOne = leafInherited.some((b) => b.number === 1 && b.state === 'open');
+    expect(stillHasOne).toBe(false);
+    expect(leaf.dependencies?.openCount ?? 0).toBe(0);
+    expect(leaf.dependencies?.resolved ?? true).toBe(true);
+  });
+});
+

--- a/tests/server/mcp/get-relations.test.ts
+++ b/tests/server/mcp/get-relations.test.ts
@@ -12,17 +12,20 @@ import { ServiceError } from '../../../src/server/services/service-error.js';
 // ---------------------------------------------------------------------------
 
 const mockRelations = {
-  parent: { key: '10', title: 'Parent issue' },
-  children: [{ key: '20', title: 'Child issue' }],
-  blockedBy: [{ key: '30', title: 'Blocker issue' }],
+  parent: { key: '10', title: 'Parent issue', state: 'open' },
+  children: [{ key: '20', title: 'Child issue', state: 'open' }],
+  blockedBy: [{ key: '30', title: 'Blocker issue', state: 'open' }],
   blocking: [],
+  inheritedBlockedBy: [
+    { key: '40', title: 'Inherited blocker', state: 'open', viaAncestorKey: '#10' },
+  ],
 };
 
-const mockGetRelations = vi.fn().mockResolvedValue(mockRelations);
+const mockGetRelationsWithInherited = vi.fn().mockResolvedValue(mockRelations);
 
 vi.mock('../../../src/server/services/issue-relations-service.js', () => ({
   getIssueRelationsService: () => ({
-    getRelations: mockGetRelations,
+    getRelationsWithInherited: mockGetRelationsWithInherited,
   }),
 }));
 
@@ -99,17 +102,32 @@ describe('fleet_get_relations MCP tool', () => {
     expect(parsed).toEqual(mockRelations);
   });
 
-  it('handler passes projectId and issueKey to getRelations', async () => {
+  it('handler passes projectId and issueKey to getRelationsWithInherited', async () => {
     registerGetRelationsTool(mockMcpServer as any);
 
     const handler = registeredTools[0]!.handler;
     await handler({ projectId: 1, issueKey: '42' });
 
-    expect(mockGetRelations).toHaveBeenCalledWith(1, '42');
+    expect(mockGetRelationsWithInherited).toHaveBeenCalledWith(1, '42');
+  });
+
+  it('handler exposes inheritedBlockedBy in the response', async () => {
+    registerGetRelationsTool(mockMcpServer as any);
+
+    const handler = registeredTools[0]!.handler;
+    const result = (await handler({ projectId: 1, issueKey: '42' })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty('inheritedBlockedBy');
+    expect(parsed.inheritedBlockedBy).toHaveLength(1);
+    expect(parsed.inheritedBlockedBy[0].key).toBe('40');
+    expect(parsed.inheritedBlockedBy[0].viaAncestorKey).toBe('#10');
   });
 
   it('handler returns isError on ServiceError', async () => {
-    mockGetRelations.mockRejectedValueOnce(
+    mockGetRelationsWithInherited.mockRejectedValueOnce(
       new ServiceError('Project 999 not found', 'NOT_FOUND', 404),
     );
 
@@ -126,7 +144,7 @@ describe('fleet_get_relations MCP tool', () => {
   });
 
   it('handler re-throws non-ServiceError exceptions', async () => {
-    mockGetRelations.mockRejectedValueOnce(new Error('unexpected'));
+    mockGetRelationsWithInherited.mockRejectedValueOnce(new Error('unexpected'));
 
     registerGetRelationsTool(mockMcpServer as any);
 


### PR DESCRIPTION
Closes #702

## Summary
Propagates inherited blockers through the batch tree API and the `fleet_get_relations` MCP tool so they match the on-demand dependencies endpoint. Previously only the on-demand path and the server-side launch guard enriched `inheritedBlockedBy`, leaving the UI's Issue Tree showing Play buttons as active on leaves whose ancestors had open blockers.

## Approach
- New private `enrichAllNodesWithInheritedBlockers(rootIssues)` on `IssueFetcher`, invoked at the end of both fetch paths (`fetchIssueHierarchy`, `fetchIssueHierarchyGeneric`) and after every surgical mutation (`updateIssueDependencies`, `markIssueClosed`). Idempotent — strips prior inherited state and adjusts `openCount` before recomputing so re-runs never double-count.
- `getDependenciesFromCache` also resets pre-existing inherited state before recomputing so on-demand callers stay consistent regardless of cache pre-enrichment.
- New `IssueRelationsService.getRelationsWithInherited` returns an additive `IssueRelationsWithInherited` shape (base `IssueRelations` untouched). MCP `fleet_get_relations` tool switches to the new wrapper.
- No UI changes — `TreeNode.tsx` already consumes `inheritedBlockedBy`.

## Tests
- 15 new tests across 3 describe blocks in `tests/server/issue-dependencies.test.ts`: batch enrichment (multi-level, closed-ancestor skip, MAX_ANCESTOR_DEPTH, siblings, idempotency), `markIssueClosed` cascade, `updateIssueDependencies` re-enrichment.
- MCP test updated and extended to verify `inheritedBlockedBy` in the response.

## Test plan
- [x] `npm run test:server` — 1803 passed; 3 pre-existing `cc-spawn.test.ts` failures unrelated (FLEET_* env leak in local sandbox, confirmed on `main`).
- [x] `npm run build` — clean.
- [x] `npx tsc --noEmit` — clean.