### PR TITLE
Issue #728: adopt TaskCreated hook with native owner attribution

### DIFF
--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -84,6 +84,7 @@ function buildPayloadFromCcStdin(body: Record<string, unknown>): EventPayload {
   payload.source = str(cc.source);
   payload.notification_type = str(cc.notification_type);
   payload.agent_id = str(cc.agent_id);
+  payload.owner = str(cc.owner);
   payload.cwd = str(cc.cwd);
 
   return payload;
@@ -112,6 +113,7 @@ function buildPayloadFromLegacy(body: Record<string, unknown>): EventPayload {
     worktree_path: str(body.worktree_path),
     msg_to: str(body.msg_to),
     msg_summary: str(body.msg_summary),
+    owner: str(body.owner),
   };
 }
 

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -19,6 +19,7 @@ import type { TeamStatus, TeamPhase } from '../../shared/types.js';
 import { TERMINAL_STATUSES } from '../../shared/types.js';
 import type { SSEEventType, SSEEventPayloads } from './sse-broker.js';
 import config from '../config.js';
+import { recordHookTaskId, clearHookTaskIdsForTeam } from './task-dedup.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -50,6 +51,7 @@ export interface EventPayload {
   source?: string;              // e.g. "tool_use", "user"
   notification_type?: string;   // e.g. "stuck", "idle"
   agent_id?: string;            // CC agent identifier
+  owner?: string;               // Task owner — set on TaskCreated hook events (CC 2.1.143+).
   cwd?: string;                 // working directory of the CC process
 }
 
@@ -433,6 +435,7 @@ export function processEvent(
   if (isTerminal) {
     cleanSubagentTrackersForTeam(payload.team);
     lastToolUseByTeam.delete(payload.team);
+    clearHookTaskIdsForTeam(teamId);
   }
 
   // ── Collect transition data (without writing to DB yet) ──────────
@@ -768,6 +771,9 @@ export function processEvent(
 
   // ── Task extraction from TaskCreated events ─────────────────────
   // Parse TaskCreated hook events and upsert task data into team_tasks.
+  // CC 2.1.143+ ships native `owner` and `agent_id` fields in cc_stdin; we
+  // prefer those over the event-level `agent_type` (which identifies the
+  // emitter, not necessarily the task's owner).
   if (eventType === 'TaskCreated' && db.upsertTeamTask) {
     try {
       // Parse cc_stdin for task fields (hook sends raw CC stdin JSON)
@@ -789,7 +795,17 @@ export function processEvent(
       const taskId = (ccData.task_id ?? `task-${teamId}-${subjectSlug}`) as string;
       const description = (ccData.description ?? null) as string | null;
       const status = (ccData.status ?? 'pending') as string;
-      const owner = normalizeAgentName(payload.agent_type);
+      // Owner priority: explicit owner from CC hook > agent_id of creating subagent
+      // > event-level agent_type. The route handler lifts cc.owner onto
+      // payload.owner; we also accept ccData.owner directly for callers that
+      // bypass the route (e.g., direct processEvent calls). All routed through
+      // normalizeAgentName for consistency with subagent/agent_messages
+      // attribution.
+      const ccOwner = typeof ccData.owner === 'string' ? ccData.owner : undefined;
+      const ccAgentId = typeof ccData.agent_id === 'string' ? ccData.agent_id : undefined;
+      const ownerRaw =
+        payload.owner ?? ccOwner ?? payload.agent_id ?? ccAgentId ?? payload.agent_type;
+      const owner = normalizeAgentName(ownerRaw);
 
       const task = db.upsertTeamTask({
         teamId,
@@ -799,6 +815,10 @@ export function processEvent(
         status,
         owner,
       });
+
+      // Record this taskId so the legacy stream-event TodoWrite parser in
+      // team-manager.ts skips redundant upserts/broadcasts for the same task.
+      recordHookTaskId(teamId, taskId);
 
       sse.broadcast('task_updated', {
         team_id: teamId,

--- a/src/server/services/task-dedup.ts
+++ b/src/server/services/task-dedup.ts
@@ -1,0 +1,78 @@
+/**
+ * Task dedup — soft dedup for the TaskCreated hook vs stream-event fallback.
+ *
+ * CC 2.1.143+ fires a native `TaskCreated` hook with stable `task_id`,
+ * `subject`, `description`, `status`, and `owner` fields. The legacy
+ * stream-event parser in `team-manager.ts` still extracts the same task
+ * data from `TodoWrite` tool_use blocks for older CC versions.
+ *
+ * During the transitional period (CC 2.1.143+ but both paths active),
+ * both signals may fire for the same task. The hook is the canonical
+ * source — when it fires first, `recordHookTaskId` is called after a
+ * successful upsert, and the stream-event parser checks
+ * `wasTaskSeenByHook` and skips the redundant upsert + SSE broadcast.
+ *
+ * This is a soft dedup, not a hard guarantee:
+ *   - Module-level in-memory state, lost on server restart (acceptable —
+ *     the database upsert is idempotent via ON CONFLICT DO UPDATE).
+ *   - Set-per-team capped at 256 entries; over-cap entries are dropped
+ *     oldest-first by recreating the Set (Set preserves insertion order).
+ *   - Cleared per team on terminal-state transition via
+ *     `clearHookTaskIdsForTeam` to bound memory.
+ *
+ * Keyed by numeric `teamId` (not worktree name) because the stream-event
+ * fallback in `team-manager.ts` only has `teamId` in scope.
+ */
+
+/** Max task_ids tracked per team before dropping oldest. */
+const MAX_TASK_IDS_PER_TEAM = 256;
+
+/** Per-team set of task_ids seen via the TaskCreated hook. */
+const hookSeenTaskIds = new Map<number, Set<string>>();
+
+/**
+ * Record that a `task_id` was successfully upserted via the TaskCreated hook.
+ * Subsequent stream-event TodoWrite events for the same `(teamId, taskId)`
+ * will be skipped by `wasTaskSeenByHook`.
+ */
+export function recordHookTaskId(teamId: number, taskId: string): void {
+  let set = hookSeenTaskIds.get(teamId);
+  if (!set) {
+    set = new Set<string>();
+    hookSeenTaskIds.set(teamId, set);
+  }
+
+  set.add(taskId);
+
+  // Drop oldest entries when over cap. Set preserves insertion order, so we
+  // recreate it from the last MAX_TASK_IDS_PER_TEAM values.
+  if (set.size > MAX_TASK_IDS_PER_TEAM) {
+    const values = Array.from(set);
+    const trimmed = new Set(values.slice(values.length - MAX_TASK_IDS_PER_TEAM));
+    hookSeenTaskIds.set(teamId, trimmed);
+  }
+}
+
+/**
+ * Returns true if `recordHookTaskId` was previously called for this
+ * `(teamId, taskId)` pair (and not since cleared).
+ */
+export function wasTaskSeenByHook(teamId: number, taskId: string): boolean {
+  const set = hookSeenTaskIds.get(teamId);
+  return set ? set.has(taskId) : false;
+}
+
+/**
+ * Drop the entire dedup set for a team. Called when the team enters a
+ * terminal status so its slot in the map is freed.
+ */
+export function clearHookTaskIdsForTeam(teamId: number): void {
+  hookSeenTaskIds.delete(teamId);
+}
+
+/**
+ * Reset all dedup state. Intended for use in tests only.
+ */
+export function resetTaskDedupState(): void {
+  hookSeenTaskIds.clear();
+}

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -26,6 +26,7 @@ import { resolveMessage } from '../utils/resolve-message.js';
 import { CircularBuffer } from '../utils/circular-buffer.js';
 import { getHookFiles as getManifestHookFiles, getAgentFiles as getManifestAgentFiles, getGuideFiles as getManifestGuideFiles, getWorkflowFile, getGitignoreEntries } from '../utils/fc-manifest.js';
 import { classifyAgentRole, shouldAdvancePhase } from './event-collector.js';
+import { wasTaskSeenByHook } from './task-dedup.js';
 import type { TeamPhase } from '../../shared/types.js';
 import { isValidGithubRepo } from '../utils/exec-gh.js';
 import { generateIssueContext } from './issue-context-generator.js';
@@ -38,6 +39,16 @@ const execAsync = promisify(execCallback);
 
 const MAX_OUTPUT_LINES = config.outputBufferLines;
 const MAX_PARSED_EVENTS = 1000;
+
+// ---------------------------------------------------------------------------
+// Task extraction dedup logging (Issue #728)
+// ---------------------------------------------------------------------------
+// When both the TaskCreated hook AND the legacy stream-event TodoWrite parser
+// fire for the same task, the stream parser skips silently — but emits a
+// one-time log line per (teamId, taskId) so operators can confirm the
+// transition is working. This Set tracks which (team, task) pairs have
+// already been logged to avoid spamming the log.
+const loggedTaskDedupes = new Set<string>();
 
 // ---------------------------------------------------------------------------
 // summarizeEvent — short text summary for console logging
@@ -2479,6 +2490,11 @@ export class TeamManager {
                     }
 
                     // Stdout fallback: extract tasks from TodoWrite tool_use blocks
+                    // NOTE: CC 2.1.143+ ships a native `TaskCreated` hook with
+                    // the same data — that path runs first via event-collector
+                    // and is canonical. We skip the upsert+SSE here when the
+                    // hook already recorded this taskId; a one-time log line
+                    // surfaces the dedup so operators can confirm coverage.
                     if (toolName === 'TodoWrite') {
                       try {
                         const input = toolBlock.input as Record<string, unknown> | undefined;
@@ -2489,6 +2505,21 @@ export class TeamManager {
                             const taskId = (todo.id ?? `team-${teamId}-task-${todos.indexOf(todo)}`) as string;
                             const subject = (todo.content ?? todo.title ?? todo.subject ?? 'Untitled task') as string;
                             const status = (todo.status ?? 'pending') as string;
+
+                            // Dedup: if the TaskCreated hook already inserted
+                            // this taskId, skip the upsert AND the SSE
+                            // broadcast. Log once per (team, task) pair.
+                            if (wasTaskSeenByHook(teamId, taskId)) {
+                              const dedupeKey = `${teamId}:${taskId}`;
+                              if (!loggedTaskDedupes.has(dedupeKey)) {
+                                loggedTaskDedupes.add(dedupeKey);
+                                console.log(
+                                  `[TaskExtraction] dedupe: stream-event TodoWrite "${subject}" task_id=${taskId} already captured via TaskCreated hook (team=${teamId})`
+                                );
+                              }
+                              continue;
+                            }
+
                             // Derive owner from parent_tool_use_id if available
                             const parentId = (ev.parent_tool_use_id as string | null | undefined) ?? null;
                             const owner = parentId ? (agentMap.get(parentId) ?? 'team-lead') : 'team-lead';

--- a/tests/server/event-collector-task-created.test.ts
+++ b/tests/server/event-collector-task-created.test.ts
@@ -1,0 +1,448 @@
+// =============================================================================
+// Fleet Commander — Event Collector: TaskCreated Hook Tests (Issue #728)
+// =============================================================================
+// Focused tests for the TaskCreated hook handler in event-collector.ts.
+// Covers CC 2.1.143+ native fields (`owner`, `agent_id`), owner priority chain,
+// dedup recording, terminal-state cleanup, and edge cases.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  processEvent,
+  resetThrottleState,
+  resetSubagentTrackers,
+  resetPrPollState,
+  resetEventDedupState,
+  type EventPayload,
+  type EventCollectorDb,
+  type SseBroker,
+} from '../../src/server/services/event-collector.js';
+import {
+  recordHookTaskId,
+  wasTaskSeenByHook,
+  clearHookTaskIdsForTeam,
+  resetTaskDedupState,
+} from '../../src/server/services/task-dedup.js';
+
+// ---------------------------------------------------------------------------
+// Mock factories (mirrors event-collector.test.ts conventions)
+// ---------------------------------------------------------------------------
+
+function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
+  let nextEventId = 1;
+  let nextMsgId = 1;
+
+  const insertEvent = vi.fn().mockImplementation(() => ({ id: nextEventId++ }));
+  const updateTeam = vi.fn();
+  const insertTransition = vi.fn();
+  const insertAgentMessage = vi.fn().mockImplementation(() => ({ id: nextMsgId++ }));
+
+  const processEventTransaction = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+      eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string };
+      agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
+    }) => {
+      if (ops.transition) insertTransition(ops.transition);
+      if (ops.statusUpdate) updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+      const result = insertEvent(ops.eventInsert);
+      const eventId = result.id;
+      if (ops.agentMessages) {
+        for (const msg of ops.agentMessages) {
+          insertAgentMessage({ ...msg, eventId });
+        }
+      }
+      return { eventId };
+    },
+  );
+
+  const processThrottledUpdate = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+    }) => {
+      if (ops.transition) insertTransition(ops.transition);
+      if (ops.statusUpdate) updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+    },
+  );
+
+  return {
+    getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    insertEvent,
+    updateTeam,
+    updateTeamSilent: updateTeam,
+    insertTransition,
+    insertAgentMessage,
+    processEventTransaction,
+    processThrottledUpdate,
+    ...overrides,
+  };
+}
+
+function createMockSse(): SseBroker {
+  return { broadcast: vi.fn() };
+}
+
+function makePayload(overrides?: Partial<EventPayload>): EventPayload {
+  return {
+    event: 'task_created',
+    team: 'kea-100',
+    timestamp: new Date().toISOString(),
+    session_id: 'sess-abc',
+    ...overrides,
+  };
+}
+
+// Default upsertTeamTask that echoes its input fields. The handler reads
+// `task.taskId`, `task.subject`, `task.status`, `task.owner` from the return
+// value when broadcasting the SSE, so the mock must mirror the input.
+function makeUpsertTeamTask() {
+  return vi.fn().mockImplementation((data: {
+    teamId: number;
+    taskId: string;
+    subject: string;
+    description?: string | null;
+    status: string;
+    owner: string;
+  }) => ({
+    id: 1,
+    teamId: data.teamId,
+    taskId: data.taskId,
+    subject: data.subject,
+    status: data.status,
+    owner: data.owner,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetThrottleState();
+  resetSubagentTrackers();
+  resetPrPollState();
+  resetEventDedupState();
+  resetTaskDedupState();
+});
+
+// =============================================================================
+// TaskCreated hook handler
+// =============================================================================
+
+describe('TaskCreated hook handler', () => {
+  it('processes TaskCreated hook with full CC 2.1.143 payload', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-abc',
+        subject: 'Implement the foo widget',
+        description: 'Build foo and wire it up to bar',
+        status: 'in_progress',
+        owner: 'planner',
+        agent_id: 'fleet-planner',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledTimes(1);
+    expect(upsertTeamTask).toHaveBeenCalledWith({
+      teamId: 1,
+      taskId: 'task-abc',
+      subject: 'Implement the foo widget',
+      description: 'Build foo and wire it up to bar',
+      status: 'in_progress',
+      owner: 'planner',
+    });
+
+    const taskBroadcasts = (sse.broadcast as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => call[0] === 'task_updated',
+    );
+    expect(taskBroadcasts).toHaveLength(1);
+    expect(taskBroadcasts[0][1]).toMatchObject({
+      team_id: 1,
+      task_id: 'task-abc',
+      subject: 'Implement the foo widget',
+      status: 'in_progress',
+      owner: 'planner',
+    });
+  });
+
+  it('attributes task to subagent when agent_id is set and owner is absent', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'A task',
+        status: 'pending',
+        agent_id: 'fleet-dev',
+      }),
+    });
+    // Simulate buildPayloadFromCcStdin extracting agent_id
+    payload.agent_id = 'fleet-dev';
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'dev' }),
+    );
+  });
+
+  it('attributes task to team-lead when neither owner nor agent_id is set', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'A task',
+        status: 'pending',
+      }),
+    });
+    // agent_type intentionally not set (TL emits with no agent_type)
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'team-lead' }),
+    );
+  });
+
+  it('prefers owner over agent_id when both present', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'A task',
+        status: 'pending',
+        owner: 'planner',
+        agent_id: 'fleet-dev',
+      }),
+    });
+    payload.owner = 'planner';
+    payload.agent_id = 'fleet-dev';
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'planner' }),
+    );
+  });
+
+  it('records taskId in hook dedup set after successful upsert', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-xyz',
+        subject: 'Hooked task',
+        status: 'pending',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(wasTaskSeenByHook(1, 'task-xyz')).toBe(true);
+  });
+
+  it('does NOT record taskId when upsertTeamTask is missing on db', () => {
+    const db = createMockDb();
+    // Simulate older db without upsertTeamTask
+    delete (db as Record<string, unknown>).upsertTeamTask;
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-no-upsert',
+        subject: 'A task',
+        status: 'pending',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(wasTaskSeenByHook(1, 'task-no-upsert')).toBe(false);
+  });
+
+  it('clears dedup set when team enters terminal state', () => {
+    // Pre-seed dedup state for team 1
+    recordHookTaskId(1, 'task-old');
+    expect(wasTaskSeenByHook(1, 'task-old')).toBe(true);
+
+    // Process any event for a team that is now in terminal status.
+    // The terminal-state cleanup path runs `clearHookTaskIdsForTeam(teamId)`.
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'done' }),
+    });
+    const sse = createMockSse();
+
+    const payload = makePayload({ event: 'stop' });
+    processEvent(payload, db, sse);
+
+    expect(wasTaskSeenByHook(1, 'task-old')).toBe(false);
+  });
+
+  it('handles malformed cc_stdin gracefully with content-based stable taskId', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: 'not valid json{{{',
+      message: 'Some subject',
+    });
+
+    const result = processEvent(payload, db, sse);
+    expect(result.processed).toBe(true);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        taskId: 'task-1-some-subject',
+        subject: 'Some subject',
+        // Description must NOT echo the payload.message — subject already
+        // came from it, so description stays null.
+        description: null,
+        status: 'pending',
+      }),
+    );
+  });
+
+  it('falls back to ccData.description when subject came from cc_stdin', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'A',
+        description: 'B',
+        status: 'pending',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'A',
+        description: 'B',
+      }),
+    );
+  });
+
+  it('produces stable taskId across compaction events with same subject', () => {
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    // Two events: same subject, different tool_use_ids (post-compaction).
+    // Both should derive identical taskId from subject content.
+    const payload1 = makePayload({
+      cc_stdin: 'malformed{{{',
+      message: 'Implement login page',
+      tool_use_id: 'toolu_abc',
+    });
+    const payload2 = makePayload({
+      cc_stdin: 'malformed{{{',
+      message: 'Implement login page',
+      tool_use_id: 'toolu_def',
+    });
+
+    processEvent(payload1, db, sse);
+    processEvent(payload2, db, sse);
+
+    expect(upsertTeamTask.mock.calls[0][0].taskId).toBe('task-1-implement-login-page');
+    expect(upsertTeamTask.mock.calls[1][0].taskId).toBe('task-1-implement-login-page');
+  });
+
+  it('normalizes raw agent_type owner via normalizeAgentName', () => {
+    // No cc_stdin owner/agent_id — falls through to payload.agent_type.
+    // payload.agent_type='fleet-reviewer' should become owner='reviewer'.
+    const upsertTeamTask = makeUpsertTeamTask();
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      agent_type: 'fleet-reviewer',
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'A task',
+        status: 'pending',
+      }),
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'reviewer' }),
+    );
+  });
+});
+
+// =============================================================================
+// task-dedup module
+// =============================================================================
+
+describe('task-dedup module', () => {
+  it('recordHookTaskId then wasTaskSeenByHook returns true', () => {
+    recordHookTaskId(42, 'task-foo');
+    expect(wasTaskSeenByHook(42, 'task-foo')).toBe(true);
+  });
+
+  it('wasTaskSeenByHook returns false for unknown team', () => {
+    expect(wasTaskSeenByHook(999, 'task-foo')).toBe(false);
+  });
+
+  it('wasTaskSeenByHook returns false for unknown taskId on known team', () => {
+    recordHookTaskId(42, 'task-foo');
+    expect(wasTaskSeenByHook(42, 'task-bar')).toBe(false);
+  });
+
+  it('clearHookTaskIdsForTeam removes only that team', () => {
+    recordHookTaskId(1, 'task-1');
+    recordHookTaskId(2, 'task-2');
+    clearHookTaskIdsForTeam(1);
+    expect(wasTaskSeenByHook(1, 'task-1')).toBe(false);
+    expect(wasTaskSeenByHook(2, 'task-2')).toBe(true);
+  });
+
+  it('caps each team set at 256 entries', () => {
+    // Insert 300 ids — older ones should be evicted.
+    for (let i = 0; i < 300; i++) {
+      recordHookTaskId(1, `task-${i}`);
+    }
+    // First 44 (300-256) should be evicted.
+    expect(wasTaskSeenByHook(1, 'task-0')).toBe(false);
+    expect(wasTaskSeenByHook(1, 'task-43')).toBe(false);
+    // Last 256 should be retained.
+    expect(wasTaskSeenByHook(1, 'task-44')).toBe(true);
+    expect(wasTaskSeenByHook(1, 'task-299')).toBe(true);
+  });
+
+  it('resetTaskDedupState clears all teams', () => {
+    recordHookTaskId(1, 'task-1');
+    recordHookTaskId(2, 'task-2');
+    resetTaskDedupState();
+    expect(wasTaskSeenByHook(1, 'task-1')).toBe(false);
+    expect(wasTaskSeenByHook(2, 'task-2')).toBe(false);
+  });
+});

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -2001,6 +2001,24 @@ describe('buildPayloadFromCcStdin', () => {
     expect(payload.cwd).toBe('/home/user/project');
   });
 
+  it('extracts owner field from cc_stdin (Issue #728)', () => {
+    const ccData = {
+      task_id: 'task-1',
+      subject: 'A task',
+      status: 'pending',
+      owner: 'planner',
+    };
+    const body = {
+      event: 'task_created',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify(ccData),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.owner).toBe('planner');
+  });
+
   it('handles invalid cc_stdin JSON gracefully', () => {
     const body = {
       event: 'tool_use',
@@ -2130,6 +2148,18 @@ describe('buildPayloadFromLegacy', () => {
     const payload = buildPayloadFromLegacy(body);
 
     expect(payload.cc_stdin).toBeUndefined();
+  });
+
+  it('extracts owner field from legacy body (Issue #728)', () => {
+    const body = {
+      event: 'task_created',
+      team: 'kea-100',
+      owner: 'reviewer',
+    };
+
+    const payload = buildPayloadFromLegacy(body);
+
+    expect(payload.owner).toBe('reviewer');
   });
 });
 
@@ -3240,6 +3270,40 @@ describe('TaskCreated event processing', () => {
     // The event should be stored with normalized type
     const insertCall = db.processEventTransaction.mock.calls[0][0];
     expect(insertCall.eventInsert.eventType).toBe('TaskCreated');
+  });
+
+  it('extracts owner from cc_stdin when present', () => {
+    // Issue #728: TaskCreated hook now ships an explicit `owner` field.
+    // The handler should use payload.owner directly, ahead of agent_id and
+    // agent_type fallbacks.
+    const upsertTeamTask = vi.fn().mockReturnValue({
+      id: 1,
+      teamId: 1,
+      taskId: 'task-1',
+      subject: 'Implement feature',
+      status: 'in_progress',
+      owner: 'planner',
+    });
+    const db = createMockDb({ upsertTeamTask });
+    const sse = createMockSse();
+
+    const payload = makePayload({
+      event: 'task_created',
+      cc_stdin: JSON.stringify({
+        task_id: 'task-1',
+        subject: 'Implement feature',
+        status: 'in_progress',
+        owner: 'planner',
+      }),
+    });
+    // Simulate buildPayloadFromCcStdin lifting cc.owner onto payload.owner.
+    payload.owner = 'planner';
+
+    processEvent(payload, db, sse);
+
+    expect(upsertTeamTask).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'planner' }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Promote CC 2.1.143 `TaskCreated` hook to the canonical task source for `team_tasks`, with proper owner attribution from CC's native `owner`/`agent_id` fields (priority chain `payload.owner ?? ccData.owner ?? payload.agent_id ?? ccData.agent_id ?? payload.agent_type`, all normalized via `normalizeAgentName`).
- Demote the legacy stream-event `TodoWrite` parser in `team-manager.ts` to a deduped fallback. New `src/server/services/task-dedup.ts` tracks task_ids seen via the hook (keyed by numeric `teamId`, 256-cap per team, cleared on terminal state) so the stream path skips redundant upserts and logs the dedupe once per (team, task).
- 17 new tests in `tests/server/event-collector-task-created.test.ts` + 3 added tests in `event-collector.test.ts` covering owner extraction from cc_stdin / legacy payloads.

Closes #728

## Test plan
- [x] `npm run test:server` — 1969 passed (3 pre-existing `cc-spawn.test.ts` failures on `origin/main`, unrelated to this change; diff for those files is empty)
- [x] `npx tsc --noEmit` — zero errors
- [x] All 241 event-collector + task-created + team-manager tests pass