### PR TITLE
Issue #704: reconcile PR before externally-closed team transitions to done

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -398,6 +398,7 @@ class GitHubPoller {
       ciFailCount,
       checksJson,
       baseRefName,
+      mergedAt: data.mergedAt ?? null,
     };
 
     if (existing) {

--- a/src/server/services/issue-update-poller.ts
+++ b/src/server/services/issue-update-poller.ts
@@ -370,6 +370,22 @@ class IssueUpdatePoller {
           }
 
           const db = getDatabase();
+
+          // Guard against duplicate done-transition. reconcilePR → pollPR
+          // may have already flipped the team to 'done' internally via the
+          // merged-branch path (github-poller.ts:644-674). Mirrors the guard
+          // pattern at github-poller.ts:647. If the team is already done,
+          // the transition row, status update, SSE broadcast, and graceful
+          // shutdown timer have all been handled — skip the fallthrough
+          // block to avoid duplicate audit rows, duplicate SSE events, and
+          // preempting the gracefulShutdown grace timer with manager.stop().
+          const currentTeam = db.getTeam(team.id);
+          if (currentTeam && currentTeam.status === 'done') {
+            // Snapshot cleanup is still needed so we don't leak state.
+            this.snapshots.delete(team.id);
+            break;
+          }
+
           const previousStatus = team.status;
 
           db.insertTransition({

--- a/src/server/services/issue-update-poller.ts
+++ b/src/server/services/issue-update-poller.ts
@@ -350,6 +350,25 @@ class IssueUpdatePoller {
 
         // External closure triggers graceful shutdown
         if (change.type === 'closed') {
+          // Force a PR reconcile BEFORE flipping team status. When a PR
+          // auto-closes an issue via `Closes #N`, the github-poller will
+          // skip that PR once the team is `done`, leaving the PR row stale
+          // (state='open', merge_status='blocked_unknown'). Reconciling here
+          // ensures the dashboard shows the correct "merged" pill without
+          // a manual refresh. See issue #704.
+          if (team.prNumber) {
+            try {
+              const { githubPoller } = await import('./github-poller.js');
+              await githubPoller.reconcilePR(team.id);
+            } catch (err) {
+              console.error(
+                `[IssueUpdatePoller] Forced reconcilePR failed for team ${team.id} (PR #${team.prNumber}):`,
+                err instanceof Error ? err.message : err,
+              );
+              // Fall through — still mark the team done even if reconcile fails.
+            }
+          }
+
           const db = getDatabase();
           const previousStatus = team.status;
 

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -253,11 +253,12 @@ describe('PR state transitions', () => {
     expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
     // processQueue should NOT be called since team is already done
     expect(mockManager.processQueue).not.toHaveBeenCalled();
-    // mergedAt should NOT be written again either
-    expect(mockDb.updatePullRequest).not.toHaveBeenCalledWith(
-      42,
-      expect.objectContaining({ mergedAt: expect.any(String) }),
-    );
+    // The "done" branch (insertTransition + mark done) must not run again —
+    // this is the protection the test actually cares about.
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+    // Note: the standard pollPR update path still persists mergedAt every
+    // time `changed` is true (fix #704). That is intentional and safe — it
+    // only refreshes the PR row, it does not re-trigger graceful shutdown.
   });
 
   it('calls processQueue immediately on PR merge to advance queued teams', async () => {
@@ -335,6 +336,72 @@ describe('PR state transitions', () => {
 
     expect(mockDb.updatePullRequest).not.toHaveBeenCalled();
     expect(mockSseBroker.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('persists mergedAt on every pollPR update when PR is merged', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'CLOSED',
+        mergedAt: '2025-07-01T10:00:00Z',
+      }),
+    );
+
+    await githubPoller.poll();
+
+    // Standard update path must carry mergedAt forward
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        state: 'merged',
+        mergedAt: '2025-07-01T10:00:00Z',
+      }),
+    );
+  });
+
+  it('passes null mergedAt when PR is still open', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 42, status: 'running' });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 42,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    // CI flips to passing so `changed` is true and we hit the update path
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergedAt: null,
+        statusCheckRollup: [{ name: 'ci', conclusion: 'SUCCESS' }],
+      }),
+    );
+
+    await githubPoller.poll();
+
+    expect(mockDb.updatePullRequest).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ mergedAt: null }),
+    );
   });
 });
 

--- a/tests/server/issue-update-poller.test.ts
+++ b/tests/server/issue-update-poller.test.ts
@@ -54,6 +54,13 @@ vi.mock('../../src/server/services/team-manager.js', () => ({
   getTeamManager: () => mockManager,
 }));
 
+const mockGithubPoller = {
+  reconcilePR: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock('../../src/server/services/github-poller.js', () => ({
+  githubPoller: mockGithubPoller,
+}));
+
 const mockExecGHAsync = vi.fn().mockResolvedValue(null);
 vi.mock('../../src/server/utils/exec-gh.js', () => ({
   execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
@@ -367,6 +374,97 @@ describe('IssueUpdatePoller', () => {
     );
 
     // Should stop the team
+    expect(mockManager.stop).toHaveBeenCalledWith(1);
+  });
+
+  it('reconciles PR before marking team done when issue auto-closes via PR merge', async () => {
+    const team = makeTeam({ status: 'running', prNumber: 123 });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — OPEN
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'OPEN' }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — CLOSED (auto-closed by PR merge)
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'CLOSED' }));
+    mockResolveMessage.mockReturnValue('Issue #42 was closed externally.');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // reconcilePR must be called with the team's id
+    expect(mockGithubPoller.reconcilePR).toHaveBeenCalledWith(1);
+
+    // Order: reconcilePR runs BEFORE updateTeamSilent flips status to 'done'
+    const reconcileCall = mockGithubPoller.reconcilePR.mock.invocationCallOrder[0]!;
+    const doneUpdateCall = mockDb.updateTeamSilent.mock.calls.findIndex(
+      (call) => (call[1] as { status?: string }).status === 'done',
+    );
+    expect(doneUpdateCall).toBeGreaterThanOrEqual(0);
+    const doneUpdateOrder =
+      mockDb.updateTeamSilent.mock.invocationCallOrder[doneUpdateCall]!;
+    expect(reconcileCall).toBeLessThan(doneUpdateOrder);
+
+    // Team still marked done and stopped
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done', phase: 'done' }),
+    );
+    expect(mockManager.stop).toHaveBeenCalledWith(1);
+  });
+
+  it('skips PR reconcile when team has no prNumber', async () => {
+    const team = makeTeam({ status: 'running', prNumber: null });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — OPEN
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'OPEN' }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — CLOSED
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'CLOSED' }));
+    mockResolveMessage.mockReturnValue('Issue #42 was closed externally.');
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // No reconcile call — no PR to reconcile
+    expect(mockGithubPoller.reconcilePR).not.toHaveBeenCalled();
+
+    // Team still marked done
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done', phase: 'done' }),
+    );
+  });
+
+  it('still marks team done when reconcilePR throws', async () => {
+    const team = makeTeam({ status: 'running', prNumber: 456 });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — OPEN
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'OPEN' }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — CLOSED, but reconcilePR blows up (gh CLI down)
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'CLOSED' }));
+    mockResolveMessage.mockReturnValue('Issue #42 was closed externally.');
+    mockGithubPoller.reconcilePR.mockRejectedValueOnce(new Error('gh CLI down'));
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Reconcile attempted
+    expect(mockGithubPoller.reconcilePR).toHaveBeenCalledWith(1);
+
+    // Team still transitions to done despite reconcile failure
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done', phase: 'done' }),
+    );
     expect(mockManager.stop).toHaveBeenCalledWith(1);
   });
 

--- a/tests/server/issue-update-poller.test.ts
+++ b/tests/server/issue-update-poller.test.ts
@@ -440,6 +440,55 @@ describe('IssueUpdatePoller', () => {
     );
   });
 
+  it('does NOT double-transition when reconcilePR internally marks team done', async () => {
+    const team = makeTeam({ status: 'running', prNumber: 123 });
+    const project = makeProject();
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getProjects.mockReturnValue([project]);
+
+    // First poll — OPEN (initializes snapshot; no getTeam call expected yet)
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'OPEN' }));
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // Second poll — CLOSED. Simulate reconcilePR's internal pollPR merged-branch
+    // side-effect by having reconcilePR flip the DB: subsequent db.getTeam()
+    // returns a team already marked 'done'.
+    mockExecGHAsync.mockResolvedValueOnce(makeGHIssueView({ state: 'CLOSED' }));
+    mockResolveMessage.mockReturnValue('Issue #42 was closed externally.');
+
+    mockGithubPoller.reconcilePR.mockImplementationOnce(async () => {
+      // Pretend the internal pollPR ran its merged-branch block:
+      // - inserted a transition ('PR merged')
+      // - called updateTeamSilent({status:'done'})
+      // - scheduled gracefulShutdown
+      // From the poller's perspective, the next getTeam call must reflect done.
+      mockDb.getTeam.mockReturnValue({ ...team, status: 'done' });
+    });
+
+    await (issueUpdatePoller as unknown as { poll(): Promise<void> }).poll();
+
+    // reconcilePR must have been attempted
+    expect(mockGithubPoller.reconcilePR).toHaveBeenCalledWith(1);
+
+    // Guard must have kicked in: the closure-path fallthrough block is SKIPPED.
+    // - No transition inserted by issue-update-poller (reconcile's internal
+    //   pollPR mock is a no-op DB-wise in this test harness; we only assert
+    //   the poller itself did not insert).
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+
+    // - No updateTeamSilent call from the fallthrough path
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalled();
+
+    // - No SSE broadcast from the fallthrough path
+    expect(mockSseBroker.broadcast).not.toHaveBeenCalled();
+
+    // - No manager.stop — gracefulShutdown is already scheduled by pollPR
+    expect(mockManager.stop).not.toHaveBeenCalled();
+
+    // Reset getTeam default so later tests get undefined
+    mockDb.getTeam.mockReset();
+  });
+
   it('still marks team done when reconcilePR throws', async () => {
     const team = makeTeam({ status: 'running', prNumber: 456 });
     const project = makeProject();


### PR DESCRIPTION
Closes #704

## Summary
When a PR body contains `Closes #N` and merges, GitHub auto-closes the linked issue. The `issue-update-poller` detected the close and marked the team `done` but never reconciled the PR record first, while the `github-poller` skipped the PR because the team was no longer active. Result: `pull_requests` row stayed stale (state='open', merge_status='blocked_unknown', merged_at=null) and the dashboard showed a wrong "mergeable" pill.

## Changes
- **src/server/services/issue-update-poller.ts** — force `githubPoller.reconcilePR(team.id)` before the team transitions to `done`, guarded by `team.prNumber` and wrapped in a try/catch so a gh outage still lets the team transition. Added a re-read guard that skips the secondary `insertTransition` / `updateTeamSilent` / SSE broadcast / `manager.stop` calls when `reconcilePR → pollPR` has already flipped the team to `done` internally (prevents duplicate transitions and grace-timer preemption).
- **src/server/services/github-poller.ts** — persist `mergedAt` in the standard `pollPR` update path (not only the dedicated "mark done" branch).
- **tests/server/issue-update-poller.test.ts** — 4 new tests (reconcile-before-done ordering, no-PR skip, reconcile-throws fallthrough, guard against duplicate transition).
- **tests/server/github-poller.test.ts** — 2 new tests covering `mergedAt` persistence; updated one stale assertion.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run tests/server/issue-update-poller.test.ts tests/server/github-poller.test.ts` — 98/98 pass
- [x] Full server suite — 3 pre-existing unrelated `cc-spawn` env-isolation failures confirmed on `origin/main`