### PR TITLE
Issue #713: Capture and display TL→subagent spawn prompts in Team tab

### DIFF
--- a/src/client/components/CommGraph.tsx
+++ b/src/client/components/CommGraph.tsx
@@ -49,6 +49,18 @@ interface GraphLink {
 interface CommGraphProps {
   edges: MessageEdge[];
   agents: TeamMember[];
+  /**
+   * Optional click handler invoked with the agent name (id) when the user
+   * clicks a node. Issue #713: used by TeamDetail to open the spawn-prompt
+   * panel. When undefined, click is a no-op (preserving prior behavior).
+   */
+  onNodeClick?: (agentName: string) => void;
+  /**
+   * Optional set of agent names that have spawn records and should be
+   * visually highlighted as clickable. When undefined, no ring is drawn
+   * (preserving prior behavior). Issue #713.
+   */
+  clickableAgents?: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,7 +76,7 @@ const FONT_SIZE_LABEL = 10;
 // Component
 // ---------------------------------------------------------------------------
 
-export function CommGraph({ edges, agents }: CommGraphProps) {
+export function CommGraph({ edges, agents, onNodeClick, clickableAgents }: CommGraphProps) {
   const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink>>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 500, height: 380 });
@@ -226,6 +238,17 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
       const fontSize = FONT_SIZE_INITIAL / globalScale;
       const labelFontSize = FONT_SIZE_LABEL / globalScale;
 
+      // Clickable ring (Issue #713): subtle outer ring drawn at r+4 in the
+      // agent's color when this node has spawn records to inspect. Drawn
+      // first so the regular node renders on top.
+      if (clickableAgents && clickableAgents.has(node.id)) {
+        ctx.beginPath();
+        ctx.arc(x, y, r + 4, 0, 2 * Math.PI);
+        ctx.strokeStyle = node.color;
+        ctx.lineWidth = 2 / globalScale;
+        ctx.stroke();
+      }
+
       // Node circle fill
       ctx.beginPath();
       ctx.arc(x, y, r, 0, 2 * Math.PI);
@@ -268,7 +291,7 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
         ctx.fillText(node.role, x, y + r + 20 / globalScale);
       }
     },
-    [],
+    [clickableAgents],
   );
 
   // Node pointer area for hover/click detection
@@ -282,6 +305,27 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
       ctx.fill();
     },
     [],
+  );
+
+  // Handle node click — issue #713. Stable callback referencing the prop.
+  const handleNodeClick = useCallback(
+    (node: GraphNode) => {
+      if (onNodeClick) onNodeClick(node.id);
+    },
+    [onNodeClick],
+  );
+
+  // Hover tooltip on a node — show agent name + clickable hint when applicable.
+  const nodeLabel = useCallback(
+    (node: GraphNode) => {
+      const hint = onNodeClick && clickableAgents && clickableAgents.has(node.id)
+        ? '<br/><span style="color:#8B949E;font-size:10px;">click for spawn prompts</span>'
+        : '';
+      return `<div style="padding:4px 8px;background:#161B22;border:1px solid #30363D;border-radius:4px;font-size:11px;color:#E6EDF3;">
+        <b>${node.name}</b>${node.role ? ` <span style="color:#8B949E;">(${node.role})</span>` : ''}${hint}
+      </div>`;
+    },
+    [onNodeClick, clickableAgents],
   );
 
   // Link width based on message count
@@ -344,6 +388,8 @@ export function CommGraph({ edges, agents }: CommGraphProps) {
         nodeCanvasObject={nodeCanvasObject}
         nodeCanvasObjectMode={() => 'replace'}
         nodePointerAreaPaint={nodePointerAreaPaint}
+        nodeLabel={nodeLabel}
+        onNodeClick={handleNodeClick}
         linkWidth={linkWidth}
         linkColor={linkColor}
         linkLineDash={linkLineDash}

--- a/src/client/components/HandoffFileCard.tsx
+++ b/src/client/components/HandoffFileCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import type { HandoffFile } from '../../shared/types';
+import { formatRelativeTime } from '../utils/format-time';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -11,19 +12,6 @@ const FILE_TYPE_META: Record<string, { label: string; color: string }> = {
   'changes.md': { label: 'Changes', color: '#3FB950' },
   'review.md': { label: 'Review', color: '#D29922' },
 };
-
-/** Format ISO timestamp to a readable relative or absolute time */
-function formatTimestamp(iso: string): string {
-  const d = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return 'just now';
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHours = Math.floor(diffMin / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -88,7 +76,7 @@ export function HandoffFileCard({ file, defaultExpanded = false }: HandoffFileCa
 
         {/* Timestamp */}
         <span className="text-xs text-dark-muted">
-          {formatTimestamp(file.capturedAt)}
+          {formatRelativeTime(file.capturedAt)}
         </span>
       </button>
 

--- a/src/client/components/SpawnPromptPanel.tsx
+++ b/src/client/components/SpawnPromptPanel.tsx
@@ -1,0 +1,193 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { SpawnRecord } from '../../shared/types';
+import { formatRelativeTime } from '../utils/format-time';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pill colors per terminal status. Matches the dark-theme palette used
+ * elsewhere in the app: green=done, blue=running.
+ */
+const STATUS_PILL: Record<string, { label: string; color: string }> = {
+  running: { label: 'running', color: '#58A6FF' },
+  done: { label: 'done', color: '#3FB950' },
+  // 'crashed' is not emitted from the server in v1; included for forward compat.
+  crashed: { label: 'crashed', color: '#F85149' },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-component: SpawnCard — one captured spawn entry
+// ---------------------------------------------------------------------------
+
+interface SpawnCardProps {
+  spawn: SpawnRecord;
+}
+
+function SpawnCard({ spawn }: SpawnCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (!spawn.content) return;
+    navigator.clipboard.writeText(spawn.content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard API may not be available
+    });
+  }, [spawn.content]);
+
+  const pill = STATUS_PILL[spawn.terminalStatus] || { label: spawn.terminalStatus, color: '#8B949E' };
+
+  return (
+    <div className="border border-dark-border/50 rounded-md bg-dark-surface/40">
+      {/* Header row */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-dark-border/30">
+        <span
+          className="text-[10px] font-medium px-1.5 py-0.5 rounded"
+          style={{ backgroundColor: pill.color + '20', color: pill.color }}
+        >
+          {pill.label}
+        </span>
+        <span className="text-xs text-dark-muted">from</span>
+        <span className="text-xs text-dark-text font-mono">{spawn.sender}</span>
+        <span className="flex-1" />
+        <span className="text-xs text-dark-muted" title={spawn.createdAt}>
+          {formatRelativeTime(spawn.createdAt)}
+        </span>
+      </div>
+
+      {/* Prompt body */}
+      {spawn.content === null ? (
+        <div className="px-3 py-3 text-xs italic text-dark-muted/80">
+          no prompt recorded
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-end px-3 py-1 bg-dark-surface/30">
+            <button
+              onClick={handleCopy}
+              className="text-xs text-dark-muted hover:text-dark-text transition-colors flex items-center gap-1"
+              title="Copy prompt"
+            >
+              {copied ? (
+                <>
+                  <svg className="w-3 h-3 text-[#3FB950]" viewBox="0 0 16 16" fill="currentColor">
+                    <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+                  </svg>
+                  Copied
+                </>
+              ) : (
+                <>
+                  <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+                    <path fillRule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z" clipRule="evenodd" />
+                    <path fillRule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z" clipRule="evenodd" />
+                  </svg>
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+          <pre className="px-3 py-2 text-xs text-dark-text/90 whitespace-pre-wrap break-words max-h-72 overflow-y-auto custom-scrollbar font-mono leading-relaxed">
+            {spawn.content}
+          </pre>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface SpawnPromptPanelProps {
+  agentName: string;
+  spawns: SpawnRecord[];
+  onClose: () => void;
+}
+
+/**
+ * Floating side panel shown inside the Team tab when a CommGraph node is
+ * clicked. Lists every captured TL->subagent spawn for the selected agent
+ * with its prompt, timestamp, sender, and terminal status. Issue #713.
+ *
+ * Closes on:
+ *   - the X button
+ *   - Escape key (handler installed at panel level so it fires before the
+ *     parent TeamDetail's Esc handler)
+ *   - click outside the panel
+ */
+export function SpawnPromptPanel({ agentName, spawns, onClose }: SpawnPromptPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Escape key — close panel. Capture phase so we run BEFORE the parent
+  // TeamDetail's Esc handler which closes the whole panel.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [onClose]);
+
+  // Click outside — close panel. We listen on mousedown to mirror the
+  // pattern used elsewhere in the codebase.
+  useEffect(() => {
+    function handleMouseDown(e: MouseEvent) {
+      const node = panelRef.current;
+      if (node && !node.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute top-2 right-2 w-[480px] max-w-[90%] max-h-[85%] flex flex-col border border-dark-border bg-dark-surface rounded-md shadow-lg z-10"
+      role="dialog"
+      aria-label={`Spawn prompts for ${agentName}`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-dark-border shrink-0">
+        <span className="text-sm font-semibold text-dark-text truncate">{agentName}</span>
+        <span className="text-xs text-dark-muted">
+          {spawns.length} spawn{spawns.length === 1 ? '' : 's'}
+        </span>
+        <span className="flex-1" />
+        <button
+          onClick={onClose}
+          className="text-dark-muted hover:text-dark-text transition-colors p-1 rounded hover:bg-dark-border/30"
+          title="Close (Esc)"
+          aria-label="Close spawn prompt panel"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-3 py-3 space-y-2">
+        {spawns.length === 0 ? (
+          <div className="text-center py-8 text-sm text-dark-muted/80 italic">
+            No spawn records for this agent
+          </div>
+        ) : (
+          spawns.map((spawn) => <SpawnCard key={spawn.id} spawn={spawn} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useSelection, useConnection, useThinking } from '../context/FleetContext';
 import { useApi } from '../hooks/useApi';
 import { useFleetSSE } from '../hooks/useFleetSSE';
@@ -9,6 +9,7 @@ import { UnifiedTimeline } from './UnifiedTimeline';
 import { CommandInput } from './CommandInput';
 import { CommGraph } from './CommGraph';
 import { HandoffFileCard } from './HandoffFileCard';
+import { SpawnPromptPanel } from './SpawnPromptPanel';
 import { STATUS_COLORS } from '../utils/constants';
 import { getMergeStatusLabel } from '../utils/merge-status';
 import { formatIssueKey } from '../../shared/issue-provider';
@@ -39,7 +40,7 @@ export function TeamDetail() {
   const api = useApi();
 
   // Parallelized data fetching with caching (extracted hook)
-  const { detail, transitions, roster, messageEdges, loading, error, refreshDetail } =
+  const { detail, transitions, roster, messageEdges, spawnRecords, loading, error, refreshDetail } =
     useTeamDetailData(selectedTeamId, lastEvent, lastEventTeamId);
 
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -52,10 +53,29 @@ export function TeamDetail() {
   const [handoffFilesLoading, setHandoffFilesLoading] = useState(false);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const [agentFilters, setAgentFilters] = useState<Set<string>>(new Set());
+  // Issue #713: which agent's spawn prompts are open in the side panel.
+  const [selectedSpawnAgent, setSelectedSpawnAgent] = useState<string | null>(null);
   const templateCacheRef = useRef<{ data: Array<{ id: string; template: string; enabled: boolean }>; fetchedAt: number } | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const selectedTeamIdRef = useRef(selectedTeamId);
   const activeTabRef = useRef(activeTab);
+
+  // Issue #713: agent names that have at least one spawn record. Used to
+  // visually highlight clickable nodes in CommGraph and to filter spawns
+  // for the side panel. Includes agents that may appear in spawnRecords
+  // even if they're not yet in the roster (subagent_start without any
+  // tool_use yet).
+  const clickableAgents = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of spawnRecords) set.add(s.recipient);
+    for (const a of roster) set.add(a.name);
+    return set;
+  }, [spawnRecords, roster]);
+
+  const filteredSpawns = useMemo(() => {
+    if (selectedSpawnAgent == null) return [];
+    return spawnRecords.filter((s) => s.recipient === selectedSpawnAgent);
+  }, [spawnRecords, selectedSpawnAgent]);
 
   const isOpen = selectedTeamId !== null;
 
@@ -75,7 +95,16 @@ export function TeamDetail() {
     setMetadataCollapsed(false);
     // Reset agent filters to "All" for new team
     setAgentFilters(new Set());
+    // Issue #713: close any open spawn prompt panel on team change
+    setSelectedSpawnAgent(null);
   }, [selectedTeamId]);
+
+  // Issue #713: close the spawn prompt panel when the user switches tabs
+  useEffect(() => {
+    if (activeTab !== 'team') {
+      setSelectedSpawnAgent(null);
+    }
+  }, [activeTab]);
 
   // Auto-collapse metadata when team transitions to terminal state
   useEffect(() => {
@@ -731,8 +760,20 @@ export function TeamDetail() {
                 )}
 
                 {activeTab === 'team' && (
-                  <div className="flex-1 min-h-0 px-5 py-3">
-                    <CommGraph edges={messageEdges} agents={roster} />
+                  <div className="flex-1 min-h-0 px-5 py-3 relative">
+                    <CommGraph
+                      edges={messageEdges}
+                      agents={roster}
+                      onNodeClick={setSelectedSpawnAgent}
+                      clickableAgents={clickableAgents}
+                    />
+                    {selectedSpawnAgent !== null && (
+                      <SpawnPromptPanel
+                        agentName={selectedSpawnAgent}
+                        spawns={filteredSpawns}
+                        onClose={() => setSelectedSpawnAgent(null)}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -64,16 +64,24 @@ export function TeamDetail() {
   // visually highlight clickable nodes in CommGraph and to filter spawns
   // for the side panel. Includes agents that may appear in spawnRecords
   // even if they're not yet in the roster (subagent_start without any
-  // tool_use yet).
+  // tool_use yet). Defensive Array.isArray checks: these inputs come from
+  // useTeamDetailData which already coerces failures to []; defaulting
+  // again here keeps test fixtures that mock everything as the team
+  // detail object (instead of arrays) from blowing up.
   const clickableAgents = useMemo(() => {
     const set = new Set<string>();
-    for (const s of spawnRecords) set.add(s.recipient);
-    for (const a of roster) set.add(a.name);
+    if (Array.isArray(spawnRecords)) {
+      for (const s of spawnRecords) set.add(s.recipient);
+    }
+    if (Array.isArray(roster)) {
+      for (const a of roster) set.add(a.name);
+    }
     return set;
   }, [spawnRecords, roster]);
 
   const filteredSpawns = useMemo(() => {
     if (selectedSpawnAgent == null) return [];
+    if (!Array.isArray(spawnRecords)) return [];
     return spawnRecords.filter((s) => s.recipient === selectedSpawnAgent);
   }, [spawnRecords, selectedSpawnAgent]);
 

--- a/src/client/hooks/useTeamDetailData.ts
+++ b/src/client/hooks/useTeamDetailData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useApi } from './useApi';
-import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember, MessageEdge } from '../../shared/types';
+import type { TeamDetail as TeamDetailType, TeamTransition, TeamMember, MessageEdge, SpawnRecord } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -16,6 +16,7 @@ interface UseTeamDetailDataResult {
   transitions: TeamTransition[];
   roster: TeamMember[];
   messageEdges: MessageEdge[];
+  spawnRecords: SpawnRecord[];
   loading: boolean;
   error: string | null;
   refreshDetail: () => void;
@@ -70,6 +71,7 @@ export function useTeamDetailData(
   const [transitions, setTransitions] = useState<TeamTransition[]>([]);
   const [roster, setRoster] = useState<TeamMember[]>([]);
   const [messageEdges, setMessageEdges] = useState<MessageEdge[]>([]);
+  const [spawnRecords, setSpawnRecords] = useState<SpawnRecord[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,6 +83,7 @@ export function useTeamDetailData(
   const transitionsCacheRef = useRef<CacheEntry<TeamTransition[]> | null>(null);
   const rosterCacheRef = useRef<CacheEntry<TeamMember[]> | null>(null);
   const edgesCacheRef = useRef<CacheEntry<MessageEdge[]> | null>(null);
+  const spawnRecordsCacheRef = useRef<CacheEntry<SpawnRecord[]> | null>(null);
 
   // Keep ref in sync for use in async callbacks
   useEffect(() => {
@@ -96,9 +99,11 @@ export function useTeamDetailData(
       setTransitions([]);
       setRoster([]);
       setMessageEdges([]);
+      setSpawnRecords([]);
       transitionsCacheRef.current = null;
       rosterCacheRef.current = null;
       edgesCacheRef.current = null;
+      spawnRecordsCacheRef.current = null;
       return;
     }
 
@@ -108,12 +113,13 @@ export function useTeamDetailData(
       setLoading(true);
       setError(null);
 
-      const [detailResult, transResult, rosterResult, edgesResult] =
+      const [detailResult, transResult, rosterResult, edgesResult, spawnsResult] =
         await Promise.allSettled([
           api.get<TeamDetailType>(`teams/${selectedTeamId}`),
           api.get<TeamTransition[]>(`teams/${selectedTeamId}/transitions`),
           api.get<TeamMember[]>(`teams/${selectedTeamId}/roster`),
           api.get<MessageEdge[]>(`teams/${selectedTeamId}/messages/summary`),
+          api.get<SpawnRecord[]>(`teams/${selectedTeamId}/spawns`),
         ]);
 
       if (cancelled) return;
@@ -151,6 +157,14 @@ export function useTeamDetailData(
         setMessageEdges([]);
       }
 
+      // Spawn records (Issue #713) — non-critical
+      if (spawnsResult.status === 'fulfilled') {
+        setSpawnRecords(spawnsResult.value);
+        spawnRecordsCacheRef.current = { data: spawnsResult.value, fetchedAt: Date.now() };
+      } else {
+        setSpawnRecords([]);
+      }
+
       setLoading(false);
     }
 
@@ -182,6 +196,8 @@ export function useTeamDetailData(
       now - rosterCacheRef.current.fetchedAt >= CACHE_TTL;
     const edgesStale = !edgesCacheRef.current ||
       now - edgesCacheRef.current.fetchedAt >= CACHE_TTL;
+    const spawnsStale = !spawnRecordsCacheRef.current ||
+      now - spawnRecordsCacheRef.current.fetchedAt >= CACHE_TTL;
 
     if (transStale) {
       staleCalls.push(api.get<TeamTransition[]>(`teams/${teamId}/transitions`));
@@ -191,6 +207,9 @@ export function useTeamDetailData(
     }
     if (edgesStale) {
       staleCalls.push(api.get<MessageEdge[]>(`teams/${teamId}/messages/summary`));
+    }
+    if (spawnsStale) {
+      staleCalls.push(api.get<SpawnRecord[]>(`teams/${teamId}/spawns`));
     }
 
     Promise.allSettled(staleCalls).then((results) => {
@@ -231,6 +250,16 @@ export function useTeamDetailData(
           const data = r.value as MessageEdge[];
           setMessageEdges(data);
           edgesCacheRef.current = { data, fetchedAt: Date.now() };
+        }
+      }
+
+      // Spawn records (Issue #713)
+      if (spawnsStale) {
+        const r = results[idx++];
+        if (r && r.status === 'fulfilled') {
+          const data = r.value as SpawnRecord[];
+          setSpawnRecords(data);
+          spawnRecordsCacheRef.current = { data, fetchedAt: Date.now() };
         }
       }
     });
@@ -278,5 +307,5 @@ export function useTeamDetailData(
     };
   }, [selectedTeamId, refreshDetail]);
 
-  return { detail, transitions, roster, messageEdges, loading, error, refreshDetail };
+  return { detail, transitions, roster, messageEdges, spawnRecords, loading, error, refreshDetail };
 }

--- a/src/client/hooks/useTeamDetailData.ts
+++ b/src/client/hooks/useTeamDetailData.ts
@@ -157,8 +157,10 @@ export function useTeamDetailData(
         setMessageEdges([]);
       }
 
-      // Spawn records (Issue #713) — non-critical
-      if (spawnsResult.status === 'fulfilled') {
+      // Spawn records (Issue #713) — non-critical. Defensive: only accept
+      // an array; some test mocks return the same detail object for every
+      // endpoint, and a non-array value would break downstream `for...of`.
+      if (spawnsResult.status === 'fulfilled' && Array.isArray(spawnsResult.value)) {
         setSpawnRecords(spawnsResult.value);
         spawnRecordsCacheRef.current = { data: spawnsResult.value, fetchedAt: Date.now() };
       } else {
@@ -253,10 +255,10 @@ export function useTeamDetailData(
         }
       }
 
-      // Spawn records (Issue #713)
+      // Spawn records (Issue #713) — defensive array check (see primary fetch)
       if (spawnsStale) {
         const r = results[idx++];
-        if (r && r.status === 'fulfilled') {
+        if (r && r.status === 'fulfilled' && Array.isArray(r.value)) {
           const data = r.value as SpawnRecord[];
           setSpawnRecords(data);
           spawnRecordsCacheRef.current = { data, fetchedAt: Date.now() };

--- a/src/client/utils/format-time.ts
+++ b/src/client/utils/format-time.ts
@@ -1,0 +1,26 @@
+// =============================================================================
+// Time formatting helpers (shared across components)
+// =============================================================================
+
+/**
+ * Format an ISO 8601 timestamp into a human-readable relative or absolute
+ * representation. Used by HandoffFileCard and SpawnPromptPanel to label
+ * captured artifacts and spawn events.
+ *
+ * Returns:
+ *   - "just now"               when the diff is < 1 minute
+ *   - "Xm ago"                 when the diff is < 1 hour
+ *   - "Xh ago"                 when the diff is < 24 hours
+ *   - "M/D/YYYY HH:MM"         otherwise (locale-formatted absolute)
+ */
+export function formatRelativeTime(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -31,6 +31,8 @@ import type {
   TeamTask,
   HandoffFile,
   HandoffFileType,
+  SpawnRecord,
+  SpawnTerminalStatus,
 } from '../shared/types.js';
 import { encrypt, decrypt, isEncrypted, decryptWithKey } from './utils/crypto.js';
 import config from './config.js';
@@ -2264,8 +2266,18 @@ export class FleetDatabase {
     return this.mapAgentMessageRow(row);
   }
 
-  getAgentMessages(teamId: number, limit?: number): AgentMessage[] {
-    const cols = 'id, team_id, event_id, sender, recipient, summary, session_id, created_at';
+  /**
+   * Fetch agent messages for a team, ordered newest-first.
+   *
+   * The `content` column is excluded by default to keep response payloads
+   * small for the message-list use case. Pass `includeContent=true` to opt
+   * into receiving the (potentially large) message bodies — used by the
+   * spawn-prompt panel to display captured TL->subagent prompts.
+   */
+  getAgentMessages(teamId: number, limit?: number, includeContent = false): AgentMessage[] {
+    const cols = includeContent
+      ? 'id, team_id, event_id, sender, recipient, summary, content, session_id, created_at'
+      : 'id, team_id, event_id, sender, recipient, summary, session_id, created_at';
     const sql = limit
       ? `SELECT ${cols} FROM agent_messages WHERE team_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`
       : `SELECT ${cols} FROM agent_messages WHERE team_id = ? ORDER BY created_at DESC, id DESC`;
@@ -2318,6 +2330,159 @@ export class FleetDatabase {
       count: r.count,
       lastSummary: r.last_summary ?? null,
     }));
+  }
+
+  // -------------------------------------------------------------------------
+  // Spawn Records (Issue #713)
+  // -------------------------------------------------------------------------
+  //
+  // The `agent_messages` table doubles as the carrier for TL->subagent spawn
+  // records. Rows where `summary='spawned agent'` have `content` populated
+  // with the TL's spawn prompt (capped at 50KB). The prompt is captured at
+  // insert time (from SubagentStart's tool_input.prompt when present) OR
+  // back-filled from the subsequent PostToolUse(Task) event.
+
+  /** 50KB cap (in bytes) for spawn prompt content. */
+  private static readonly SPAWN_PROMPT_MAX_BYTES = 51200;
+
+  /**
+   * Normalize a Task tool's `subagent_type` value to match the recipient
+   * stored in `agent_messages`. CC may emit values like:
+   *   - `dev`                                  (already normalized)
+   *   - `fleet-dev`                            (with the fleet- prefix)
+   *   - `feature-dev:code-explorer`            (with a plugin namespace prefix)
+   *   - `fleet-feature-dev:code-explorer`      (both)
+   *
+   * The recipient stored on the SubagentStart row is the result of
+   * `normalizeAgentName(payload.teammate_name)` which strips the `fleet-`
+   * prefix only. To match a namespaced value like `feature-dev:dev` against
+   * a recipient like `dev`, we also strip everything up to and including
+   * the last colon.
+   */
+  private static normalizeSubagentType(raw: string): string {
+    let name = raw.trim();
+    if (name.startsWith('fleet-')) name = name.slice(6);
+    const colonIdx = name.lastIndexOf(':');
+    if (colonIdx !== -1 && colonIdx < name.length - 1) {
+      name = name.slice(colonIdx + 1);
+    }
+    return name;
+  }
+
+  /**
+   * Back-fill the spawn prompt onto the OLDEST unfilled `agent_messages`
+   * row matching `summary='spawned agent'`, `content IS NULL`, and the
+   * normalized recipient. Used when `PostToolUse(Task)` carries the prompt
+   * the TL passed to the Task tool, but the preceding `SubagentStart`
+   * didn't.
+   *
+   * Edge case: when two consecutive spawns of the same agent type fire
+   * before either Task PostToolUse arrives, both rows have `content=NULL`.
+   * We back-fill the OLDEST first (`id = MIN(id) WHERE …`) so the prompts
+   * line up with the spawn order.
+   *
+   * Returns true on update, false otherwise (no match, empty taskSubagentType,
+   * or empty prompt).
+   */
+  backfillSpawnPromptForTask(data: {
+    teamId: number;
+    taskSubagentType: string | null;
+    prompt: string;
+  }): boolean {
+    if (!data.taskSubagentType || data.taskSubagentType.trim() === '') return false;
+    if (!data.prompt || data.prompt.length === 0) return false;
+
+    const normalized = FleetDatabase.normalizeSubagentType(data.taskSubagentType);
+    if (!normalized) return false;
+
+    const cappedPrompt = data.prompt.slice(0, FleetDatabase.SPAWN_PROMPT_MAX_BYTES);
+
+    // Try exact match on the normalized recipient first; fall back to a
+    // suffix LIKE match if no exact row exists. Within each match attempt
+    // we update only the OLDEST unfilled row (MIN(id)).
+    const updateExact = this.stmt(`
+      UPDATE agent_messages
+         SET content = @content
+       WHERE id = (
+         SELECT MIN(id) FROM agent_messages
+          WHERE team_id = @teamId
+            AND summary = 'spawned agent'
+            AND content IS NULL
+            AND recipient = @recipient
+       )
+    `);
+    const exactInfo = updateExact.run({
+      teamId: data.teamId,
+      recipient: normalized,
+      content: cappedPrompt,
+    });
+    if (exactInfo.changes > 0) return true;
+
+    // Fall-back: looser match for historical recipients that may have been
+    // stored with the `fleet-` prefix (pre-normalization data).
+    const updateLike = this.stmt(`
+      UPDATE agent_messages
+         SET content = @content
+       WHERE id = (
+         SELECT MIN(id) FROM agent_messages
+          WHERE team_id = @teamId
+            AND summary = 'spawned agent'
+            AND content IS NULL
+            AND (recipient = @recipient OR recipient LIKE @likePattern)
+       )
+    `);
+    const likeInfo = updateLike.run({
+      teamId: data.teamId,
+      recipient: normalized,
+      likePattern: `%${normalized}`,
+      content: cappedPrompt,
+    });
+    return likeInfo.changes > 0;
+  }
+
+  /**
+   * Fetch all spawn records for a team in chronological order (oldest first).
+   *
+   * Each row corresponds to one `SubagentStart` hook event. The
+   * `terminalStatus` is computed at query time by checking whether a
+   * `SubagentStop` event for the same recipient was recorded at or after
+   * the spawn's `created_at`. A `'crashed'` status is intentionally NOT
+   * surfaced from the DB in v1 — see `SpawnTerminalStatus` doc.
+   */
+  getSpawnRecords(teamId: number): SpawnRecord[] {
+    // Per-row correlated subquery counts SubagentStop events for the same
+    // normalized recipient since the spawn timestamp. This is bounded by
+    // typical team size (< 50 spawns) and uses the existing
+    // idx_events_team_id_created_at index. The OUTER ORDER BY uses
+    // (created_at ASC, id ASC) so spawns are returned chronologically.
+    const sql = `
+      SELECT
+        am.id           AS id,
+        am.recipient    AS recipient,
+        am.sender       AS sender,
+        am.content      AS content,
+        am.session_id   AS session_id,
+        am.created_at   AS created_at,
+        am.event_id     AS event_id,
+        (
+          SELECT COUNT(*) FROM events e
+           WHERE e.team_id = am.team_id
+             AND e.event_type = 'SubagentStop'
+             AND (
+               CASE
+                 WHEN e.agent_name LIKE 'fleet-%' THEN SUBSTR(e.agent_name, 7)
+                 ELSE e.agent_name
+               END
+             ) = am.recipient
+             AND e.created_at >= am.created_at
+        ) AS stop_count
+      FROM agent_messages am
+      WHERE am.team_id = ?
+        AND am.summary = 'spawned agent'
+      ORDER BY am.created_at ASC, am.id ASC
+    `;
+    const rows = this.stmt(sql).all(teamId) as Record<string, unknown>[];
+    return rows.map((r) => this.mapSpawnRecordRow(r));
   }
 
   // -------------------------------------------------------------------------
@@ -3216,6 +3381,25 @@ export class FleetDatabase {
       content: (row.content as string | null) ?? null,
       sessionId: (row.session_id as string | null) ?? null,
       createdAt: utcify(row.created_at as string),
+    };
+  }
+
+  /**
+   * Map a row from `getSpawnRecords` to a SpawnRecord. Computes the
+   * `terminalStatus` from the per-row `stop_count` correlated subquery.
+   */
+  private mapSpawnRecordRow(row: Record<string, unknown>): SpawnRecord {
+    const stopCount = (row.stop_count as number | null) ?? 0;
+    const terminalStatus: SpawnTerminalStatus = stopCount > 0 ? 'done' : 'running';
+    return {
+      id: row.id as number,
+      recipient: row.recipient as string,
+      sender: row.sender as string,
+      content: (row.content as string | null) ?? null,
+      sessionId: (row.session_id as string | null) ?? null,
+      createdAt: utcify(row.created_at as string),
+      eventId: (row.event_id as number | null) ?? null,
+      terminalStatus,
     };
   }
 

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -839,23 +839,31 @@ const teamsRoutes: FastifyPluginCallback = (
   // -------------------------------------------------------------------------
   // GET /api/teams/:id/messages — agent messages for this team
   // -------------------------------------------------------------------------
+  // Query params:
+  //   - limit:           positive integer, capped at 1000 (default: unbounded)
+  //   - include_content: "true"/"1" to include the message `content` column in
+  //                      the response. Defaults to false so existing callers
+  //                      see no payload bloat. Used by the spawn-prompt panel
+  //                      to display captured TL->subagent prompts (issue #713).
   fastify.get(
     '/api/teams/:id/messages',
     async (
-      request: FastifyRequest<{ Params: TeamIdParams; Querystring: { limit?: string } }>,
+      request: FastifyRequest<{ Params: TeamIdParams; Querystring: { limit?: string; include_content?: string } }>,
       reply: FastifyReply,
     ) => {
       try {
         const teamId = parseIdParam(request.params.id, 'id');
-        const limitParam = (request.query as { limit?: string }).limit;
-        const rawLimit = limitParam ? parseInt(limitParam, 10) : undefined;
+        const query = request.query as { limit?: string; include_content?: string };
+        const rawLimit = query.limit ? parseInt(query.limit, 10) : undefined;
         if (rawLimit !== undefined && (isNaN(rawLimit) || rawLimit < 1)) {
           return reply.code(400).send({ error: 'Bad Request', message: 'limit must be a positive integer' });
         }
         const limit = rawLimit !== undefined ? Math.min(rawLimit, 1000) : undefined;
 
+        const includeContent = query.include_content === 'true' || query.include_content === '1';
+
         const service = getTeamService();
-        const messages = service.getMessages(teamId, limit);
+        const messages = service.getMessages(teamId, limit, includeContent);
         return reply.code(200).send(messages);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {
@@ -905,6 +913,38 @@ const teamsRoutes: FastifyPluginCallback = (
           return reply.code(err.statusCode).send({ error: err.code, message: err.message });
         }
         request.log.error(err, 'Failed to get agent message summary');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // GET /api/teams/:id/spawns — TL->subagent spawn records for this team
+  // -------------------------------------------------------------------------
+  // Returns a chronological list of `SpawnRecord` entries — one per
+  // SubagentStart hook event — with the captured spawn prompt (or null when
+  // the prompt was not captured) and a terminal status of `running` or
+  // `done`. Used by the Team tab to display the original TL prompts when
+  // a subagent node is clicked (issue #713).
+  fastify.get(
+    '/api/teams/:id/spawns',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseIdParam(request.params.id, 'id');
+        const service = getTeamService();
+        const records = service.getSpawnRecords(teamId);
+        return reply.code(200).send(records);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to get spawn records');
         return reply.code(500).send({
           error: 'Internal Server Error',
           message: err instanceof Error ? err.message : String(err),

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -321,6 +321,22 @@ CREATE INDEX IF NOT EXISTS idx_team_transitions_team ON team_transitions(team_id
 -- ---------------------------------------------------------------------------
 -- AGENT MESSAGES — inter-agent message routing captured from SendMessage
 -- ---------------------------------------------------------------------------
+-- This table doubles as the carrier for two different kinds of records:
+--
+--   1. SendMessage routing (sender, recipient, summary, content) — the
+--      original use of this table. `summary` is the message subject and
+--      `content` is the message body.
+--
+--   2. TL->subagent spawn records (issue #713) — rows where
+--      `summary='spawned agent'`. These rows are inserted on every
+--      `SubagentStart` hook event with `sender='team-lead'` and
+--      `recipient` set to the normalized subagent name. For these rows,
+--      `content` carries the TL's spawn prompt (extracted from the Task
+--      tool's `tool_input.prompt`), capped at 50KB at insert time. The
+--      prompt may be captured directly from `SubagentStart` (CC version-
+--      dependent) or back-filled from the subsequent
+--      `PostToolUse(Task)` event. When neither path captures it, content
+--      stays NULL and the UI renders a "no prompt recorded" placeholder.
 CREATE TABLE IF NOT EXISTS agent_messages (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   team_id         INTEGER NOT NULL REFERENCES teams(id),

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -109,6 +109,17 @@ export interface EventCollectorDb {
     content: string;
     agentName?: string | null;
   }): { file: HandoffFile; deduplicated: boolean };
+  /**
+   * Back-fill the spawn prompt onto the OLDEST unfilled `agent_messages` row
+   * with `summary='spawned agent'` for the given team and recipient. Used
+   * when `PostToolUse(Task)` carries the prompt that wasn't present on the
+   * preceding `SubagentStart`. Returns true on update, false otherwise.
+   */
+  backfillSpawnPromptForTask?(data: {
+    teamId: number;
+    taskSubagentType: string | null;
+    prompt: string;
+  }): boolean;
 }
 
 /** SSE broker interface for broadcasting events */
@@ -227,6 +238,61 @@ export function normalizeAgentName(name: string | null | undefined): string {
     normalized = normalized.slice(6);
   }
   return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Spawn prompt capture (Issue #713)
+// ---------------------------------------------------------------------------
+
+/** 50KB cap (in bytes) for spawn prompt content stored in agent_messages.content. */
+const SPAWN_PROMPT_MAX_BYTES = 51200;
+
+/**
+ * Extract the TL's spawn prompt from a hook payload's `tool_input` field.
+ *
+ * Both `SubagentStart` and `PostToolUse(Task)` hook events may include a
+ * `tool_input` field carrying the JSON-stringified Task tool input. When
+ * present, the parsed object's `prompt` property is the prompt the TL passed
+ * to the Task tool. We extract it opportunistically and cap the length at
+ * 50KB to bound storage.
+ *
+ * Returns `null` when:
+ *   - `tool_input` is missing or empty
+ *   - `tool_input` is not valid JSON
+ *   - the parsed value is not an object or has no non-empty string `prompt` property
+ */
+export function extractSpawnPrompt(payload: EventPayload): string | null {
+  const raw = payload.tool_input;
+  if (!raw || typeof raw !== 'string' || raw.trim() === '') return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.prompt !== 'string' || obj.prompt.length === 0) return null;
+    return obj.prompt.slice(0, SPAWN_PROMPT_MAX_BYTES);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the `subagent_type` field from a hook payload's `tool_input` field.
+ * Used to look up the matching spawn row when back-filling the prompt from
+ * a `PostToolUse(Task)` event. Returns `null` when the field is missing or
+ * `tool_input` is unparseable.
+ */
+function extractSubagentType(payload: EventPayload): string | null {
+  const raw = payload.tool_input;
+  if (!raw || typeof raw !== 'string' || raw.trim() === '') return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.subagent_type !== 'string' || obj.subagent_type.length === 0) return null;
+    return obj.subagent_type;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -513,12 +579,17 @@ export function processEvent(
     const subagentName = payload.teammate_name || payload.agent_type || 'unknown';
     const senderName = normalizeAgentName(null); // TL spawns subagents
     const recipientName = normalizeAgentName(subagentName);
+    // Issue #713: capture the TL's spawn prompt when present in tool_input.
+    // The prompt may arrive on SubagentStart (CC version-dependent) OR on
+    // the subsequent PostToolUse(Task) event (handled via back-fill below).
+    // 50KB cap is enforced inside extractSpawnPrompt.
+    const spawnPrompt = extractSpawnPrompt(payload);
     agentMessages.push({
       teamId,
       sender: senderName,
       recipient: recipientName,
       summary: 'spawned agent',
-      content: null,
+      content: spawnPrompt,
       sessionId: payload.session_id || null,
     });
   }
@@ -532,6 +603,39 @@ export function processEvent(
       content: payload.message || null,
       sessionId: payload.session_id || null,
     });
+  }
+
+  // ── Back-fill spawn prompt from PostToolUse(Task) (issue #713) ───
+  // When TL invokes the Task tool, two hook events arrive:
+  //   1. SubagentStart — fires when the subagent process starts. May or may
+  //      not carry tool_input.prompt depending on CC version.
+  //   2. ToolUse for tool_name=Task — fires after the subagent finishes.
+  //      Reliably carries tool_input.{subagent_type, description, prompt}.
+  // If the SubagentStart row has no captured content yet, opportunistically
+  // populate it now from the Task tool's prompt. This is opt-in (the DB
+  // method may be undefined on the mock interface) and best-effort.
+  if (
+    evtLower === 'tool_use' &&
+    payload.tool_name === 'Task' &&
+    typeof db.backfillSpawnPromptForTask === 'function'
+  ) {
+    try {
+      const taskPrompt = extractSpawnPrompt(payload);
+      const taskSubagentType = extractSubagentType(payload);
+      if (taskPrompt && taskSubagentType) {
+        db.backfillSpawnPromptForTask({
+          teamId,
+          taskSubagentType,
+          prompt: taskPrompt,
+        });
+      }
+    } catch (err) {
+      // Non-critical: spawn-prompt back-fill is opportunistic. Log but do
+      // not abort event processing.
+      console.warn(
+        `[EventCollector] Spawn prompt back-fill failed for team=${payload.team}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   // ── Dedup: drop back-to-back identical shutdown events (issue #691 C) ─

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -1125,11 +1125,15 @@ export class TeamService {
    *
    * @param teamId - The team ID
    * @param limit - Optional max messages to return
+   * @param includeContent - Optional flag; when true the message `content`
+   *                         column is included in the result (capped at
+   *                         50KB per row). Defaults to false to keep
+   *                         message-list responses small.
    * @returns Array of agent messages
    * @throws ServiceError with code VALIDATION if teamId is invalid
    * @throws ServiceError with code NOT_FOUND if team doesn't exist
    */
-  getMessages(teamId: number, limit?: number): unknown[] {
+  getMessages(teamId: number, limit?: number, includeContent?: boolean): unknown[] {
     if (isNaN(teamId) || teamId < 1) {
       throw validationError('Invalid team ID');
     }
@@ -1140,7 +1144,31 @@ export class TeamService {
       throw notFoundError(`Team ${teamId} not found`);
     }
 
-    return db.getAgentMessages(teamId, limit);
+    return db.getAgentMessages(teamId, limit, includeContent);
+  }
+
+  /**
+   * Get all TL->subagent spawn records for a team in chronological order.
+   * Each record includes the captured spawn prompt (or null if it was not
+   * captured) plus the spawn's terminal status.
+   *
+   * @param teamId - The team ID
+   * @returns Array of SpawnRecord ordered by created_at ASC
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getSpawnRecords(teamId: number): unknown[] {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    return db.getSpawnRecords(teamId);
   }
 
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -479,6 +479,42 @@ export interface MessageEdge {
   lastSummary: string | null;
 }
 
+/**
+ * Terminal status of a subagent spawn.
+ *
+ * - `running`: no `SubagentStop` event has been observed for this spawn yet.
+ * - `done`: a `SubagentStop` event was recorded after the spawn timestamp.
+ *
+ * Note: a `'crashed'` value is intentionally NOT emitted in v1. The crash
+ * heuristic (early SubagentStop with few tool_use events) lives in the
+ * runtime tracker; surfacing it from the DB is future work.
+ */
+export type SpawnTerminalStatus = 'running' | 'done';
+
+/**
+ * A captured TL->subagent spawn event with optional prompt content.
+ *
+ * One row per `SubagentStart` hook event. The `content` field carries the
+ * TL's spawn prompt (extracted from `tool_input.prompt` on `SubagentStart`
+ * or back-filled from the subsequent `PostToolUse(Task)` event). When the
+ * prompt could not be captured, `content` is `null` and the UI renders a
+ * "no prompt recorded" placeholder.
+ *
+ * `terminalStatus` is computed at query time by checking whether a
+ * `SubagentStop` event for the same recipient was recorded at or after
+ * the spawn's `createdAt` timestamp.
+ */
+export interface SpawnRecord {
+  id: number;
+  recipient: string;
+  sender: string;
+  content: string | null;
+  sessionId: string | null;
+  createdAt: string;
+  eventId: number | null;
+  terminalStatus: SpawnTerminalStatus;
+}
+
 // ---------------------------------------------------------------------------
 // Issue Dependencies (GitHub issue dependency tracking)
 // ---------------------------------------------------------------------------

--- a/tests/client/CommGraph.test.tsx
+++ b/tests/client/CommGraph.test.tsx
@@ -164,4 +164,73 @@ describe('CommGraph', () => {
     expect(devNode!.fx).toBeUndefined();
     expect(devNode!.fy).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #713: onNodeClick + clickableAgents props
+  // ---------------------------------------------------------------------------
+
+  it('forwards onNodeClick prop to ForceGraph and invokes with agent id', () => {
+    const agents = [
+      makeAgent({ name: 'team-lead', role: 'team-lead' }),
+      makeAgent({ name: 'dev', role: 'developer' }),
+    ];
+    const handler = vi.fn();
+
+    render(<CommGraph edges={[]} agents={agents} onNodeClick={handler} />);
+    expect(mockForceGraph).toHaveBeenCalled();
+
+    const call = mockForceGraph.mock.calls[0][0] as { onNodeClick?: (node: { id: string }) => void };
+    expect(typeof call.onNodeClick).toBe('function');
+
+    // Simulate ForceGraph invoking the click handler with a graph node
+    call.onNodeClick?.({ id: 'dev' });
+    expect(handler).toHaveBeenCalledWith('dev');
+  });
+
+  it('passes a noop-style click handler when onNodeClick prop is omitted', () => {
+    const agents = [makeAgent({ name: 'dev' })];
+    render(<CommGraph edges={[]} agents={agents} />);
+    const call = mockForceGraph.mock.calls[0][0] as { onNodeClick?: (node: { id: string }) => void };
+    // Always wired (simplifies ForceGraph), but the inner handler short-circuits.
+    expect(typeof call.onNodeClick).toBe('function');
+    expect(() => call.onNodeClick?.({ id: 'dev' })).not.toThrow();
+  });
+
+  it('forwards a nodeLabel callback that includes a click hint when clickable', () => {
+    const agents = [makeAgent({ name: 'dev', role: 'developer' })];
+    const clickable = new Set<string>(['dev']);
+    const handler = vi.fn();
+
+    render(
+      <CommGraph
+        edges={[]}
+        agents={agents}
+        onNodeClick={handler}
+        clickableAgents={clickable}
+      />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as { nodeLabel?: (n: { id: string; name: string; role: string }) => string };
+    const html = call.nodeLabel?.({ id: 'dev', name: 'dev', role: 'developer' }) ?? '';
+    expect(html).toContain('click for spawn prompts');
+  });
+
+  it('omits the click hint from nodeLabel when the node is not clickable', () => {
+    const agents = [makeAgent({ name: 'dev', role: 'developer' })];
+    const clickable = new Set<string>(); // empty
+    const handler = vi.fn();
+
+    render(
+      <CommGraph
+        edges={[]}
+        agents={agents}
+        onNodeClick={handler}
+        clickableAgents={clickable}
+      />,
+    );
+
+    const call = mockForceGraph.mock.calls[0][0] as { nodeLabel?: (n: { id: string; name: string; role: string }) => string };
+    const html = call.nodeLabel?.({ id: 'dev', name: 'dev', role: 'developer' }) ?? '';
+    expect(html).not.toContain('click for spawn prompts');
+  });
 });

--- a/tests/client/useTeamDetailData.test.ts
+++ b/tests/client/useTeamDetailData.test.ts
@@ -77,6 +77,21 @@ function makeEdges() {
   ];
 }
 
+function makeSpawns() {
+  return [
+    {
+      id: 1,
+      recipient: 'dev',
+      sender: 'team-lead',
+      content: 'do feature X',
+      sessionId: 'sess-1',
+      createdAt: '2026-03-21T10:00:00Z',
+      eventId: 1,
+      terminalStatus: 'running' as const,
+    },
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -97,21 +112,24 @@ describe('useTeamDetailData', () => {
     expect(result.current.transitions).toEqual([]);
     expect(result.current.roster).toEqual([]);
     expect(result.current.messageEdges).toEqual([]);
+    expect(result.current.spawnRecords).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
-  it('fires all 4 fetches in parallel when selectedTeamId is set', async () => {
+  it('fires all 5 fetches in parallel when selectedTeamId is set', async () => {
     const detail = makeDetail();
     const transitions = makeTransitions();
     const rosterData = makeRoster();
     const edges = makeEdges();
+    const spawns = makeSpawns();
 
     mockGet.mockImplementation((path: string) => {
       if (path === 'teams/1') return Promise.resolve(detail);
       if (path === 'teams/1/transitions') return Promise.resolve(transitions);
       if (path === 'teams/1/roster') return Promise.resolve(rosterData);
       if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      if (path === 'teams/1/spawns') return Promise.resolve(spawns);
       return Promise.reject(new Error(`Unexpected path: ${path}`));
     });
 
@@ -123,16 +141,18 @@ describe('useTeamDetailData', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledTimes(4);
+    expect(mockGet).toHaveBeenCalledTimes(5);
     expect(mockGet).toHaveBeenCalledWith('teams/1');
     expect(mockGet).toHaveBeenCalledWith('teams/1/transitions');
     expect(mockGet).toHaveBeenCalledWith('teams/1/roster');
     expect(mockGet).toHaveBeenCalledWith('teams/1/messages/summary');
+    expect(mockGet).toHaveBeenCalledWith('teams/1/spawns');
 
     expect(result.current.detail).toEqual(detail);
     expect(result.current.transitions).toEqual(transitions);
     expect(result.current.roster).toEqual(rosterData);
     expect(result.current.messageEdges).toEqual(edges);
+    expect(result.current.spawnRecords).toEqual(spawns);
     expect(result.current.error).toBeNull();
   });
 
@@ -144,6 +164,7 @@ describe('useTeamDetailData', () => {
       if (path === 'teams/1/transitions') return Promise.resolve(transitions);
       if (path === 'teams/1/roster') return Promise.resolve([]);
       if (path === 'teams/1/messages/summary') return Promise.resolve([]);
+      if (path === 'teams/1/spawns') return Promise.resolve([]);
       return Promise.reject(new Error(`Unexpected path: ${path}`));
     });
 
@@ -198,6 +219,7 @@ describe('useTeamDetailData', () => {
     expect(result.current.transitions).toEqual([]);
     expect(result.current.roster).toEqual([]);
     expect(result.current.messageEdges).toEqual([]);
+    expect(result.current.spawnRecords).toEqual([]);
   });
 
   it('refreshDetail re-fetches only detail when caches are fresh', async () => {
@@ -205,12 +227,14 @@ describe('useTeamDetailData', () => {
     const transitions = makeTransitions();
     const rosterData = makeRoster();
     const edges = makeEdges();
+    const spawns = makeSpawns();
 
     mockGet.mockImplementation((path: string) => {
       if (path === 'teams/1') return Promise.resolve(detail);
       if (path === 'teams/1/transitions') return Promise.resolve(transitions);
       if (path === 'teams/1/roster') return Promise.resolve(rosterData);
       if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      if (path === 'teams/1/spawns') return Promise.resolve(spawns);
       return Promise.reject(new Error(`Unexpected path: ${path}`));
     });
 
@@ -226,6 +250,7 @@ describe('useTeamDetailData', () => {
       if (path === 'teams/1/transitions') return Promise.resolve(transitions);
       if (path === 'teams/1/roster') return Promise.resolve(rosterData);
       if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      if (path === 'teams/1/spawns') return Promise.resolve(spawns);
       return Promise.reject(new Error(`Unexpected path: ${path}`));
     });
 
@@ -275,12 +300,14 @@ describe('useTeamDetailData', () => {
     const transitions = makeTransitions();
     const rosterData = makeRoster();
     const edges = makeEdges();
+    const spawns = makeSpawns();
 
     mockGet.mockImplementation((path: string) => {
       if (path === 'teams/1') return Promise.resolve(detail);
       if (path === 'teams/1/transitions') return Promise.resolve(transitions);
       if (path === 'teams/1/roster') return Promise.resolve(rosterData);
       if (path === 'teams/1/messages/summary') return Promise.resolve(edges);
+      if (path === 'teams/1/spawns') return Promise.resolve(spawns);
       return Promise.reject(new Error(`Unexpected path: ${path}`));
     });
 
@@ -331,6 +358,47 @@ describe('useTeamDetailData', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('exposes spawnRecords from the /spawns endpoint', async () => {
+    const detail = makeDetail();
+    const spawns = makeSpawns();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/spawns') return Promise.resolve(spawns);
+      // Other endpoints return empty so test focuses on spawnRecords
+      return Promise.resolve([]);
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.spawnRecords).toEqual(spawns);
+  });
+
+  it('falls back to empty spawnRecords when the /spawns endpoint fails', async () => {
+    const detail = makeDetail();
+
+    mockGet.mockImplementation((path: string) => {
+      if (path === 'teams/1') return Promise.resolve(detail);
+      if (path === 'teams/1/spawns') return Promise.reject(new Error('500'));
+      return Promise.resolve([]);
+    });
+
+    const { result } = renderHook(() => useTeamDetailData(1, null, null));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toEqual(detail);
+    expect(result.current.spawnRecords).toEqual([]);
+    // Failure of a non-critical endpoint must NOT set the error state
+    expect(result.current.error).toBeNull();
   });
 
   it('exposes refreshDetail as a stable function', async () => {

--- a/tests/integration/api-endpoints.test.ts
+++ b/tests/integration/api-endpoints.test.ts
@@ -144,6 +144,49 @@ beforeAll(async () => {
     },
   );
 
+  // GET /api/teams/:id/messages — manual registration mirroring teamsRoutes
+  // (avoids pulling in team-manager dependencies). Issue #713: ?include_content=true
+  server.get<{ Params: { id: string }; Querystring: { limit?: string; include_content?: string } }>(
+    '/api/teams/:id/messages',
+    async (req, reply) => {
+      const teamId = parseInt(req.params.id, 10);
+      if (isNaN(teamId) || teamId < 1) {
+        return reply.code(400).send({ error: 'Bad Request', message: 'Invalid team ID' });
+      }
+      const db = getDatabase();
+      const team = db.getTeam(teamId);
+      if (!team) {
+        return reply.code(404).send({ error: 'Not Found', message: `Team ${teamId} not found` });
+      }
+      const rawLimit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+      if (rawLimit !== undefined && (isNaN(rawLimit) || rawLimit < 1)) {
+        return reply.code(400).send({ error: 'Bad Request', message: 'limit must be a positive integer' });
+      }
+      const limit = rawLimit !== undefined ? Math.min(rawLimit, 1000) : undefined;
+      const includeContent = req.query.include_content === 'true' || req.query.include_content === '1';
+      const messages = db.getAgentMessages(teamId, limit, includeContent);
+      return reply.code(200).send(messages);
+    },
+  );
+
+  // GET /api/teams/:id/spawns — Issue #713
+  server.get<{ Params: { id: string } }>(
+    '/api/teams/:id/spawns',
+    async (req, reply) => {
+      const teamId = parseInt(req.params.id, 10);
+      if (isNaN(teamId) || teamId < 1) {
+        return reply.code(400).send({ error: 'Bad Request', message: 'Invalid team ID' });
+      }
+      const db = getDatabase();
+      const team = db.getTeam(teamId);
+      if (!team) {
+        return reply.code(404).send({ error: 'Not Found', message: `Team ${teamId} not found` });
+      }
+      const records = db.getSpawnRecords(teamId);
+      return reply.code(200).send(records);
+    },
+  );
+
   // Register GET /api/prs manually to avoid gh CLI usage in POST routes
   server.get('/api/prs', async (_req, reply) => {
     const db = getDatabase();
@@ -465,6 +508,155 @@ describe('Teams API (read-only)', () => {
   it('GET /api/teams/:id returns 400 for non-numeric ID', async () => {
     const res = await server.inject({ method: 'GET', url: '/api/teams/abc' });
 
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// =============================================================================
+// Issue #713: Messages content opt-in + Spawn records endpoint
+// =============================================================================
+
+describe('Spawn prompt API (Issue #713)', () => {
+  let spawnTeamId: number;
+
+  beforeAll(() => {
+    // Seed a fresh team in this group's namespace; reuse later
+    const team = seedTeam({ issueNumber: 713, worktreeName: 'kea-713' });
+    spawnTeamId = team.id;
+  });
+
+  beforeEach(() => {
+    const db = getDatabase();
+    // Clear any spawn rows for our team between tests so each case is independent
+    db.raw.prepare('DELETE FROM agent_messages WHERE team_id = ?').run(spawnTeamId);
+  });
+
+  function seedSpawn(recipient: string, content: string | null = null): { id: number } {
+    const db = getDatabase();
+    const eventInfo = db.insertEvent({
+      teamId: spawnTeamId,
+      eventType: 'SubagentStart',
+      agentName: `fleet-${recipient}`,
+    });
+    return db.insertAgentMessage({
+      teamId: spawnTeamId,
+      eventId: eventInfo.id,
+      sender: 'team-lead',
+      recipient,
+      summary: 'spawned agent',
+      content,
+    });
+  }
+
+  it('GET /api/teams/:id/messages excludes content by default', async () => {
+    seedSpawn('dev', 'secret prompt');
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/messages`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(1);
+    expect(body[0].content).toBeNull();
+    expect(body[0].summary).toBe('spawned agent');
+  });
+
+  it('GET /api/teams/:id/messages includes content when include_content=true', async () => {
+    seedSpawn('dev', 'real prompt content');
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/messages?include_content=true`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].content).toBe('real prompt content');
+  });
+
+  it('GET /api/teams/:id/messages accepts include_content=1 alias', async () => {
+    seedSpawn('dev', 'alias');
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/messages?include_content=1`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body[0].content).toBe('alias');
+  });
+
+  it('GET /api/teams/:id/spawns returns SpawnRecord[] in chronological order', async () => {
+    seedSpawn('dev', 'first');
+    seedSpawn('reviewer', 'second');
+    seedSpawn('dev', 'third');
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/spawns`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(3);
+    // Each entry must carry the expected SpawnRecord shape
+    for (const r of body) {
+      expect(r).toHaveProperty('id');
+      expect(r).toHaveProperty('recipient');
+      expect(r).toHaveProperty('sender');
+      expect(r).toHaveProperty('content');
+      expect(r).toHaveProperty('createdAt');
+      expect(r).toHaveProperty('terminalStatus');
+      expect(['running', 'done']).toContain(r.terminalStatus);
+    }
+    // Chronological ordering preserved
+    expect(body.map((r: { content: string }) => r.content)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('GET /api/teams/:id/spawns returns terminalStatus=running when no SubagentStop', async () => {
+    seedSpawn('dev', 'running');
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/spawns`,
+    });
+
+    const body = res.json();
+    expect(body[0].terminalStatus).toBe('running');
+  });
+
+  it('GET /api/teams/:id/spawns returns null content when prompt was not captured', async () => {
+    seedSpawn('dev', null);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `/api/teams/${spawnTeamId}/spawns`,
+    });
+
+    const body = res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].content).toBeNull();
+  });
+
+  it('GET /api/teams/:id/spawns returns 404 for unknown team', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/teams/9999/spawns',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('GET /api/teams/:id/spawns returns 400 for invalid team ID', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/teams/abc/spawns',
+    });
     expect(res.statusCode).toBe(400);
   });
 });

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -1065,6 +1065,382 @@ describe('Agent Messages CRUD', () => {
 
     expect(msg.createdAt).toMatch(/T.*Z$/);
   });
+
+  it('getAgentMessages includes content only when includeContent=true', () => {
+    db.insertAgentMessage({
+      teamId: 1,
+      eventId: 1,
+      sender: 'coordinator',
+      recipient: 'dev-ts',
+      summary: 'Task assigned',
+      content: 'Full message content with the actual prompt',
+    });
+
+    const without = db.getAgentMessages(1);
+    expect(without).toHaveLength(1);
+    expect(without[0].content).toBeNull();
+
+    const withContent = db.getAgentMessages(1, undefined, true);
+    expect(withContent).toHaveLength(1);
+    expect(withContent[0].content).toBe('Full message content with the actual prompt');
+  });
+});
+
+// =============================================================================
+// Spawn Records (Issue #713) — back-fill + getSpawnRecords
+// =============================================================================
+
+describe('Spawn Records (Issue #713)', () => {
+  beforeEach(() => {
+    db.insertTeam({ issueNumber: 100, worktreeName: 'kea-100', status: 'running', phase: 'implementing' });
+    // Two seed events used as event_id foreign keys in spawn rows
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'fleet-dev' });
+    db.insertEvent({ teamId: 1, eventType: 'SubagentStart', agentName: 'fleet-reviewer' });
+  });
+
+  describe('backfillSpawnPromptForTask', () => {
+    it('updates the OLDEST unfilled matching spawn row', () => {
+      const a = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      // Different recipient, should NOT be touched
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 2,
+        sender: 'team-lead',
+        recipient: 'reviewer',
+        summary: 'spawned agent',
+        content: null,
+      });
+
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'dev',
+        prompt: 'do thing',
+      });
+
+      expect(ok).toBe(true);
+      const all = db.getAgentMessages(1, undefined, true);
+      const dev = all.find((m) => m.id === a.id);
+      const rev = all.find((m) => m.recipient === 'reviewer');
+      expect(dev?.content).toBe('do thing');
+      expect(rev?.content).toBeNull();
+    });
+
+    it('back-fills the OLDEST unfilled row when two same-recipient spawns exist', () => {
+      const first = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      const second = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'dev',
+        prompt: 'first prompt',
+      });
+
+      expect(ok).toBe(true);
+      const all = db.getAgentMessages(1, undefined, true);
+      const firstRow = all.find((m) => m.id === first.id);
+      const secondRow = all.find((m) => m.id === second.id);
+      expect(firstRow?.content).toBe('first prompt');
+      expect(secondRow?.content).toBeNull();
+    });
+
+    it('returns false when no matching unfilled spawn exists', () => {
+      // No spawn rows inserted at all
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'dev',
+        prompt: 'no match',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('skips rows where content is already populated', () => {
+      const a = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'already set',
+      });
+
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'dev',
+        prompt: 'replacement',
+      });
+
+      expect(ok).toBe(false);
+      const all = db.getAgentMessages(1, undefined, true);
+      expect(all.find((m) => m.id === a.id)?.content).toBe('already set');
+    });
+
+    it('normalizes taskSubagentType with fleet- prefix', () => {
+      const a = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'fleet-dev',
+        prompt: 'normalized',
+      });
+      expect(ok).toBe(true);
+      expect(db.getAgentMessages(1, undefined, true).find((m) => m.id === a.id)?.content).toBe(
+        'normalized',
+      );
+    });
+
+    it('normalizes taskSubagentType with namespace colon prefix', () => {
+      const a = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'feature-dev:dev',
+        prompt: 'with-colon',
+      });
+      expect(ok).toBe(true);
+      expect(db.getAgentMessages(1, undefined, true).find((m) => m.id === a.id)?.content).toBe(
+        'with-colon',
+      );
+    });
+
+    it('caps prompt content at 50KB', () => {
+      const a = db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      const big = 'x'.repeat(60_000);
+      const ok = db.backfillSpawnPromptForTask({
+        teamId: 1,
+        taskSubagentType: 'dev',
+        prompt: big,
+      });
+      expect(ok).toBe(true);
+      const got = db.getAgentMessages(1, undefined, true).find((m) => m.id === a.id);
+      expect(got?.content?.length).toBe(51200);
+    });
+
+    it('returns false when taskSubagentType is null or empty', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      expect(
+        db.backfillSpawnPromptForTask({ teamId: 1, taskSubagentType: null, prompt: 'p' }),
+      ).toBe(false);
+      expect(
+        db.backfillSpawnPromptForTask({ teamId: 1, taskSubagentType: '', prompt: 'p' }),
+      ).toBe(false);
+    });
+
+    it('returns false when prompt is empty', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      expect(
+        db.backfillSpawnPromptForTask({ teamId: 1, taskSubagentType: 'dev', prompt: '' }),
+      ).toBe(false);
+    });
+  });
+
+  describe('getSpawnRecords', () => {
+    it('returns terminalStatus=running when no SubagentStop exists', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'do X',
+      });
+      const records = db.getSpawnRecords(1);
+      expect(records).toHaveLength(1);
+      expect(records[0].recipient).toBe('dev');
+      expect(records[0].terminalStatus).toBe('running');
+      expect(records[0].content).toBe('do X');
+    });
+
+    it('returns terminalStatus=done when SubagentStop exists after spawn', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'do X',
+      });
+      // Insert a SubagentStop event for the same recipient AFTER the spawn.
+      // SQLite created_at uses datetime('now') so this is always later than the spawn.
+      db.insertEvent({ teamId: 1, eventType: 'SubagentStop', agentName: 'fleet-dev' });
+
+      const records = db.getSpawnRecords(1);
+      expect(records).toHaveLength(1);
+      expect(records[0].terminalStatus).toBe('done');
+    });
+
+    it('returns multiple spawns of the same recipient in chronological order', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'first',
+      });
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'second',
+      });
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'third',
+      });
+
+      const records = db.getSpawnRecords(1);
+      expect(records.map((r) => r.content)).toEqual(['first', 'second', 'third']);
+    });
+
+    it('returns the captured prompt as content (or null when not captured)', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'with prompt',
+      });
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 2,
+        sender: 'team-lead',
+        recipient: 'reviewer',
+        summary: 'spawned agent',
+        content: null,
+      });
+
+      const records = db.getSpawnRecords(1);
+      expect(records).toHaveLength(2);
+      expect(records[0].content).toBe('with prompt');
+      expect(records[1].content).toBeNull();
+    });
+
+    it('excludes non-spawn agent_messages rows', () => {
+      // SendMessage routing rows should not appear in spawn records
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'dev',
+        recipient: 'reviewer',
+        summary: 'review me',
+        content: 'please review',
+      });
+      // Plus one actual spawn row
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'do X',
+      });
+
+      const records = db.getSpawnRecords(1);
+      expect(records).toHaveLength(1);
+      expect(records[0].recipient).toBe('dev');
+    });
+
+    it('excludes spawns from other teams', () => {
+      db.insertTeam({ issueNumber: 200, worktreeName: 'kea-200', status: 'running', phase: 'implementing' });
+      db.insertEvent({ teamId: 2, eventType: 'SubagentStart', agentName: 'fleet-dev' });
+
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'team1',
+      });
+      db.insertAgentMessage({
+        teamId: 2,
+        eventId: 3,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'team2',
+      });
+
+      expect(db.getSpawnRecords(1)).toHaveLength(1);
+      expect(db.getSpawnRecords(1)[0].content).toBe('team1');
+      expect(db.getSpawnRecords(2)).toHaveLength(1);
+      expect(db.getSpawnRecords(2)[0].content).toBe('team2');
+    });
+
+    it('returns ISO 8601 createdAt with trailing Z', () => {
+      db.insertAgentMessage({
+        teamId: 1,
+        eventId: 1,
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: null,
+      });
+      const records = db.getSpawnRecords(1);
+      expect(records[0].createdAt).toMatch(/T.*Z$/);
+    });
+  });
 });
 
 // =============================================================================

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -16,6 +16,7 @@ import {
   shouldAdvancePhase,
   PHASE_ORDER,
   EventCollectorError,
+  extractSpawnPrompt,
   type EventPayload,
   type EventCollectorDb,
   type SseBroker,
@@ -1264,6 +1265,229 @@ describe('Subagent spawn message recording', () => {
 
     // insertAgentMessage should NOT have been called (no SendMessage tool_name either)
     expect(db.insertAgentMessage).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Spawn prompt capture & back-fill (Issue #713)
+// =============================================================================
+
+describe('Spawn prompt capture (Issue #713)', () => {
+  it('extractSpawnPrompt returns prompt when tool_input has prompt field', () => {
+    const payload = makePayload({
+      tool_input: JSON.stringify({ subagent_type: 'dev', prompt: 'do X' }),
+    });
+    expect(extractSpawnPrompt(payload)).toBe('do X');
+  });
+
+  it('extractSpawnPrompt returns null when tool_input is missing', () => {
+    const payload = makePayload({ tool_input: undefined });
+    expect(extractSpawnPrompt(payload)).toBeNull();
+  });
+
+  it('extractSpawnPrompt returns null when tool_input is malformed JSON', () => {
+    const payload = makePayload({ tool_input: 'not json' });
+    expect(extractSpawnPrompt(payload)).toBeNull();
+  });
+
+  it('extractSpawnPrompt returns null when prompt field is missing', () => {
+    const payload = makePayload({
+      tool_input: JSON.stringify({ subagent_type: 'dev' }),
+    });
+    expect(extractSpawnPrompt(payload)).toBeNull();
+  });
+
+  it('extractSpawnPrompt caps prompt content at 50KB (51200 bytes)', () => {
+    const big = 'x'.repeat(60_000);
+    const payload = makePayload({
+      tool_input: JSON.stringify({ subagent_type: 'dev', prompt: big }),
+    });
+    const result = extractSpawnPrompt(payload);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(51200);
+  });
+
+  it('captures prompt from tool_input on subagent_start when present', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({
+        event: 'subagent_start',
+        teammate_name: 'fleet-dev',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({ subagent_type: 'dev', prompt: 'implement feature' }),
+      }),
+      db,
+      sse,
+    );
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: 'team-lead',
+        recipient: 'dev',
+        summary: 'spawned agent',
+        content: 'implement feature',
+      }),
+    );
+  });
+
+  it('handles missing tool_input gracefully on subagent_start (content=null)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({
+        event: 'subagent_start',
+        teammate_name: 'fleet-dev',
+        agent_type: 'coordinator',
+        tool_input: undefined,
+      }),
+      db,
+      sse,
+    );
+
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'spawned agent',
+        content: null,
+      }),
+    );
+  });
+
+  it('handles malformed tool_input JSON on subagent_start (content=null, no throw)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const result = processEvent(
+      makePayload({
+        event: 'subagent_start',
+        teammate_name: 'fleet-dev',
+        agent_type: 'coordinator',
+        tool_input: 'not-json{',
+      }),
+      db,
+      sse,
+    );
+
+    expect(result.processed).toBe(true);
+    expect(db.insertAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'spawned agent',
+        content: null,
+      }),
+    );
+  });
+
+  it('caps prompt content at 50KB on subagent_start', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const big = 'x'.repeat(60_000);
+
+    processEvent(
+      makePayload({
+        event: 'subagent_start',
+        teammate_name: 'fleet-dev',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({ subagent_type: 'dev', prompt: big }),
+      }),
+      db,
+      sse,
+    );
+
+    const call = (db.insertAgentMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.content).toBeDefined();
+    expect((call.content as string).length).toBe(51200);
+  });
+
+  it('back-fills spawn prompt from PostToolUse(Task)', () => {
+    const backfillSpawnPromptForTask = vi.fn().mockReturnValue(true);
+    const db = createMockDb({ backfillSpawnPromptForTask });
+    const sse = createMockSse();
+
+    // Simulate the Task tool's PostToolUse event
+    processEvent(
+      makePayload({
+        event: 'tool_use',
+        tool_name: 'Task',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({
+          subagent_type: 'dev',
+          description: 'Implement feature',
+          prompt: 'back-filled prompt',
+        }),
+      }),
+      db,
+      sse,
+    );
+
+    expect(backfillSpawnPromptForTask).toHaveBeenCalledWith({
+      teamId: 1,
+      taskSubagentType: 'dev',
+      prompt: 'back-filled prompt',
+    });
+  });
+
+  it('does not call backfillSpawnPromptForTask for non-Task tool_use events', () => {
+    const backfillSpawnPromptForTask = vi.fn().mockReturnValue(true);
+    const db = createMockDb({ backfillSpawnPromptForTask });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({
+        event: 'tool_use',
+        tool_name: 'Bash',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({ command: 'ls' }),
+      }),
+      db,
+      sse,
+    );
+
+    expect(backfillSpawnPromptForTask).not.toHaveBeenCalled();
+  });
+
+  it('back-fill is best-effort: throw inside backfillSpawnPromptForTask does not break event processing', () => {
+    const backfillSpawnPromptForTask = vi.fn().mockImplementation(() => {
+      throw new Error('DB error');
+    });
+    const db = createMockDb({ backfillSpawnPromptForTask });
+    const sse = createMockSse();
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = processEvent(
+      makePayload({
+        event: 'tool_use',
+        tool_name: 'Task',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({ subagent_type: 'dev', prompt: 'p' }),
+      }),
+      db,
+      sse,
+    );
+
+    expect(result.processed).toBe(true);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('does not call backfillSpawnPromptForTask when Task tool_input has no prompt', () => {
+    const backfillSpawnPromptForTask = vi.fn().mockReturnValue(true);
+    const db = createMockDb({ backfillSpawnPromptForTask });
+    const sse = createMockSse();
+
+    processEvent(
+      makePayload({
+        event: 'tool_use',
+        tool_name: 'Task',
+        agent_type: 'coordinator',
+        tool_input: JSON.stringify({ subagent_type: 'dev', description: 'no prompt here' }),
+      }),
+      db,
+      sse,
+    );
+
+    expect(backfillSpawnPromptForTask).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Surfaces the TL's spawn prompt for every subagent in the Team tab. Captures the prompt server-side from `subagent_start` (with back-fill from `PostToolUse(Task)`), exposes it via a new `GET /api/teams/:id/spawns` endpoint, and adds a clickable side-panel anchored to each CommGraph node so users can audit what each subagent was actually asked to do.

- 50 KB cap enforced at every insertion path.
- `agent_messages.content` carries the prompt for spawn rows; no schema migration needed (schema version stays at 20).
- Existing `/messages` and `/messages/summary` endpoints retain their shape; `?include_content=true` is opt-in.
- v1 terminal status is `running | done`; `crashed` is left as future work.

Closes #713

## Test plan

- [x] `npm run build` clean (tsc + Vite)
- [x] `tsc --noEmit` clean
- [x] Server tests: 1920 pass; the 3 failures in `tests/server/cc-spawn.test.ts` are pre-existing (env-var leakage on Windows, also fails on `origin/main`)
- [x] Targeted client tests for changed files all pass
- [x] New tests added: 13 in `event-collector.test.ts`, 12 in `db.test.ts`, 9 in integration, 2 in `useTeamDetailData.test.ts`, 4 in `CommGraph.test.tsx`
- [ ] CI green