### PR TITLE
Issue #723: poller merges ready PRs directly

### DIFF
--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -18,7 +18,7 @@ import { getDatabase } from '../db.js';
 import config from '../config.js';
 import { sseBroker } from './sse-broker.js';
 import { resolveMessage } from '../utils/resolve-message.js';
-import { execGHAsync, execGitAsync, isValidGithubRepo, isValidBranchName } from '../utils/exec-gh.js';
+import { execGHAsync, execGHResult, execGitAsync, isValidGithubRepo, isValidBranchName } from '../utils/exec-gh.js';
 import type { PRState, CIStatus, MergeStatus } from '../../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -88,6 +88,17 @@ class GitHubPoller {
   private warnedCollisions = new Set<string>();
 
   /**
+   * In-memory throttle for direct PR merge attempts.
+   * Maps teamId -> last attempt timestamp (ms). Prevents the poller from
+   * retry-storming `gh pr merge` while the merge call is in flight or
+   * after a recent failure. Cleared when the team transitions to done.
+   */
+  private mergeAttempts = new Map<number, number>();
+
+  /** Minimum interval between direct merge attempts per team (ms). */
+  private static readonly MERGE_RETRY_THROTTLE_MS = 60_000;
+
+  /**
    * Start the polling loop. Uses adaptive intervals:
    * - Normal: config.githubPollIntervalMs (default 30s)
    * - Fast: 10s when teams are awaiting PR detection or have pending CI
@@ -147,6 +158,9 @@ class GitHubPoller {
       this.interval = null;
       console.log('[GitHubPoller] Stopped');
     }
+    // Drop in-memory state so a subsequent start() begins from a clean slate
+    // (also important for tests that share a singleton across cases).
+    this.mergeAttempts.clear();
   }
 
   /**
@@ -536,95 +550,6 @@ class GitHubPoller {
 
         // Merge notification is now handled by gracefulShutdown below
         // (sends pr_merged_shutdown instead of pr_merged to avoid duplicates)
-
-        // ── Early shutdown on CI green + auto-merge happy path ────────
-        // When CI turns green, auto-merge is enabled, the PR is still open,
-        // and merge state is clean/unknown, the team can shut down
-        // immediately — GitHub will handle the actual merge. This avoids
-        // the grace period wait that normally follows pr_merged detection.
-        //
-        // We only fire when mergeStatus is one of {clean, unknown} — any
-        // "blocked_*", "behind", or "dirty" state means the PR cannot
-        // actually be merged yet and we'd be racing against active rebase
-        // / CI / review work. In those cases we leave the team alive and
-        // keep polling so the TL can unblock the PR.
-        const earlyShutdownEligibleMergeState =
-          mergeState === 'clean' || mergeState === 'unknown';
-        if (
-          existing.ciStatus !== ciStatus &&
-          ciStatus === 'passing' &&
-          autoMerge &&
-          state !== 'merged' &&
-          earlyShutdownEligibleMergeState
-        ) {
-          const team = db.getTeam(teamId);
-          if (team && team.status !== 'done') {
-            try {
-              const { getTeamManager } = await import('./team-manager.js');
-              const manager = getTeamManager();
-
-              // Send the early shutdown message
-              const shutdownMsg = resolveMessage('ci_green_auto_shutdown', {
-                PR_NUMBER: String(prNumber),
-              });
-              if (shutdownMsg) manager.sendMessage(teamId, shutdownMsg, 'fc', 'ci_green_auto_shutdown');
-
-              // Transition team to done
-              const previousStatus = team.status;
-              db.insertTransition({
-                teamId,
-                fromStatus: previousStatus,
-                toStatus: 'done',
-                trigger: 'poller',
-                reason: `CI green + auto-merge on PR #${prNumber} — early shutdown`,
-              });
-              db.updateTeamSilent(teamId, { status: 'done', phase: 'done', stoppedAt: new Date().toISOString() });
-
-              sseBroker.broadcast(
-                'team_status_changed',
-                {
-                  team_id: teamId,
-                  status: 'done',
-                  previous_status: previousStatus,
-                },
-                teamId,
-              );
-
-              console.log(
-                `[GitHubPoller] Team ${teamId} early shutdown — CI green + auto-merge on PR #${prNumber}`,
-              );
-
-              // Initiate graceful shutdown (notify TL, grace period, then kill)
-              manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
-
-              // Advance the queue immediately — the slot is free
-              if (team.projectId) {
-                manager.processQueue(team.projectId).catch((err) => {
-                  console.error(
-                    `[GitHubPoller] processQueue error after early shutdown for team ${teamId}:`,
-                    err instanceof Error ? err.message : err,
-                  );
-                });
-              }
-            } catch (err) {
-              console.error(`[GitHubPoller] Failed to initiate early shutdown for team ${teamId}:`, err);
-            }
-
-            return { ciStatus, state };
-          }
-        } else if (
-          existing.ciStatus !== ciStatus &&
-          ciStatus === 'passing' &&
-          autoMerge &&
-          state !== 'merged'
-        ) {
-          // Early-shutdown trigger conditions met (CI just turned green,
-          // auto-merge on) but merge state is not eligible — keep the team
-          // alive and let the poller keep watching.
-          console.log(
-            `[GitHubPoller] Team ${teamId} NOT early-shutting-down — mergeStatus=${mergeState} (PR #${prNumber})`,
-          );
-        }
       }
     } else {
       // First time we see this PR — insert it
@@ -664,6 +589,24 @@ class GitHubPoller {
           console.error(`[GitHubPoller] Failed to send initial merge_conflict to team ${teamId}:`, err);
         }
       }
+    }
+
+    // ── Merge-when-ready (issue #723) ────────────────────────────
+    // The poller's primary job is to merge PRs that are ready, regardless
+    // of whether GitHub auto-merge is armed on the PR. This runs on every
+    // poll cycle (not just on CI transitions) so PRs that were already
+    // ready when the poller booted, or teams that got stuck after CI
+    // turned green, still progress to merge.
+    //
+    // Auto-merge on the PR remains a safety net: if our direct merge call
+    // fails for some reason, GitHub will pick the PR up if --auto was set.
+    if (state === 'open' && ciStatus === 'passing' && mergeState === 'clean') {
+      await this.attemptMergeReadyPR({
+        teamId,
+        prNumber,
+        githubRepo,
+        autoMerge,
+      });
     }
 
     // If the PR was merged, update the team status to 'done'
@@ -799,6 +742,135 @@ class GitHubPoller {
     }
 
     return { ciStatus, state };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: attempt to merge a PR that polling has determined is ready
+  // -------------------------------------------------------------------------
+
+  /**
+   * Attempt to merge a PR that the poller has determined is ready
+   * (state=open, CI=passing, mergeStatus=clean). Throttled per team so
+   * a failed call does not retry-storm. On success, transitions the team
+   * to `done`, sends the shutdown message to the TL, kicks off
+   * `gracefulShutdown`, and advances the project queue. On failure, logs
+   * and leaves the team alone — the next poll cycle (after the throttle
+   * window) retries, and PR-level auto-merge (if armed) remains as a
+   * safety net.
+   *
+   * Issue #723.
+   */
+  private async attemptMergeReadyPR(args: {
+    teamId: number;
+    prNumber: number;
+    githubRepo: string;
+    autoMerge: boolean;
+  }): Promise<void> {
+    const { teamId, prNumber, githubRepo, autoMerge } = args;
+    const db = getDatabase();
+
+    // Skip teams that are already terminal — nothing to shut down.
+    const team = db.getTeam(teamId);
+    if (!team) return;
+    if (team.status === 'done' || team.status === 'failed') {
+      // Cleanup throttle entry since no further attempts are needed
+      this.mergeAttempts.delete(teamId);
+      return;
+    }
+
+    // Throttle so a transient failure cannot retry-storm `gh pr merge`.
+    const now = Date.now();
+    const lastAttempt = this.mergeAttempts.get(teamId) ?? 0;
+    if (now - lastAttempt < GitHubPoller.MERGE_RETRY_THROTTLE_MS) {
+      return;
+    }
+    this.mergeAttempts.set(teamId, now);
+
+    if (!isValidGithubRepo(githubRepo)) {
+      console.error(
+        `[GitHubPoller] Invalid github repo "${githubRepo}" for team ${teamId} — skipping direct merge`,
+      );
+      return;
+    }
+
+    const mergeCmd = `gh pr merge ${prNumber} --squash --delete-branch --repo ${githubRepo}`;
+    const result = await execGHResult(mergeCmd, { timeout: 30_000 });
+
+    if (!result.ok) {
+      // Don't escalate — auto-merge (if armed) is the safety net, and the
+      // throttle window will let us retry on the next eligible poll cycle.
+      console.warn(
+        `[GitHubPoller] Direct merge failed for PR #${prNumber} (team ${teamId}, autoMerge=${autoMerge}): ${result.error?.slice(0, 200) ?? 'unknown'}`,
+      );
+      return;
+    }
+
+    console.log(
+      `[GitHubPoller] Team ${teamId} merged PR #${prNumber} directly via poller`,
+    );
+
+    // Transition the team to done. We deliberately do NOT wait for the
+    // next poll cycle to detect state=merged on GitHub — we already know
+    // the merge succeeded.
+    const previousStatus = team.status;
+    db.insertTransition({
+      teamId,
+      fromStatus: previousStatus,
+      toStatus: 'done',
+      trigger: 'poller',
+      reason: `Poller merged PR #${prNumber} directly`,
+    });
+    db.updateTeamSilent(teamId, {
+      status: 'done',
+      phase: 'done',
+      stoppedAt: new Date().toISOString(),
+    });
+    db.updatePullRequest(prNumber, {
+      state: 'merged' as PRState,
+      mergedAt: new Date().toISOString(),
+    });
+
+    sseBroker.broadcast(
+      'team_status_changed',
+      {
+        team_id: teamId,
+        status: 'done',
+        previous_status: previousStatus,
+      },
+      teamId,
+    );
+
+    // Notify the TL and start graceful shutdown.
+    try {
+      const { getTeamManager } = await import('./team-manager.js');
+      const manager = getTeamManager();
+
+      const shutdownMsg = resolveMessage('ci_green_auto_shutdown', {
+        PR_NUMBER: String(prNumber),
+      });
+      if (shutdownMsg) {
+        manager.sendMessage(teamId, shutdownMsg, 'fc', 'ci_green_auto_shutdown');
+      }
+
+      manager.gracefulShutdown(teamId, prNumber, config.mergeShutdownGraceMs);
+
+      if (team.projectId) {
+        manager.processQueue(team.projectId).catch((err) => {
+          console.error(
+            `[GitHubPoller] processQueue error after direct merge for team ${teamId}:`,
+            err instanceof Error ? err.message : err,
+          );
+        });
+      }
+    } catch (err) {
+      console.error(
+        `[GitHubPoller] Failed to initiate graceful shutdown after direct merge for team ${teamId}:`,
+        err,
+      );
+    }
+
+    // Done with this team — drop the throttle entry.
+    this.mergeAttempts.delete(teamId);
   }
 
   // -------------------------------------------------------------------------

--- a/tests/server/github-poller.test.ts
+++ b/tests/server/github-poller.test.ts
@@ -84,6 +84,7 @@ vi.mock('../../src/server/services/project-service.js', () => ({
 
 // Mock the shared async exec utilities (replaces the old child_process mock)
 const mockExecGHAsync = vi.fn().mockResolvedValue(null);
+const mockExecGHResult = vi.fn().mockResolvedValue({ ok: true, stdout: '' });
 const mockExecGitAsync = vi.fn().mockResolvedValue(null);
 
 // Import the real validators — they are pure functions with no side effects
@@ -93,6 +94,7 @@ const { isValidGithubRepo, isValidBranchName } = await import(
 
 vi.mock('../../src/server/utils/exec-gh.js', () => ({
   execGHAsync: (...args: unknown[]) => mockExecGHAsync(...args),
+  execGHResult: (...args: unknown[]) => mockExecGHResult(...args),
   execGitAsync: (...args: unknown[]) => mockExecGitAsync(...args),
   isValidGithubRepo: (repo: string) => /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(repo),
   isValidBranchName: (branch: string) => /^[a-zA-Z0-9._/\-]+$/.test(branch),
@@ -1638,11 +1640,12 @@ describe('Surgical cache update on PR merge', () => {
 });
 
 
-// CI green + auto-merge early shutdown
+// Merge-when-ready (issue #723) — the poller is the primary merger.
+// Auto-merge on the PR is just a safety net.
 // =============================================================================
 
-describe('CI green + auto-merge early shutdown', () => {
-  it('triggers early shutdown when CI turns green with auto-merge and clean merge state', async () => {
+describe('Merge-when-ready (issue #723)', () => {
+  it('directly merges when CI is passing and merge state is clean (auto-merge ON)', async () => {
     const project = makeProject();
     const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
     mockDb.getProjects.mockReturnValue([project]);
@@ -1657,7 +1660,6 @@ describe('CI green + auto-merge early shutdown', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    // CI turns green, auto-merge enabled, merge state clean
     mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'OPEN',
@@ -1666,45 +1668,84 @@ describe('CI green + auto-merge early shutdown', () => {
         autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
       }),
     );
+    mockExecGHResult.mockResolvedValue({ ok: true, stdout: 'merged' });
 
-    // resolveMessage returns a non-null message so sendMessage fires
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('CI green auto shutdown msg');
+    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('CI green shutdown msg');
 
     await githubPoller.poll();
 
-    // Team should be transitioned to done
+    // gh pr merge --squash --delete-branch should have been issued
+    expect(mockExecGHResult).toHaveBeenCalledWith(
+      expect.stringContaining('gh pr merge 42 --squash --delete-branch --repo owner/repo'),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+
+    // Team should be transitioned to done by the direct merge path
     expect(mockDb.insertTransition).toHaveBeenCalledWith(
       expect.objectContaining({
         teamId: 1,
         toStatus: 'done',
         trigger: 'poller',
-        reason: expect.stringContaining('early shutdown'),
+        reason: expect.stringContaining('Poller merged PR #42 directly'),
       }),
     );
     expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({
-        status: 'done',
-        phase: 'done',
-      }),
+      expect.objectContaining({ status: 'done', phase: 'done' }),
     );
-
-    // Graceful shutdown should be initiated
     expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
-
-    // Queue should be processed immediately
     expect(mockManager.processQueue).toHaveBeenCalledWith(1);
-
-    // ci_green_auto_shutdown message should be sent
     expect(mockManager.sendMessage).toHaveBeenCalledWith(
       1,
-      'CI green auto shutdown msg',
+      'CI green shutdown msg',
       'fc',
       'ci_green_auto_shutdown',
     );
   });
 
-  it('does NOT trigger early shutdown when merge state is dirty', async () => {
+  it('directly merges when CI is passing and merge state is clean (auto-merge OFF)', async () => {
+    // The whole point of issue #723: poller must not depend on --auto being
+    // armed. Auto-merge is just a safety net for poller failures.
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 99, status: 'running', projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 99,
+      state: 'open',
+      ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: false,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
+        autoMergeRequest: null,
+      }),
+    );
+    mockExecGHResult.mockResolvedValue({ ok: true, stdout: 'merged' });
+
+    await githubPoller.poll();
+
+    expect(mockExecGHResult).toHaveBeenCalledWith(
+      expect.stringContaining('gh pr merge 99 --squash --delete-branch --repo owner/repo'),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toStatus: 'done',
+        reason: expect.stringContaining('Poller merged PR #99 directly'),
+      }),
+    );
+    expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 99, 120000);
+  });
+
+  it('does NOT attempt merge when merge state is dirty', async () => {
     const project = makeProject();
     const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
     mockDb.getProjects.mockReturnValue([project]);
@@ -1719,7 +1760,6 @@ describe('CI green + auto-merge early shutdown', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    // CI turns green, auto-merge enabled, but merge state is dirty
     mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'OPEN',
@@ -1729,22 +1769,14 @@ describe('CI green + auto-merge early shutdown', () => {
       }),
     );
 
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
-
     await githubPoller.poll();
 
-    // Should NOT have transitioned to done via early shutdown
-    const transitionCalls = mockDb.insertTransition.mock.calls;
-    const earlyShutdownTransition = transitionCalls.find(
-      (call: unknown[]) => {
-        const arg = call[0] as { reason?: string };
-        return arg.reason?.includes('early shutdown');
-      },
-    );
-    expect(earlyShutdownTransition).toBeUndefined();
+    // No merge call, no shutdown
+    expect(mockExecGHResult).not.toHaveBeenCalled();
+    expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
   });
 
-  it('does NOT trigger early shutdown when merge state is behind (base branch advanced)', async () => {
+  it('does NOT attempt merge when merge state is behind (base branch advanced)', async () => {
     const project = makeProject();
     const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
     mockDb.getProjects.mockReturnValue([project]);
@@ -1759,9 +1791,6 @@ describe('CI green + auto-merge early shutdown', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    // CI turns green, auto-merge enabled, but branch is behind base
     mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'OPEN',
@@ -1771,32 +1800,16 @@ describe('CI green + auto-merge early shutdown', () => {
       }),
     );
 
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
-
     await githubPoller.poll();
 
-    // Should NOT have called gracefulShutdown
+    expect(mockExecGHResult).not.toHaveBeenCalled();
     expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
-
-    // Should NOT have transitioned to done via early shutdown
-    const earlyShutdownTransition = mockDb.insertTransition.mock.calls.find(
-      (call: unknown[]) => {
-        const arg = call[0] as { reason?: string };
-        return arg.reason?.includes('early shutdown');
-      },
-    );
-    expect(earlyShutdownTransition).toBeUndefined();
-
-    // Skip log line should be emitted
-    const skipLogged = logSpy.mock.calls.some((call) =>
-      String(call[0] ?? '').includes('NOT early-shutting-down'),
-    );
-    expect(skipLogged).toBe(true);
-
-    logSpy.mockRestore();
   });
 
-  it('does NOT trigger early shutdown when merge state is blocked by conflict (dirty)', async () => {
+  it('does NOT attempt merge when merge state is unknown', async () => {
+    // Be conservative: if GitHub hasn't computed mergeability yet, wait for
+    // the next poll. Auto-merge stays armed as a safety net if the TL set
+    // it; otherwise the next clean poll will trigger the direct merge.
     const project = makeProject();
     const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
     mockDb.getProjects.mockReturnValue([project]);
@@ -1811,56 +1824,6 @@ describe('CI green + auto-merge early shutdown', () => {
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    // CI turns green, auto-merge enabled, but PR has merge conflict
-    mockExecGHAsync.mockResolvedValue(
-      makeGHPRViewResult({
-        state: 'OPEN',
-        mergeStateStatus: 'DIRTY',
-        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
-        autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
-      }),
-    );
-
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
-
-    await githubPoller.poll();
-
-    expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
-
-    const earlyShutdownTransition = mockDb.insertTransition.mock.calls.find(
-      (call: unknown[]) => {
-        const arg = call[0] as { reason?: string };
-        return arg.reason?.includes('early shutdown');
-      },
-    );
-    expect(earlyShutdownTransition).toBeUndefined();
-
-    const skipLogged = logSpy.mock.calls.some((call) =>
-      String(call[0] ?? '').includes('NOT early-shutting-down'),
-    );
-    expect(skipLogged).toBe(true);
-
-    logSpy.mockRestore();
-  });
-
-  it('still triggers early shutdown when merge state is unknown (common first-poll case)', async () => {
-    const project = makeProject();
-    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
-    mockDb.getProjects.mockReturnValue([project]);
-    mockDb.getActiveTeams.mockReturnValue([team]);
-    mockDb.getPullRequest.mockReturnValue({
-      prNumber: 42,
-      state: 'open',
-      ciStatus: 'pending',
-      mergeStatus: 'unknown',
-      autoMerge: true,
-      ciFailCount: 0,
-    });
-    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
-
-    // CI turns green, auto-merge enabled, GitHub hasn't computed mergeability
     mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'OPEN',
@@ -1870,37 +1833,77 @@ describe('CI green + auto-merge early shutdown', () => {
       }),
     );
 
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('msg');
-
     await githubPoller.poll();
 
-    // Should have fired gracefulShutdown — we don't want to stall on
-    // missing/unknown data from GitHub
-    expect(mockManager.gracefulShutdown).toHaveBeenCalledWith(1, 42, 120000);
-    expect(mockDb.insertTransition).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toStatus: 'done',
-        reason: expect.stringContaining('early shutdown'),
-      }),
+    expect(mockExecGHResult).not.toHaveBeenCalled();
+    expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
+    // No transition either — we keep polling
+    const doneTransition = mockDb.insertTransition.mock.calls.find(
+      (call: unknown[]) => (call[0] as { toStatus?: string }).toStatus === 'done',
     );
+    expect(doneTransition).toBeUndefined();
   });
 
-  it('does NOT trigger early shutdown when auto-merge is NOT enabled', async () => {
+  it('leaves the team alive when the direct merge call fails (auto-merge backup remains)', async () => {
     const project = makeProject();
-    const team = makeTeam({ prNumber: 42, status: 'running', projectId: 1 });
+    const team = makeTeam({ prNumber: 7, status: 'running', projectId: 1 });
     mockDb.getProjects.mockReturnValue([project]);
     mockDb.getActiveTeams.mockReturnValue([team]);
     mockDb.getPullRequest.mockReturnValue({
-      prNumber: 42,
+      prNumber: 7,
       state: 'open',
       ciStatus: 'pending',
+      mergeStatus: 'clean',
+      autoMerge: true,
+      ciFailCount: 0,
+    });
+    mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
+
+    mockExecGHAsync.mockResolvedValue(
+      makeGHPRViewResult({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [{ name: 'build', conclusion: 'SUCCESS' }],
+        autoMergeRequest: { enabledAt: '2025-01-01T00:00:00Z' },
+      }),
+    );
+    mockExecGHResult.mockResolvedValue({ ok: false, error: 'permission denied' });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await githubPoller.poll();
+
+    // Merge was attempted
+    expect(mockExecGHResult).toHaveBeenCalled();
+    // But team was NOT transitioned to done
+    const doneTransition = mockDb.insertTransition.mock.calls.find(
+      (call: unknown[]) => (call[0] as { toStatus?: string }).toStatus === 'done',
+    );
+    expect(doneTransition).toBeUndefined();
+    expect(mockManager.gracefulShutdown).not.toHaveBeenCalled();
+    // And we logged a warning so the operator can see why
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Direct merge failed'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not retry-storm: second poll within the throttle window does not re-attempt merge after a failure', async () => {
+    const project = makeProject();
+    const team = makeTeam({ prNumber: 8, status: 'running', projectId: 1 });
+    mockDb.getProjects.mockReturnValue([project]);
+    mockDb.getActiveTeams.mockReturnValue([team]);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 8,
+      state: 'open',
+      ciStatus: 'passing',
       mergeStatus: 'clean',
       autoMerge: false,
       ciFailCount: 0,
     });
     mockDb.getTeam.mockReturnValue({ ...team, status: 'running' });
 
-    // CI turns green, merge state clean, but auto-merge NOT enabled
     mockExecGHAsync.mockResolvedValue(
       makeGHPRViewResult({
         state: 'OPEN',
@@ -1909,20 +1912,18 @@ describe('CI green + auto-merge early shutdown', () => {
         autoMergeRequest: null,
       }),
     );
+    mockExecGHResult.mockResolvedValue({ ok: false, error: 'transient gh failure' });
 
-    (mockResolveMessage as ReturnType<typeof vi.fn>).mockReturnValue('some msg');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await githubPoller.poll();
+    await githubPoller.poll();
 
-    // Should NOT have transitioned to done via early shutdown
-    const transitionCalls = mockDb.insertTransition.mock.calls;
-    const earlyShutdownTransition = transitionCalls.find(
-      (call: unknown[]) => {
-        const arg = call[0] as { reason?: string };
-        return arg.reason?.includes('early shutdown');
-      },
+    // The throttle should ensure exactly one merge attempt within the window
+    const mergeCalls = mockExecGHResult.mock.calls.filter((call: unknown[]) =>
+      String(call[0] ?? '').includes('gh pr merge'),
     );
-    expect(earlyShutdownTransition).toBeUndefined();
+    expect(mergeCalls.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #723.

## Summary

- Replace the auto-merge-gated early-shutdown block with an unconditional **merge-when-ready** path that runs every poll cycle: when `state=open`, `ciStatus=passing`, and `mergeStatus=clean`, the poller calls `gh pr merge {n} --squash --delete-branch --repo {slug}` directly.
- On success: transition team to `done` (reason "Poller merged PR #N directly"), kick `gracefulShutdown` + `processQueue`.
- On failure: log a warning and leave the team alive. The 60s per-team throttle prevents retry-storm. Auto-merge on the PR remains as a safety net.
- Throttle map is cleared in `stop()`.

## Why

PR #722 sat in `MERGEABLE` / `CLEAN` / CI-green for ~30 minutes while team #549 was `stuck` — exactly the case the poller is supposed to prevent. The previous logic only acted when the TL had armed `gh pr merge --auto`; if the TL got stuck before that step (or after a force-push silently dropped auto-merge), the poller did nothing.

## Test plan

- [x] `npx vitest run tests/server/github-poller.test.ts` — 74/74 pass (replaced 6 obsolete tests with 6 covering the new behavior, including direct-merge with `autoMerge=false`, no-merge in dirty/behind/unknown states, failure path, and 60s throttle).
- [x] `npm test` — 1960/1960 pass.
- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [ ] After merge, verify on a real PR that the poller calls `gh pr merge` within ~30s of CI turning green even when `--auto` was never armed.

## Notes

The shutdown message subtype is still `ci_green_auto_shutdown` for backwards compatibility with the existing message template; the template text still mentions auto-merge, which is now slightly misleading but not incorrect (auto-merge stays armed as a safety net). Consider a follow-up to rename the subtype/template to something like `pr_merged_by_poller`.