### PR TITLE
Issue #710: detect auto-merge availability and inject monitor instruction

### DIFF
--- a/prompts/default-prompt.md
+++ b/prompts/default-prompt.md
@@ -21,3 +21,5 @@ You are the Team Lead (TL). Your job:
 **CRITICAL — never declare a PR merged from memory.** After ANY `git push --force-with-lease` on the PR branch, GitHub drops the pending auto-merge silently. You MUST re-run `gh pr view {PR} --json state,mergeStateStatus,autoMergeRequest` and, if `autoMergeRequest` is `null`, re-arm with `gh pr merge {PR} --auto --squash --delete-branch`. Only mark "Phase 3: Create PR and merge" completed when `state == MERGED` or auto-merge is armed and merge state is not blocked. FC will refuse a `done` transition whose shutdown reason claims merge while the PR is still open.
 
 Issue: #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}
+
+{{AUTO_MERGE_WARNING}}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -120,6 +120,14 @@ const config = Object.freeze({
   usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '900000', 'FLEET_USAGE_POLL_MS'),
   mapCleanupIntervalMs: safeParseInt(process.env['FLEET_MAP_CLEANUP_MS'] || '3600000', 'FLEET_MAP_CLEANUP_MS'),
 
+  /**
+   * TTL for the cached `auto_merge_enabled` value on each project row.
+   * After this many milliseconds, the next launch (and the next github-poller
+   * cycle) will refresh the bit via `gh api repos/{slug}`. Default 24h since
+   * org-level auto-merge settings rarely change. Clamped to [60_000, 30 days].
+   */
+  autoMergeRefreshMs: safeParseInt(process.env['FLEET_AUTO_MERGE_REFRESH_MS'] || '86400000', 'FLEET_AUTO_MERGE_REFRESH_MS'),
+
   idleThresholdMin: safeParseInt(process.env['FLEET_IDLE_THRESHOLD_MIN'] || '5', 'FLEET_IDLE_THRESHOLD_MIN'),
   stuckThresholdMin: safeParseInt(process.env['FLEET_STUCK_THRESHOLD_MIN'] || '10', 'FLEET_STUCK_THRESHOLD_MIN'),
   launchTimeoutMin: safeParseInt(process.env['FLEET_LAUNCH_TIMEOUT_MIN'] || '5', 'FLEET_LAUNCH_TIMEOUT_MIN'),
@@ -232,6 +240,21 @@ export function validateConfig(): void {
     if (isNaN(value) || value <= 0) {
       throw new Error(`${name} must be a positive integer, got: ${value}`);
     }
+  }
+
+  // FLEET_AUTO_MERGE_REFRESH_MS is clamped to [60s, 30 days] to prevent
+  // pathological configurations (e.g. refresh every millisecond burns gh quota,
+  // or never-refresh leaves stale values forever).
+  const minAutoMergeMs = 60_000;
+  const maxAutoMergeMs = 30 * 24 * 60 * 60 * 1000; // 30 days
+  if (
+    isNaN(config.autoMergeRefreshMs) ||
+    config.autoMergeRefreshMs < minAutoMergeMs ||
+    config.autoMergeRefreshMs > maxAutoMergeMs
+  ) {
+    throw new Error(
+      `autoMergeRefreshMs must be between ${minAutoMergeMs} and ${maxAutoMergeMs}, got: ${config.autoMergeRefreshMs}`
+    );
   }
 
   const nonNegativeIntegers: Array<[string, number]> = [

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -124,7 +124,8 @@ const config = Object.freeze({
    * TTL for the cached `auto_merge_enabled` value on each project row.
    * After this many milliseconds, the next launch (and the next github-poller
    * cycle) will refresh the bit via `gh api repos/{slug}`. Default 24h since
-   * org-level auto-merge settings rarely change. Clamped to [60_000, 30 days].
+   * org-level auto-merge settings rarely change. Validated against
+   * [60_000, 30 days]; out-of-range values throw at startup.
    */
   autoMergeRefreshMs: safeParseInt(process.env['FLEET_AUTO_MERGE_REFRESH_MS'] || '86400000', 'FLEET_AUTO_MERGE_REFRESH_MS'),
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -247,6 +247,8 @@ export interface ProjectUpdate {
   issueProvider?: string | null;
   projectKey?: string | null;
   providerConfig?: string | null;
+  autoMergeEnabled?: boolean | null;
+  autoMergeCheckedAt?: string | null;
 }
 
 export interface ProjectGroupInsert {
@@ -428,6 +430,9 @@ export class FleetDatabase {
 
     // Add effort column to projects (v19 migration — adaptive-reasoning effort level)
     this.addEffortColumn();
+
+    // Add auto_merge_enabled / auto_merge_checked_at columns to projects (v20 migration)
+    this.addAutoMergeColumns();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1219,6 +1224,44 @@ export class FleetDatabase {
   }
 
   /**
+   * Add auto_merge_enabled and auto_merge_checked_at columns to projects table
+   * if they don't exist (v20 migration). These columns cache whether the
+   * project's GitHub repo allows auto-merge so the team-launch path can
+   * conditionally inject a warning paragraph into the launch prompt for repos
+   * where `gh pr merge --auto` does not work.
+   *
+   * - auto_merge_enabled  INTEGER (nullable): 0|1|NULL. NULL = unknown / not
+   *   yet detected, or non-GitHub project.
+   * - auto_merge_checked_at TEXT (nullable): ISO timestamp of last check,
+   *   used to throttle refreshes (default 24h TTL via FLEET_AUTO_MERGE_REFRESH_MS).
+   *
+   * Fresh databases get the columns via schema.sql; upgraded databases use
+   * this migration. Idempotent across restarts.
+   */
+  private addAutoMergeColumns(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+      // Fresh DB: projects table doesn't exist yet — schema.sql will create it
+      // with both columns already present. Nothing to migrate.
+      if (cols.length === 0) return;
+      const hasEnabled = cols.some((c) => c.name === 'auto_merge_enabled');
+      const hasCheckedAt = cols.some((c) => c.name === 'auto_merge_checked_at');
+      if (!hasEnabled) {
+        this.db.exec('ALTER TABLE projects ADD COLUMN auto_merge_enabled INTEGER');
+        console.log('[DB] v20 migration: added auto_merge_enabled column to projects');
+      }
+      if (!hasCheckedAt) {
+        this.db.exec('ALTER TABLE projects ADD COLUMN auto_merge_checked_at TEXT');
+        console.log('[DB] v20 migration: added auto_merge_checked_at column to projects');
+      }
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (20)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v20 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
    * Migrate branch_behind and branch_behind_resolved message templates
    * from hardcoded 'main' to use {{BASE_BRANCH}} placeholder.
    * Only updates templates that exactly match the old defaults (user edits are preserved).
@@ -1403,6 +1446,15 @@ export class FleetDatabase {
     if (fields.providerConfig !== undefined) {
       setClauses.push('provider_config = @providerConfig');
       params.providerConfig = fields.providerConfig ? encrypt(fields.providerConfig) : fields.providerConfig;
+    }
+    if (fields.autoMergeEnabled !== undefined) {
+      setClauses.push('auto_merge_enabled = @autoMergeEnabled');
+      params.autoMergeEnabled =
+        fields.autoMergeEnabled === null ? null : (fields.autoMergeEnabled ? 1 : 0);
+    }
+    if (fields.autoMergeCheckedAt !== undefined) {
+      setClauses.push('auto_merge_checked_at = @autoMergeCheckedAt');
+      params.autoMergeCheckedAt = fields.autoMergeCheckedAt;
     }
 
     if (setClauses.length === 0) return this.getProject(id);
@@ -2962,6 +3014,12 @@ export class FleetDatabase {
       }
     }
 
+    const rawAutoMerge = row.auto_merge_enabled;
+    const autoMergeEnabled =
+      rawAutoMerge === null || rawAutoMerge === undefined
+        ? null
+        : (rawAutoMerge as number) === 1;
+
     return {
       id: row.id as number,
       name: row.name as string,
@@ -2977,6 +3035,8 @@ export class FleetDatabase {
       issueProvider: (row.issue_provider as string | null) ?? 'github',
       projectKey: (row.project_key as string | null) ?? null,
       providerConfig,
+      autoMergeEnabled,
+      autoMergeCheckedAt: (row.auto_merge_checked_at as string | null) ?? null,
       createdAt: utcify(row.created_at as string),
       updatedAt: utcify(row.updated_at as string),
     };

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -37,6 +37,8 @@ CREATE TABLE IF NOT EXISTS projects (
   issue_provider  TEXT DEFAULT 'github',              -- issue provider: github | jira | linear
   project_key     TEXT,                               -- provider-specific project key (e.g. Jira project key)
   provider_config TEXT,                               -- JSON blob of provider-specific configuration
+  auto_merge_enabled INTEGER,                         -- 0|1|NULL (NULL = unknown / not yet detected; non-GitHub projects stay NULL)
+  auto_merge_checked_at TEXT,                         -- ISO timestamp of last gh check, or NULL
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -388,4 +390,4 @@ CREATE TABLE IF NOT EXISTS provider_state (
 );
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (19);
+INSERT OR IGNORE INTO schema_version (version) VALUES (20);

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -183,6 +183,31 @@ class GitHubPoller {
         }
       }
 
+      // Refresh auto_merge_enabled for projects whose check is stale.
+      // The cached bit feeds the team-launch path (issue #710) so the
+      // "no-auto-merge" warning paragraph can be injected into the prompt
+      // without a hot `gh` call on every launch.
+      // Lazy import to avoid a circular dependency through services.
+      for (const project of projects) {
+        const checkedAtMs = project.autoMergeCheckedAt
+          ? new Date(project.autoMergeCheckedAt).getTime()
+          : 0;
+        if (
+          isNaN(checkedAtMs) ||
+          Date.now() - checkedAtMs > config.autoMergeRefreshMs
+        ) {
+          try {
+            const { refreshAutoMergeForProject } = await import('./project-service.js');
+            await refreshAutoMergeForProject(project.id, { skipIfFresh: false });
+          } catch (err) {
+            console.warn(
+              `[GitHubPoller] auto-merge refresh failed for project ${project.id}:`,
+              err instanceof Error ? err.message : err,
+            );
+          }
+        }
+      }
+
       const teams = db.getActiveTeams();
       let wantFast = false;
 

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -243,6 +243,13 @@ export async function refreshAutoMergeForProject(
 
   if (!settings) {
     // gh failed / unreachable — throttle retries by bumping checkedAt only.
+    // Log at warn level so operators can see repeated failures without the
+    // `gh` CLI's bare error log (which has no project context).
+    console.warn(
+      `[ProjectService] Auto-merge gh check failed for project ${projectId} ` +
+      `(${project.githubRepo}); leaving autoMergeEnabled unchanged ` +
+      `(${previousEnabled === null ? 'null' : previousEnabled})`,
+    );
     db.updateProject(projectId, { autoMergeCheckedAt: now });
     return previousEnabled;
   }

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -173,6 +173,99 @@ export async function checkRepoSettings(githubRepo: string | null | undefined): 
 }
 
 /**
+ * Refresh the cached `auto_merge_enabled` value on a project row.
+ *
+ * Uses the existing `checkRepoSettings()` infrastructure but persists the
+ * boolean directly on the projects row (auto_merge_enabled / auto_merge_checked_at)
+ * so the team-launch path can synchronously decide whether to inject the
+ * "no-auto-merge" warning into the prompt without a hot `gh` call on every
+ * launch.
+ *
+ * Behavior summary:
+ * - Non-GitHub project (issueProvider !== 'github' or no githubRepo): writes
+ *   autoMergeEnabled = null and bumps autoMergeCheckedAt so we don't keep
+ *   retrying on every launch. Returns null.
+ * - skipIfFresh: true and autoMergeCheckedAt within `config.autoMergeRefreshMs`:
+ *   returns the cached value without a `gh` call.
+ * - Otherwise calls checkRepoSettings(). On success, persists the bit and
+ *   bumps autoMergeCheckedAt. On failure (returns undefined), only updates
+ *   autoMergeCheckedAt (so we throttle retries) but leaves autoMergeEnabled
+ *   unchanged.
+ * - Broadcasts `project_updated` SSE only when the autoMergeEnabled value
+ *   actually changes (to avoid grid spam on every refresh).
+ *
+ * @param projectId - The project ID to refresh
+ * @param options.skipIfFresh - When true, skip the gh call if last check is
+ *   within `config.autoMergeRefreshMs`. Default false.
+ * @returns The up-to-date autoMergeEnabled value (boolean | null), or null
+ *   if the project does not exist.
+ */
+export async function refreshAutoMergeForProject(
+  projectId: number,
+  options?: { skipIfFresh?: boolean },
+): Promise<boolean | null> {
+  const db = getDatabase();
+  const project = db.getProject(projectId);
+  if (!project) return null;
+
+  const previousEnabled = project.autoMergeEnabled;
+  const now = new Date().toISOString();
+
+  // Non-GitHub or no githubRepo: write null and stop retrying.
+  // We bump autoMergeCheckedAt so the poller's stale-check skips this project
+  // until the TTL elapses, but we keep autoMergeEnabled = null.
+  if (project.issueProvider !== 'github' || !project.githubRepo) {
+    db.updateProject(projectId, {
+      autoMergeEnabled: null,
+      autoMergeCheckedAt: now,
+    });
+    if (previousEnabled !== null) {
+      // Value changed (was non-null, now null) — broadcast.
+      sseBroker.broadcast('project_updated', {
+        project_id: projectId,
+        name: project.name,
+        status: project.status,
+      });
+    }
+    return null;
+  }
+
+  // skipIfFresh: short-circuit when the cache is still warm.
+  if (options?.skipIfFresh && project.autoMergeCheckedAt) {
+    const checkedAtMs = new Date(project.autoMergeCheckedAt).getTime();
+    if (!isNaN(checkedAtMs) && Date.now() - checkedAtMs < config.autoMergeRefreshMs) {
+      return previousEnabled;
+    }
+  }
+
+  // Fetch via existing infrastructure.
+  const settings = await checkRepoSettings(project.githubRepo);
+
+  if (!settings) {
+    // gh failed / unreachable — throttle retries by bumping checkedAt only.
+    db.updateProject(projectId, { autoMergeCheckedAt: now });
+    return previousEnabled;
+  }
+
+  const newEnabled = settings.autoMergeEnabled;
+  db.updateProject(projectId, {
+    autoMergeEnabled: newEnabled,
+    autoMergeCheckedAt: now,
+  });
+
+  // Broadcast only when the bit actually flipped.
+  if (previousEnabled !== newEnabled) {
+    sseBroker.broadcast('project_updated', {
+      project_id: projectId,
+      name: project.name,
+      status: project.status,
+    });
+  }
+
+  return newEnabled;
+}
+
+/**
  * Extract Fleet Commander version stamp from the first few lines of a file.
  * Supports shell scripts (`# fleet-commander vX.Y.Z`), markdown
  * files (`<!-- fleet-commander vX.Y.Z -->`), and YAML frontmatter
@@ -899,6 +992,18 @@ export class ProjectService {
 
     // Re-fetch to get updated hooks_installed
     const finalProject = db.getProject(project.id)!;
+
+    // Detect auto-merge availability so day-one launches can inject the
+    // "no-auto-merge" warning into the prompt when applicable. Non-fatal —
+    // installation must succeed even if `gh api` is offline.
+    try {
+      await refreshAutoMergeForProject(finalProject.id);
+    } catch (err) {
+      console.warn(
+        `[ProjectService] Auto-merge detection failed for project ${finalProject.id} (non-fatal):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
 
     // Ensure the issue fetcher's polling loop is running
     const issueFetcher = getIssueFetcher();

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -142,6 +142,31 @@ interface TokenCounter {
 }
 
 export class TeamManager {
+  /**
+   * Warning paragraph injected into the launch prompt for projects whose
+   * GitHub repo does not allow auto-merge. Issue #710.
+   *
+   * The Monitor tool (per CC runtime semantics) streams stdout events from a
+   * background bash process started with `Bash run_in_background: true`. We
+   * pair it with `gh pr checks {PR} --watch` so the TL can react to CI
+   * completion without polling. ScheduleWakeup is the documented fallback if
+   * Monitor is unavailable.
+   */
+  private static readonly AUTO_MERGE_WARNING_TEXT = `**Repo does not allow auto-merge.** When you reach Phase 4 and have created the PR, you cannot rely on \`gh pr merge --auto\`. Instead:
+
+1. After \`gh pr create\`, do NOT call \`gh pr merge --auto\`.
+2. Run CI watch as a background process and stream its events with the Monitor tool:
+   \`\`\`
+   Bash(command: "gh pr checks {PR} --watch", run_in_background: true)
+   Monitor(...background bash id...)
+   \`\`\`
+   Each Monitor notification reports a check status update. When all required checks complete:
+   - **All green** -> run \`gh pr merge {PR} --squash --delete-branch\` (no \`--auto\`), then close the issue and shut down.
+   - **Any failing** -> forward failure details to dev, dev fixes and pushes, restart the watch.
+3. If a \`git push --force-with-lease\` happens (rebase), the watch process exits — restart it.
+4. FC will still send \`ci_red\` / \`ci_blocked\` / \`pr_merged\` to your stdin, but \`ci_green_auto_shutdown\` will NOT fire on this repo (auto-merge is disabled). You must perform the merge manually after CI is green.
+5. If \`Monitor\` is unavailable or \`gh pr checks --watch\` fails, fall back to \`ScheduleWakeup(delaySeconds: 270, ...)\` and poll \`gh pr view {PR} --json state,statusCheckRollup\` on each wake.`;
+
   private outputBuffers: Map<number, CircularBuffer<string>> = new Map();
   private childProcesses: Map<number, ChildProcess> = new Map();
   private stdinPipes: Map<number, Writable> = new Map();
@@ -428,7 +453,8 @@ export class TeamManager {
     });
 
     // ── Step 4: Spawn Claude Code process ──
-    const resolvedPrompt = prompt || this.resolvePromptFromFile(project, effectiveIssueKey, issueTitle);
+    const autoMergeWarning = await this.buildAutoMergeWarning(project);
+    const resolvedPrompt = prompt || this.resolvePromptFromFile(project, effectiveIssueKey, issueTitle, autoMergeWarning);
     const isHeadless = headless !== false;
 
     if (!isHeadless && process.platform === 'win32') {
@@ -1400,7 +1426,8 @@ export class TeamManager {
     });
 
     // ── Step 3: Spawn Claude Code ──
-    const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, effectiveIssueKey, team.issueTitle ?? undefined);
+    const autoMergeWarning = await this.buildAutoMergeWarning(project);
+    const resolvedPrompt = team.customPrompt || this.resolvePromptFromFile(project, effectiveIssueKey, team.issueTitle ?? undefined, autoMergeWarning);
     const isHeadless = team.headless;
 
     if (!isHeadless && process.platform === 'win32') {
@@ -1697,15 +1724,56 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // buildAutoMergeWarning — return the no-auto-merge warning paragraph
+  //                        when the project's repo has it disabled
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve the auto-merge warning paragraph for the launch prompt.
+   *
+   * Returns the long warning text only when the project's
+   * `auto_merge_enabled` is exactly `false`. For `null` (unknown / non-GitHub)
+   * or `true`, returns empty string — we deliberately under-warn rather than
+   * over-warn for transiently-unreachable repos.
+   *
+   * Lazy import of `refreshAutoMergeForProject` avoids a circular dependency
+   * (project-service imports team-manager via getTeamManager()).
+   *
+   * Defensive: any thrown error returns '' so a flaky `gh` never breaks a
+   * launch.
+   */
+  private async buildAutoMergeWarning(project: Project): Promise<string> {
+    try {
+      const { refreshAutoMergeForProject } = await import('./project-service.js');
+      const enabled = await refreshAutoMergeForProject(project.id, { skipIfFresh: true });
+      return enabled === false ? TeamManager.AUTO_MERGE_WARNING_TEXT : '';
+    } catch (err) {
+      console.warn(
+        `[TeamManager] buildAutoMergeWarning failed for project ${project.id} (non-fatal):`,
+        err instanceof Error ? err.message : err,
+      );
+      return '';
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // resolvePromptFromFile — read prompt from project's prompt file on disk
   // -------------------------------------------------------------------------
 
   /**
-   * Read prompts/default-prompt.md and replace {{ISSUE_NUMBER}} / {{ISSUE_KEY}} / {{ISSUE_TITLE}} placeholders.
+   * Read prompts/default-prompt.md and replace {{ISSUE_NUMBER}} / {{ISSUE_KEY}} /
+   * {{ISSUE_TITLE}} / {{AUTO_MERGE_WARNING}} placeholders.
    * Accepts issueKey (string) which replaces the placeholder even for non-numeric keys.
+   * `autoMergeWarning` is the substituted warning paragraph (or empty string when
+   * the project's repo allows auto-merge / detection is unknown).
    * Fallback chain: prompts/default-prompt.md > hardcoded default.
    */
-  private resolvePromptFromFile(_project: Project, issueKey: string, issueTitle?: string): string {
+  private resolvePromptFromFile(
+    _project: Project,
+    issueKey: string,
+    issueTitle?: string,
+    autoMergeWarning: string = '',
+  ): string {
     // Always read the shared default-prompt.md
     const defaultPath = path.join(config.fleetCommanderRoot, 'prompts', 'default-prompt.md');
     if (fs.existsSync(defaultPath)) {
@@ -1714,7 +1782,8 @@ export class TeamManager {
         const resolved = template
           .replace(/\{\{ISSUE_NUMBER\}\}/g, issueKey)
           .replace(/\{\{ISSUE_KEY\}\}/g, issueKey)
-          .replace(/\{\{ISSUE_TITLE\}\}/g, issueTitle ?? '');
+          .replace(/\{\{ISSUE_TITLE\}\}/g, issueTitle ?? '')
+          .replace(/\{\{AUTO_MERGE_WARNING\}\}/g, autoMergeWarning);
         console.log(`[TeamManager] Resolved prompt from default: prompts/default-prompt.md`);
         return resolved;
       } catch {
@@ -1723,7 +1792,8 @@ export class TeamManager {
     }
 
     // Hardcoded fallback (should not normally be reached)
-    const fallback = `Read the ENTIRE file .claude/prompts/fleet-workflow.md before taking any actions.\nYou are the TL. There is NO coordinator — you orchestrate the Diamond team directly.\nPhase 0: Spawn fleet-planner. Wait for plan. Phase 1: Spawn fleet-dev WITH the planner's plan. Wait for ready. Phase 2: Spawn fleet-reviewer. Dev and reviewer communicate p2p. Planner stays alive for p2p questions.\nIssue: #${issueKey}`;
+    const baseFallback = `Read the ENTIRE file .claude/prompts/fleet-workflow.md before taking any actions.\nYou are the TL. There is NO coordinator — you orchestrate the Diamond team directly.\nPhase 0: Spawn fleet-planner. Wait for plan. Phase 1: Spawn fleet-dev WITH the planner's plan. Wait for ready. Phase 2: Spawn fleet-reviewer. Dev and reviewer communicate p2p. Planner stays alive for p2p questions.\nIssue: #${issueKey}`;
+    const fallback = autoMergeWarning ? `${baseFallback}\n\n${autoMergeWarning}` : baseFallback;
     console.log(`[TeamManager] Using hardcoded fallback prompt`);
     return fallback;
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -62,6 +62,16 @@ export interface Project {
   issueProvider: string | null;
   projectKey: string | null;
   providerConfig: string | null;
+  /**
+   * Cached value of the GitHub repo's `allow_auto_merge` setting.
+   * `null` = unknown / not yet detected (or non-GitHub project).
+   * `false` = repo does NOT allow auto-merge — team-launch path injects a
+   * warning paragraph into the prompt instructing the TL to merge manually.
+   * `true` = repo allows auto-merge (existing happy path applies).
+   */
+  autoMergeEnabled: boolean | null;
+  /** ISO timestamp of last `gh api` check used to throttle refreshes. */
+  autoMergeCheckedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -1618,6 +1618,97 @@ describe('Issue Provider Migration', () => {
   });
 });
 
+// =============================================================================
+// Auto-merge cache columns (issue #710)
+// =============================================================================
+
+describe('Auto-merge cache columns', () => {
+  it('reads autoMergeEnabled and autoMergeCheckedAt as null on a fresh project', () => {
+    const project = db.insertProject({
+      name: 'auto-merge-fresh',
+      repoPath: '/tmp/auto-merge-fresh',
+      githubRepo: 'owner/repo',
+    });
+
+    expect(project.autoMergeEnabled).toBeNull();
+    expect(project.autoMergeCheckedAt).toBeNull();
+
+    const reloaded = db.getProject(project.id);
+    expect(reloaded?.autoMergeEnabled).toBeNull();
+    expect(reloaded?.autoMergeCheckedAt).toBeNull();
+  });
+
+  it('persists autoMergeEnabled = false through updateProject and getProject', () => {
+    const project = db.insertProject({
+      name: 'auto-merge-false',
+      repoPath: '/tmp/auto-merge-false',
+      githubRepo: 'owner/repo',
+    });
+
+    const checkedAt = new Date().toISOString();
+    const updated = db.updateProject(project.id, {
+      autoMergeEnabled: false,
+      autoMergeCheckedAt: checkedAt,
+    });
+
+    expect(updated?.autoMergeEnabled).toBe(false);
+    expect(updated?.autoMergeCheckedAt).toBe(checkedAt);
+
+    // Re-fetch confirms the value round-trips through SQLite
+    const reloaded = db.getProject(project.id);
+    expect(reloaded?.autoMergeEnabled).toBe(false);
+  });
+
+  it('persists autoMergeEnabled = true through updateProject and getProject', () => {
+    const project = db.insertProject({
+      name: 'auto-merge-true',
+      repoPath: '/tmp/auto-merge-true',
+      githubRepo: 'owner/repo',
+    });
+
+    const updated = db.updateProject(project.id, {
+      autoMergeEnabled: true,
+      autoMergeCheckedAt: new Date().toISOString(),
+    });
+
+    expect(updated?.autoMergeEnabled).toBe(true);
+
+    const reloaded = db.getProject(project.id);
+    expect(reloaded?.autoMergeEnabled).toBe(true);
+  });
+
+  it('clears autoMergeEnabled back to null via updateProject', () => {
+    const project = db.insertProject({
+      name: 'auto-merge-clear',
+      repoPath: '/tmp/auto-merge-clear',
+      githubRepo: 'owner/repo',
+    });
+
+    db.updateProject(project.id, { autoMergeEnabled: true });
+    expect(db.getProject(project.id)?.autoMergeEnabled).toBe(true);
+
+    db.updateProject(project.id, { autoMergeEnabled: null });
+    expect(db.getProject(project.id)?.autoMergeEnabled).toBeNull();
+  });
+
+  it('includes auto_merge_enabled and auto_merge_checked_at columns', () => {
+    const cols = db.raw
+      .prepare('PRAGMA table_info(projects)')
+      .all() as Array<{ name: string }>;
+
+    const colNames = cols.map((c) => c.name);
+    expect(colNames).toContain('auto_merge_enabled');
+    expect(colNames).toContain('auto_merge_checked_at');
+  });
+
+  it('includes schema version 20 for the auto-merge migration', () => {
+    const row = db.raw
+      .prepare('SELECT MAX(version) AS version FROM schema_version')
+      .get() as { version: number };
+    expect(row.version).toBeGreaterThanOrEqual(20);
+  });
+});
+
 describe('Connection management', () => {
   it('closes the database', () => {
     db.close();

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../src/server/config.js', () => ({
     maxUniqueCiFailures: 3,
     mergeShutdownGraceMs: 120000,
     worktreeDir: '.claude/worktrees',
+    autoMergeRefreshMs: 86_400_000, // 24h, matches the production default
   },
 }));
 
@@ -70,6 +71,15 @@ const mockFetcher = {
 };
 vi.mock('../../src/server/services/issue-fetcher.js', () => ({
   getIssueFetcher: () => mockFetcher,
+}));
+
+// project-service is dynamically imported by the poller's stale-refresh loop
+// (issue #710). We mock the lazy import target so we can assert which
+// projects triggered a refresh in a poll cycle.
+const mockRefreshAutoMergeForProject = vi.fn().mockResolvedValue(null);
+vi.mock('../../src/server/services/project-service.js', () => ({
+  refreshAutoMergeForProject: mockRefreshAutoMergeForProject,
+  checkRepoSettings: vi.fn(),
 }));
 
 // Mock the shared async exec utilities (replaces the old child_process mock)
@@ -2434,5 +2444,80 @@ describe('Fix #692 (A) — branch collision audit warning', () => {
       (call) => call[0] === 'team_warning',
     );
     expect(collisionCall).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Issue #710 — auto-merge stale-refresh in the poller cycle
+// =============================================================================
+
+describe('Issue #710 — auto-merge stale-refresh', () => {
+  it('refreshes a stale project (autoMergeCheckedAt older than TTL) and skips a fresh one', async () => {
+    const stale = makeProject({
+      id: 100,
+      name: 'stale-project',
+      // 48h ago — older than the 24h TTL in the config mock
+      autoMergeCheckedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+      autoMergeEnabled: false,
+    });
+    const fresh = makeProject({
+      id: 101,
+      name: 'fresh-project',
+      githubRepo: 'owner/fresh-repo',
+      // 1h ago — well within the 24h TTL
+      autoMergeCheckedAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+      autoMergeEnabled: true,
+    });
+
+    mockDb.getProjects.mockReturnValue([stale, fresh]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    await githubPoller.poll();
+
+    // Stale project must trigger refresh; fresh project must NOT.
+    expect(mockRefreshAutoMergeForProject).toHaveBeenCalledTimes(1);
+    expect(mockRefreshAutoMergeForProject).toHaveBeenCalledWith(
+      stale.id,
+      expect.objectContaining({ skipIfFresh: false }),
+    );
+    // Confirm the fresh project was NOT refreshed
+    const calledIds = mockRefreshAutoMergeForProject.mock.calls.map((c) => c[0]);
+    expect(calledIds).not.toContain(fresh.id);
+  });
+
+  it('refreshes a project that has never been checked (autoMergeCheckedAt = null)', async () => {
+    const neverChecked = makeProject({
+      id: 200,
+      name: 'never-checked',
+      autoMergeCheckedAt: null,
+      autoMergeEnabled: null,
+    });
+
+    mockDb.getProjects.mockReturnValue([neverChecked]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    await githubPoller.poll();
+
+    expect(mockRefreshAutoMergeForProject).toHaveBeenCalledWith(
+      neverChecked.id,
+      expect.objectContaining({ skipIfFresh: false }),
+    );
+  });
+
+  it('handles a thrown refresh error without aborting the poll cycle', async () => {
+    const stale = makeProject({
+      id: 300,
+      name: 'stale-throws',
+      autoMergeCheckedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+    });
+
+    mockDb.getProjects.mockReturnValue([stale]);
+    mockDb.getActiveTeams.mockReturnValue([]);
+
+    mockRefreshAutoMergeForProject.mockRejectedValueOnce(new Error('boom'));
+
+    // Should NOT throw — the poll cycle keeps going
+    await expect(githubPoller.poll()).resolves.toBeUndefined();
+    expect(mockRefreshAutoMergeForProject).toHaveBeenCalled();
   });
 });

--- a/tests/server/services/auto-merge-detection.test.ts
+++ b/tests/server/services/auto-merge-detection.test.ts
@@ -1,0 +1,283 @@
+// =============================================================================
+// Fleet Commander -- Auto-merge detection tests (issue #710)
+// =============================================================================
+// Tests refreshAutoMergeForProject() — the function that fetches the GitHub
+// repo's `allow_auto_merge` setting via `gh api`, persists the boolean on the
+// projects row, and broadcasts SSE only when the value actually changes.
+//
+// We mock execGHAsync at the exec-gh module boundary so the cross-module call
+// from refreshAutoMergeForProject -> checkRepoSettings -> execGHAsync can be
+// intercepted (vi.spyOn does not work across ESM module bindings).
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared BEFORE importing project-service
+// ---------------------------------------------------------------------------
+
+const mockExecGHAsync = vi.hoisted(() => vi.fn());
+const mockExecGitAsync = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/server/utils/exec-gh.js', () => ({
+  execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
+  execGitAsync: (...args: unknown[]) => mockExecGitAsync(...args),
+  execGHResult: vi.fn(),
+  isValidGithubRepo: (repo: string) =>
+    /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(repo),
+  isValidBranchName: (branch: string) => /^[a-zA-Z0-9._/\-]+$/.test(branch),
+}));
+
+const mockBroadcast = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/server/services/sse-broker.js', () => ({
+  sseBroker: {
+    broadcast: mockBroadcast,
+    stop: vi.fn(),
+  },
+}));
+
+// Import AFTER mocks
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { refreshAutoMergeForProject } from '../../../src/server/services/project-service.js';
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+
+// ---------------------------------------------------------------------------
+// DB lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-auto-merge-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+});
+
+afterAll(() => {
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: gh returns { allow_auto_merge: false } for repos query and null
+  // for branch protection (404 = not configured). Individual tests override.
+  mockExecGHAsync.mockImplementation(async (cmd: string) => {
+    if (cmd.includes('/branches/')) return null;
+    if (cmd.includes('/repos/') || cmd.includes('repos/')) {
+      return JSON.stringify({ allow_auto_merge: false, default_branch: 'main' });
+    }
+    return null;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let nameCounter = 0;
+function unique(prefix: string): string {
+  nameCounter++;
+  return `${prefix}-${Date.now()}-${nameCounter}-${Math.random().toString(36).slice(2)}`;
+}
+
+function seedGithubProject(githubRepo: string | null = 'owner/repo') {
+  const db = getDatabase();
+  return db.insertProject({
+    name: unique('auto-merge-proj'),
+    repoPath: `/tmp/${unique('auto-merge-repo')}`,
+    githubRepo,
+    issueProvider: 'github',
+  });
+}
+
+function seedJiraProject() {
+  const db = getDatabase();
+  return db.insertProject({
+    name: unique('auto-merge-jira-proj'),
+    repoPath: `/tmp/${unique('auto-merge-jira-repo')}`,
+    githubRepo: null,
+    issueProvider: 'jira',
+    projectKey: 'PROJ',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('refreshAutoMergeForProject', () => {
+  it('returns null and writes checkedAt for a project with no githubRepo', async () => {
+    const project = seedGithubProject(null);
+
+    const result = await refreshAutoMergeForProject(project.id);
+
+    expect(result).toBeNull();
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+
+    // Verify checkedAt was bumped
+    const reloaded = getDatabase().getProject(project.id)!;
+    expect(reloaded.autoMergeEnabled).toBeNull();
+    expect(reloaded.autoMergeCheckedAt).not.toBeNull();
+  });
+
+  it('returns null and writes checkedAt for a non-GitHub (jira) project', async () => {
+    const project = seedJiraProject();
+
+    const result = await refreshAutoMergeForProject(project.id);
+
+    expect(result).toBeNull();
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+
+    const reloaded = getDatabase().getProject(project.id)!;
+    expect(reloaded.autoMergeEnabled).toBeNull();
+    expect(reloaded.autoMergeCheckedAt).not.toBeNull();
+  });
+
+  it('does NOT call gh when skipIfFresh is true and check is recent', async () => {
+    const project = seedGithubProject('owner/repo');
+
+    // Pre-populate a recent autoMergeCheckedAt and autoMergeEnabled
+    getDatabase().updateProject(project.id, {
+      autoMergeEnabled: true,
+      autoMergeCheckedAt: new Date().toISOString(),
+    });
+
+    const result = await refreshAutoMergeForProject(project.id, {
+      skipIfFresh: true,
+    });
+
+    expect(result).toBe(true); // returns cached
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+  });
+
+  it('DOES call gh when skipIfFresh is false even with a recent check', async () => {
+    const project = seedGithubProject('owner/repo');
+
+    getDatabase().updateProject(project.id, {
+      autoMergeEnabled: true,
+      autoMergeCheckedAt: new Date().toISOString(),
+    });
+
+    // Override default mock to return false this time
+    mockExecGHAsync.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('/branches/')) return null;
+      return JSON.stringify({ allow_auto_merge: false, default_branch: 'main' });
+    });
+
+    const result = await refreshAutoMergeForProject(project.id, {
+      skipIfFresh: false,
+    });
+
+    expect(result).toBe(false);
+    expect(mockExecGHAsync).toHaveBeenCalled();
+
+    const reloaded = getDatabase().getProject(project.id)!;
+    expect(reloaded.autoMergeEnabled).toBe(false);
+  });
+
+  it('persists the value returned by gh on success (true)', async () => {
+    const project = seedGithubProject('owner/repo');
+
+    mockExecGHAsync.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('/branches/')) return null;
+      return JSON.stringify({ allow_auto_merge: true, default_branch: 'main' });
+    });
+
+    const result = await refreshAutoMergeForProject(project.id);
+
+    expect(result).toBe(true);
+
+    const reloaded = getDatabase().getProject(project.id)!;
+    expect(reloaded.autoMergeEnabled).toBe(true);
+    expect(reloaded.autoMergeCheckedAt).not.toBeNull();
+  });
+
+  it('preserves prior autoMergeEnabled when gh fails (returns null)', async () => {
+    const project = seedGithubProject('owner/repo');
+
+    // Seed a known prior value with stale checkedAt (48h ago)
+    getDatabase().updateProject(project.id, {
+      autoMergeEnabled: true,
+      autoMergeCheckedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+    });
+
+    // Simulate gh failure: execGHAsync returns null
+    mockExecGHAsync.mockResolvedValue(null);
+
+    const result = await refreshAutoMergeForProject(project.id);
+
+    expect(result).toBe(true); // unchanged
+
+    const reloaded = getDatabase().getProject(project.id)!;
+    expect(reloaded.autoMergeEnabled).toBe(true);
+    // checkedAt advanced (so we throttle retries)
+    expect(reloaded.autoMergeCheckedAt).not.toBeNull();
+    const newCheckedAtMs = new Date(reloaded.autoMergeCheckedAt!).getTime();
+    expect(Date.now() - newCheckedAtMs).toBeLessThan(60_000);
+  });
+
+  it('broadcasts project_updated only when the value actually changes', async () => {
+    const project = seedGithubProject('owner/repo');
+
+    // First call — value goes from null to true. Should broadcast.
+    mockExecGHAsync.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('/branches/')) return null;
+      return JSON.stringify({ allow_auto_merge: true, default_branch: 'main' });
+    });
+
+    await refreshAutoMergeForProject(project.id);
+
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'project_updated',
+      expect.objectContaining({ project_id: project.id }),
+    );
+
+    mockBroadcast.mockClear();
+
+    // Second call — value stays true. Should NOT broadcast.
+    await refreshAutoMergeForProject(project.id);
+
+    expect(mockBroadcast).not.toHaveBeenCalled();
+
+    // Third call — value flips to false. Should broadcast.
+    mockExecGHAsync.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('/branches/')) return null;
+      return JSON.stringify({ allow_auto_merge: false, default_branch: 'main' });
+    });
+
+    await refreshAutoMergeForProject(project.id);
+
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'project_updated',
+      expect.objectContaining({ project_id: project.id }),
+    );
+  });
+
+  it('returns null for a missing project id', async () => {
+    const result = await refreshAutoMergeForProject(999_999);
+    expect(result).toBeNull();
+    expect(mockExecGHAsync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/services/auto-merge-detection.test.ts
+++ b/tests/server/services/auto-merge-detection.test.ts
@@ -238,6 +238,36 @@ describe('refreshAutoMergeForProject', () => {
     expect(Date.now() - newCheckedAtMs).toBeLessThan(60_000);
   });
 
+  it('emits a warn log when gh fails so operators can see repeated failures', async () => {
+    const project = seedGithubProject('owner/repo');
+    mockExecGHAsync.mockResolvedValue(null);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let messages: string[] = [];
+    try {
+      const result = await refreshAutoMergeForProject(project.id);
+      // sanity: confirm the gh-failure path actually ran
+      expect(result).toBeNull();
+      expect(mockExecGHAsync).toHaveBeenCalled();
+      // Snapshot calls BEFORE mockRestore (which clears the call record).
+      messages = warnSpy.mock.calls.map((args) => args.join(' '));
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // The warn must mention the project id and the github repo so logs are
+    // searchable per project, and must indicate the persisted value is left
+    // unchanged.
+    expect(
+      messages.some(
+        (m) =>
+          m.includes('Auto-merge gh check failed') &&
+          m.includes(`project ${project.id}`) &&
+          m.includes('owner/repo'),
+      ),
+    ).toBe(true);
+  });
+
   it('broadcasts project_updated only when the value actually changes', async () => {
     const project = seedGithubProject('owner/repo');
 

--- a/tests/server/team-manager-prompt.test.ts
+++ b/tests/server/team-manager-prompt.test.ts
@@ -1,0 +1,328 @@
+// =============================================================================
+// Fleet Commander -- TeamManager prompt-substitution tests (issue #710)
+// =============================================================================
+// Tests the {{AUTO_MERGE_WARNING}} placeholder substitution in
+// resolvePromptFromFile() and the buildAutoMergeWarning() decision logic.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Project } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted via vi.hoisted so vi.mock factories can reference them
+// ---------------------------------------------------------------------------
+
+const mockDb = vi.hoisted(() => ({
+  getProject: vi.fn(),
+  getTeam: vi.fn(),
+  getActiveTeams: vi.fn().mockReturnValue([]),
+  getActiveTeamCountByProject: vi.fn().mockReturnValue(0),
+  getQueuedTeamsByProject: vi.fn().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
+  updateProject: vi.fn(),
+  insertTransition: vi.fn(),
+  insertEvent: vi.fn(),
+  getPullRequest: vi.fn(),
+}));
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    worktreeDir: '.claude/worktrees',
+    outputBufferLines: 500,
+    claudeCmd: 'claude',
+    skipPermissions: true,
+    terminalCmd: 'auto',
+    mergeShutdownGraceMs: 120000,
+    fleetCommanderRoot: '/tmp/fleet-prompt-test',
+    mapCleanupIntervalMs: 3600000,
+    fcHooksDir: '/tmp/fleet/hooks',
+    hookDir: '.claude/hooks',
+    fcAgentsDir: '/tmp/fleet/agents',
+    fcGuidesDir: '/tmp/fleet/guides',
+    fcWorkflowTemplate: '/tmp/fleet/templates/workflow.md',
+    autoMergeRefreshMs: 86_400_000,
+  },
+}));
+
+const mockSseBroker = vi.hoisted(() => ({
+  broadcast: vi.fn(),
+  getSnapshot: vi.fn().mockReturnValue([]),
+}));
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+vi.mock('../../src/server/utils/find-git-bash.js', () => ({
+  findGitBash: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue('Shutdown message'),
+}));
+
+vi.mock('../../src/server/services/usage-tracker.js', () => ({
+  getUsageZone: vi.fn().mockReturnValue('green'),
+  isUsageBlocked: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/server/utils/resolve-claude-path.js', () => ({
+  resolveClaudePath: vi.fn().mockReturnValue('claude'),
+}));
+
+vi.mock('../../src/server/services/issue-fetcher.js', () => ({
+  getIssueFetcher: () => ({
+    fetchDependenciesForIssue: vi.fn().mockResolvedValue({
+      issueNumber: 0, blockedBy: [], resolved: true, openCount: 0,
+    }),
+  }),
+  detectCircularDependencies: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/services/github-poller.js', () => ({
+  githubPoller: {
+    trackBlockedIssue: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/server/utils/exec-gh.js', () => ({
+  execGHAsync: vi.fn(),
+  execGitAsync: vi.fn(),
+  execGHResult: vi.fn(),
+  isValidGithubRepo: (repo: string) =>
+    /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(repo),
+  isValidBranchName: (branch: string) => /^[a-zA-Z0-9._/\-]+$/.test(branch),
+}));
+
+vi.mock('../../src/server/utils/fc-manifest.js', () => ({
+  getHookFiles: vi.fn().mockReturnValue([]),
+  getAgentFiles: vi.fn().mockReturnValue([]),
+  getGuideFiles: vi.fn().mockReturnValue([]),
+  getWorkflowFile: vi.fn().mockReturnValue(null),
+  getGitignoreEntries: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../../src/server/services/event-collector.js', () => ({
+  classifyAgentRole: vi.fn().mockReturnValue('tl'),
+  shouldAdvancePhase: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/server/services/issue-context-generator.js', () => ({
+  generateIssueContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/server/utils/cc-spawn.js', () => ({
+  spawnHeadless: vi.fn(),
+  spawnInteractive: vi.fn(),
+}));
+
+// Mock fs to control file existence and content for resolvePromptFromFile
+const mockFs = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  copyFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn().mockReturnValue([]),
+  writeFileSync: vi.fn(),
+  statSync: vi.fn().mockReturnValue({ isDirectory: () => false }),
+  rmSync: vi.fn(),
+  openSync: vi.fn(),
+  readSync: vi.fn(),
+  closeSync: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  default: mockFs,
+  ...mockFs,
+}));
+
+// Mock project-service refreshAutoMergeForProject to control what
+// buildAutoMergeWarning sees without invoking the real gh path.
+const mockRefreshAutoMerge = vi.hoisted(() =>
+  vi.fn<(projectId: number, options?: { skipIfFresh?: boolean }) => Promise<boolean | null>>(),
+);
+
+vi.mock('../../src/server/services/project-service.js', () => ({
+  refreshAutoMergeForProject: (projectId: number, options?: { skipIfFresh?: boolean }) =>
+    mockRefreshAutoMerge(projectId, options),
+  // Re-export the rest as no-ops so accidental imports don't blow up
+  checkRepoSettings: vi.fn(),
+}));
+
+import { TeamManager } from '../../src/server/services/team-manager.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/test-project',
+    githubRepo: 'owner/repo',
+    groupId: null,
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 5,
+    promptFile: null,
+    model: null,
+    effort: null,
+    issueProvider: 'github',
+    projectKey: null,
+    providerConfig: null,
+    autoMergeEnabled: null,
+    autoMergeCheckedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — resolvePromptFromFile {{AUTO_MERGE_WARNING}} substitution
+// ---------------------------------------------------------------------------
+
+describe('TeamManager.resolvePromptFromFile {{AUTO_MERGE_WARNING}} substitution', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('substitutes {{AUTO_MERGE_WARNING}} with the supplied warning string', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      'Issue: #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}\n\n{{AUTO_MERGE_WARNING}}',
+    );
+
+    // resolvePromptFromFile is private — cast to any to access for testing
+    const project = makeProject();
+    const result = (tm as unknown as {
+      resolvePromptFromFile: (
+        p: Project,
+        key: string,
+        title?: string,
+        warning?: string,
+      ) => string;
+    }).resolvePromptFromFile(project, '42', 'Test', 'INJECTED_WARNING_TEXT');
+
+    expect(result).toContain('INJECTED_WARNING_TEXT');
+    expect(result).not.toContain('{{AUTO_MERGE_WARNING}}');
+    expect(result).toContain('#42');
+    expect(result).toContain('Test');
+  });
+
+  it('substitutes {{AUTO_MERGE_WARNING}} with empty string when no warning passed', () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      'Issue: #{{ISSUE_NUMBER}}\n\n{{AUTO_MERGE_WARNING}}',
+    );
+
+    const project = makeProject();
+    const result = (tm as unknown as {
+      resolvePromptFromFile: (p: Project, key: string, title?: string, warning?: string) => string;
+    }).resolvePromptFromFile(project, '42', 'Test');
+
+    expect(result).not.toContain('{{AUTO_MERGE_WARNING}}');
+    // Empty string produced — the placeholder is just gone
+    expect(result).toContain('Issue: #42');
+  });
+
+  it('hardcoded fallback appends warning when prompt file missing and warning supplied', () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const project = makeProject();
+    const result = (tm as unknown as {
+      resolvePromptFromFile: (p: Project, key: string, title?: string, warning?: string) => string;
+    }).resolvePromptFromFile(project, '42', undefined, 'WARNING_X');
+
+    expect(result).toContain('WARNING_X');
+    expect(result).toContain('#42');
+  });
+
+  it('hardcoded fallback omits the warning when warning is empty string', () => {
+    mockFs.existsSync.mockReturnValue(false);
+
+    const project = makeProject();
+    const result = (tm as unknown as {
+      resolvePromptFromFile: (p: Project, key: string, title?: string, warning?: string) => string;
+    }).resolvePromptFromFile(project, '42', undefined, '');
+
+    expect(result).not.toContain('Repo does not allow auto-merge');
+    expect(result).toContain('#42');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — buildAutoMergeWarning decision logic
+// ---------------------------------------------------------------------------
+
+describe('TeamManager.buildAutoMergeWarning', () => {
+  let tm: TeamManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tm = new TeamManager();
+  });
+
+  it('returns empty string for a project with autoMergeEnabled = true', async () => {
+    mockRefreshAutoMerge.mockResolvedValue(true);
+
+    const result = await (tm as unknown as {
+      buildAutoMergeWarning: (project: Project) => Promise<string>;
+    }).buildAutoMergeWarning(makeProject({ autoMergeEnabled: true }));
+
+    expect(result).toBe('');
+    expect(mockRefreshAutoMerge).toHaveBeenCalledWith(1, { skipIfFresh: true });
+  });
+
+  it('returns empty string for a project with autoMergeEnabled = null (unknown)', async () => {
+    mockRefreshAutoMerge.mockResolvedValue(null);
+
+    const result = await (tm as unknown as {
+      buildAutoMergeWarning: (project: Project) => Promise<string>;
+    }).buildAutoMergeWarning(makeProject({ autoMergeEnabled: null }));
+
+    expect(result).toBe('');
+  });
+
+  it('returns the long warning text when autoMergeEnabled = false', async () => {
+    mockRefreshAutoMerge.mockResolvedValue(false);
+
+    const result = await (tm as unknown as {
+      buildAutoMergeWarning: (project: Project) => Promise<string>;
+    }).buildAutoMergeWarning(makeProject({ autoMergeEnabled: false }));
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('Repo does not allow auto-merge');
+    expect(result).toContain('Monitor');
+    expect(result).toContain('ScheduleWakeup');
+    expect(result).toContain('gh pr merge');
+  });
+
+  it('returns empty string when refreshAutoMergeForProject throws (defensive)', async () => {
+    mockRefreshAutoMerge.mockRejectedValue(new Error('boom'));
+
+    const result = await (tm as unknown as {
+      buildAutoMergeWarning: (project: Project) => Promise<string>;
+    }).buildAutoMergeWarning(makeProject({ autoMergeEnabled: false }));
+
+    expect(result).toBe('');
+  });
+
+  it('passes skipIfFresh: true so launches use the cached value', async () => {
+    mockRefreshAutoMerge.mockResolvedValue(false);
+
+    await (tm as unknown as {
+      buildAutoMergeWarning: (project: Project) => Promise<string>;
+    }).buildAutoMergeWarning(makeProject({ id: 42 }));
+
+    expect(mockRefreshAutoMerge).toHaveBeenCalledWith(42, { skipIfFresh: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Detect per-project GitHub auto-merge availability via `gh api`, cache `auto_merge_enabled` + `auto_merge_checked_at` on the projects row (schema v20 migration).
- Refresh strategy: lazy-on-launch + lazy-on-install + periodic-via-poller, gated by `FLEET_AUTO_MERGE_REFRESH_MS` (default 24h).
- When `auto_merge_enabled === false`, inject a warning paragraph into the launch prompt instructing the TL to use the Claude Code `Monitor` tool (with `gh pr checks --watch` background process) and a `ScheduleWakeup` polling fallback for repos where `gh pr merge --auto` won't work.

## Test plan

- [x] `npm run build` passes cleanly (tsc + vite)
- [x] `npm test` — 1846 server tests pass (3 pre-existing cc-spawn.test.ts env-leak failures, unrelated to this PR)
- [x] 27 new/updated tests covering: schema migration + round-trip, refreshAutoMergeForProject decision matrix, prompt placeholder substitution, github-poller stale-refresh
- [x] Two-pass code review (round 2 APPROVE) verified all 15 acceptance criteria

Closes #710