### PR TITLE
Issue #727: surface StopFailure as a distinct lifecycle transition

### DIFF
--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -405,6 +405,66 @@ function normalizeEventType(raw: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// StopFailure classification (Issue #727)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a StopFailure hook payload's error string as transient, fatal, or unknown.
+ *
+ * - `'fatal'`: authentication/permission errors that will not self-recover. Auto-retry
+ *   is suppressed by exhausting the retry budget (see processEvent).
+ * - `'transient'`: rate limits, server errors, network issues that may succeed on retry.
+ *   The normal `failed-queued-auto` retry path applies.
+ * - `'unknown'`: anything that does not match either bucket. Treated as transient for
+ *   retry purposes (permissive) — `retryMaxCount` cap is the backstop.
+ *
+ * Matching is case-insensitive substring matching. If `errorDetails` is empty, falls
+ * back to the `errorFallback` string (typically the legacy `error` field).
+ */
+export function classifyStopFailure(
+  errorDetails: string | undefined,
+  errorFallback: string | undefined,
+): 'transient' | 'fatal' | 'unknown' {
+  const raw = (errorDetails || errorFallback || '').toLowerCase();
+  if (!raw) return 'unknown';
+
+  const FATAL_SUBSTRINGS = [
+    'auth',
+    'unauthorized',
+    '401',
+    '403',
+    'invalid api key',
+    'permission',
+    'forbidden',
+  ];
+  for (const needle of FATAL_SUBSTRINGS) {
+    if (raw.includes(needle)) return 'fatal';
+  }
+
+  const TRANSIENT_SUBSTRINGS = [
+    'rate limit',
+    'rate_limit',
+    'overloaded',
+    'server error',
+    '500',
+    '502',
+    '503',
+    '504',
+    'timeout',
+    'econnrefused',
+    'enotfound',
+    'etimedout',
+    'network',
+    'temporarily unavailable',
+  ];
+  for (const needle of TRANSIENT_SUBSTRINGS) {
+    if (raw.includes(needle)) return 'transient';
+  }
+
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
 // Core processing
 // ---------------------------------------------------------------------------
 
@@ -471,7 +531,7 @@ export function processEvent(
   let statusUpdateData: { teamId: number; fields: Record<string, unknown> } | undefined;
   let previousStatus: TeamStatus | undefined;
 
-  const DORMANCY_EVENTS = new Set(['stop', 'stop_failure', 'session_end']);
+  const DORMANCY_EVENTS = new Set(['stop', 'session_end']);
   const eventNameLower = payload.event.toLowerCase();
 
   // ── State transition: idle/stuck -> running on activity events ─────
@@ -506,6 +566,40 @@ export function processEvent(
         statusUpdateData = { teamId, fields: { status: 'running' } };
         previousStatus = 'launching';
       }
+    }
+  }
+
+  // ── State transition: stop_failure -> failed (Issue #727) ─────────
+  // StopFailure hook indicates the CC turn ended due to an API error
+  // (rate limit, auth, 5xx, etc.) — NOT normal completion. We mark the
+  // team failed immediately with a classified reason so the operator can
+  // see why the failure happened and so auto-retry can be suppressed for
+  // fatal causes (auth/permission). This block runs after any default
+  // idle/stuck or launching transition logic above and OVERWRITES the
+  // collected transition data so the failed transition wins.
+  if (!isTerminal && eventNameLower === 'stop_failure') {
+    const freshTeam = db.getTeamByWorktree(payload.team);
+    if (freshTeam && !TERMINAL_STATUSES.has(freshTeam.status)) {
+      const classification = classifyStopFailure(payload.error_details, payload.error);
+      const detail = (payload.error_details || payload.error || 'unknown error').slice(0, 500);
+      const reasonTag = classification === 'fatal' ? ' [no-retry]' : '';
+      transitionData = {
+        teamId,
+        fromStatus: freshTeam.status,
+        toStatus: 'failed',
+        trigger: 'hook',
+        reason: `StopFailure: ${detail} (${classification})${reasonTag}`,
+      };
+      const statusFields: Record<string, unknown> = {
+        status: 'failed',
+        stoppedAt: nowIso,
+        pid: null,
+      };
+      if (classification === 'fatal') {
+        statusFields.retryCount = config.retryMaxCount;
+      }
+      statusUpdateData = { teamId, fields: statusFields };
+      previousStatus = freshTeam.status;
     }
   }
 
@@ -743,10 +837,14 @@ export function processEvent(
   // ── Broadcast via SSE (after transaction commits) ────────────────
   // Emit a single team_status_changed event carrying both status and
   // phase info when both change simultaneously (avoids double-broadcast).
+  // Derive the new status from statusUpdateData so transitions that target
+  // statuses other than 'running' (e.g. running -> failed on StopFailure,
+  // issue #727) broadcast the correct new status.
+  const broadcastStatus = (statusUpdateData?.fields.status as string | undefined) || 'running';
   if (previousStatus !== undefined && phaseUpdateData) {
     sse.broadcast('team_status_changed', {
       team_id: teamId,
-      status: 'running',
+      status: broadcastStatus,
       previous_status: previousStatus,
       phase: phaseUpdateData.phase,
       previous_phase: phaseUpdateData.previousPhase,
@@ -754,7 +852,7 @@ export function processEvent(
   } else if (previousStatus !== undefined) {
     sse.broadcast('team_status_changed', {
       team_id: teamId,
-      status: 'running',
+      status: broadcastStatus,
       previous_status: previousStatus,
     }, teamId);
   } else if (phaseUpdateData) {
@@ -765,6 +863,14 @@ export function processEvent(
       phase: phaseUpdateData.phase,
       previous_phase: phaseUpdateData.previousPhase,
     }, teamId);
+  }
+
+  // ── Broadcast team_stopped when status transitions to failed (#727) ──
+  // Replicates team-manager.handleProcessExit behavior so the UI converges
+  // immediately on StopFailure-driven failures (the team-manager won't
+  // observe a process exit until the CC process actually dies).
+  if (statusUpdateData?.fields.status === 'failed') {
+    sse.broadcast('team_stopped', { team_id: teamId }, teamId);
   }
 
   sse.broadcast('team_event', {

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -194,6 +194,23 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     hookEvent: null,
   },
   {
+    id: 'running-failed-api',
+    from: 'running',
+    to: 'failed',
+    trigger: 'hook',
+    triggerLabel: 'API failure (StopFailure hook)',
+    description:
+      "Claude Code's StopFailure hook fired — the turn ended due to an API " +
+      'error (rate limit, auth failure, server error, etc.) rather than ' +
+      'normal completion. The team is marked failed immediately; the ' +
+      'transition reason carries the error_details string. If the failure ' +
+      'is classified as transient (rate limit, server error, network), the ' +
+      'normal failed-queued-auto auto-retry path applies; fatal classifications ' +
+      '(auth, permission) suppress retry by exhausting the retry budget.',
+    condition: 'StopFailure hook event received while team is in running state',
+    hookEvent: 'stop_failure',
+  },
+  {
     id: 'launching-failed',
     from: 'launching',
     to: 'failed',

--- a/tests/server/event-collector-stop-failure.test.ts
+++ b/tests/server/event-collector-stop-failure.test.ts
@@ -1,0 +1,535 @@
+// =============================================================================
+// Fleet Commander — Event Collector StopFailure Transition Tests (Issue #727)
+// =============================================================================
+//
+// Tests for the `running -> failed-api` transition driven by the StopFailure
+// Claude Code hook. Covers transient/fatal/unknown classification, retry
+// suppression for fatal errors, payload truncation, terminal-state guards,
+// and SSE broadcast behavior.
+//
+// The classifyStopFailure helper is also tested directly.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import config from '../../src/server/config.js';
+import {
+  processEvent,
+  classifyStopFailure,
+  resetThrottleState,
+  resetSubagentTrackers,
+  resetPrPollState,
+  resetEventDedupState,
+  type EventPayload,
+  type EventCollectorDb,
+  type SseBroker,
+  type TeamMessageSender,
+} from '../../src/server/services/event-collector.js';
+
+// ---------------------------------------------------------------------------
+// Mock factories (inlined from tests/server/event-collector.test.ts so this
+// file is independently runnable. Keep in sync if the canonical helpers in the
+// sibling file evolve.)
+// ---------------------------------------------------------------------------
+
+function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
+  let nextEventId = 1;
+  let nextMsgId = 1;
+
+  const insertEvent = vi.fn().mockImplementation(() => ({ id: nextEventId++ }));
+  const updateTeam = vi.fn();
+  const insertTransition = vi.fn();
+  const insertAgentMessage = vi.fn().mockImplementation(() => ({ id: nextMsgId++ }));
+
+  const processEventTransaction = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+      eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string };
+      agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+      const result = insertEvent(ops.eventInsert);
+      const eventId = result.id;
+      if (ops.agentMessages) {
+        for (const msg of ops.agentMessages) {
+          insertAgentMessage({ ...msg, eventId });
+        }
+      }
+      return { eventId };
+    },
+  );
+
+  const processThrottledUpdate = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+    },
+  );
+
+  return {
+    getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    insertEvent,
+    updateTeam,
+    updateTeamSilent: updateTeam,
+    insertTransition,
+    insertAgentMessage,
+    processEventTransaction,
+    processThrottledUpdate,
+    ...overrides,
+  };
+}
+
+function createMockSse(): SseBroker {
+  return {
+    broadcast: vi.fn(),
+  };
+}
+
+function makePayload(overrides?: Partial<EventPayload>): EventPayload {
+  return {
+    event: 'stop_failure',
+    team: 'kea-100',
+    timestamp: new Date().toISOString(),
+    session_id: 'sess-abc',
+    agent_type: 'coordinator',
+    ...overrides,
+  };
+}
+
+function createMockMessageSender(): TeamMessageSender & { sendMessage: ReturnType<typeof vi.fn> } {
+  return {
+    sendMessage: vi.fn().mockReturnValue(true),
+  };
+}
+
+beforeEach(() => {
+  resetThrottleState();
+  resetSubagentTrackers();
+  resetPrPollState();
+  resetEventDedupState();
+});
+
+// =============================================================================
+// classifyStopFailure (direct unit tests)
+// =============================================================================
+
+describe('classifyStopFailure', () => {
+  it('classifies rate_limit as transient', () => {
+    expect(classifyStopFailure('rate_limit', undefined)).toBe('transient');
+    expect(classifyStopFailure('rate limit exceeded', undefined)).toBe('transient');
+  });
+
+  it('classifies HTTP 5xx errors as transient', () => {
+    expect(classifyStopFailure('server error 500', undefined)).toBe('transient');
+    expect(classifyStopFailure('HTTP 502 bad gateway', undefined)).toBe('transient');
+    expect(classifyStopFailure('503 service unavailable', undefined)).toBe('transient');
+    expect(classifyStopFailure('504 gateway timeout', undefined)).toBe('transient');
+  });
+
+  it('classifies network errors as transient', () => {
+    expect(classifyStopFailure('ECONNREFUSED', undefined)).toBe('transient');
+    expect(classifyStopFailure('Network unreachable', undefined)).toBe('transient');
+    expect(classifyStopFailure('ETIMEDOUT', undefined)).toBe('transient');
+    expect(classifyStopFailure('ENOTFOUND api.example.com', undefined)).toBe('transient');
+  });
+
+  it('classifies overloaded as transient', () => {
+    expect(classifyStopFailure('overloaded', undefined)).toBe('transient');
+    expect(classifyStopFailure('temporarily unavailable', undefined)).toBe('transient');
+  });
+
+  it('classifies auth errors as fatal', () => {
+    expect(classifyStopFailure('Authentication failed', undefined)).toBe('fatal');
+    expect(classifyStopFailure('401 Unauthorized', undefined)).toBe('fatal');
+    expect(classifyStopFailure('403 Forbidden', undefined)).toBe('fatal');
+    expect(classifyStopFailure('Invalid API key', undefined)).toBe('fatal');
+    expect(classifyStopFailure('Permission denied', undefined)).toBe('fatal');
+  });
+
+  it('classifies unknown strings as unknown', () => {
+    expect(classifyStopFailure('something weird happened', undefined)).toBe('unknown');
+    expect(classifyStopFailure('xyzzy', undefined)).toBe('unknown');
+  });
+
+  it('returns unknown when both error_details and error are empty/missing', () => {
+    expect(classifyStopFailure(undefined, undefined)).toBe('unknown');
+    expect(classifyStopFailure('', '')).toBe('unknown');
+    expect(classifyStopFailure(undefined, '')).toBe('unknown');
+  });
+
+  it('falls back to error string when error_details is missing', () => {
+    expect(classifyStopFailure(undefined, 'rate_limit')).toBe('transient');
+    expect(classifyStopFailure(undefined, '401 Unauthorized')).toBe('fatal');
+  });
+
+  it('is case-insensitive', () => {
+    expect(classifyStopFailure('RATE_LIMIT', undefined)).toBe('transient');
+    expect(classifyStopFailure('Auth', undefined)).toBe('fatal');
+    expect(classifyStopFailure('SERVER ERROR', undefined)).toBe('transient');
+  });
+
+  it('prefers fatal over transient when both substrings present', () => {
+    // 'auth' takes precedence — fatal trumps transient in the iteration order.
+    expect(classifyStopFailure('auth rate_limit', undefined)).toBe('fatal');
+  });
+});
+
+// =============================================================================
+// stop_failure -> failed transition
+// =============================================================================
+
+describe('stop_failure transition (Issue #727)', () => {
+  it('transitions running -> failed on stop_failure with rate_limit (transient)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit exceeded' });
+
+    processEvent(payload, db, sse);
+
+    // Status update to failed with stoppedAt and pid cleared
+    const failedUpdate = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status === 'failed',
+    );
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate![1]).toMatchObject({
+      status: 'failed',
+      stoppedAt: expect.any(String),
+      pid: null,
+    });
+    // retryCount must NOT be set for transient classification
+    expect(failedUpdate![1]).not.toHaveProperty('retryCount');
+
+    // Transition row
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'failed',
+        trigger: 'hook',
+        reason: expect.stringContaining('transient'),
+      }),
+    );
+    // No [no-retry] tag for transient
+    const transitionCall = (db.insertTransition as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(transitionCall.reason).not.toContain('[no-retry]');
+  });
+
+  it('transitions running -> failed on stop_failure with auth error (fatal)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: '401 Unauthorized — invalid API key' });
+
+    processEvent(payload, db, sse);
+
+    // Fatal classification: retryCount set to config.retryMaxCount
+    const failedUpdate = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status === 'failed',
+    );
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate![1]).toMatchObject({
+      status: 'failed',
+      stoppedAt: expect.any(String),
+      pid: null,
+      retryCount: config.retryMaxCount,
+    });
+
+    // Reason carries (fatal) and [no-retry]
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toStatus: 'failed',
+        trigger: 'hook',
+        reason: expect.stringContaining('(fatal) [no-retry]'),
+      }),
+    );
+  });
+
+  it('transitions idle -> failed on stop_failure', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'idle',
+        toStatus: 'failed',
+        trigger: 'hook',
+      }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+
+  it('transitions stuck -> failed on stop_failure', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'stuck',
+        toStatus: 'failed',
+        trigger: 'hook',
+      }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+
+  it('does NOT transition team already in failed state, but still inserts event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'failed', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    // No transition recorded
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    // No status updates beyond heartbeat
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    // But the event itself IS inserted (for forensic visibility)
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'StopFailure' }),
+    );
+  });
+
+  it('does NOT transition team already in done state, but still inserts event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'pr' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertTransition).not.toHaveBeenCalled();
+    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    );
+    expect(statusCalls).toHaveLength(0);
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'StopFailure' }),
+    );
+  });
+
+  it('falls back to error field when error_details is missing', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'stop_failure',
+      team: 'kea-100',
+      error: 'API rate limit exceeded',
+    };
+
+    processEvent(payload, db, sse);
+
+    // Should still transition to failed, reason should reference rate limit text and classify as transient
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toStatus: 'failed',
+        reason: expect.stringContaining('API rate limit exceeded'),
+      }),
+    );
+    const transitionCall = (db.insertTransition as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(transitionCall.reason).toContain('(transient)');
+  });
+
+  it('classifies unknown error strings as unknown but still transitions, no retry suppression', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'something weird happened' });
+
+    processEvent(payload, db, sse);
+
+    // Transition still fires
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toStatus: 'failed',
+        reason: expect.stringContaining('(unknown)'),
+      }),
+    );
+    // retryCount NOT set for unknown classification
+    const failedUpdate = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).status === 'failed',
+    );
+    expect(failedUpdate).toBeDefined();
+    expect(failedUpdate![1]).not.toHaveProperty('retryCount');
+    // No [no-retry] tag for unknown
+    const transitionCall = (db.insertTransition as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(transitionCall.reason).not.toContain('[no-retry]');
+  });
+
+  it('broadcasts team_stopped SSE event when transitioning to failed', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_stopped',
+      { team_id: 1 },
+      1,
+    );
+  });
+
+  it('broadcasts team_status_changed SSE event with correct previous_status', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'team_status_changed',
+      expect.objectContaining({
+        team_id: 1,
+        status: 'failed',
+        previous_status: 'running',
+      }),
+      1,
+    );
+  });
+
+  it('inserts StopFailure event with full payload JSON regardless of transition', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({
+      error_details: 'rate_limit',
+      last_assistant_message: 'About to run tests when API failed',
+    });
+
+    processEvent(payload, db, sse);
+
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'StopFailure' }),
+    );
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedPayload = JSON.parse(insertCall.payload);
+    expect(storedPayload.error_details).toBe('rate_limit');
+    expect(storedPayload.last_assistant_message).toBe('About to run tests when API failed');
+  });
+
+  it('transitions on stop_failure even when both error_details and error are missing', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'stop_failure',
+      team: 'kea-100',
+    };
+
+    processEvent(payload, db, sse);
+
+    // Transition fires with "unknown error" detail and unknown classification
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toStatus: 'failed',
+        reason: expect.stringContaining('unknown error'),
+      }),
+    );
+    const transitionCall = (db.insertTransition as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(transitionCall.reason).toContain('(unknown)');
+    expect(transitionCall.reason).not.toContain('[no-retry]');
+  });
+
+  it('truncates error_details longer than 500 characters in reason', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const longDetail = 'x'.repeat(800);
+    const payload = makePayload({ error_details: longDetail });
+
+    processEvent(payload, db, sse);
+
+    const transitionCall = (db.insertTransition as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // Reason format: "StopFailure: <detail>  (<class>)<tag>" — the detail portion
+    // must be capped at 500 chars. We assert the count of 'x' characters in the
+    // reason is exactly 500.
+    const xCount = (transitionCall.reason.match(/x/g) || []).length;
+    expect(xCount).toBe(500);
+  });
+
+  it('transitions launching -> failed on stop_failure (records actual fromStatus)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'launching', phase: 'init' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse);
+
+    // launching -> failed: actual fromStatus is recorded even though canonical
+    // state-machine entry shows 'running' as the from.
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'launching',
+        toStatus: 'failed',
+        trigger: 'hook',
+      }),
+    );
+  });
+
+  it('does not invoke messageSender for stop_failure events', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const messageSender = createMockMessageSender();
+    const payload = makePayload({ error_details: 'rate_limit' });
+
+    processEvent(payload, db, sse, messageSender);
+
+    // stop_failure should not directly trigger any message send (PR poll
+    // warning or crash detection paths require different event types).
+    expect(messageSender.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -950,7 +950,7 @@ describe('StopFailure event', () => {
     expect(storedPayload.last_assistant_message).toBe('I was about to run the tests when...');
   });
 
-  it('is treated as a dormancy event (does not transition idle -> running)', () => {
+  it('transitions idle -> failed on stop_failure (Issue #727)', () => {
     const db = createMockDb({
       getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
     });
@@ -959,15 +959,21 @@ describe('StopFailure event', () => {
 
     processEvent(payload, db, sse);
 
-    // Should NOT have called updateTeam with status: 'running'
-    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    // Should have called updateTeam with status: 'failed'
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
     );
-    expect(statusCalls).toHaveLength(0);
-    expect(db.insertTransition).not.toHaveBeenCalled();
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'idle',
+        toStatus: 'failed',
+        trigger: 'hook',
+      }),
+    );
   });
 
-  it('is treated as a dormancy event (does not transition stuck -> running)', () => {
+  it('transitions stuck -> failed on stop_failure (Issue #727)', () => {
     const db = createMockDb({
       getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
     });
@@ -976,14 +982,20 @@ describe('StopFailure event', () => {
 
     processEvent(payload, db, sse);
 
-    const statusCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (call: unknown[]) => (call[1] as Record<string, unknown>).status !== undefined,
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
     );
-    expect(statusCalls).toHaveLength(0);
-    expect(db.insertTransition).not.toHaveBeenCalled();
+    expect(db.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'stuck',
+        toStatus: 'failed',
+        trigger: 'hook',
+      }),
+    );
   });
 
-  it('still updates lastEventAt for stop_failure events', () => {
+  it('still updates lastEventAt for stop_failure events and transitions to failed', () => {
     const db = createMockDb({
       getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
     });
@@ -995,6 +1007,10 @@ describe('StopFailure event', () => {
     expect(db.updateTeam).toHaveBeenCalledWith(
       1,
       expect.objectContaining({ lastEventAt: expect.any(String) }),
+    );
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
     );
   });
 


### PR DESCRIPTION
## Summary

- Adds a new `running-failed-api` state-machine transition triggered by Claude Code's `StopFailure` hook event.
- `stop_failure` for a non-terminal team now immediately transitions to `failed`, with `error_details` recorded in `team_transitions.reason` and the classification bucket (transient/fatal/unknown) appended.
- Fatal API errors (auth, permission) suppress auto-retry by exhausting `retryCount = config.retryMaxCount`. Transient (rate limit, 5xx, network) and unknown errors leave `retryCount` untouched so `failed-queued-auto` can retry.
- Removes `stop_failure` from `DORMANCY_EVENTS` and emits both `team_status_changed` and `team_stopped` SSE events on the failed transition.

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [x] `npm run test:server` — 1974 passed (3 pre-existing `cc-spawn.test.ts` env-var-leak failures on clean main, unrelated)
- [x] New `tests/server/event-collector-stop-failure.test.ts` — 25 tests covering classifyStopFailure (10 cases) and transition behavior (15 cases)
- [x] Updated `tests/server/event-collector.test.ts` StopFailure describe block — positive `idle/stuck -> failed` assertions replace the old dormancy ones
- [x] State-machine tests (27) and team-manager lifecycle tests (43) still pass

Closes #727