### PR TITLE
Issue #725: double GitHub polling defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,9 +230,9 @@ The SSE broker emits 18 event types:
 | `FLEET_PROMPT_CACHE_1H` | `true` | When `true`, set `ENABLE_PROMPT_CACHING_1H=1` on spawned CC processes for 1-hour prompt cache TTL. Set to `false` to use the default 5-minute TTL. |
 | `FLEET_DEBUG_RAW_ISSUE_BODY` | `false` | When `true`, write `.fleet-issue-body-raw.md` next to `.fleet-issue-context.md` containing the unmodified GitHub issue body, for debugging image-preservation discrepancies. |
 | `LOG_LEVEL` | `info` | Server log level |
-| `FLEET_GITHUB_POLL_MS` | `30000` | GitHub PR/CI/merge poll interval (ms) |
-| `FLEET_ISSUE_POLL_MS` | `300000` | Issue list poll interval (ms, default 5min) |
-| `FLEET_ISSUE_UPDATE_POLL_MS` | `30000` | Issue update (comments, labels, body) poll interval (ms) |
+| `FLEET_GITHUB_POLL_MS` | `60000` | GitHub PR/CI/merge poll interval (ms) |
+| `FLEET_ISSUE_POLL_MS` | `600000` | Issue list poll interval (ms, default 10min) |
+| `FLEET_ISSUE_UPDATE_POLL_MS` | `60000` | Issue update (comments, labels, body) poll interval (ms) |
 | `FLEET_STUCK_CHECK_MS` | `60000` | Stuck/idle detection check interval (ms) |
 | `FLEET_USAGE_POLL_MS` | `900000` | Usage percentage poll interval (ms, default 15min) |
 | `FLEET_MAP_CLEANUP_MS` | `3600000` | In-memory map cleanup interval (ms, default 1hr) |

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -113,9 +113,9 @@ const config = Object.freeze({
   /** Absolute path to the fleet-commander installation itself */
   fleetCommanderRoot,
 
-  githubPollIntervalMs: safeParseInt(process.env['FLEET_GITHUB_POLL_MS'] || '30000', 'FLEET_GITHUB_POLL_MS'),
-  issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '300000', 'FLEET_ISSUE_POLL_MS'),
-  issueUpdatePollMs: safeParseInt(process.env['FLEET_ISSUE_UPDATE_POLL_MS'] || '30000', 'FLEET_ISSUE_UPDATE_POLL_MS'),
+  githubPollIntervalMs: safeParseInt(process.env['FLEET_GITHUB_POLL_MS'] || '60000', 'FLEET_GITHUB_POLL_MS'),
+  issuePollIntervalMs: safeParseInt(process.env['FLEET_ISSUE_POLL_MS'] || '600000', 'FLEET_ISSUE_POLL_MS'),
+  issueUpdatePollMs: safeParseInt(process.env['FLEET_ISSUE_UPDATE_POLL_MS'] || '60000', 'FLEET_ISSUE_UPDATE_POLL_MS'),
   stuckCheckIntervalMs: safeParseInt(process.env['FLEET_STUCK_CHECK_MS'] || '60000', 'FLEET_STUCK_CHECK_MS'),
   usagePollIntervalMs: safeParseInt(process.env['FLEET_USAGE_POLL_MS'] || '900000', 'FLEET_USAGE_POLL_MS'),
   mapCleanupIntervalMs: safeParseInt(process.env['FLEET_MAP_CLEANUP_MS'] || '3600000', 'FLEET_MAP_CLEANUP_MS'),

--- a/src/server/services/github-poller.ts
+++ b/src/server/services/github-poller.ts
@@ -90,7 +90,7 @@ class GitHubPoller {
   /**
    * Start the polling loop. Uses adaptive intervals:
    * - Normal: config.githubPollIntervalMs (default 30s)
-   * - Fast: 10s when teams are awaiting PR detection or have pending CI
+   * - Fast: 20s when teams are awaiting PR detection or have pending CI
    */
   start(): void {
     if (this.interval) {
@@ -110,7 +110,7 @@ class GitHubPoller {
     }
 
     console.log(
-      `[GitHubPoller] Started — base interval ${config.githubPollIntervalMs}ms, fast 10s when PRs pending`
+      `[GitHubPoller] Started — base interval ${config.githubPollIntervalMs}ms, fast 20s when PRs pending`
     );
   }
 
@@ -120,7 +120,7 @@ class GitHubPoller {
       clearTimeout(this.interval);
     }
     const delay = this.needsFastPoll
-      ? Math.min(10_000, config.githubPollIntervalMs)
+      ? Math.min(20_000, config.githubPollIntervalMs)
       : config.githubPollIntervalMs;
     this.interval = setTimeout(() => {
       this.poll().finally(() => this.scheduleNextPoll());


### PR DESCRIPTION
Closes #725.

## Summary

Doubles the defaults of every GitHub-touching poller so the steady-state GraphQL spend is halved:

| Env var | Old | New |
|---|---|---|
| `FLEET_GITHUB_POLL_MS` | 30000 | 60000 |
| `FLEET_ISSUE_POLL_MS` | 300000 | 600000 |
| `FLEET_ISSUE_UPDATE_POLL_MS` | 30000 | 60000 |
| Hardcoded fast-poll floor in `github-poller.ts` | 10000 | 20000 |

`FLEET_USAGE_POLL_MS` is unchanged — it hits Anthropic, not GitHub GraphQL. Operators with explicit env-var overrides are unaffected.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run tests/server/github-poller.test.ts` — pass
- [ ] After merge, `[GitHubPoller] Started — base interval 60000ms, fast 20s when PRs pending` shows in the server log on a fresh start.