### PR TITLE
Issue #709: fix CommGraph empty for active teams

### DIFF
--- a/src/client/hooks/useTeamDetailData.ts
+++ b/src/client/hooks/useTeamDetailData.ts
@@ -26,10 +26,13 @@ interface UseTeamDetailDataResult {
 // ---------------------------------------------------------------------------
 
 /** Cache TTL for non-critical data (roster, transitions, message edges) */
-const CACHE_TTL = 30_000;
+const CACHE_TTL = 5_000;
 
 /** Debounce delay for SSE-triggered refreshes */
 const SSE_DEBOUNCE_MS = 2_000;
+
+/** Periodic refresh interval used to recover from SSE-debounce reset loops on active teams */
+const POLL_INTERVAL_MS = 5_000;
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -46,7 +49,12 @@ const SSE_DEBOUNCE_MS = 2_000;
  *
  * On SSE events for the selected team, only re-fetches the detail endpoint
  * (debounced at 2s). Roster, transitions, and message edges are only
- * re-fetched if their cache is stale (> 30s).
+ * re-fetched if their cache is stale (> 5s).
+ *
+ * A periodic 5s interval also calls `refreshDetail()` while a team is
+ * selected. This guarantees that roster and message edges populate even when
+ * the SSE-driven debounce keeps getting reset by continuous events on a
+ * highly-active team.
  */
 export function useTeamDetailData(
   selectedTeamId: number | null,
@@ -253,6 +261,22 @@ export function useTeamDetailData(
       }
     };
   }, [lastEvent, lastEventTeamId, selectedTeamId, refreshDetail]);
+
+  // ---------------------------------------------------------------------------
+  // Periodic refresh — guarantees roster/edges populate even when continuous
+  // SSE events keep resetting the debounce timer above (active-team case).
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (selectedTeamId == null) return;
+
+    const handle = setInterval(() => {
+      refreshDetail();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(handle);
+    };
+  }, [selectedTeamId, refreshDetail]);
 
   return { detail, transitions, roster, messageEdges, loading, error, refreshDetail };
 }

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -883,6 +883,22 @@ const teamsRoutes: FastifyPluginCallback = (
         const teamId = parseIdParam(request.params.id, 'id');
         const service = getTeamService();
         const summary = service.getMessageSummary(teamId);
+
+        // Diagnostic: if the message summary is empty but the team has spawned
+        // a subagent in the last 30 minutes, something has gone wrong in the
+        // inter-agent message capture pipeline. Emit a warn-level log so it
+        // shows up in production logs without affecting the response.
+        if (Array.isArray(summary) && summary.length === 0) {
+          const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+          const recentSubagentStarts = service.countRecentSubagentStarts(teamId, since);
+          if (recentSubagentStarts > 0) {
+            request.log.warn(
+              { teamId, recentSubagentStarts, since },
+              'Empty agent_messages/summary despite recent SubagentStart events',
+            );
+          }
+        }
+
         return reply.code(200).send(summary);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -1166,6 +1166,48 @@ export class TeamService {
   }
 
   /**
+   * Count `SubagentStart` events for a team since a given ISO timestamp.
+   *
+   * Used by the messages/summary route to emit a diagnostic warning when the
+   * team has recently spawned subagents but the message-summary response is
+   * empty — a strong signal that something has gone wrong in the inter-agent
+   * message capture pipeline.
+   *
+   * @param teamId - The team ID
+   * @param sinceIso - ISO 8601 timestamp; only events with `created_at >= sinceIso` are counted
+   * @returns Integer count of matching events
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  countRecentSubagentStarts(teamId: number, sinceIso: string): number {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    // SQLite stores `events.created_at` in `YYYY-MM-DD HH:MM:SS` format
+    // (from `datetime('now')`), but the route hands us an ISO 8601 string
+    // like `2026-05-08T11:00:00.000Z`. The comparison `created_at >= @since`
+    // is a plain string compare, so we must normalize the ISO string to
+    // SQLite's native format before delegating, otherwise zero rows ever
+    // match.
+    const sinceSqlite = sinceIso.includes('T')
+      ? sinceIso.replace('T', ' ').replace(/\.\d{3}Z?$/, '').replace(/Z$/, '')
+      : sinceIso;
+
+    return db.getAllEventsCount({
+      teamId,
+      eventType: 'SubagentStart',
+      since: sinceSqlite,
+    });
+  }
+
+  /**
    * Get tasks for a team.
    *
    * @param teamId - The team ID

--- a/tests/client/useTeamDetailData.test.ts
+++ b/tests/client/useTeamDetailData.test.ts
@@ -270,6 +270,69 @@ describe('useTeamDetailData', () => {
     expect(mockGet.mock.calls.length).toBe(callCountAfterInit);
   });
 
+  it('periodic refresh re-fetches roster and message edges while a team is selected', async () => {
+    const detail = makeDetail();
+    const transitions = makeTransitions();
+    const rosterData = makeRoster();
+    const edges = makeEdges();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/transitions') return Promise.resolve(transitions);
+      if (path === 'teams/1/roster') return Promise.resolve(rosterData);
+      if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    // Install fake timers BEFORE rendering so the hook's setInterval is
+    // registered with the fake-timer queue. Use shouldAdvanceTime: true so
+    // micro-timers (like the ones React uses internally) still progress and
+    // don't deadlock the initial useEffect.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { result, rerender } = renderHook(
+        ({ teamId, lastEvent, lastEventTeamId }: {
+          teamId: number | null;
+          lastEvent: Date | null;
+          lastEventTeamId: number | null;
+        }) => useTeamDetailData(teamId, lastEvent, lastEventTeamId),
+        { initialProps: { teamId: 1, lastEvent: null as Date | null, lastEventTeamId: null as number | null } },
+      );
+
+      // Wait for the initial Promise.allSettled to resolve. With shouldAdvanceTime:true,
+      // waitFor's internal setTimeout still polls.
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const initialRosterCalls = mockGet.mock.calls.filter(([p]) => p === 'teams/1/roster').length;
+      const initialEdgesCalls = mockGet.mock.calls.filter(([p]) => p === 'teams/1/messages/summary').length;
+
+      expect(initialRosterCalls).toBe(1);
+      expect(initialEdgesCalls).toBe(1);
+
+      // Simulate continuous SSE events at 1 Hz for 6 seconds, like an active
+      // team would emit. Each rerender resets the SSE debounce timer (the bug
+      // being worked around). The new periodic interval (POLL_INTERVAL_MS =
+      // 5_000) should still fire at t=5s and re-fetch the stale caches.
+      for (let t = 1; t <= 6; t++) {
+        await act(async () => {
+          rerender({ teamId: 1, lastEvent: new Date(), lastEventTeamId: 1 });
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+      }
+
+      const rosterCallsAfter = mockGet.mock.calls.filter(([p]) => p === 'teams/1/roster').length;
+      const edgesCallsAfter = mockGet.mock.calls.filter(([p]) => p === 'teams/1/messages/summary').length;
+
+      // The periodic interval should have fired at least once (at t=5s) and refetched roster + edges.
+      expect(rosterCallsAfter).toBeGreaterThan(initialRosterCalls);
+      expect(edgesCallsAfter).toBeGreaterThan(initialEdgesCalls);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('exposes refreshDetail as a stable function', async () => {
     const detail = makeDetail();
     mockGet.mockResolvedValue(detail);

--- a/tests/server/routes/teams-routes.test.ts
+++ b/tests/server/routes/teams-routes.test.ts
@@ -1017,3 +1017,133 @@ describe('NaN guard on :id param', () => {
     expect(res.json().message).toContain('positive integer');
   });
 });
+
+// =============================================================================
+// Tests: GET /api/teams/:id/messages/summary diagnostic warn-log
+// =============================================================================
+// These tests need their own Fastify instance with a spy-able logger so we can
+// assert that the diagnostic log fires (or does not fire) under specific
+// conditions. The shared test server has `logger: false` and produces a noop
+// logger, so request.log.warn() calls there cannot be observed.
+// =============================================================================
+
+describe('GET /api/teams/:id/messages/summary diagnostic warn-log', () => {
+  let warnSpy: ReturnType<typeof vi.fn>;
+  let logServer: FastifyInstance;
+
+  beforeAll(async () => {
+    warnSpy = vi.fn();
+    const stubLogger = {
+      level: 'info',
+      fatal: vi.fn(),
+      error: vi.fn(),
+      warn: warnSpy,
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      silent: vi.fn(),
+      child: function () { return this; },
+    };
+
+    // Fastify's typings for `loggerInstance` are heavily generic; cast through
+    // unknown for the test stub since we only need a minimal logger surface.
+    logServer = Fastify({ loggerInstance: stubLogger } as unknown as Parameters<typeof Fastify>[0]);
+    await logServer.register(teamsRoutes);
+    await logServer.ready();
+  });
+
+  afterAll(async () => {
+    await logServer.close();
+  });
+
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('logs warning when summary is empty but recent SubagentStart events exist', async () => {
+    const team = seedTeam({ worktreeName: `warn-empty-${Date.now()}` });
+    const db = getDatabase();
+
+    // Insert a SubagentStart event with a recent created_at (5 minutes ago)
+    // in SQLite's native datetime format `YYYY-MM-DD HH:MM:SS`.
+    const recentTimestamp = new Date(Date.now() - 5 * 60 * 1000)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d{3}Z$/, '');
+    db.raw
+      .prepare(
+        `INSERT INTO events (team_id, event_type, agent_name, created_at)
+         VALUES (?, 'SubagentStart', 'planner', ?)`,
+      )
+      .run(team.id, recentTimestamp);
+
+    // Do NOT insert any agent_messages — getMessageSummary should return []
+
+    const res = await logServer.inject({
+      method: 'GET',
+      url: `/api/teams/${team.id}/messages/summary`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    const [payload, message] = warnSpy.mock.calls[0] as [
+      { teamId: number; recentSubagentStarts: number; since: string },
+      string,
+    ];
+    expect(payload).toMatchObject({
+      teamId: team.id,
+      recentSubagentStarts: 1,
+    });
+    expect(typeof payload.since).toBe('string');
+    expect(message).toContain('Empty agent_messages/summary');
+  });
+
+  it('does NOT log warning when team has no recent SubagentStart events', async () => {
+    const team = seedTeam({ worktreeName: `warn-quiet-${Date.now()}` });
+
+    // No events inserted, no agent_messages inserted -> empty response, no warn
+
+    const res = await logServer.inject({
+      method: 'GET',
+      url: `/api/teams/${team.id}/messages/summary`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log warning when summary is non-empty', async () => {
+    const team = seedTeam({ worktreeName: `warn-nonempty-${Date.now()}` });
+    const db = getDatabase();
+
+    // Insert a recent SubagentStart event AND a real agent_message so the
+    // summary response is non-empty. The diagnostic guard short-circuits
+    // before counting subagent starts.
+    db.raw
+      .prepare(
+        `INSERT INTO events (team_id, event_type, agent_name)
+         VALUES (?, 'SubagentStart', 'planner')`,
+      )
+      .run(team.id);
+    db.raw
+      .prepare(
+        `INSERT INTO agent_messages (team_id, sender, recipient, summary)
+         VALUES (?, 'team-lead', 'planner', 'do the work')`,
+      )
+      .run(team.id);
+
+    const res = await logServer.inject({
+      method: 'GET',
+      url: `/api/teams/${team.id}/messages/summary`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/services/team-service.test.ts
+++ b/tests/server/services/team-service.test.ts
@@ -1168,3 +1168,112 @@ describe('TeamService.cancelQueuedTeam', () => {
     }
   });
 });
+
+// =============================================================================
+// Tests: countRecentSubagentStarts
+// =============================================================================
+
+describe('TeamService.countRecentSubagentStarts', () => {
+  /** Insert an event row with a specific created_at (SQLite native format). */
+  function insertEventRaw(
+    teamId: number,
+    eventType: string,
+    createdAt: string,
+  ): void {
+    const db = getDatabase();
+    db.raw
+      .prepare(
+        `INSERT INTO events (team_id, event_type, agent_name, created_at)
+         VALUES (?, ?, 'planner', ?)`,
+      )
+      .run(teamId, eventType, createdAt);
+  }
+
+  /** Convert ms-ago to SQLite native datetime format. */
+  function sqliteAgo(msAgo: number): string {
+    return new Date(Date.now() - msAgo)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d{3}Z$/, '');
+  }
+
+  it('should throw VALIDATION for invalid team ID (NaN)', () => {
+    try {
+      service.countRecentSubagentStarts(NaN, new Date().toISOString());
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw VALIDATION for invalid team ID (0)', () => {
+    try {
+      service.countRecentSubagentStarts(0, new Date().toISOString());
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND for unknown team', () => {
+    try {
+      service.countRecentSubagentStarts(999999, new Date().toISOString());
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('returns 0 when team has no events', () => {
+    const team = seedTeam({ worktreeName: `count-empty-${Date.now()}` });
+    const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+
+    const count = service.countRecentSubagentStarts(team.id, since);
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 when team has events but none are SubagentStart', () => {
+    const team = seedTeam({ worktreeName: `count-no-start-${Date.now()}` });
+
+    insertEventRaw(team.id, 'ToolUse', sqliteAgo(5 * 60 * 1000));
+    insertEventRaw(team.id, 'SubagentStop', sqliteAgo(5 * 60 * 1000));
+    insertEventRaw(team.id, 'Notification', sqliteAgo(5 * 60 * 1000));
+
+    const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const count = service.countRecentSubagentStarts(team.id, since);
+    expect(count).toBe(0);
+  });
+
+  it('returns the count of SubagentStart events within the since window', () => {
+    const team = seedTeam({ worktreeName: `count-window-${Date.now()}` });
+
+    // Within window (5min, 10min, 25min ago)
+    insertEventRaw(team.id, 'SubagentStart', sqliteAgo(5 * 60 * 1000));
+    insertEventRaw(team.id, 'SubagentStart', sqliteAgo(10 * 60 * 1000));
+    insertEventRaw(team.id, 'SubagentStart', sqliteAgo(25 * 60 * 1000));
+    // Outside window (60min ago)
+    insertEventRaw(team.id, 'SubagentStart', sqliteAgo(60 * 60 * 1000));
+    // Wrong type
+    insertEventRaw(team.id, 'ToolUse', sqliteAgo(5 * 60 * 1000));
+
+    const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const count = service.countRecentSubagentStarts(team.id, since);
+    expect(count).toBe(3);
+  });
+
+  it('does not count events from other teams', () => {
+    const team = seedTeam({ worktreeName: `count-iso-team-a-${Date.now()}` });
+    const otherTeam = seedTeam({ worktreeName: `count-iso-team-b-${Date.now()}` });
+
+    insertEventRaw(team.id, 'SubagentStart', sqliteAgo(5 * 60 * 1000));
+    insertEventRaw(otherTeam.id, 'SubagentStart', sqliteAgo(5 * 60 * 1000));
+    insertEventRaw(otherTeam.id, 'SubagentStart', sqliteAgo(10 * 60 * 1000));
+
+    const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    expect(service.countRecentSubagentStarts(team.id, since)).toBe(1);
+    expect(service.countRecentSubagentStarts(otherTeam.id, since)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Client: add 5s periodic refresh to `useTeamDetailData` and reduce `CACHE_TTL` to 5s — fixes the debounce-reset loop where continuous SSE events on active teams kept clearing the 2s timer so `refreshDetail()` never fired.
- Server: emit a diagnostic `request.log.warn` on `GET /api/teams/:id/messages/summary` when the response is empty but a `SubagentStart` event exists in the last 30 minutes.
- New helper `TeamService.countRecentSubagentStarts(teamId, sinceIso)` with ISO->SQLite native datetime normalization (SQLite's `events.created_at` is `YYYY-MM-DD HH:MM:SS`, so a raw ISO `since` would never match the lex compare).

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run typecheck` clean
- [x] `npm test` (server): 1829/1832 — same 3 pre-existing `cc-spawn.test.ts` failures as `origin/main`
- [x] Targeted: 153/153 pass for new tests across `useTeamDetailData`, `team-service`, `teams-routes`
- [x] No changes to `schema.sql`, `db.ts`, `event-collector.ts`, or SSE event payloads

Closes #709