### PR TITLE
Issue #720: extractVersionStamp reads 4096 bytes

### DIFF
--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -283,12 +283,15 @@ export async function refreshAutoMergeForProject(
  * @param filePath - Absolute path to the installed file
  * @returns The version string (e.g. "0.0.6") or undefined if not found
  */
-function extractVersionStamp(filePath: string): string | undefined {
+export function extractVersionStamp(filePath: string): string | undefined {
   try {
-    // Read first 512 bytes — the stamp is within the first few lines
-    const buf = Buffer.alloc(512);
+    // Read first 4096 bytes — covers shell-script line 2 stamps and
+    // markdown YAML frontmatter even when the frontmatter is long
+    // (e.g. fleet-reviewer.md has a multi-line description + comments
+    // that push _fleetCommanderVersion past byte 512). See issue #720.
+    const buf = Buffer.alloc(4096);
     const fd = fs.openSync(filePath, 'r');
-    const bytesRead = fs.readSync(fd, buf, 0, 512, 0);
+    const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
     fs.closeSync(fd);
     const header = buf.subarray(0, bytesRead).toString('utf-8');
     // Try HTML comment / shell comment format first

--- a/tests/server/services/extract-version-stamp.test.ts
+++ b/tests/server/services/extract-version-stamp.test.ts
@@ -1,0 +1,68 @@
+// =============================================================================
+// Fleet Commander — extractVersionStamp Tests
+// =============================================================================
+// Verifies the version-stamp parser reads enough of the file to find stamps
+// that live past the first few hundred bytes (e.g. fleet-reviewer.md with a
+// long YAML frontmatter). Regression test for issue #720.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { extractVersionStamp } from '../../../src/server/services/project-service.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fc-version-stamp-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, content: string): string {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('extractVersionStamp', () => {
+  it('reads YAML frontmatter stamp at the top', () => {
+    const file = writeFile('short.md', `---\nname: foo\n_fleetCommanderVersion: "1.2.3"\n---\nbody\n`);
+    expect(extractVersionStamp(file)).toBe('1.2.3');
+  });
+
+  it('reads shell-script stamp on line 2', () => {
+    const file = writeFile('hook.sh', `#!/bin/sh\n# fleet-commander v0.0.24\necho hi\n`);
+    expect(extractVersionStamp(file)).toBe('0.0.24');
+  });
+
+  it('finds YAML stamp past byte 512 (regression: #720)', () => {
+    // Simulate fleet-reviewer.md shape: long description + comment lines that
+    // push _fleetCommanderVersion past the historic 512-byte read window.
+    const padding = 'x'.repeat(800);
+    const content =
+      `---\n` +
+      `name: fleet-reviewer\n` +
+      `description: ${padding}\n` +
+      `model: inherit\n` +
+      `_fleetCommanderVersion: "0.0.24"\n` +
+      `---\n` +
+      `body\n`;
+    expect(content.indexOf('_fleetCommanderVersion')).toBeGreaterThan(512);
+
+    const file = writeFile('long-frontmatter.md', content);
+    expect(extractVersionStamp(file)).toBe('0.0.24');
+  });
+
+  it('returns undefined when no stamp is present', () => {
+    const file = writeFile('plain.md', `# hello\n\nno stamp here\n`);
+    expect(extractVersionStamp(file)).toBeUndefined();
+  });
+
+  it('returns undefined for a missing file', () => {
+    expect(extractVersionStamp(path.join(tmpDir, 'does-not-exist.md'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #720.

## Summary

- Bump `extractVersionStamp` read window from 512 → 4096 bytes so YAML frontmatter stamps past byte 512 (e.g. `fleet-reviewer.md`) are detected.
- Export `extractVersionStamp` so it can be unit-tested.
- Add regression tests for short frontmatter, shell-script stamps, long frontmatter past byte 512, missing stamps, and missing files.

## Test plan

- [x] `npx vitest run tests/server/services/extract-version-stamp.test.ts` — 5/5 pass
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [ ] After merge, install-status report should show `installedVersion` for `fleet-reviewer.md` and stop flagging it as outdated.