### PR TITLE
Issue #729: prefer last_assistant_message from Stop/SubagentStop hook payload

### DIFF
--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
 import { processEvent, EventCollectorError } from '../services/event-collector.js';
-import type { EventPayload, EventCollectorDb, SseBroker, TeamMessageSender } from '../services/event-collector.js';
+import type { EventPayload, EventCollectorDb, SseBroker, TeamMessageSender, LastAssistantMessageSink } from '../services/event-collector.js';
 import { getDatabase } from '../db.js';
 import { sseBroker } from '../services/sse-broker.js';
 import { getTeamManager } from '../services/team-manager.js';
@@ -142,7 +142,13 @@ const eventsRoutes: FastifyPluginCallback = (
 
         const db = getDatabase();
         const manager = getTeamManager();
-        const result = processEvent(payload, db as unknown as EventCollectorDb, sseBroker as unknown as SseBroker, manager as unknown as TeamMessageSender);
+        const result = processEvent(
+          payload,
+          db as unknown as EventCollectorDb,
+          sseBroker as unknown as SseBroker,
+          manager as unknown as TeamMessageSender,
+          manager as unknown as LastAssistantMessageSink,
+        );
 
         // When a stop event is received, a team may be finishing —
         // trigger queue processing so queued teams can launch.

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -128,6 +128,19 @@ export interface TeamMessageSender {
   sendMessage(teamId: number, message: string, source?: 'user' | 'fc', subtype?: string): boolean;
 }
 
+/**
+ * Optional sink for capturing the team-lead's `last_assistant_message` field
+ * from Stop / SubagentStop / StopFailure hook input (CC 2.1.46+). Issue #729.
+ *
+ * The captured value is consumed by `TeamManager.handleProcessExit` as the
+ * authoritative source for the merge-claim cross-check, falling back to the
+ * existing `parsedEvents` buffer extraction for older CC versions or when the
+ * field is absent.
+ */
+export interface LastAssistantMessageSink {
+  noteLastAssistantMessage(teamId: number, text: string): void;
+}
+
 // ---------------------------------------------------------------------------
 // Throttle state — module-level, persists across requests
 // ---------------------------------------------------------------------------
@@ -161,6 +174,18 @@ const DEDUP_EVENT_TYPES = new Set<string>([
   'stop_failure',
   'session_end',
   'subagent_stop',
+]);
+
+/**
+ * Hook event types that may carry `last_assistant_message` from CC 2.1.46+
+ * stdin. The team-lead's exit chatter on any of these is the authoritative
+ * source for the merge-claim cross-check (issue #729). Subagent stops are
+ * ignored because the cross-check only inspects the TL's shutdown reason.
+ */
+const TL_TERMINAL_EVENTS = new Set<string>([
+  'stop',
+  'subagent_stop',
+  'stop_failure',
 ]);
 
 interface DedupEntry {
@@ -401,6 +426,7 @@ export function processEvent(
   db: EventCollectorDb,
   sse: SseBroker,
   messageSender?: TeamMessageSender,
+  lastAssistantSink?: LastAssistantMessageSink,
 ): ProcessEventResult {
   // ── Validate required fields ─────────────────────────────────────
   if (!payload.event || !payload.team) {
@@ -666,6 +692,28 @@ export function processEvent(
       for (const [k, v] of lastEventFingerprint) {
         if (now - v.at > DEDUP_WINDOW_MS * 20) lastEventFingerprint.delete(k);
       }
+    }
+  }
+
+  // ── Capture TL's last_assistant_message for merge-claim cross-check ──
+  // Issue #729: CC 2.1.46+ emits `last_assistant_message` on Stop /
+  // SubagentStop / StopFailure hook stdin. The merge-claim cross-check in
+  // team-manager.handleProcessExit prefers this value over the parsedEvents
+  // buffer extraction. Filter on agentName === 'team-lead' so subagent stops
+  // don't shadow the TL message in the cache. Non-empty string only.
+  if (
+    lastAssistantSink &&
+    TL_TERMINAL_EVENTS.has(eventNameLower) &&
+    agentName === 'team-lead' &&
+    typeof payload.last_assistant_message === 'string' &&
+    payload.last_assistant_message.length > 0
+  ) {
+    try {
+      lastAssistantSink.noteLastAssistantMessage(teamId, payload.last_assistant_message);
+    } catch (err) {
+      console.warn(
+        `[EventCollector] noteLastAssistantMessage failed for team=${payload.team}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -221,6 +221,16 @@ export class TeamManager {
     Map<string, { lastEventAt: number; toolUseId: string; startedAt: number }>
   > = new Map();
 
+  /**
+   * Per-team cache of the team-lead's most recent `last_assistant_message`
+   * captured from Stop / SubagentStop / StopFailure hook input (CC 2.1.46+,
+   * issue #729). Populated by event-collector via the `LastAssistantMessageSink`
+   * interface and consumed by `handleProcessExit` as the authoritative source
+   * for the merge-claim cross-check. Falls back to parsedEvents extraction
+   * when empty (older CC versions). Values are capped at 16KB to bound memory.
+   */
+  private lastAssistantMessages: Map<number, string> = new Map();
+
   // -------------------------------------------------------------------------
   // syncWithOrigin — fetch + pull before creating a worktree
   // -------------------------------------------------------------------------
@@ -848,6 +858,7 @@ export class TeamManager {
     this.thinkingTeams.clear();
     this.thinkingStartTimes.clear();
     this.thinkingBlockIndex.clear();
+    this.lastAssistantMessages.clear();
   }
 
   // -------------------------------------------------------------------------
@@ -1628,6 +1639,26 @@ export class TeamManager {
   }
 
   // -------------------------------------------------------------------------
+  // noteLastAssistantMessage — cache TL's last_assistant_message (issue #729)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Cache the team-lead's most recent `last_assistant_message` value captured
+   * by event-collector from a Stop / SubagentStop / StopFailure hook payload
+   * (CC 2.1.46+). The cached value is consumed by `handleProcessExit` as the
+   * authoritative source for the merge-claim cross-check, with a fallback to
+   * `parsedEvents` buffer extraction when the cache is empty.
+   *
+   * Empty / non-string inputs are ignored. Values larger than 16KB are
+   * truncated to bound memory. Implements `LastAssistantMessageSink`.
+   */
+  noteLastAssistantMessage(teamId: number, text: string): void {
+    if (typeof text !== 'string' || text.length === 0) return;
+    const capped = text.length > 16384 ? text.slice(0, 16384) : text;
+    this.lastAssistantMessages.set(teamId, capped);
+  }
+
+  // -------------------------------------------------------------------------
   // getStdinPipe — expose stdin pipe for external graceful shutdown
   // -------------------------------------------------------------------------
 
@@ -1952,13 +1983,19 @@ export class TeamManager {
    * @param code The process exit code (0 = normal, non-zero = failure).
    * @param signal The signal that killed the process, if any.
    * @param tlTextSnapshot Concatenated recent team-lead assistant text,
-   *   captured before purgeTeamMaps cleared the parsed-event buffer.
+   *   captured before purgeTeamMaps cleared the parsed-event buffer. Used as
+   *   fallback when `cachedLastAssistantMessage` is empty.
+   * @param cachedLastAssistantMessage The TL's `last_assistant_message` from
+   *   the most recent Stop / SubagentStop / StopFailure hook input (CC 2.1.46+,
+   *   issue #729). Preferred over `tlTextSnapshot` for the merge-claim
+   *   cross-check; falls back to `tlTextSnapshot` when empty.
    */
   private async handleProcessExit(
     teamId: number,
     code: number | null,
     signal: NodeJS.Signals | null,
     tlTextSnapshot: string,
+    cachedLastAssistantMessage: string,
   ): Promise<void> {
     const db = getDatabase();
     const currentTeam = db.getTeam(teamId);
@@ -2015,7 +2052,12 @@ export class TeamManager {
       const freshPr = db.getPullRequest(currentTeam.prNumber);
       const prStillOpen =
         freshPr !== undefined && (freshPr.state === 'open' || freshPr.state === 'draft');
-      const claimsMerge = containsMergeClaim(tlTextSnapshot);
+      // Issue #729: prefer the cached `last_assistant_message` from CC 2.1.46+
+      // Stop / SubagentStop hook input over the parsedEvents extraction. The
+      // hook field is the authoritative source; the buffer extraction stays
+      // as fallback for older CC versions or when the field is empty.
+      const tlTextForCheck = cachedLastAssistantMessage || tlTextSnapshot;
+      const claimsMerge = containsMergeClaim(tlTextForCheck);
 
       if (prStillOpen && claimsMerge) {
         // Reject the done transition. Keep the team in its current live
@@ -2024,7 +2066,7 @@ export class TeamManager {
           `[TeamManager] REJECTING done transition for team ${teamId}: ` +
             `TL claims PR #${currentTeam.prNumber} merged but github-poller ` +
             `reports state=${freshPr?.state ?? 'unknown'}. TL text snippet: ` +
-            `"${tlTextSnapshot.slice(0, 200).replace(/\s+/g, ' ')}"`,
+            `"${tlTextForCheck.slice(0, 200).replace(/\s+/g, ' ')}"`,
         );
 
         db.insertTransition({
@@ -2107,6 +2149,12 @@ export class TeamManager {
         this.parsedEvents.get(teamId)?.toArray(),
       );
 
+      // Snapshot the cached `last_assistant_message` from CC 2.1.46+ Stop /
+      // SubagentStop hook input BEFORE purgeTeamMaps clears it (issue #729).
+      // Preferred over `tlTextSnapshot` in the merge-claim cross-check; falls
+      // back to the parsedEvents extraction when empty.
+      const cachedLastAssistantMessage = this.lastAssistantMessages.get(teamId) ?? '';
+
       this.purgeTeamMaps(teamId);
 
       // Offload the (potentially async) transition decision. The exit event
@@ -2114,7 +2162,13 @@ export class TeamManager {
       // and let it resolve in the background. All DB work inside the IIFE is
       // sync (better-sqlite3); the only async step is the forced poller
       // reconcile, which we MUST await before committing the done state.
-      void this.handleProcessExit(teamId, code, signal, tlTextSnapshot).catch((err) => {
+      void this.handleProcessExit(
+        teamId,
+        code,
+        signal,
+        tlTextSnapshot,
+        cachedLastAssistantMessage,
+      ).catch((err) => {
         console.error(
           `[TeamManager] handleProcessExit error for team ${teamId}:`,
           err instanceof Error ? err.message : err,
@@ -2900,7 +2954,8 @@ export class TeamManager {
   // corresponding .delete() call here. The maps cleaned are:
   //   outputBuffers, childProcesses, stdinPipes, parsedEvents, tokenCounters,
   //   agentMaps, lastStreamAt, shutdownTimers, thinkingTeams,
-  //   thinkingStartTimes, thinkingBlockIndex, subagentActivity
+  //   thinkingStartTimes, thinkingBlockIndex, subagentActivity,
+  //   lastAssistantMessages (issue #729)
   // -------------------------------------------------------------------------
 
   /**
@@ -2928,6 +2983,7 @@ export class TeamManager {
     this.agentMaps.delete(teamId);
     this.lastStreamAt.delete(teamId);
     this.subagentActivity.delete(teamId);
+    this.lastAssistantMessages.delete(teamId);
   }
 
   // -------------------------------------------------------------------------
@@ -2980,6 +3036,7 @@ export class TeamManager {
     for (const id of this.thinkingStartTimes.keys()) allTeamIds.add(id);
     for (const id of this.thinkingBlockIndex.keys()) allTeamIds.add(id);
     for (const id of this.subagentActivity.keys()) allTeamIds.add(id);
+    for (const id of this.lastAssistantMessages.keys()) allTeamIds.add(id);
 
     let purged = 0;
     for (const teamId of allTeamIds) {

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -132,7 +132,7 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     trigger: 'system',
     triggerLabel: 'Done rejected — bogus merge claim',
     description:
-      'Process exited with code 0 and the TL\'s shutdown reason or last assistant message claimed the PR was merged, but the final forced github-poller reconcile shows the PR is still OPEN on GitHub. FC refuses the done transition, sends a verification_required message to the TL via stdin, and logs a warning. Typical cause: force-push after enabling auto-merge silently dropped the pending auto-merge and the TL declared merge success from memory without re-verifying (see issue #701).',
+      'Process exited with code 0 and the TL\'s shutdown reason or last assistant message claimed the PR was merged, but the final forced github-poller reconcile shows the PR is still OPEN on GitHub. FC refuses the done transition, sends a verification_required message to the TL via stdin, and logs a warning. Typical cause: force-push after enabling auto-merge silently dropped the pending auto-merge and the TL declared merge success from memory without re-verifying (see issue #701). Cross-check prefers `last_assistant_message` from CC 2.1.46+ Stop/SubagentStop hook input, falling back to FC\'s in-memory parsedEvents buffer for older CC versions (see issue #729).',
     condition:
       'Process exit code 0 AND shutdown reason claims merge AND forced reconcile shows PR state = open',
     hookEvent: 'session_end',

--- a/tests/server/services/event-collector-last-assistant.test.ts
+++ b/tests/server/services/event-collector-last-assistant.test.ts
@@ -1,0 +1,330 @@
+// =============================================================================
+// Fleet Commander — Event Collector last_assistant_message capture tests
+// =============================================================================
+// Issue #729: CC 2.1.46+ emits `last_assistant_message` on Stop / SubagentStop
+// / StopFailure hook input. EventCollector forwards this value to TeamManager
+// via the optional `LastAssistantMessageSink` so the merge-claim cross-check
+// can use it as the authoritative source (with parsedEvents extraction as
+// fallback). These tests cover all gating conditions on the capture path.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  processEvent,
+  resetThrottleState,
+  resetSubagentTrackers,
+  resetPrPollState,
+  resetEventDedupState,
+  type EventPayload,
+  type EventCollectorDb,
+  type SseBroker,
+  type LastAssistantMessageSink,
+} from '../../../src/server/services/event-collector.js';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+function createMockDb(overrides?: Partial<EventCollectorDb>): EventCollectorDb {
+  let nextEventId = 1;
+  let nextMsgId = 1;
+
+  const insertEvent = vi.fn().mockImplementation(() => ({ id: nextEventId++ }));
+  const updateTeam = vi.fn();
+  const insertTransition = vi.fn();
+  const insertAgentMessage = vi.fn().mockImplementation(() => ({ id: nextMsgId++ }));
+
+  const processEventTransaction = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+      eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string };
+      agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+      const result = insertEvent(ops.eventInsert);
+      const eventId = result.id;
+      if (ops.agentMessages) {
+        for (const msg of ops.agentMessages) {
+          insertAgentMessage({ ...msg, eventId });
+        }
+      }
+      return { eventId };
+    },
+  );
+
+  const processThrottledUpdate = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+    },
+  );
+
+  return {
+    getTeamByWorktree: vi.fn().mockReturnValue({ id: 42, status: 'running', phase: 'implementing' }),
+    insertEvent,
+    updateTeam,
+    updateTeamSilent: updateTeam,
+    insertTransition,
+    insertAgentMessage,
+    processEventTransaction,
+    processThrottledUpdate,
+    ...overrides,
+  };
+}
+
+function createMockSse(): SseBroker {
+  return {
+    broadcast: vi.fn(),
+  };
+}
+
+function createMockSink(): LastAssistantMessageSink & {
+  noteLastAssistantMessage: ReturnType<typeof vi.fn>;
+} {
+  return {
+    noteLastAssistantMessage: vi.fn(),
+  };
+}
+
+function makeStopPayload(overrides?: Partial<EventPayload>): EventPayload {
+  // Default: a TL `stop` event with last_assistant_message. agent_type is left
+  // undefined so normalizeAgentName() returns 'team-lead'.
+  return {
+    event: 'stop',
+    team: 'proj-100',
+    timestamp: new Date().toISOString(),
+    session_id: 'sess-abc',
+    last_assistant_message: 'PR #42 merged, issue #10 closed. Team done.',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetThrottleState();
+  resetSubagentTrackers();
+  resetPrPollState();
+  resetEventDedupState();
+});
+
+// =============================================================================
+// Capture path — happy cases
+// =============================================================================
+
+describe('EventCollector — last_assistant_message capture (issue #729)', () => {
+  it('captures last_assistant_message on stop event from team-lead', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    const payload = makeStopPayload({
+      event: 'stop',
+      last_assistant_message: 'All phases complete, PR merged.',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledTimes(1);
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledWith(
+      42,
+      'All phases complete, PR merged.',
+    );
+  });
+
+  it('captures last_assistant_message on subagent_stop event from team-lead', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    // SubagentStop fired by the TL (main agent has no agent_type, normalizes
+    // to 'team-lead'). Mirrors what CC 2.1.46+ emits when a subagent finishes.
+    const payload = makeStopPayload({
+      event: 'subagent_stop',
+      last_assistant_message: 'Subagent dev returned successfully.',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledTimes(1);
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledWith(
+      42,
+      'Subagent dev returned successfully.',
+    );
+  });
+
+  it('captures last_assistant_message on stop_failure event from team-lead', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    const payload = makeStopPayload({
+      event: 'stop_failure',
+      error_details: 'rate_limit',
+      last_assistant_message: 'About to verify PR merge state.',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledTimes(1);
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledWith(
+      42,
+      'About to verify PR merge state.',
+    );
+  });
+
+  // =============================================================================
+  // Negative cases — capture is filtered out
+  // =============================================================================
+
+  it('does NOT capture from a non-team-lead agent (subagent stop attributed to dev)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    // SubagentStop attributed to a subagent (agent_type='fleet-dev' normalizes
+    // to 'dev', not 'team-lead'). The cross-check only inspects the TL's
+    // shutdown reason — subagent chatter must not shadow it.
+    const payload = makeStopPayload({
+      event: 'subagent_stop',
+      agent_type: 'fleet-dev',
+      last_assistant_message: 'Dev finished implementing the feature.',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture from non-terminal events (tool_use)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      tool_name: 'Bash',
+      last_assistant_message: 'Running the tests now.', // Present but should be ignored
+    };
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture when last_assistant_message is an empty string', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    const payload = makeStopPayload({
+      event: 'stop',
+      last_assistant_message: '',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture when last_assistant_message is missing', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    // Stop event with no last_assistant_message field at all (older CC version).
+    const payload: EventPayload = {
+      event: 'stop',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+    };
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    expect(sink.noteLastAssistantMessage).not.toHaveBeenCalled();
+  });
+
+  // =============================================================================
+  // Sink absence and error handling
+  // =============================================================================
+
+  it('does not throw when sink is not provided', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const payload = makeStopPayload({
+      event: 'stop',
+      last_assistant_message: 'PR merged.',
+    });
+
+    // No sink argument — capture path should be a no-op.
+    expect(() => processEvent(payload, db, sse)).not.toThrow();
+    // Event still processed normally.
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'Stop' }),
+    );
+  });
+
+  it('catches sink errors and logs a warning without breaking event processing', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink: LastAssistantMessageSink = {
+      noteLastAssistantMessage: vi.fn().mockImplementation(() => {
+        throw new Error('sink exploded');
+      }),
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const payload = makeStopPayload({
+      event: 'stop',
+      last_assistant_message: 'PR merged.',
+    });
+
+    // processEvent must NOT propagate sink errors.
+    expect(() => processEvent(payload, db, sse, undefined, sink)).not.toThrow();
+
+    expect(sink.noteLastAssistantMessage).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('noteLastAssistantMessage failed'),
+    );
+    // Event was still inserted (capture failure is non-critical).
+    expect(db.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'Stop' }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  // =============================================================================
+  // Persistence — payload regression check
+  // =============================================================================
+
+  it('still persists last_assistant_message inside events.payload JSON (no regression)', () => {
+    const db = createMockDb();
+    const sse = createMockSse();
+    const sink = createMockSink();
+    const payload = makeStopPayload({
+      event: 'stop',
+      last_assistant_message: 'PR #42 merged, issue closed.',
+    });
+
+    processEvent(payload, db, sse, undefined, sink);
+
+    const insertCall = (db.insertEvent as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    const storedPayload = JSON.parse(insertCall.payload) as { last_assistant_message?: string };
+    expect(storedPayload.last_assistant_message).toBe('PR #42 merged, issue closed.');
+  });
+});

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -860,6 +860,208 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
       expect.objectContaining({ status: 'done' }),
     );
   });
+
+  // =========================================================================
+  // Issue #729 — cache `last_assistant_message` and prefer over parsedEvents
+  // =========================================================================
+
+  it('issue #729: rejects done using cached last_assistant_message alone (buffer has no TL text)', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: 50 });
+    setupTeamMaps(1, child);
+
+    // Buffer intentionally empty — the only source of merge-claim text is
+    // the cached `last_assistant_message` set via noteLastAssistantMessage().
+    // This proves the cache is wired into the cross-check.
+    (tm as TeamManager).noteLastAssistantMessage(
+      1,
+      'PR #50 merged via auto-merge. Closing issue and exiting.',
+    );
+
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 50,
+      teamId: 1,
+      title: null,
+      state: 'open',
+      mergeStatus: 'blocked_ci_pending',
+      ciStatus: 'pending',
+      ciFailCount: 0,
+      checksJson: null,
+      autoMerge: false,
+      mergedAt: null,
+      baseRefName: 'main',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    // Cross-check rejected the done transition based on the cached value.
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'running',
+        trigger: 'system',
+        reason: expect.stringContaining('Done transition rejected'),
+      }),
+    );
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done' }),
+    );
+    // Warning log includes the cached snippet, proving the cache fed the check.
+    expect(warnSpy.mock.calls[0]![0]).toContain('PR #50');
+    expect(warnSpy.mock.calls[0]![0]).toContain('merged via auto-merge');
+
+    warnSpy.mockRestore();
+  });
+
+  it('issue #729: prefers cached last_assistant_message over parsedEvents buffer', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: 51 });
+    setupTeamMaps(1, child);
+
+    // Buffer contains benign text (no merge claim). If the implementation
+    // (incorrectly) preferred the buffer, the transition would be accepted.
+    const events = (tm as any).parsedEvents.get(1) as CircularBuffer<any>;
+    events.push({
+      type: 'assistant',
+      agentName: 'team-lead',
+      message: {
+        content: [{ type: 'text', text: 'Wrapping up; all phases complete.' }],
+      },
+    });
+
+    // Cache claims merge. Cross-check must use the cache, NOT the buffer.
+    (tm as TeamManager).noteLastAssistantMessage(
+      1,
+      'PR #51 has been merged successfully. Issue closed.',
+    );
+
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 51,
+      teamId: 1,
+      title: null,
+      state: 'open',
+      mergeStatus: 'blocked_ci_pending',
+      ciStatus: 'pending',
+      ciFailCount: 0,
+      checksJson: null,
+      autoMerge: false,
+      mergedAt: null,
+      baseRefName: 'main',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    // Rejected — cached merge claim wins over the buffer's benign text.
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'running',
+        reason: expect.stringContaining('Done transition rejected'),
+      }),
+    );
+    // Warning snippet must contain the cached text, NOT the buffer text.
+    expect(warnSpy.mock.calls[0]![0]).toContain('PR #51 has been merged');
+    expect(warnSpy.mock.calls[0]![0]).not.toContain('Wrapping up');
+
+    warnSpy.mockRestore();
+  });
+
+  it('issue #729: falls back to parsedEvents buffer when cache is empty', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: 52 });
+    setupTeamMaps(1, child);
+
+    // NO noteLastAssistantMessage call — cache is empty (older CC version).
+    // Buffer has merge claim — the fallback path must trigger the rejection.
+    const events = (tm as any).parsedEvents.get(1) as CircularBuffer<any>;
+    events.push({
+      type: 'assistant',
+      agentName: 'team-lead',
+      message: {
+        content: [
+          { type: 'text', text: 'PR #52 merged, issue resolved. Goodbye.' },
+        ],
+      },
+    });
+
+    const mockStdin = createMockStdin();
+    (tm as any).stdinPipes.set(1, mockStdin);
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getPullRequest.mockReturnValue({
+      prNumber: 52,
+      teamId: 1,
+      title: null,
+      state: 'open',
+      mergeStatus: 'blocked_ci_pending',
+      ciStatus: 'pending',
+      ciFailCount: 0,
+      checksJson: null,
+      autoMerge: false,
+      mergedAt: null,
+      baseRefName: 'main',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    // Rejected via the fallback path — buffer text was used.
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        fromStatus: 'running',
+        toStatus: 'running',
+        reason: expect.stringContaining('Done transition rejected'),
+      }),
+    );
+    expect(warnSpy.mock.calls[0]![0]).toContain('PR #52 merged');
+
+    warnSpy.mockRestore();
+  });
+
+  it('issue #729: purgeTeamMaps clears the cached last_assistant_message entry', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: null });
+    setupTeamMaps(1, child);
+
+    // Seed the cache; verify it is present before the exit handler runs.
+    (tm as TeamManager).noteLastAssistantMessage(1, 'Some final TL message.');
+    expect((tm as any).lastAssistantMessages.has(1)).toBe(true);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    // After exit, purgeTeamMaps ran — the cache entry must be gone.
+    expect((tm as any).lastAssistantMessages.has(1)).toBe(false);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
Closes #729

## Summary

Wires CC 2.1.46+ `last_assistant_message` from `Stop` / `SubagentStop` / `StopFailure` hook input into the merge-claim cross-check in `TeamManager.handleProcessExit`. The hook field is now the authoritative source; the existing `extractRecentTlText` extraction from the in-memory `parsedEvents` buffer remains as fallback for older CC versions or when the field is empty.

## Approach

- New optional sibling interface `LastAssistantMessageSink` on `event-collector.ts` mirrors the existing `TeamMessageSender` pattern.
- `processEvent` accepts an optional 5th `lastAssistantSink` and captures the value only on the three terminal event types when the agent normalizes to `team-lead` and the field is non-empty. Sink errors are swallowed with a warning.
- `TeamManager` owns a per-team `Map<number, string>` populated via `noteLastAssistantMessage` (16 KB cap). The exit handler snapshots the cached value before `purgeTeamMaps` clears it and passes both the cached value and `tlTextSnapshot` into `handleProcessExit`, which uses `cachedLastAssistantMessage || tlTextSnapshot`.
- `purgeTeamMaps`, `sweepOrphanedMaps`, and `killAll` all maintain the new map.
- `routes/events.ts` wires `getTeamManager()` as both `TeamMessageSender` and `LastAssistantMessageSink` via structural casts.
- `src/shared/state-machine.ts` `running-done-rejected` description updated per CLAUDE.md rule 13.

No schema migration, no hook script changes.

## Test plan

- [x] `npm run build` (success, 1631 modules)
- [x] `npm run typecheck` (clean, server + client)
- [x] `npm test` (1966/1966 with env-var workaround for pre-existing `cc-spawn.test.ts` env-leak)
- [x] New `tests/server/services/event-collector-last-assistant.test.ts` — 10 tests covering all gating branches (stop / subagent_stop / stop_failure capture, non-team-lead agent reject, non-terminal event reject, empty field reject, missing field reject, sink-optional, sink-error swallowing, payload-JSON persistence regression)
- [x] 4 new tests in `tests/server/team-manager-lifecycle.test.ts` (cache-only, cache-prefers-over-buffer, fallback-when-cache-empty, purge-clears-cache)
- [x] All 187 existing event-collector tests pass unchanged
- [x] All 43 existing team-manager-lifecycle tests pass unchanged