### PR TITLE
Issue #712: add per-project refresh option in issues view

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2229,9 +2229,19 @@ curl -s http://localhost:4680/api/projects/1/issues/dependencies
 
 ### POST /api/issues/refresh
 
-Force re-fetch the issue hierarchy from GitHub for all projects. Clears the cache and fetches fresh data.
+Force re-fetch the issue hierarchy from the configured issue provider. Clears the cache and fetches fresh data.
 
-**Request Body:** None
+**Request Body:** Optional `{ projectId?: number }`
+
+- When the body is omitted or `projectId` is not provided, the cache is refreshed for **all projects** (legacy behaviour). The response `tree` is the merged hierarchy across every project.
+- When `projectId` is provided, only that project's cache is refreshed. The response `tree`, `issueCount`, and `refreshedAt` are scoped to that project.
+
+**Errors:**
+
+| Code | Description |
+|------|-------------|
+| 400 | `projectId` is present but not a positive integer |
+| 404 | `projectId` references a project that does not exist |
 
 **Response:** `200 OK`
 
@@ -2244,7 +2254,13 @@ Force re-fetch the issue hierarchy from GitHub for all projects. Clears the cach
 ```
 
 ```bash
+# Refresh all projects (legacy)
 curl -s -X POST http://localhost:4680/api/issues/refresh
+
+# Refresh a single project
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"projectId":1}' \
+  http://localhost:4680/api/issues/refresh
 ```
 
 ---

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -76,6 +76,9 @@ export function IssueTreeView() {
   const [tree, setTree] = useState<IssueNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  // Tracks per-project refreshes that are in flight. Each ProjectGroup /
+  // SingleProjectTree shows a spinner only when its own ID is in this set.
+  const [refreshingProjects, setRefreshingProjects] = useState<Set<number>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [cachedAt, setCachedAt] = useState<string | null>(null);
   const [issueCount, setIssueCount] = useState(0);
@@ -187,6 +190,10 @@ export function IssueTreeView() {
 
   const handleRefresh = useCallback(async () => {
     if (refreshing) return;
+    // Avoid running the all-projects refresh while a per-project refresh is
+    // still in flight — the two share the same fetcher singleton on the
+    // server and racing them would produce inconsistent UI state.
+    if (refreshingProjects.size > 0) return;
     setRefreshing(true);
     try {
       setError(null);
@@ -199,7 +206,41 @@ export function IssueTreeView() {
     } finally {
       setRefreshing(false);
     }
-  }, [api, refreshing, fetchTree]);
+  }, [api, refreshing, refreshingProjects, fetchTree]);
+
+  // -------------------------------------------------------------------------
+  // Per-project refresh — invoked from a project group header
+  // -------------------------------------------------------------------------
+
+  const handleRefreshProject = useCallback(async (projectId: number) => {
+    // Already refreshing this project, or a global refresh is in flight: noop.
+    if (refreshingProjects.has(projectId)) return;
+    if (refreshing) return;
+
+    setRefreshingProjects((prev) => {
+      const next = new Set(prev);
+      next.add(projectId);
+      return next;
+    });
+
+    try {
+      setError(null);
+      await api.post<IssueRefreshResponse>('issues/refresh', { projectId });
+      // Re-fetch the full tree so this group's `cachedAt` and counts update.
+      // Other groups still serve from their cache (no GitHub round-trip).
+      await fetchTree();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+    } finally {
+      setRefreshingProjects((prev) => {
+        if (!prev.has(projectId)) return prev;
+        const next = new Set(prev);
+        next.delete(projectId);
+        return next;
+      });
+    }
+  }, [api, refreshing, refreshingProjects, fetchTree]);
 
   // -------------------------------------------------------------------------
   // Relations panel toggle + relation change handler
@@ -784,7 +825,8 @@ export function IssueTreeView() {
 
         <button
           onClick={handleRefresh}
-          disabled={refreshing}
+          disabled={refreshing || refreshingProjects.size > 0}
+          title="Refresh all projects"
           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-dark-border text-dark-muted hover:text-dark-text hover:border-dark-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <svg
@@ -861,6 +903,8 @@ export function IssueTreeView() {
                 onToggleRelations={handleToggleRelations}
                 relationsMap={relationsMap}
                 onRelationChanged={handleRelationChanged}
+                onRefreshProject={handleRefreshProject}
+                refreshingProjects={refreshingProjects}
               />
             ))}
           </div>
@@ -882,6 +926,8 @@ export function IssueTreeView() {
                 onToggleRelations={handleToggleRelations}
                 relationsMap={relationsMap}
                 onRelationChanged={handleRelationChanged}
+                onRefreshProject={handleRefreshProject}
+                isRefreshing={refreshingProjects.has(group.projectId)}
               />
             ))}
           </div>
@@ -902,6 +948,8 @@ export function IssueTreeView() {
             onToggleRelations={handleToggleRelations}
             relationsMap={relationsMap}
             onRelationChanged={handleRelationChanged}
+            onRefreshProject={handleRefreshProject}
+            isRefreshing={launchProjectId !== null && refreshingProjects.has(launchProjectId)}
           />
         )}
       </div>
@@ -1362,9 +1410,13 @@ interface ProjectGroupSectionProps {
   onToggleRelations?: (issueKey: string) => void;
   relationsMap?: Map<string, IssueRelations>;
   onRelationChanged?: (issueKey: string) => void;
+  /** Trigger a per-project cache refresh for a single project. */
+  onRefreshProject?: (projectId: number) => Promise<void>;
+  /** Set of project IDs whose per-project refresh is currently in flight. */
+  refreshingProjects?: Set<number>;
 }
 
-function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged }: ProjectGroupSectionProps) {
+function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, refreshingProjects }: ProjectGroupSectionProps) {
   const expanded = !collapsedNodes.has(bucket.key);
   const totalIssueCount = (bucket.projects ?? []).reduce((sum, p) => sum + countNodes(p.tree), 0);
 
@@ -1416,6 +1468,8 @@ function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, 
                 onToggleRelations={onToggleRelations}
                 relationsMap={relationsMap}
                 onRelationChanged={onRelationChanged}
+                onRefreshProject={onRefreshProject}
+                isRefreshing={refreshingProjects?.has(group.projectId) ?? false}
               />
             ))}
           </div>
@@ -1442,9 +1496,13 @@ interface ProjectGroupProps {
   onToggleRelations?: (issueKey: string) => void;
   relationsMap?: Map<string, IssueRelations>;
   onRelationChanged?: (issueKey: string) => void;
+  /** Trigger a per-project cache refresh for this group's project. */
+  onRefreshProject?: (projectId: number) => Promise<void>;
+  /** True while this project's refresh is in flight (spinner). */
+  isRefreshing?: boolean;
 }
 
-function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged }: ProjectGroupProps) {
+function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false }: ProjectGroupProps) {
   const api = useApi();
   const projectNodeId = `project-${group.projectId}`;
   const expanded = !collapsedNodes.has(projectNodeId);
@@ -1551,6 +1609,28 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
             {headerCountText}
           </span>
         </button>
+
+        {onRefreshProject && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              void onRefreshProject(group.projectId);
+            }}
+            disabled={isRefreshing}
+            data-testid={`project-refresh-${group.projectId}`}
+            className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title={`Refresh ${group.projectName}`}
+            aria-label={`Refresh ${group.projectName}`}
+          >
+            <svg
+              className={`w-3.5 h-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z" />
+            </svg>
+          </button>
+        )}
 
         <button
           onClick={() => setShowDepGraph(true)}
@@ -1873,9 +1953,13 @@ interface SingleProjectTreeProps {
   onToggleRelations?: (issueKey: string) => void;
   relationsMap?: Map<string, IssueRelations>;
   onRelationChanged?: (issueKey: string) => void;
+  /** Trigger a per-project cache refresh. Hidden when projectId is null. */
+  onRefreshProject?: (projectId: number) => Promise<void>;
+  /** True while this project's refresh is in flight (spinner). */
+  isRefreshing?: boolean;
 }
 
-function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged }: SingleProjectTreeProps) {
+function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false }: SingleProjectTreeProps) {
   const api = useApi();
   const prioritization = usePrioritization();
   const selection = useIssueSelection();
@@ -1900,6 +1984,28 @@ function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIs
     <div className="flex flex-col h-full">
       {/* Prioritize controls */}
       <div className="flex items-center gap-2 px-2 pb-2 shrink-0">
+        {projectId !== null && onRefreshProject && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              void onRefreshProject(projectId);
+            }}
+            disabled={isRefreshing}
+            data-testid={`project-refresh-${projectId}`}
+            className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title={`Refresh ${projectName ?? 'this project'}`}
+            aria-label={`Refresh ${projectName ?? 'this project'}`}
+          >
+            <svg
+              className={`w-3.5 h-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z" />
+            </svg>
+          </button>
+        )}
+
         <button
           onClick={() => setShowDepGraph(true)}
           className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors"

--- a/src/client/views/IssueTreeView.tsx
+++ b/src/client/views/IssueTreeView.tsx
@@ -905,6 +905,7 @@ export function IssueTreeView() {
                 onRelationChanged={handleRelationChanged}
                 onRefreshProject={handleRefreshProject}
                 refreshingProjects={refreshingProjects}
+                globalRefreshing={refreshing}
               />
             ))}
           </div>
@@ -928,6 +929,7 @@ export function IssueTreeView() {
                 onRelationChanged={handleRelationChanged}
                 onRefreshProject={handleRefreshProject}
                 isRefreshing={refreshingProjects.has(group.projectId)}
+                globalRefreshing={refreshing}
               />
             ))}
           </div>
@@ -950,6 +952,7 @@ export function IssueTreeView() {
             onRelationChanged={handleRelationChanged}
             onRefreshProject={handleRefreshProject}
             isRefreshing={launchProjectId !== null && refreshingProjects.has(launchProjectId)}
+            globalRefreshing={refreshing}
           />
         )}
       </div>
@@ -1414,9 +1417,11 @@ interface ProjectGroupSectionProps {
   onRefreshProject?: (projectId: number) => Promise<void>;
   /** Set of project IDs whose per-project refresh is currently in flight. */
   refreshingProjects?: Set<number>;
+  /** True while the all-projects refresh is in flight. Disables per-project buttons. */
+  globalRefreshing?: boolean;
 }
 
-function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, refreshingProjects }: ProjectGroupSectionProps) {
+function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, refreshingProjects, globalRefreshing }: ProjectGroupSectionProps) {
   const expanded = !collapsedNodes.has(bucket.key);
   const totalIssueCount = (bucket.projects ?? []).reduce((sum, p) => sum + countNodes(p.tree), 0);
 
@@ -1470,6 +1475,7 @@ function ProjectGroupSection({ bucket, onLaunch, launchingIssues, launchErrors, 
                 onRelationChanged={onRelationChanged}
                 onRefreshProject={onRefreshProject}
                 isRefreshing={refreshingProjects?.has(group.projectId) ?? false}
+                globalRefreshing={globalRefreshing}
               />
             ))}
           </div>
@@ -1500,9 +1506,11 @@ interface ProjectGroupProps {
   onRefreshProject?: (projectId: number) => Promise<void>;
   /** True while this project's refresh is in flight (spinner). */
   isRefreshing?: boolean;
+  /** True while the all-projects refresh is in flight. Disables this button. */
+  globalRefreshing?: boolean;
 }
 
-function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false }: ProjectGroupProps) {
+function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false, globalRefreshing = false }: ProjectGroupProps) {
   const api = useApi();
   const projectNodeId = `project-${group.projectId}`;
   const expanded = !collapsedNodes.has(projectNodeId);
@@ -1616,10 +1624,10 @@ function ProjectGroup({ group, onLaunch, launchingIssues, launchErrors, forceExp
               e.stopPropagation();
               void onRefreshProject(group.projectId);
             }}
-            disabled={isRefreshing}
+            disabled={isRefreshing || globalRefreshing}
             data-testid={`project-refresh-${group.projectId}`}
             className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            title={`Refresh ${group.projectName}`}
+            title={isRefreshing ? `Refreshing ${group.projectName}…` : `Refresh ${group.projectName}`}
             aria-label={`Refresh ${group.projectName}`}
           >
             <svg
@@ -1957,9 +1965,11 @@ interface SingleProjectTreeProps {
   onRefreshProject?: (projectId: number) => Promise<void>;
   /** True while this project's refresh is in flight (spinner). */
   isRefreshing?: boolean;
+  /** True while the all-projects refresh is in flight. Disables this button. */
+  globalRefreshing?: boolean;
 }
 
-function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false }: SingleProjectTreeProps) {
+function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIssues, launchErrors, forceExpand, fetchTree, collapsedNodes, onToggleCollapse, relationsOpenKeys, onToggleRelations, relationsMap, onRelationChanged, onRefreshProject, isRefreshing = false, globalRefreshing = false }: SingleProjectTreeProps) {
   const api = useApi();
   const prioritization = usePrioritization();
   const selection = useIssueSelection();
@@ -1990,10 +2000,10 @@ function SingleProjectTree({ tree, projectId, projectName, onLaunch, launchingIs
               e.stopPropagation();
               void onRefreshProject(projectId);
             }}
-            disabled={isRefreshing}
+            disabled={isRefreshing || globalRefreshing}
             data-testid={`project-refresh-${projectId}`}
             className="inline-flex items-center justify-center w-7 h-7 rounded border border-dark-border text-dark-muted hover:text-dark-accent hover:border-dark-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            title={`Refresh ${projectName ?? 'this project'}`}
+            title={isRefreshing ? `Refreshing ${projectName ?? 'this project'}…` : `Refresh ${projectName ?? 'this project'}`}
             aria-label={`Refresh ${projectName ?? 'this project'}`}
           >
             <svg

--- a/src/server/routes/issues.ts
+++ b/src/server/routes/issues.ts
@@ -221,23 +221,43 @@ async function issueRoutes(server: FastifyInstance): Promise<void> {
 
   /**
    * POST /api/issues/refresh — Force re-fetch from GitHub
-   * Clears the cache and re-fetches the full hierarchy for all projects.
+   * Clears the cache and re-fetches the hierarchy.
+   *
+   * Body (optional): `{ projectId?: number }`
+   *   - When `projectId` is provided, only that project's cache is refreshed
+   *     and the response tree / counts / cachedAt are scoped to it.
+   *   - When the body is missing or `projectId` is undefined, all projects
+   *     are refreshed (legacy behaviour, unchanged).
    */
-  server.post('/api/issues/refresh', async (_request: FastifyRequest, reply: FastifyReply) => {
-    try {
-      const service = getIssueService();
-      return await service.refresh();
-    } catch (err: unknown) {
-      if (err instanceof ServiceError) {
-        return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+  server.post<{ Body: { projectId?: number } | null }>(
+    '/api/issues/refresh',
+    async (
+      request: FastifyRequest<{ Body: { projectId?: number } | null }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const body = (request.body ?? {}) as { projectId?: unknown };
+        let projectId: number | undefined;
+        if (body.projectId !== undefined && body.projectId !== null) {
+          // Coerce to string and re-validate so `parseIdParam` produces a
+          // consistent 400 ServiceError for non-numeric / non-positive values.
+          projectId = parseIdParam(String(body.projectId), 'projectId');
+        }
+
+        const service = getIssueService();
+        return await service.refresh(projectId);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to refresh issues');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
       }
-      _request.log.error(err, 'Failed to refresh issues');
-      return reply.code(500).send({
-        error: 'Internal Server Error',
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  });
+    },
+  );
 }
 
 export default issueRoutes;

--- a/src/server/services/issue-service.ts
+++ b/src/server/services/issue-service.ts
@@ -379,22 +379,45 @@ export class IssueService {
   }
 
   /**
-   * Force re-fetch from GitHub. Clears the cache and re-fetches the full hierarchy.
+   * Force re-fetch from the issue provider. Clears the cache and re-fetches
+   * the issue hierarchy.
    *
+   * When `projectId` is provided, only that project's cache is refreshed and
+   * the returned `tree` / `issueCount` / `refreshedAt` are scoped to it. When
+   * `projectId` is omitted, all projects are refreshed and the response covers
+   * the merged hierarchy across all of them (legacy behaviour).
+   *
+   * @param projectId - Optional project ID to scope the refresh to a single project
    * @returns Refreshed issue tree with metadata
+   * @throws ServiceError with code VALIDATION if projectId is invalid
+   * @throws ServiceError with code NOT_FOUND if projectId is provided but the project doesn't exist
    */
-  async refresh(): Promise<{
+  async refresh(projectId?: number): Promise<{
     refreshedAt: string | null;
     issueCount: number;
     tree: IssueNode[];
   }> {
-    const fetcher = getIssueFetcher();
-    const issues = await fetcher.refresh();
+    if (projectId !== undefined) {
+      if (isNaN(projectId) || projectId < 1) {
+        throw validationError('projectId must be a positive integer');
+      }
 
-    const enriched = fetcher.enrichWithTeamInfo(issues);
+      // Verify the project exists; otherwise `fetcher.refresh(projectId)` would
+      // silently return [] for unknown IDs, which is a confusing 200-success.
+      const db = getDatabase();
+      const project = db.getProject(projectId);
+      if (!project) {
+        throw notFoundError(`Project ${projectId} not found`);
+      }
+    }
+
+    const fetcher = getIssueFetcher();
+    const issues = await fetcher.refresh(projectId);
+
+    const enriched = fetcher.enrichWithTeamInfo(issues, projectId);
 
     return {
-      refreshedAt: fetcher.getCachedAt(),
+      refreshedAt: fetcher.getCachedAt(projectId),
       issueCount: countIssues(enriched),
       tree: enriched,
     };

--- a/tests/client/IssueTreeView.test.tsx
+++ b/tests/client/IssueTreeView.test.tsx
@@ -1183,4 +1183,79 @@ describe('IssueTreeView', () => {
       expect.arrayContaining(['provider-1-github', 'provider-1-jira', 'project-1', '10', '20']),
     );
   });
+
+  // -------------------------------------------------------------------------
+  // Per-project refresh button (Issue #712)
+  // -------------------------------------------------------------------------
+
+  it('top-bar Refresh button posts no body to /issues/refresh', async () => {
+    setupMockApi();
+    mockPost.mockResolvedValue({ tree: [], refreshedAt: null, issueCount: 0 });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Refresh')).toBeInTheDocument();
+    });
+
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(screen.getByText('Refresh'));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('issues/refresh');
+    });
+  });
+
+  it('per-project Refresh button posts { projectId } when clicked from a project group header', async () => {
+    const issueA = { number: 11, title: 'A', state: 'open', labels: [], children: [], activeTeam: null };
+    const issueB = { number: 22, title: 'B', state: 'open', labels: [], children: [], activeTeam: null };
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'issues') {
+        return Promise.resolve({
+          tree: [issueA, issueB],
+          groups: [
+            { projectId: 1, projectName: 'alpha', tree: [issueA], cachedAt: null, count: 1 },
+            { projectId: 2, projectName: 'beta', tree: [issueB], cachedAt: null, count: 1 },
+          ],
+          cachedAt: '2026-04-02T10:00:00Z',
+          count: 2,
+        });
+      }
+      if (path === 'projects') {
+        return Promise.resolve([
+          { id: 1, name: 'alpha', githubRepo: 'u/alpha', maxActiveTeams: 5, activeTeamCount: 0, queuedTeamCount: 0, status: 'active' },
+          { id: 2, name: 'beta', githubRepo: 'u/beta', maxActiveTeams: 5, activeTeamCount: 0, queuedTeamCount: 0, status: 'active' },
+        ]);
+      }
+      return Promise.resolve({});
+    });
+    mockPost.mockResolvedValue({ tree: [], refreshedAt: null, issueCount: 0 });
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('alpha')).toBeInTheDocument();
+    });
+
+    const projectRefreshBtn = screen.getByTestId('project-refresh-1');
+    expect(projectRefreshBtn).toHaveAttribute('aria-label', 'Refresh alpha');
+
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.click(projectRefreshBtn);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('issues/refresh', { projectId: 1 });
+    });
+  });
+
+  it('per-project Refresh button is rendered in single-project view', async () => {
+    setupMockApi();
+
+    render(<IssueTreeView />);
+    await waitFor(() => {
+      expect(screen.getByText('Issue Tree')).toBeInTheDocument();
+    });
+
+    // The single active project has id=1 (from makeProjectsResponse)
+    const projectRefreshBtn = await screen.findByTestId('project-refresh-1');
+    expect(projectRefreshBtn).toHaveAttribute('aria-label', 'Refresh test-project');
+  });
 });

--- a/tests/server/routes/issues-refresh.test.ts
+++ b/tests/server/routes/issues-refresh.test.ts
@@ -1,0 +1,236 @@
+// =============================================================================
+// Fleet Commander -- POST /api/issues/refresh: HTTP contract tests
+// =============================================================================
+// Tests the issues route plugin for the refresh endpoint specifically:
+//   - no-body call refreshes ALL projects (legacy behaviour)
+//   - { projectId: <n> } body scopes the refresh to one project
+//   - invalid projectId values produce a 400 with a ServiceError code
+//
+// Mocks the IssueService (exposed via getIssueService) so we exercise only
+// the HTTP layer / parameter validation. Mirrors the structure of
+// `issue-relations-routes.test.ts`.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+
+// Import routes
+import issueRoutes from '../../../src/server/routes/issues.js';
+
+// ---------------------------------------------------------------------------
+// Service mock — only `refresh` is exercised here, but other methods need to
+// exist on the singleton so the imported routes file does not crash if the
+// Fastify lifecycle touches them.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/services/issue-service.js', () => {
+  const mockService = {
+    getAllIssues: vi.fn(),
+    getProjectIssues: vi.fn(),
+    getNextIssue: vi.fn(),
+    getAvailableIssues: vi.fn(),
+    getIssue: vi.fn(),
+    getIssueByKey: vi.fn(),
+    getProjectDependencies: vi.fn(),
+    getIssueDependencies: vi.fn(),
+    getExecutionPlan: vi.fn(),
+    refresh: vi.fn(),
+  };
+  return {
+    getIssueService: () => mockService,
+    __mockService: mockService,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test-level state
+// ---------------------------------------------------------------------------
+
+let dbPath: string;
+let app: FastifyInstance;
+
+let mockService: {
+  getAllIssues: ReturnType<typeof vi.fn>;
+  getProjectIssues: ReturnType<typeof vi.fn>;
+  getNextIssue: ReturnType<typeof vi.fn>;
+  getAvailableIssues: ReturnType<typeof vi.fn>;
+  getIssue: ReturnType<typeof vi.fn>;
+  getIssueByKey: ReturnType<typeof vi.fn>;
+  getProjectDependencies: ReturnType<typeof vi.fn>;
+  getIssueDependencies: ReturnType<typeof vi.fn>;
+  getExecutionPlan: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+};
+
+// ---------------------------------------------------------------------------
+// DB + app lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-issues-refresh-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  app = Fastify({ logger: false });
+  await app.register(issueRoutes);
+  await app.ready();
+
+  const mod = await import('../../../src/server/services/issue-service.js');
+  mockService = (mod as unknown as { __mockService: typeof mockService }).__mockService;
+});
+
+afterAll(async () => {
+  await app.close();
+  sseBroker.stop();
+  closeDatabase();
+
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/issues/refresh
+// ---------------------------------------------------------------------------
+
+describe('POST /api/issues/refresh', () => {
+  it('should refresh all projects when no body is sent', async () => {
+    mockService.refresh.mockResolvedValueOnce({
+      refreshedAt: '2026-04-01T00:00:00.000Z',
+      issueCount: 5,
+      tree: [],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.refreshedAt).toBe('2026-04-01T00:00:00.000Z');
+    expect(body.issueCount).toBe(5);
+    expect(Array.isArray(body.tree)).toBe(true);
+    expect(mockService.refresh).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should refresh all projects when body is empty object', async () => {
+    mockService.refresh.mockResolvedValueOnce({
+      refreshedAt: null,
+      issueCount: 0,
+      tree: [],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockService.refresh).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should pass projectId to the service when provided', async () => {
+    mockService.refresh.mockResolvedValueOnce({
+      refreshedAt: '2026-04-01T00:00:00.000Z',
+      issueCount: 3,
+      tree: [],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: { projectId: 5 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockService.refresh).toHaveBeenCalledWith(5);
+  });
+
+  it('should return 400 when projectId is non-numeric', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: { projectId: 'abc' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('VALIDATION');
+    expect(mockService.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when projectId is zero', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: { projectId: 0 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('VALIDATION');
+    expect(mockService.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when projectId is negative', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: { projectId: -1 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('VALIDATION');
+    expect(mockService.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should propagate ServiceError statusCode and code from service', async () => {
+    const { ServiceError } = await import('../../../src/server/services/service-error.js');
+    mockService.refresh.mockRejectedValueOnce(
+      new ServiceError('Provider unavailable', 'EXTERNAL_ERROR', 502),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+      payload: { projectId: 5 },
+    });
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('EXTERNAL_ERROR');
+  });
+
+  it('should return 500 for unexpected errors', async () => {
+    mockService.refresh.mockRejectedValueOnce(new Error('boom'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/issues/refresh',
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/tests/server/services/issue-service.test.ts
+++ b/tests/server/services/issue-service.test.ts
@@ -551,4 +551,45 @@ describe('IssueService.refresh', () => {
     expect(Array.isArray(result.tree)).toBe(true);
     expect(mockRefresh).toHaveBeenCalled();
   });
+
+  it('should refresh all projects when projectId is undefined', async () => {
+    await service.refresh();
+
+    expect(mockRefresh).toHaveBeenCalledWith(undefined);
+    expect(mockEnrichWithTeamInfo).toHaveBeenCalledWith(mockIssueTree, undefined);
+    expect(mockGetCachedAt).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should pass projectId to fetcher when provided', async () => {
+    const project = seedProject();
+    const result = await service.refresh(project.id);
+
+    expect(mockRefresh).toHaveBeenCalledWith(project.id);
+    expect(mockEnrichWithTeamInfo).toHaveBeenCalledWith(mockIssueTree, project.id);
+    expect(mockGetCachedAt).toHaveBeenCalledWith(project.id);
+    expect(result).toHaveProperty('refreshedAt');
+    expect(result).toHaveProperty('issueCount');
+    expect(result).toHaveProperty('tree');
+    expect(Array.isArray(result.tree)).toBe(true);
+  });
+
+  it('should throw VALIDATION for invalid projectId', async () => {
+    try {
+      await service.refresh(0);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('VALIDATION');
+    }
+  });
+
+  it('should throw NOT_FOUND when projectId references an unknown project', async () => {
+    try {
+      await service.refresh(99999);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServiceError);
+      expect((err as ServiceError).code).toBe('NOT_FOUND');
+    }
+  });
 });


### PR DESCRIPTION
Closes #712

## Summary
- Extends `POST /api/issues/refresh` to accept an optional `{ projectId }` body field; omitting it preserves the global all-projects refresh behavior.
- Adds VALIDATION (400) for invalid `projectId` and NOT_FOUND (404) for unknown IDs at the service layer.
- Adds a per-project Refresh icon button to each `ProjectGroup` header and to `SingleProjectTree`, with scope-indicating tooltip and aria-label.
- Tracks per-project refresh state via `refreshingProjects: Set<number>` so spinners and disabled state are scoped accurately; global and per-project refreshes are mutually exclusive.

## Test plan
- [x] `npm run build` passes
- [x] `tests/server/services/issue-service.test.ts` — 31 pass (incl. new VALIDATION + NOT_FOUND coverage)
- [x] `tests/server/routes/issues-refresh.test.ts` — 8 pass (legacy/scoped/invalid/error/500 paths)
- [x] `tests/client/IssueTreeView.test.tsx` — 39 pass (incl. new global vs per-project refresh tests)
- [ ] Manual: confirm per-project Refresh button hits only one project; global Refresh still hits all