### PR TITLE
Issue #706: add per-project effort level setting (Opus 4.7 adaptive reasoning)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ The SSE broker emits 18 event types:
 | `FLEET_MAX_PR_POLL_CALLS` | `5` | Max gh pr view/checks calls per team per 10-minute window before sending a poll_warning |
 | `FLEET_MERGE_SHUTDOWN_GRACE_MS` | `600000` | Grace period (ms) after PR merge before stopping the team |
 | `FLEET_DEFAULT_MODEL` | `opus` | Default model name shown when neither the team nor the project specifies a model |
+| `FLEET_DEFAULT_EFFORT` | (unset) | Default adaptive-reasoning effort level (`low\|medium\|high\|xhigh\|max`) applied when a project has no `effort` set. Unset = let CC decide. |
 | `FLEET_CC_QUERY_MODEL` | `sonnet` | Claude model for CC query operations (e.g. `sonnet`, `opus`) |
 | `FLEET_CC_QUERY_TIMEOUT_MS` | `30000` | Timeout (ms) for individual CC query calls |
 | `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` | `300000` | Timeout (ms) for AI issue prioritization |

--- a/src/client/components/AddProjectDialog.tsx
+++ b/src/client/components/AddProjectDialog.tsx
@@ -34,6 +34,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
   const [githubRepo, setGithubRepo] = useState('');
   const [maxActiveTeams, setMaxActiveTeams] = useState(5);
   const [model, setModel] = useState('');
+  const [effort, setEffort] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -87,6 +88,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
       setGithubRepo('');
       setMaxActiveTeams(5);
       setModel('');
+      setEffort('');
       setError(null);
       setLoading(false);
       setSuggestions([]);
@@ -282,6 +284,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
         githubRepo: githubRepo.trim() || undefined,
         maxActiveTeams,
         model: model.trim() || undefined,
+        effort: effort || undefined,
         issueProvider,
       };
 
@@ -303,7 +306,7 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
     } finally {
       setLoading(false);
     }
-  }, [name, repoPath, githubRepo, maxActiveTeams, model, issueProvider, jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey, api, onAdded]);
+  }, [name, repoPath, githubRepo, maxActiveTeams, model, effort, issueProvider, jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey, api, onAdded]);
 
   // Keyboard navigation for suggestions + Enter to submit
   const handlePathKeyDown = useCallback(
@@ -659,6 +662,29 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
             />
             <p className="mt-1 text-xs text-dark-muted/60">
               Claude model to use for teams in this project. Empty uses the default model.
+            </p>
+          </div>
+
+          {/* Effort */}
+          <div>
+            <label className="block text-sm text-dark-muted mb-1">
+              Effort Level <span className="text-dark-muted/50">(optional)</span>
+            </label>
+            <select
+              value={effort}
+              onChange={(e) => setEffort(e.target.value)}
+              className="w-full px-3 py-2 text-sm rounded border border-dark-border bg-dark-base text-dark-text focus:outline-none focus:border-dark-accent focus:ring-1 focus:ring-dark-accent/30"
+              disabled={loading}
+            >
+              <option value="">Default (CC decides)</option>
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+              <option value="xhigh">xhigh (Opus 4.7 default)</option>
+              <option value="max">max (Opus 4.7 only)</option>
+            </select>
+            <p className="mt-1 text-xs text-dark-muted/60">
+              Adaptive-reasoning effort level. xhigh/max apply only to Opus 4.7+; other models silently fall back.
             </p>
           </div>
 

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -660,6 +660,7 @@ function ProjectCard({
   onToggleExpand,
   onSaveLimit,
   onSaveModel,
+  onSaveEffort,
   onReinstall,
   onCleanup,
   onDelete,
@@ -675,6 +676,7 @@ function ProjectCard({
   onToggleExpand: () => void;
   onSaveLimit: (projectId: number, value: number) => void;
   onSaveModel: (projectId: number, value: string) => void;
+  onSaveEffort: (projectId: number, value: string) => void;
   onReinstall: (p: ProjectSummary) => void;
   onCleanup: (p: ProjectSummary) => void;
   onDelete: (p: ProjectSummary) => void;
@@ -942,6 +944,25 @@ function ProjectCard({
                   <PencilIcon size={11} className="text-dark-muted/40 group-hover:text-dark-muted transition-colors" />
                 </span>
               )}
+
+              {/* Effort (select) */}
+              <span className="shrink-0 inline-flex items-center gap-1">
+                <span>Effort:</span>
+                <select
+                  value={project.effort ?? ''}
+                  onChange={(e) => onSaveEffort(project.id, e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="shrink-0 px-1 py-0 text-xs rounded border border-dark-border bg-dark-base text-dark-muted hover:text-dark-text focus:outline-none cursor-pointer"
+                  title="Effort level (Opus 4.7 adaptive reasoning)"
+                >
+                  <option value="">default</option>
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                  <option value="xhigh">xhigh</option>
+                  <option value="max">max</option>
+                </select>
+              </span>
 
               {/* Max teams (editable) */}
               {limitEdit.isEditing ? (
@@ -1440,6 +1461,23 @@ export function ProjectsPage() {
     [api, fetchProjects],
   );
 
+  const handleSaveEffort = useCallback(
+    async (projectId: number, value: string) => {
+      const normalized = value || null;
+      // Optimistic update
+      setProjects((prev) =>
+        prev.map((p) => (p.id === projectId ? { ...p, effort: normalized } : p)),
+      );
+      try {
+        await api.put(`projects/${projectId}`, { effort: normalized });
+      } catch {
+        // Revert on failure by refetching
+        await fetchProjects();
+      }
+    },
+    [api, fetchProjects],
+  );
+
   // --- Computed: group projects by groupId ---
   const { groupedSections, ungroupedProjects } = useMemo(() => {
     const ungrouped = projects.filter((p) => p.groupId == null);
@@ -1467,6 +1505,7 @@ export function ProjectsPage() {
     reinstallResult,
     onSaveLimit: handleSaveLimit,
     onSaveModel: handleSaveModel,
+    onSaveEffort: handleSaveEffort,
     onReinstall: handleReinstall,
     onCleanup: handleCleanup,
     onDelete: handleDelete,

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -170,6 +170,7 @@ const config = Object.freeze({
   retryMaxCount: safeParseInt(process.env['FLEET_RETRY_MAX_COUNT'] || '2', 'FLEET_RETRY_MAX_COUNT'),
 
   defaultModel: process.env['FLEET_DEFAULT_MODEL'] || 'opus',
+  defaultEffort: process.env['FLEET_DEFAULT_EFFORT'] || null,
   ccQueryModel: process.env['FLEET_CC_QUERY_MODEL'] || 'sonnet',
   ccQueryTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_TIMEOUT_MS'] || '30000', 'FLEET_CC_QUERY_TIMEOUT_MS'),
   ccQueryPrioritizeTimeoutMs: safeParseInt(process.env['FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'] || '300000', 'FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS'),

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -228,6 +228,7 @@ export interface ProjectInsert {
   maxActiveTeams?: number;
   promptFile?: string | null;
   model?: string | null;
+  effort?: string | null;
   issueProvider?: string | null;
   projectKey?: string | null;
   providerConfig?: string | null;
@@ -242,6 +243,7 @@ export interface ProjectUpdate {
   maxActiveTeams?: number;
   promptFile?: string | null;
   model?: string | null;
+  effort?: string | null;
   issueProvider?: string | null;
   projectKey?: string | null;
   providerConfig?: string | null;
@@ -423,6 +425,9 @@ export class FleetDatabase {
 
     // Add started_at column to teams and recreate v_team_dashboard view (v18 migration)
     this.addStartedAtColumn();
+
+    // Add effort column to projects (v19 migration — adaptive-reasoning effort level)
+    this.addEffortColumn();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1187,6 +1192,33 @@ export class FleetDatabase {
   }
 
   /**
+   * Add effort column to projects table if it doesn't exist (v19 migration).
+   * Nullable TEXT with CHECK constraint restricting values to the 5 CC
+   * adaptive-reasoning effort levels: low, medium, high, xhigh, max.
+   * Fresh databases get the column via schema.sql; upgraded databases use this
+   * migration. Existing rows will have NULL effort which the CHECK allows.
+   */
+  private addEffortColumn(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+      // Fresh DB: projects table doesn't exist yet — schema.sql will create it
+      // with effort already present. Nothing to migrate.
+      if (cols.length === 0) return;
+      const hasColumn = cols.some((c) => c.name === 'effort');
+      if (!hasColumn) {
+        this.db.exec(
+          "ALTER TABLE projects ADD COLUMN effort TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh','max'))"
+        );
+        console.log('[DB] v19 migration: added effort column to projects');
+      }
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (19)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v19 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
    * Migrate branch_behind and branch_behind_resolved message templates
    * from hardcoded 'main' to use {{BASE_BRANCH}} placeholder.
    * Only updates templates that exactly match the old defaults (user edits are preserved).
@@ -1247,8 +1279,8 @@ export class FleetDatabase {
   insertProject(data: ProjectInsert): Project {
     const now = new Date().toISOString();
     const stmt = this.stmt(`
-      INSERT INTO projects (name, repo_path, github_repo, group_id, max_active_teams, prompt_file, model, issue_provider, project_key, provider_config, created_at, updated_at)
-      VALUES (@name, @repoPath, @githubRepo, @groupId, @maxActiveTeams, @promptFile, @model, @issueProvider, @projectKey, @providerConfig, @createdAt, @updatedAt)
+      INSERT INTO projects (name, repo_path, github_repo, group_id, max_active_teams, prompt_file, model, effort, issue_provider, project_key, provider_config, created_at, updated_at)
+      VALUES (@name, @repoPath, @githubRepo, @groupId, @maxActiveTeams, @promptFile, @model, @effort, @issueProvider, @projectKey, @providerConfig, @createdAt, @updatedAt)
     `);
 
     const info = stmt.run({
@@ -1259,6 +1291,7 @@ export class FleetDatabase {
       maxActiveTeams: data.maxActiveTeams ?? 5,
       promptFile: data.promptFile ?? null,
       model: data.model ?? null,
+      effort: data.effort ?? null,
       issueProvider: data.issueProvider ?? 'github',
       projectKey: data.projectKey ?? null,
       providerConfig: data.providerConfig ? encrypt(data.providerConfig) : null,
@@ -1354,6 +1387,10 @@ export class FleetDatabase {
     if (fields.model !== undefined) {
       setClauses.push('model = @model');
       params.model = fields.model;
+    }
+    if (fields.effort !== undefined) {
+      setClauses.push('effort = @effort');
+      params.effort = fields.effort;
     }
     if (fields.issueProvider !== undefined) {
       setClauses.push('issue_provider = @issueProvider');
@@ -2936,6 +2973,7 @@ export class FleetDatabase {
       maxActiveTeams: (row.max_active_teams as number | undefined) ?? 5,
       promptFile: (row.prompt_file as string | null) ?? null,
       model: (row.model as string | null) ?? null,
+      effort: (row.effort as string | null) ?? null,
       issueProvider: (row.issue_provider as string | null) ?? 'github',
       projectKey: (row.project_key as string | null) ?? null,
       providerConfig,

--- a/src/server/mcp/tools/add-project.ts
+++ b/src/server/mcp/tools/add-project.ts
@@ -24,15 +24,17 @@ import { ServiceError } from '../../services/service-error.js';
 export function registerAddProjectTool(server: McpServer): void {
   server.tool(
     'fleet_add_project',
-    'Registers a new git repository as a Fleet Commander project',
+    'Registers a new git repository as a Fleet Commander project, optionally specifying model and adaptive-reasoning effort level',
     {
       repoPath: z.string().describe('Absolute path to the git repository'),
       name: z.string().optional().describe('Project display name (defaults to directory name)'),
       githubRepo: z.string().optional().describe('GitHub repo in owner/name format (auto-detected if omitted)'),
       maxActiveTeams: z.number().optional().describe('Maximum concurrent active teams (default 5)'),
       model: z.string().optional().describe('Claude model to use for this project'),
+      effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional()
+        .describe('Adaptive-reasoning effort level (Opus 4.7+). xhigh/max are Opus-4.7-only.'),
     },
-    async ({ repoPath, name, githubRepo, maxActiveTeams, model }) => {
+    async ({ repoPath, name, githubRepo, maxActiveTeams, model, effort }) => {
       try {
         const service = getProjectService();
         const project = await service.createProject({
@@ -41,6 +43,7 @@ export function registerAddProjectTool(server: McpServer): void {
           githubRepo,
           maxActiveTeams,
           model,
+          effort,
         });
 
         return {

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -27,6 +27,7 @@ interface CreateProjectBody {
   githubRepo?: string;
   maxActiveTeams?: number;
   model?: string;
+  effort?: string | null;
   issueProvider?: string;
   projectKey?: string;
   providerConfig?: string;
@@ -40,6 +41,7 @@ interface UpdateProjectBody {
   hooksInstalled?: boolean;
   maxActiveTeams?: number;
   model?: string | null;
+  effort?: string | null;
   issueProvider?: string | null;
   projectKey?: string | null;
   providerConfig?: string | null;

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS projects (
   max_active_teams INTEGER NOT NULL DEFAULT 5,        -- max concurrent active teams before queueing
   prompt_file     TEXT,                               -- relative path to launch prompt .md file
   model           TEXT,                               -- Claude model override e.g. "opus", "sonnet", "claude-opus-4-6"
+  effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh','max')),  -- CC adaptive-reasoning effort level
   issue_provider  TEXT DEFAULT 'github',              -- issue provider: github | jira | linear
   project_key     TEXT,                               -- provider-specific project key (e.g. Jira project key)
   provider_config TEXT,                               -- JSON blob of provider-specific configuration
@@ -387,4 +388,4 @@ CREATE TABLE IF NOT EXISTS provider_state (
 );
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (18);
+INSERT OR IGNORE INTO schema_version (version) VALUES (19);

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -760,11 +760,12 @@ export class ProjectService {
     githubRepo?: string;
     maxActiveTeams?: number;
     model?: string;
+    effort?: string | null;
     issueProvider?: string;
     projectKey?: string;
     providerConfig?: string;
   }): Promise<unknown> {
-    const { name, repoPath, githubRepo, maxActiveTeams, model, issueProvider, projectKey, providerConfig } = data;
+    const { name, repoPath, githubRepo, maxActiveTeams, model, effort, issueProvider, projectKey, providerConfig } = data;
 
     // Validate name
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -842,6 +843,13 @@ export class ProjectService {
       }
     }
 
+    // Validate effort if provided (empty string coerces to null below)
+    const normalizedEffort = effort?.trim() || null;
+    if (normalizedEffort !== null &&
+        !['low', 'medium', 'high', 'xhigh', 'max'].includes(normalizedEffort)) {
+      throw validationError('Invalid effort. Must be one of: low, medium, high, xhigh, max');
+    }
+
     // Insert the project (no per-project prompt file — always use prompts/default-prompt.md)
     const project = db.insertProject({
       name: name.trim(),
@@ -850,6 +858,7 @@ export class ProjectService {
       maxActiveTeams: maxActiveTeams ?? 5,
       promptFile: null,
       model: model?.trim() || null,
+      effort: normalizedEffort,
       issueProvider: resolvedIssueProvider,
       projectKey: resolvedProjectKey,
       providerConfig: resolvedProviderConfig,
@@ -1189,6 +1198,7 @@ export class ProjectService {
     maxActiveTeams?: number;
     promptFile?: string | null;
     model?: string | null;
+    effort?: string | null;
   }): unknown {
     if (isNaN(projectId) || projectId < 1) {
       throw validationError('Invalid project ID');
@@ -1200,7 +1210,7 @@ export class ProjectService {
       throw notFoundError(`Project ${projectId} not found`);
     }
 
-    const { name, status, githubRepo, groupId, hooksInstalled, maxActiveTeams, promptFile, model } = data;
+    const { name, status, githubRepo, groupId, hooksInstalled, maxActiveTeams, promptFile, model, effort } = data;
 
     // Validate status if provided
     if (status !== undefined) {
@@ -1222,6 +1232,16 @@ export class ProjectService {
       }
     }
 
+    // Validate effort if provided (empty string coerces to null below)
+    let normalizedEffort: string | null | undefined = undefined;
+    if (effort !== undefined) {
+      normalizedEffort = effort?.trim() || null;
+      if (normalizedEffort !== null &&
+          !['low', 'medium', 'high', 'xhigh', 'max'].includes(normalizedEffort)) {
+        throw validationError('Invalid effort. Must be one of: low, medium, high, xhigh, max');
+      }
+    }
+
     const updated = db.updateProject(projectId, {
       name: name?.trim(),
       status,
@@ -1231,6 +1251,7 @@ export class ProjectService {
       maxActiveTeams,
       promptFile,
       model: model !== undefined ? (model?.trim() || null) : undefined,
+      effort: normalizedEffort,
     });
 
     // Broadcast SSE event

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -443,6 +443,7 @@ export class TeamManager {
       worktreeName,
       cwd: project.repoPath,
       model: project.model,
+      effort: project.effort ?? config.defaultEffort,
       resume: false,
       fleetContext: { teamId: worktreeName, projectId, githubRepo: project.githubRepo ?? '' },
     });
@@ -647,6 +648,7 @@ export class TeamManager {
       worktreeName: team.worktreeName,
       cwd: project.repoPath,
       model: project.model,
+      effort: project.effort ?? config.defaultEffort,
       resume: true,
       fleetContext: { teamId: team.worktreeName, projectId: project.id, githubRepo: project.githubRepo ?? '' },
     });
@@ -1413,6 +1415,7 @@ export class TeamManager {
       worktreeName: team.worktreeName,
       cwd: project.repoPath,
       model: project.model,
+      effort: project.effort ?? config.defaultEffort,
       resume: false,
       fleetContext: { teamId: team.worktreeName, projectId, githubRepo: project.githubRepo ?? '' },
     });
@@ -1780,6 +1783,7 @@ export class TeamManager {
       worktreeName: team.worktreeName,
       cwd: worktreeAbsPath,
       model: project.model,
+      effort: project.effort ?? config.defaultEffort,
       prompt,
       windowTitle: `Team ${team.worktreeName}`,
       fleetContext: { teamId: team.worktreeName, projectId: team.projectId!, githubRepo: project.githubRepo ?? '' },

--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -117,6 +117,7 @@ export interface HeadlessArgsOptions {
   worktreeName: string;
   resume?: boolean;
   model?: string | null;
+  effort?: string | null;
 }
 
 /**
@@ -128,6 +129,7 @@ export interface HeadlessArgsOptions {
 export interface InteractiveArgsOptions {
   worktreeName: string;
   model?: string | null;
+  effort?: string | null;
 }
 
 /** Options for building query (-p one-shot) CLI args. */
@@ -163,6 +165,10 @@ export function buildHeadlessArgs(options: HeadlessArgsOptions): string[] {
     args.push('--model', options.model);
   }
 
+  if (options.effort) {
+    args.push('--effort', options.effort);
+  }
+
   args.push(
     '--input-format', 'stream-json',
     '--output-format', 'stream-json',
@@ -194,6 +200,10 @@ export function buildInteractiveArgs(options: InteractiveArgsOptions): string[] 
 
   if (options.model) {
     args.push('--model', options.model);
+  }
+
+  if (options.effort) {
+    args.push('--effort', options.effort);
   }
 
   return args;
@@ -238,6 +248,8 @@ export interface HeadlessSpawnOptions {
   resume?: boolean;
   /** Optional model override from project config. */
   model?: string | null;
+  /** Optional adaptive-reasoning effort level (Opus 4.7+). */
+  effort?: string | null;
 }
 
 /**
@@ -270,12 +282,14 @@ export function spawnHeadless(options: HeadlessSpawnOptions): ChildProcess {
     worktreeName: options.worktreeName,
     resume: options.resume,
     model: options.model,
+    effort: options.effort,
   });
   const env = buildEnv(options.fleetContext);
 
   console.log(
     `[cc-spawn] headless: worktree=${options.worktreeName}` +
     ` resume=${!!options.resume} model=${options.model ?? 'default'}` +
+    ` effort=${options.effort ?? 'default'}` +
     ` cwd=${options.cwd}`,
   );
 
@@ -424,6 +438,8 @@ export interface InteractiveSpawnOptions {
   fleetContext: FleetEnvContext;
   /** Optional model override. */
   model?: string | null;
+  /** Optional adaptive-reasoning effort level (Opus 4.7+). */
+  effort?: string | null;
   /**
    * Initial prompt passed to Claude as the last positional argument.
    *
@@ -463,6 +479,7 @@ export async function spawnInteractive(options: InteractiveSpawnOptions): Promis
   const args = buildInteractiveArgs({
     worktreeName: options.worktreeName,
     model: options.model,
+    effort: options.effort,
   });
   const env = buildEnv(options.fleetContext);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,9 @@ export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'blocked_
 /** Project status */
 export type ProjectStatus = 'active' | 'archived';
 
+/** Claude Code adaptive-reasoning effort level (Opus 4.7+) */
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
 /** Usage zone for queue gating */
 export type UsageZone = 'green' | 'red' | 'hard_red';
 
@@ -55,6 +58,7 @@ export interface Project {
   maxActiveTeams: number;
   promptFile: string | null;
   model?: string | null;
+  effort?: string | null;
   issueProvider: string | null;
   projectKey: string | null;
   providerConfig: string | null;

--- a/tests/server/cc-spawn.test.ts
+++ b/tests/server/cc-spawn.test.ts
@@ -297,6 +297,26 @@ describe('cc-spawn', () => {
       expect(args).not.toContain('--model');
     });
 
+    it('includes --effort when provided', () => {
+      const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'max' });
+
+      expect(args).toContain('--effort');
+      const effortIdx = args.indexOf('--effort');
+      expect(args[effortIdx + 1]).toBe('max');
+    });
+
+    it('excludes --effort when not provided', () => {
+      const args = buildHeadlessArgs({ worktreeName: 'test-wt' });
+
+      expect(args).not.toContain('--effort');
+    });
+
+    it('excludes --effort when effort is null', () => {
+      const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: null });
+
+      expect(args).not.toContain('--effort');
+    });
+
     it('includes --resume when resume is true', () => {
       const args = buildHeadlessArgs({ worktreeName: 'test-wt', resume: true });
 
@@ -368,6 +388,26 @@ describe('cc-spawn', () => {
       const args = buildInteractiveArgs({ worktreeName: 'proj-99', model: null });
 
       expect(args).not.toContain('--model');
+    });
+
+    it('includes --effort when provided', () => {
+      const args = buildInteractiveArgs({ worktreeName: 'proj-99', effort: 'high' });
+
+      expect(args).toContain('--effort');
+      const effortIdx = args.indexOf('--effort');
+      expect(args[effortIdx + 1]).toBe('high');
+    });
+
+    it('excludes --effort when not provided', () => {
+      const args = buildInteractiveArgs({ worktreeName: 'proj-99' });
+
+      expect(args).not.toContain('--effort');
+    });
+
+    it('excludes --effort when effort is null', () => {
+      const args = buildInteractiveArgs({ worktreeName: 'proj-99', effort: null });
+
+      expect(args).not.toContain('--effort');
     });
 
     it('does NOT include stream-json flags (interactive mode)', () => {

--- a/tests/server/routes/projects-routes.test.ts
+++ b/tests/server/routes/projects-routes.test.ts
@@ -289,6 +289,73 @@ describe('PUT /api/projects/:id', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it('should accept a valid effort value', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'high' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().effort).toBe('high');
+
+    // Confirm via GET
+    const getRes = await server.inject({ method: 'GET', url: `/api/projects/${project.id}` });
+    expect(getRes.json().effort).toBe('high');
+  });
+
+  it('should reject invalid effort with 400', async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'extreme' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('should coerce empty-string effort to null', async () => {
+    const project = seedProject();
+    // First set it to something non-null
+    await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'max' },
+    });
+
+    // Now clear with empty string
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: '' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().effort).toBeNull();
+  });
+
+  it('should clear effort when explicitly set to null', async () => {
+    const project = seedProject();
+    await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'low' },
+    });
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().effort).toBeNull();
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #706

## Summary
Adds per-project `effort` setting (Opus 4.7 adaptive-reasoning level) end-to-end, mirroring the existing `model` plumbing 1:1.

- DB: `projects.effort TEXT` column + CHECK constraint (`low|medium|high|xhigh|max` or NULL); `schema_version` bumped to 19 with `addEffortColumn()` migration
- Config: `FLEET_DEFAULT_EFFORT` env var fallback (default `null`)
- Spawn: `--effort <value>` appended in `buildHeadlessArgs`/`buildInteractiveArgs` when truthy; forwarded from all 4 `team-manager` spawn sites
- API: POST/PUT `/api/projects` accept `effort`, validate against enum (400 on invalid), coerce empty string to NULL
- MCP: `fleet_add_project` accepts Zod-enum-validated `effort` parameter
- UI: `AddProjectDialog` + project card Configuration row have dropdowns with 5 options + default

## Test plan
- [x] 6 new `cc-spawn` unit tests (3 per builder: provided / undefined / null)
- [x] 4 new `projects-routes` integration tests (accept valid, reject invalid, coerce empty to NULL, clear with null)
- [x] `npm run build` clean
- [x] `npm test` — all existing tests pass (3 pre-existing env-leak failures unrelated, present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)