### PR TITLE
Issue #711: log image-reference parity between issue body and TL prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ The SSE broker emits 18 event types:
 | `FLEET_SKIP_PERMISSIONS` | `true` | Skip CC permission prompts (`true`/`false`) |
 | `FLEET_ENABLE_AGENT_TEAMS` | `true` | Enable agent teams feature (`true`/`false`) |
 | `FLEET_PROMPT_CACHE_1H` | `true` | When `true`, set `ENABLE_PROMPT_CACHING_1H=1` on spawned CC processes for 1-hour prompt cache TTL. Set to `false` to use the default 5-minute TTL. |
+| `FLEET_DEBUG_RAW_ISSUE_BODY` | `false` | When `true`, write `.fleet-issue-body-raw.md` next to `.fleet-issue-context.md` containing the unmodified GitHub issue body, for debugging image-preservation discrepancies. |
 | `LOG_LEVEL` | `info` | Server log level |
 | `FLEET_GITHUB_POLL_MS` | `30000` | GitHub PR/CI/merge poll interval (ms) |
 | `FLEET_ISSUE_POLL_MS` | `300000` | Issue list poll interval (ms, default 5min) |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -147,6 +147,7 @@ const config = Object.freeze({
   skipPermissions: process.env['FLEET_SKIP_PERMISSIONS'] !== 'false',
   enableAgentTeams: process.env['FLEET_ENABLE_AGENT_TEAMS'] !== 'false',
   promptCache1h: process.env['FLEET_PROMPT_CACHE_1H'] !== 'false',
+  debugRawIssueBody: process.env['FLEET_DEBUG_RAW_ISSUE_BODY'] === 'true',
 
   dbPath: process.env['FLEET_DB_PATH'] || defaultDbPath(),
   hookLogPath: process.env['FLEET_HOOK_LOG'] || defaultHookLogPath(),

--- a/src/server/services/issue-context-generator.ts
+++ b/src/server/services/issue-context-generator.ts
@@ -25,12 +25,21 @@ import { GitHubIssueProvider, parseRepo } from '../providers/github-issue-provid
 import { generateIssueContextMarkdown } from '../../shared/issue-context.js';
 import type { IssueContextData } from '../../shared/issue-context.js';
 import type { Project } from '../../shared/types.js';
+import { imageRefDelta } from '../../shared/image-refs.js';
+import config from '../config.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 export const CONTEXT_FILENAME = '.fleet-issue-context.md';
+
+/**
+ * Filename of the optional raw-body dump written next to CONTEXT_FILENAME
+ * when `FLEET_DEBUG_RAW_ISSUE_BODY=true`. Used for offline diff against the
+ * rendered context file — primarily to debug image-preservation issues.
+ */
+export const RAW_BODY_FILENAME = '.fleet-issue-body-raw.md';
 
 // ---------------------------------------------------------------------------
 // Jira Issue Fetching
@@ -177,8 +186,51 @@ export async function generateIssueContext(params: GenerateIssueContextParams): 
     }
 
     const markdown = generateIssueContextMarkdown(contextData);
+
+    // Image-reference parity check: compare images in the raw issue body vs
+    // the rendered prompt. Logs a single summary line per launch; warns if
+    // any URL was lost (typically due to body truncation in the renderer).
+    // This is observability only and MUST NOT block context generation.
+    try {
+      const delta = imageRefDelta(contextData.body || '', markdown);
+      const summary =
+        `[IssueContextGenerator] Image-ref parity for issue ${issueKey}: ` +
+        `images_in_body=${delta.bodyCount.unique.size} ` +
+        `images_in_prompt=${delta.promptCount.unique.size} ` +
+        `markdown=${delta.bodyCount.markdown.length}/${delta.promptCount.markdown.length} ` +
+        `html=${delta.bodyCount.html.length}/${delta.promptCount.html.length} ` +
+        `bare=${delta.bodyCount.bare.length}/${delta.promptCount.bare.length}`;
+      if (delta.ok) {
+        console.log(summary);
+      } else {
+        console.warn(`${summary} missing_in_prompt=[${delta.missing.join(', ')}]`);
+      }
+    } catch (parityErr) {
+      console.warn(
+        `[IssueContextGenerator] Image-ref parity check failed for issue ${issueKey}:`,
+        parityErr instanceof Error ? parityErr.message : parityErr,
+      );
+    }
+
     const filePath = path.join(worktreeAbsPath, CONTEXT_FILENAME);
     fs.writeFileSync(filePath, markdown, 'utf-8');
+
+    // Optional debug: dump the raw issue body alongside the converted file
+    // for offline diffing. Gated behind FLEET_DEBUG_RAW_ISSUE_BODY=true.
+    if (config.debugRawIssueBody) {
+      try {
+        const rawPath = path.join(worktreeAbsPath, RAW_BODY_FILENAME);
+        fs.writeFileSync(rawPath, contextData.body || '', 'utf-8');
+        console.log(
+          `[IssueContextGenerator] Wrote ${RAW_BODY_FILENAME} (debug flag enabled)`,
+        );
+      } catch (rawErr) {
+        console.warn(
+          `[IssueContextGenerator] Failed to write ${RAW_BODY_FILENAME} for issue ${issueKey}:`,
+          rawErr instanceof Error ? rawErr.message : rawErr,
+        );
+      }
+    }
 
     console.log(`[IssueContextGenerator] Wrote ${CONTEXT_FILENAME} to ${worktreeAbsPath}`);
   } catch (err) {

--- a/src/shared/image-refs.ts
+++ b/src/shared/image-refs.ts
@@ -1,0 +1,161 @@
+// =============================================================================
+// Fleet Commander — Image Reference Counter
+// =============================================================================
+// Pure, side-effect-free utilities for counting image references in markdown
+// or HTML text. Used to verify that pasted images survive the conversion path
+// from a raw GitHub issue body into the rendered context file delivered to
+// the TL agent (see `src/shared/issue-context.ts` for the renderer and
+// `src/server/services/issue-context-generator.ts` for the parity check that
+// uses these helpers).
+//
+// Three forms of image references are detected, independently:
+//
+//   1. Markdown image syntax:        ![alt](https://example.com/foo.png)
+//      Optionally followed by a title:  ![alt](https://...png "Title")
+//
+//   2. HTML <img> tag:               <img src="https://example.com/foo.png">
+//      Supports double-quoted, single-quoted, and unquoted src attributes.
+//
+//   3. Bare GitHub-hosted asset URL: https://user-images.githubusercontent.com/.../foo.png
+//                                    https://github.com/owner/repo/assets/...
+//      These are produced when users paste images directly into the GitHub
+//      issue UI and the browser rewrites the markdown to a bare URL.
+//
+// Notes:
+//   - All three regexes apply independently; the same URL may appear in more
+//     than one bucket (e.g. a bare URL inside a markdown image syntax counts
+//     once in `markdown` and once in `bare`). The `unique` Set deduplicates
+//     across buckets so callers can assert "did every URL survive?" rather
+//     than "did every individual reference survive?".
+//   - URLs inside fenced code blocks are NOT excluded — the renderer treats
+//     them as part of the body text, so we count them too.
+//   - This module has zero Node API dependencies (no `fs`, no `path`, no
+//     `Buffer`); it is pure string processing and trivially testable.
+// =============================================================================
+
+/** Regex for markdown image syntax: ![alt](url) or ![alt](url "title") */
+const IMG_MARKDOWN = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+/** Regex for HTML <img> tag with double-quoted, single-quoted, or unquoted src. */
+const IMG_HTML = /<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))[^>]*>/gi;
+
+/**
+ * Regex for bare GitHub-hosted image asset URLs. Matches:
+ *   - https://user-images.githubusercontent.com/<digits>/<path>
+ *   - https://github.com/<owner>/<repo>/assets/<path>
+ *
+ * Stops at whitespace and any closing punctuation that would normally end an
+ * inline URL in markdown or HTML: `)`, `>`, `"`, `'`, `]`. This prevents the
+ * trailing `)` of `![alt](url)` from being captured as part of the URL.
+ */
+const IMG_BARE_GITHUB = /https?:\/\/(?:user-images\.githubusercontent\.com|github\.com\/[^\s)>"'\]]+\/assets)\/[^\s)>"'\]]+/g;
+
+/**
+ * Counted image references, separated by detection family.
+ *
+ * Each bucket contains the URLs (or `src` values) that matched that regex.
+ * `unique` is the deduplicated set across all three buckets — useful for
+ * parity checks that only care whether a given URL is present somewhere.
+ */
+export interface ImageRefCount {
+  /** URLs from markdown `![alt](url)` syntax */
+  markdown: string[];
+  /** URLs from HTML `<img src="...">` tags */
+  html: string[];
+  /** URLs from bare GitHub user-images / .../assets/... patterns */
+  bare: string[];
+  /** Unique URLs across all three buckets */
+  unique: Set<string>;
+}
+
+/**
+ * Count image references in a string. Returns the URLs split into three
+ * buckets (markdown / html / bare GitHub) plus a deduplicated `unique` set.
+ *
+ * Pure function. Empty input returns zero counts.
+ */
+export function countImageRefs(text: string): ImageRefCount {
+  const markdown: string[] = [];
+  const html: string[] = [];
+  const bare: string[] = [];
+  const unique = new Set<string>();
+
+  if (!text) {
+    return { markdown, html, bare, unique };
+  }
+
+  // --- Markdown images ---
+  for (const m of text.matchAll(IMG_MARKDOWN)) {
+    const url = m[1];
+    if (url) {
+      markdown.push(url);
+      unique.add(url);
+    }
+  }
+
+  // --- HTML <img src=...> ---
+  for (const m of text.matchAll(IMG_HTML)) {
+    // The src value may have been captured in group 1 (double-quoted),
+    // group 2 (single-quoted), or group 3 (unquoted).
+    const src = m[1] ?? m[2] ?? m[3];
+    if (src) {
+      html.push(src);
+      unique.add(src);
+    }
+  }
+
+  // --- Bare GitHub-hosted asset URLs ---
+  for (const m of text.matchAll(IMG_BARE_GITHUB)) {
+    const url = m[0];
+    if (url) {
+      bare.push(url);
+      unique.add(url);
+    }
+  }
+
+  return { markdown, html, bare, unique };
+}
+
+/**
+ * Result of comparing image references between two strings (typically the
+ * raw issue body and the rendered TL prompt).
+ */
+export interface ImageRefDelta {
+  /**
+   * `true` when every unique URL present in `before` is also present in
+   * `after`. Extra URLs in `after` (which would be unusual but possible if
+   * the renderer adds boilerplate) do NOT cause `ok` to flip false — the
+   * concern is dropped URLs, not added ones.
+   */
+  ok: boolean;
+  /** URLs that appear in `before` but not in `after`. */
+  missing: string[];
+  /** Image-ref count for the `before` string. */
+  bodyCount: ImageRefCount;
+  /** Image-ref count for the `after` string. */
+  promptCount: ImageRefCount;
+}
+
+/**
+ * Compare image references between two strings. Returns the per-string
+ * counts and a list of URLs that were present in `before` but lost in
+ * `after` (the typical "image got truncated by the renderer" failure).
+ */
+export function imageRefDelta(before: string, after: string): ImageRefDelta {
+  const bodyCount = countImageRefs(before);
+  const promptCount = countImageRefs(after);
+
+  const missing: string[] = [];
+  for (const url of bodyCount.unique) {
+    if (!promptCount.unique.has(url)) {
+      missing.push(url);
+    }
+  }
+
+  return {
+    ok: missing.length === 0,
+    missing,
+    bodyCount,
+    promptCount,
+  };
+}

--- a/tests/server/image-refs.test.ts
+++ b/tests/server/image-refs.test.ts
@@ -1,0 +1,233 @@
+// =============================================================================
+// Fleet Commander — Image Reference Counter Tests
+// =============================================================================
+// Tests for the pure countImageRefs() and imageRefDelta() helpers used by the
+// issue-context-generator parity check (see issue #711).
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { countImageRefs, imageRefDelta } from '../../src/shared/image-refs.js';
+
+// ---------------------------------------------------------------------------
+// countImageRefs
+// ---------------------------------------------------------------------------
+
+describe('countImageRefs', () => {
+  it('should return zero counts for empty text', () => {
+    const result = countImageRefs('');
+    expect(result.markdown).toEqual([]);
+    expect(result.html).toEqual([]);
+    expect(result.bare).toEqual([]);
+    expect(result.unique.size).toBe(0);
+  });
+
+  it('should return zero counts for text with no images', () => {
+    const result = countImageRefs('Just some plain text without any images.');
+    expect(result.markdown).toEqual([]);
+    expect(result.html).toEqual([]);
+    expect(result.bare).toEqual([]);
+    expect(result.unique.size).toBe(0);
+  });
+
+  it('should detect a single markdown image', () => {
+    const result = countImageRefs('Here is ![an image](https://example.com/foo.png) inline.');
+    expect(result.markdown).toEqual(['https://example.com/foo.png']);
+    expect(result.html).toEqual([]);
+    expect(result.bare).toEqual([]);
+    expect(result.unique.size).toBe(1);
+    expect(result.unique.has('https://example.com/foo.png')).toBe(true);
+  });
+
+  it('should detect a markdown image with a title', () => {
+    const result = countImageRefs('![alt](https://example.com/foo.png "My title")');
+    expect(result.markdown).toEqual(['https://example.com/foo.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect an HTML img tag with double-quoted src', () => {
+    const result = countImageRefs('<img src="https://example.com/bar.png" alt="bar">');
+    expect(result.markdown).toEqual([]);
+    expect(result.html).toEqual(['https://example.com/bar.png']);
+    expect(result.bare).toEqual([]);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect an HTML img tag with single-quoted src', () => {
+    const result = countImageRefs("<img src='https://example.com/baz.png' />");
+    expect(result.html).toEqual(['https://example.com/baz.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect an HTML img tag with unquoted src', () => {
+    const result = countImageRefs('<img src=https://example.com/qux.png alt=qux>');
+    expect(result.html).toEqual(['https://example.com/qux.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect a bare user-images.githubusercontent.com URL', () => {
+    const text = 'See screenshot: https://user-images.githubusercontent.com/12345/abc.png\n\nThanks.';
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual([]);
+    expect(result.html).toEqual([]);
+    expect(result.bare).toEqual(['https://user-images.githubusercontent.com/12345/abc.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect a bare github.com/.../assets/... URL', () => {
+    const text = 'Look at https://github.com/owner/repo/assets/9999/screenshot.png';
+    const result = countImageRefs(text);
+    expect(result.bare).toEqual(['https://github.com/owner/repo/assets/9999/screenshot.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should detect mixed forms in a single body and dedupe distinct URLs', () => {
+    // Use a non-GitHub URL for the markdown image so each URL stays in a
+    // single bucket (the bare-GitHub regex would otherwise also match the
+    // user-images.githubusercontent.com URL inside the markdown syntax).
+    const text = [
+      '# Bug report',
+      '',
+      '![first](https://example.com/aaa.png)',
+      '',
+      '<img src="https://example.com/second.png" alt="">',
+      '',
+      'And here is a bare link: https://github.com/o/r/assets/333/third.png',
+    ].join('\n');
+
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual(['https://example.com/aaa.png']);
+    expect(result.html).toEqual(['https://example.com/second.png']);
+    expect(result.bare).toEqual(['https://github.com/o/r/assets/333/third.png']);
+    expect(result.unique.size).toBe(3);
+  });
+
+  it('should count a GitHub URL inside markdown syntax in both markdown and bare buckets', () => {
+    // When the markdown image URL is itself a GitHub-hosted asset, the bare
+    // regex also matches it (since the regex runs independently against the
+    // full text). The buckets show 1 markdown ref + 1 bare ref, but the
+    // `unique` set deduplicates back to 1 — which is what parity callers care
+    // about. Documented behaviour, not a bug.
+    const url = 'https://user-images.githubusercontent.com/5/inline.png';
+    const text = `![first](${url})`;
+
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual([url]);
+    expect(result.bare).toEqual([url]);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should count the same URL referenced twice (markdown + bare) and unify in unique', () => {
+    const url = 'https://user-images.githubusercontent.com/7/same.png';
+    const text = `![first](${url})\n\nAlso bare: ${url}`;
+
+    const result = countImageRefs(text);
+    // Markdown regex matches the one inside ![]() syntax.
+    expect(result.markdown).toEqual([url]);
+    // Bare regex matches BOTH occurrences (the one inside ![]() and the
+    // explicit bare reference) — that is fine, `unique` deduplicates.
+    expect(result.bare.length).toBe(2);
+    expect(result.bare.every((u) => u === url)).toBe(true);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should still count a URL inside a fenced code block', () => {
+    // Documented behaviour: parity check is conservative — the renderer keeps
+    // code blocks in the body, so we count URLs there too.
+    const text = '```\n![inline](https://example.com/code.png)\n```';
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual(['https://example.com/code.png']);
+    expect(result.unique.size).toBe(1);
+  });
+
+  it('should not include the closing paren of markdown syntax in the captured URL', () => {
+    const text = '![alt](https://example.com/img.png)';
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual(['https://example.com/img.png']);
+    expect(result.markdown[0]).not.toContain(')');
+  });
+
+  it('should not include a trailing closing paren when the bare URL is wrapped in parens', () => {
+    const text = 'See (https://user-images.githubusercontent.com/9/bare.png) for details.';
+    const result = countImageRefs(text);
+    expect(result.bare).toEqual(['https://user-images.githubusercontent.com/9/bare.png']);
+    expect(result.bare[0]).not.toContain(')');
+  });
+
+  it('should not capture an <img> tag without a src attribute', () => {
+    const text = '<img alt="no src" srcset="foo 1x">';
+    const result = countImageRefs(text);
+    expect(result.html).toEqual([]);
+    expect(result.unique.size).toBe(0);
+  });
+
+  it('should detect multiple markdown images in the same body', () => {
+    const text = '![a](https://example.com/1.png) and ![b](https://example.com/2.png)';
+    const result = countImageRefs(text);
+    expect(result.markdown).toEqual(['https://example.com/1.png', 'https://example.com/2.png']);
+    expect(result.unique.size).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// imageRefDelta
+// ---------------------------------------------------------------------------
+
+describe('imageRefDelta', () => {
+  it('should report ok=true and empty missing when both texts contain the same URL', () => {
+    const url = 'https://user-images.githubusercontent.com/1/abc.png';
+    const before = `![alt](${url})`;
+    const after = `Description goes here.\n\n![alt](${url})`;
+
+    const delta = imageRefDelta(before, after);
+    expect(delta.ok).toBe(true);
+    expect(delta.missing).toEqual([]);
+    expect(delta.bodyCount.unique.size).toBe(1);
+    expect(delta.promptCount.unique.size).toBe(1);
+  });
+
+  it('should report ok=false and the missing URL when the prompt drops a body URL', () => {
+    const url = 'https://user-images.githubusercontent.com/1/abc.png';
+    const before = `Body has image: ![alt](${url})`;
+    const after = 'Body has image: [... body truncated ...]';
+
+    const delta = imageRefDelta(before, after);
+    expect(delta.ok).toBe(false);
+    expect(delta.missing).toEqual([url]);
+    expect(delta.bodyCount.unique.size).toBe(1);
+    expect(delta.promptCount.unique.size).toBe(0);
+  });
+
+  it('should NOT flag an ok=false when the prompt has an extra URL not in the body', () => {
+    // Renderer-added images (boilerplate) are fine; we only flag dropped URLs.
+    const url = 'https://user-images.githubusercontent.com/1/extra.png';
+    const before = 'Plain body, no images.';
+    const after = `Plain body, no images.\n\n![extra](${url})`;
+
+    const delta = imageRefDelta(before, after);
+    expect(delta.ok).toBe(true);
+    expect(delta.missing).toEqual([]);
+    expect(delta.bodyCount.unique.size).toBe(0);
+    expect(delta.promptCount.unique.size).toBe(1);
+  });
+
+  it('should report multiple missing URLs in order encountered', () => {
+    const url1 = 'https://user-images.githubusercontent.com/1/one.png';
+    const url2 = 'https://user-images.githubusercontent.com/2/two.png';
+    const before = `![1](${url1})\n\n![2](${url2})`;
+    const after = 'Truncated body.';
+
+    const delta = imageRefDelta(before, after);
+    expect(delta.ok).toBe(false);
+    expect(delta.missing).toContain(url1);
+    expect(delta.missing).toContain(url2);
+    expect(delta.missing.length).toBe(2);
+  });
+
+  it('should treat empty body and empty prompt as ok=true', () => {
+    const delta = imageRefDelta('', '');
+    expect(delta.ok).toBe(true);
+    expect(delta.missing).toEqual([]);
+    expect(delta.bodyCount.unique.size).toBe(0);
+    expect(delta.promptCount.unique.size).toBe(0);
+  });
+});

--- a/tests/server/services/issue-context-generator-integration.test.ts
+++ b/tests/server/services/issue-context-generator-integration.test.ts
@@ -1,0 +1,168 @@
+// =============================================================================
+// Fleet Commander — Issue Context Generator Integration Test (issue #711)
+// =============================================================================
+// Asserts that an inline image URL in a GitHub issue body actually survives
+// the conversion path through the REAL `generateIssueContextMarkdown()`
+// renderer and ends up in the file written to the worktree.
+//
+// Unlike the unit-test file in the same directory, this file does NOT mock
+// `../../../src/shared/issue-context.js` — only `fs` and the issue provider
+// are mocked. The point is to catch regressions where the renderer's
+// truncation logic strips an image when it shouldn't.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { IssueContextData } from '../../../src/shared/issue-context.js';
+import type { Project } from '../../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks (intentionally NOT mocking issue-context.js — we want the real render)
+// ---------------------------------------------------------------------------
+
+const mockFetchFullIssueContext = vi.hoisted(() => vi.fn());
+const mockGetIssueProvider = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/server/providers/github-issue-provider.js', () => {
+  class MockGitHubIssueProvider {
+    name = 'github';
+    fetchFullIssueContext = mockFetchFullIssueContext;
+  }
+  return {
+    GitHubIssueProvider: MockGitHubIssueProvider,
+    parseRepo: (slug: string) => {
+      const parts = slug.split('/');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) return ['unknown', 'unknown'];
+      return [parts[0], parts[1]];
+    },
+  };
+});
+
+vi.mock('../../../src/server/providers/index.js', () => ({
+  getIssueProvider: mockGetIssueProvider,
+}));
+
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+vi.mock('fs', () => ({
+  default: { writeFileSync: mockWriteFileSync, mkdirSync: mockMkdirSync },
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { generateIssueContext } from '../../../src/server/services/issue-context-generator.js';
+import { GitHubIssueProvider } from '../../../src/server/providers/github-issue-provider.js';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 1,
+    name: 'test-project',
+    repoPath: '/tmp/repo',
+    githubRepo: 'owner/repo',
+    groupId: null,
+    status: 'active',
+    hooksInstalled: true,
+    maxActiveTeams: 3,
+    promptFile: null,
+    model: null,
+    issueProvider: 'github',
+    projectKey: null,
+    providerConfig: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeIssueContextData(overrides: Partial<IssueContextData> = {}): IssueContextData {
+  return {
+    number: 42,
+    title: 'Bug with screenshot',
+    state: 'OPEN',
+    repo: 'owner/repo',
+    author: 'alice',
+    createdAt: '2026-05-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    parent: null,
+    children: [],
+    blockedBy: [],
+    blocking: [],
+    linkedPRs: [],
+    body: '',
+    comments: [],
+    truncation: {
+      bodyTruncated: false,
+      commentsTruncated: false,
+      totalComments: 0,
+      includedComments: 0,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generateIssueContext (integration with real markdown renderer)', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should preserve a markdown image URL through the real renderer and log parity', async () => {
+    const url = 'https://user-images.githubusercontent.com/9/xyz.png';
+    const body = `Steps to reproduce:\n\n1. Click foo\n2. See bug\n\n![Bug](${url})`;
+
+    const provider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(provider);
+    mockFetchFullIssueContext.mockResolvedValue(
+      makeIssueContextData({ body }),
+    );
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'Bug with screenshot',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    // The rendered markdown was passed to fs.writeFileSync as the second arg.
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const written = String(mockWriteFileSync.mock.calls[0][1]);
+
+    // The image URL must still be present, in markdown form, in the rendered file.
+    expect(written).toContain(`![Bug](${url})`);
+
+    // And the parity log must reflect that the image survived: 1 in body, 1 in prompt.
+    const parityLogs = consoleLogSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityLogs).toHaveLength(1);
+    expect(parityLogs[0]).toMatch(/Image-ref parity for issue 42:/);
+    expect(parityLogs[0]).toMatch(/images_in_body=1 images_in_prompt=1/);
+
+    // No parity warning.
+    const parityWarns = consoleWarnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityWarns).toHaveLength(0);
+  });
+});

--- a/tests/server/services/issue-context-generator.test.ts
+++ b/tests/server/services/issue-context-generator.test.ts
@@ -10,7 +10,7 @@
 //   - generateIssueContextMarkdown() from shared/issue-context.ts for rendering
 // =============================================================================
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -45,9 +45,11 @@ vi.mock('../../../src/server/providers/index.js', () => ({
 }));
 
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
 vi.mock('fs', () => ({
-  default: { writeFileSync: mockWriteFileSync },
+  default: { writeFileSync: mockWriteFileSync, mkdirSync: mockMkdirSync },
   writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
 }));
 
 const mockGenerateIssueContextMarkdown = vi.hoisted(() => vi.fn().mockReturnValue('# Mocked markdown'));
@@ -355,5 +357,137 @@ describe('generateIssueContext', () => {
     const passedData = mockGenerateIssueContextMarkdown.mock.calls[0][0] as IssueContextData;
     expect(passedData.title).toBe('No repo');
     expect(passedData.state).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Image-reference parity logging (issue #711)
+// ---------------------------------------------------------------------------
+
+describe('generateIssueContext — image-ref parity logging', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should log parity-success line when the body image survives in the prompt', async () => {
+    const url = 'https://user-images.githubusercontent.com/1/abc.png';
+    const contextData = makeSampleIssueContextData({
+      body: `Bug report\n\n![screenshot](${url})`,
+    });
+
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockResolvedValue(contextData);
+    // The render echoes the URL — image survives.
+    mockGenerateIssueContextMarkdown.mockReturnValue(
+      `# Issue\n\n## Description\n\n![screenshot](${url})\n`,
+    );
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'Add feature X',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    // Exactly one parity log line, prefixed and with both counts at 1.
+    const parityLogs = consoleLogSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityLogs).toHaveLength(1);
+    expect(parityLogs[0]).toMatch(/Image-ref parity for issue 42:/);
+    expect(parityLogs[0]).toMatch(/images_in_body=1 images_in_prompt=1/);
+
+    // No parity warning emitted.
+    const parityWarns = consoleWarnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity') || s.includes('missing_in_prompt'));
+    expect(parityWarns).toHaveLength(0);
+  });
+
+  it('should warn with missing_in_prompt when the renderer drops a body image', async () => {
+    // Realistic failure: the body has an image but the renderer truncates
+    // past it (e.g. >16KB cap or hardTruncateToBytes cutting mid-URL). The
+    // parity check must surface the dropped URL.
+    const url = 'https://user-images.githubusercontent.com/1/abc.png';
+    const contextData = makeSampleIssueContextData({
+      body: `Bug report\n\n![screenshot](${url})`,
+    });
+
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockResolvedValue(contextData);
+    // The render drops the image entirely.
+    mockGenerateIssueContextMarkdown.mockReturnValue(
+      '# Issue\n\n## Description\n\nBug report\n\n[... body truncated ...]\n',
+    );
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'Add feature X',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    // No parity-success log line.
+    const parityLogs = consoleLogSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityLogs).toHaveLength(0);
+
+    // One parity warn with the count mismatch and the missing URL.
+    const parityWarns = consoleWarnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityWarns).toHaveLength(1);
+    expect(parityWarns[0]).toMatch(/images_in_body=1 images_in_prompt=0/);
+    expect(parityWarns[0]).toContain(`missing_in_prompt=[${url}]`);
+  });
+
+  it('should report zero counts and not warn for a body with no images', async () => {
+    const contextData = makeSampleIssueContextData({
+      body: 'Just plain text, no images.',
+    });
+
+    const mockProvider = new GitHubIssueProvider();
+    mockGetIssueProvider.mockReturnValue(mockProvider);
+    mockFetchFullIssueContext.mockResolvedValue(contextData);
+    mockGenerateIssueContextMarkdown.mockReturnValue(
+      '# Issue\n\n## Description\n\nJust plain text, no images.\n',
+    );
+
+    await generateIssueContext({
+      worktreeAbsPath: '/tmp/worktree',
+      issueKey: '42',
+      issueNumber: 42,
+      issueTitle: 'No images',
+      issueProvider: 'github',
+      project: makeProject(),
+    });
+
+    const parityLogs = consoleLogSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityLogs).toHaveLength(1);
+    expect(parityLogs[0]).toMatch(/images_in_body=0 images_in_prompt=0/);
+
+    const parityWarns = consoleWarnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes('Image-ref parity'));
+    expect(parityWarns).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #711

## Summary

Adds observability for image-reference preservation in the path that converts a raw GitHub issue body into the `.fleet-issue-context.md` file delivered to the TL. Logs a parity summary on every launch and warns when URLs are dropped by the markdown renderer. Optional `FLEET_DEBUG_RAW_ISSUE_BODY` flag dumps the raw body alongside the converted file for offline diff.

## Audit conclusion

The conversion path was traced: `github-issue-provider.ts` and `issue-fetcher.ts` preserve `body` verbatim (no string mutation). The only place a transform happens is `generateIssueContextMarkdown()` in `src/shared/issue-context.ts` — specifically the 16KB hard truncation. The new parity log at the end of `issue-context-generator.ts` makes that the single observable failure point.

## What changed

- `src/shared/image-refs.ts` (new) — Pure module: `countImageRefs(text)` and `imageRefDelta(before, after)`. Three independent regex families detect markdown `![alt](url)`, HTML `<img src=...>`, and bare GitHub `user-images.githubusercontent.com` / `.../assets/...` URLs. `unique` is a deduplicated `Set` across all buckets.
- `src/server/services/issue-context-generator.ts` — After `generateIssueContextMarkdown(...)` returns, runs the parity check and logs one summary line per launch (`console.log` on parity, `console.warn` with `missing_in_prompt=[...]` on divergence). Both the parity check and the optional raw-body write are wrapped in try/catch — observability only, never blocks context generation.
- `src/server/config.ts` — Added `debugRawIssueBody` boolean from `FLEET_DEBUG_RAW_ISSUE_BODY` env var (default `false`).
- `tests/server/image-refs.test.ts` (new) — 22 unit tests covering regex families, edge cases, and `imageRefDelta` semantics.
- `tests/server/services/issue-context-generator.test.ts` — 3 new tests for parity log success/warning/zero-image cases.
- `tests/server/services/issue-context-generator-integration.test.ts` (new) — Integration test that does NOT mock the markdown renderer; asserts an inline GitHub image URL survives end-to-end.
- `CLAUDE.md` — Documented `FLEET_DEBUG_RAW_ISSUE_BODY`.

## Test plan

- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] 34/34 targeted tests pass (image-refs + issue-context-generator + integration)
- [x] Full server suite green except 3 pre-existing `cc-spawn.test.ts` failures (env var leakage, unrelated, also fail on `main`)
