### PR TITLE
Issue #730: respect background_tasks and session_crons in Stop hook

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -400,6 +400,28 @@ export function TeamDetail() {
                       </span>
                     </div>
 
+                    {/* Background work pending (issue #730) */}
+                    {(detail.backgroundTasks?.length || detail.sessionCrons?.length) ? (
+                      <div className="mt-2 flex items-center gap-2 text-xs">
+                        <span
+                          className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border border-[#58A6FF]/40 text-[#58A6FF]"
+                          title="Agent left work pending in the background \u2014 stuck escalation suppressed"
+                        >
+                          <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                            <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                            <path d="M8 4v4l2 2" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" />
+                          </svg>
+                          Background:
+                          {detail.backgroundTasks?.length ? (
+                            <span className="ml-1">{detail.backgroundTasks.length} task(s)</span>
+                          ) : null}
+                          {detail.sessionCrons?.length ? (
+                            <span className="ml-1">{detail.sessionCrons.length} cron(s)</span>
+                          ) : null}
+                        </span>
+                      </div>
+                    ) : null}
+
                     {/* Token breakdown */}
                     {(detail.totalInputTokens + detail.totalOutputTokens) > 0 && (
                       <div className="mt-3 flex items-center gap-4 text-sm">

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -141,6 +141,8 @@ export interface TeamUpdate {
   headless?: boolean;
   blockedByJson?: string | null;
   pendingChildrenJson?: string | null;
+  backgroundTasksJson?: string | null;
+  sessionCronsJson?: string | null;
   totalInputTokens?: number;
   totalOutputTokens?: number;
   totalCacheCreationTokens?: number;
@@ -435,6 +437,9 @@ export class FleetDatabase {
 
     // Add auto_merge_enabled / auto_merge_checked_at columns to projects (v20 migration)
     this.addAutoMergeColumns();
+
+    // Add background_tasks_json / session_crons_json columns to teams (v21 migration)
+    this.addBackgroundTaskColumns();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1264,6 +1269,46 @@ export class FleetDatabase {
   }
 
   /**
+   * Add background_tasks_json and session_crons_json columns to teams table
+   * if they don't exist (v21 migration). These columns persist the
+   * `background_tasks` and `session_crons` arrays that CC 2.1.145+ ships in
+   * Stop/SubagentStop hook input (`cc_stdin`). When either column is
+   * non-empty JSON, the stuck-detector suppresses the idle->stuck
+   * transition so we do not page operators for a team that intentionally
+   * scheduled background work (see issue #730).
+   *
+   * - background_tasks_json TEXT (nullable): JSON-stringified array of
+   *   pending background tasks. NULL when no work pending.
+   * - session_crons_json    TEXT (nullable): JSON-stringified array of
+   *   pending session crons. NULL when no work pending.
+   *
+   * Fresh databases get both columns via schema.sql; upgraded databases use
+   * this migration. Idempotent across restarts.
+   */
+  private addBackgroundTaskColumns(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(teams)').all() as Array<{ name: string }>;
+      // Fresh DB: teams table doesn't exist yet — schema.sql will create it
+      // with both columns already present. Nothing to migrate.
+      if (cols.length === 0) return;
+      const hasBackgroundTasks = cols.some((c) => c.name === 'background_tasks_json');
+      const hasSessionCrons = cols.some((c) => c.name === 'session_crons_json');
+      if (!hasBackgroundTasks) {
+        this.db.exec('ALTER TABLE teams ADD COLUMN background_tasks_json TEXT');
+        console.log('[DB] v21 migration: added background_tasks_json column to teams');
+      }
+      if (!hasSessionCrons) {
+        this.db.exec('ALTER TABLE teams ADD COLUMN session_crons_json TEXT');
+        console.log('[DB] v21 migration: added session_crons_json column to teams');
+      }
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (21)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v21 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
    * Migrate branch_behind and branch_behind_resolved message templates
    * from hardcoded 'main' to use {{BASE_BRANCH}} placeholder.
    * Only updates templates that exactly match the old defaults (user edits are preserved).
@@ -1872,6 +1917,14 @@ export class FleetDatabase {
     if (fields.pendingChildrenJson !== undefined) {
       setClauses.push('pending_children_json = @pendingChildrenJson');
       params.pendingChildrenJson = fields.pendingChildrenJson;
+    }
+    if (fields.backgroundTasksJson !== undefined) {
+      setClauses.push('background_tasks_json = @backgroundTasksJson');
+      params.backgroundTasksJson = fields.backgroundTasksJson;
+    }
+    if (fields.sessionCronsJson !== undefined) {
+      setClauses.push('session_crons_json = @sessionCronsJson');
+      params.sessionCronsJson = fields.sessionCronsJson;
     }
     if (fields.totalInputTokens !== undefined) {
       setClauses.push('total_input_tokens = @totalInputTokens');
@@ -3265,6 +3318,8 @@ export class FleetDatabase {
       totalCostUsd: (row.total_cost_usd as number | undefined) ?? 0,
       blockedByJson: (row.blocked_by_json as string | null) ?? null,
       pendingChildrenJson: (row.pending_children_json as string | null) ?? null,
+      backgroundTasksJson: (row.background_tasks_json as string | null) ?? null,
+      sessionCronsJson: (row.session_crons_json as string | null) ?? null,
       retryCount: (row.retry_count as number | undefined) ?? 0,
       launchedAt: utcify(row.launched_at as string | null),
       startedAt: utcify((row.started_at as string | null) ?? null),

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -87,6 +87,17 @@ function buildPayloadFromCcStdin(body: Record<string, unknown>): EventPayload {
   payload.owner = str(cc.owner);
   payload.cwd = str(cc.cwd);
 
+  // Issue #730: CC 2.1.145+ Stop/SubagentStop hook input ships arrays of
+  // pending background tasks and session crons. Stringify them so they fit
+  // the EventPayload shape (string-only fields). The legacy shell hook path
+  // cannot transmit these — they only flow through cc_stdin.
+  if (Array.isArray(cc.background_tasks)) {
+    payload.background_tasks = JSON.stringify(cc.background_tasks);
+  }
+  if (Array.isArray(cc.session_crons)) {
+    payload.session_crons = JSON.stringify(cc.session_crons);
+  }
+
   return payload;
 }
 

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -86,6 +86,8 @@ CREATE TABLE IF NOT EXISTS teams (
   blocked_by_json TEXT,                            -- JSON array of blocking issue numbers e.g. [368, 370]
   pending_children_json TEXT,                     -- JSON array of open child issue numbers e.g. [371, 372]
   retry_count     INTEGER NOT NULL DEFAULT 0,     -- auto-retry count (0 = never retried)
+  background_tasks_json TEXT,                     -- JSON array of pending CC background tasks (CC 2.1.145+ Stop hook input); NULL when no work pending
+  session_crons_json    TEXT,                     -- JSON array of pending CC session crons (CC 2.1.145+ SubagentStop hook input); NULL when no work pending
   total_input_tokens INTEGER DEFAULT 0,
   total_output_tokens INTEGER DEFAULT 0,
   total_cache_creation_tokens INTEGER DEFAULT 0,
@@ -419,4 +421,4 @@ CREATE TABLE IF NOT EXISTS provider_state (
 );
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (20);
+INSERT OR IGNORE INTO schema_version (version) VALUES (21);

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -53,6 +53,10 @@ export interface EventPayload {
   agent_id?: string;            // CC agent identifier
   owner?: string;               // Task owner — set on TaskCreated hook events (CC 2.1.143+).
   cwd?: string;                 // working directory of the CC process
+  // CC 2.1.145+ Stop / SubagentStop hook input. The shell hook forwards
+  // these arrays as JSON strings via cc_stdin — see issue #730.
+  background_tasks?: string;    // JSON-stringified array of pending background tasks
+  session_crons?: string;       // JSON-stringified array of pending session crons
 }
 
 /** Result returned from processEvent */
@@ -405,6 +409,34 @@ function normalizeEventType(raw: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Background-task normalization (Issue #730)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a JSON-stringified array that CC ships on Stop / SubagentStop
+ * hook input (`background_tasks`, `session_crons`). Returns:
+ *   - the original JSON string when it parses to a non-empty array
+ *   - null when the input is missing, malformed, or parses to an empty array
+ *
+ * Normalizing empty arrays to null lets the stuck-detector use a cheap
+ * `IS NOT NULL` test to decide whether to suppress the idle->stuck
+ * escalation (see issue #730). Malformed JSON is treated as "no work
+ * pending" so a corrupted column never wedges the escalation forever.
+ */
+export function normalizeJsonArray(input: string | undefined): string | null {
+  if (!input) return null;
+  try {
+    const parsed: unknown = JSON.parse(input);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return JSON.stringify(parsed);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // StopFailure classification (Issue #727)
 // ---------------------------------------------------------------------------
 
@@ -518,10 +550,21 @@ export function processEvent(
   // ── Clean up subagent trackers for teams in terminal states ───────
   // If a team has reached done/failed, any orphaned tracker entries for
   // that team's subagents are removed on the next event for that team.
+  // Also clear any pending background_tasks / session_crons on the row —
+  // the team is terminal so no future suppression applies, but stale JSON
+  // would still surface in TeamDetail and confuse operators (issue #730).
   if (isTerminal) {
     cleanSubagentTrackersForTeam(payload.team);
     lastToolUseByTeam.delete(payload.team);
     clearHookTaskIdsForTeam(teamId);
+    try {
+      db.updateTeamSilent(teamId, {
+        backgroundTasksJson: null,
+        sessionCronsJson: null,
+      });
+    } catch {
+      // Best-effort cleanup — never abort event processing on a clear failure.
+    }
   }
 
   // ── Collect transition data (without writing to DB yet) ──────────
@@ -545,7 +588,19 @@ export function processEvent(
         trigger: 'hook',
         reason: `Activity resumed (${payload.event} event received)`,
       };
-      statusUpdateData = { teamId, fields: { status: 'running' } };
+      // Issue #730: clear any pending background_tasks / session_crons on
+      // resume — once the agent emits a non-dormancy event, the previously
+      // scheduled background work is no longer the reason for dormancy. If
+      // the agent is still genuinely awaiting background completion it will
+      // re-emit these on its next Stop hook.
+      statusUpdateData = {
+        teamId,
+        fields: {
+          status: 'running',
+          backgroundTasksJson: null,
+          sessionCronsJson: null,
+        },
+      };
       previousStatus = freshTeam.status;
     }
   }
@@ -641,6 +696,34 @@ export function processEvent(
             }
           }
         }
+      }
+    }
+  }
+
+  // ── Background tasks / session crons (Issue #730) ─────────────────
+  // CC 2.1.145+ ships `background_tasks` (Stop) and `session_crons`
+  // (SubagentStop) arrays inside cc_stdin. When non-empty, the agent has
+  // intentionally scheduled work to continue after the current turn ends.
+  // Persist these on the team row so stuck-detector can suppress the
+  // idle->stuck escalation while either array is non-empty. Empty arrays
+  // (and malformed JSON) normalize to NULL so the suppression is a simple
+  // `IS NOT NULL` check downstream.
+  //
+  // We only WRITE these fields here on the relevant dormancy events; we
+  // do NOT write defaults on other events because that would clobber the
+  // values set by a previous Stop hook before the agent has had a chance
+  // to resume (the resume path above clears them explicitly).
+  const BG_DORMANCY_EVENTS = new Set(['stop', 'subagent_stop', 'stop_failure', 'session_end']);
+  if (!isTerminal && BG_DORMANCY_EVENTS.has(eventNameLower)) {
+    const hasBackgroundField = payload.background_tasks !== undefined;
+    const hasCronField = payload.session_crons !== undefined;
+    if (hasBackgroundField || hasCronField) {
+      statusUpdateData ??= { teamId, fields: {} };
+      if (hasBackgroundField) {
+        statusUpdateData.fields.backgroundTasksJson = normalizeJsonArray(payload.background_tasks);
+      }
+      if (hasCronField) {
+        statusUpdateData.fields.sessionCronsJson = normalizeJsonArray(payload.session_crons);
       }
     }
   }

--- a/src/server/services/stuck-detector.ts
+++ b/src/server/services/stuck-detector.ts
@@ -206,6 +206,44 @@ class StuckDetector {
             }
           }
 
+          // Issue #730: suppress idle->stuck escalation when CC reported
+          // pending background_tasks / session_crons on its last Stop hook.
+          // The agent intentionally scheduled work to continue in the
+          // background — going dormant is expected, not a failure mode.
+          // We do NOT suppress running->idle here: that transition is
+          // legitimate (the agent really is dormant). Only the stuck alarm
+          // is suppressed.
+          if (newStatus === 'stuck') {
+            const counts: string[] = [];
+            if (team.backgroundTasksJson) {
+              try {
+                const arr: unknown = JSON.parse(team.backgroundTasksJson);
+                if (Array.isArray(arr) && arr.length > 0) {
+                  counts.push(`${arr.length} background task(s)`);
+                }
+              } catch {
+                // Malformed JSON — treat as no work pending so a corrupted
+                // column never wedges the escalation forever.
+              }
+            }
+            if (team.sessionCronsJson) {
+              try {
+                const arr: unknown = JSON.parse(team.sessionCronsJson);
+                if (Array.isArray(arr) && arr.length > 0) {
+                  counts.push(`${arr.length} session cron(s)`);
+                }
+              } catch {
+                // Malformed JSON — treat as no work pending.
+              }
+            }
+            if (counts.length > 0) {
+              console.log(
+                `[StuckDetector] Team ${team.id} skipped — awaiting ${counts.join(' and ')}`,
+              );
+              continue;
+            }
+          }
+
           const previousStatus = team.status;
           db.insertTransition({
             teamId: team.id,

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -554,6 +554,33 @@ export class TeamService {
     const outputLines = manager.getOutput(teamId, 50);
     const outputTail = outputLines.length > 0 ? outputLines.join('\n') : null;
 
+    // Issue #730: parse the persisted background_tasks / session_crons
+    // arrays from cc_stdin (CC 2.1.145+ Stop hook input). Each column holds
+    // a JSON-stringified array of task descriptors. Malformed JSON or empty
+    // arrays surface as null so the client can use a simple truthy check.
+    let backgroundTasks: unknown[] | null = null;
+    if (team.backgroundTasksJson) {
+      try {
+        const parsed: unknown = JSON.parse(team.backgroundTasksJson);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          backgroundTasks = parsed;
+        }
+      } catch {
+        // Malformed JSON — leave null
+      }
+    }
+    let sessionCrons: unknown[] | null = null;
+    if (team.sessionCronsJson) {
+      try {
+        const parsed: unknown = JSON.parse(team.sessionCronsJson);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          sessionCrons = parsed;
+        }
+      } catch {
+        // Malformed JSON — leave null
+      }
+    }
+
     return {
       id: team.id,
       issueNumber: team.issueNumber,
@@ -584,6 +611,8 @@ export class TeamService {
       pr: prDetail,
       recentEvents,
       outputTail,
+      backgroundTasks,
+      sessionCrons,
     };
   }
 

--- a/src/shared/state-machine.ts
+++ b/src/shared/state-machine.ts
@@ -144,9 +144,21 @@ export const STATE_MACHINE_TRANSITIONS: StateMachineTransition[] = [
     trigger: 'timer',
     triggerLabel: 'Stuck threshold exceeded',
     description:
-      'Team has been idle beyond the stuck detection threshold. Suppressed when the team is legitimately waiting on external CI or merge infrastructure (see issue #690).',
+      'Team has been idle beyond the stuck detection threshold. Suppressed when the team is legitimately waiting on external CI or merge infrastructure (see issue #690) OR when CC reported pending background_tasks/session_crons in its last Stop hook (see issue #730).',
     condition:
-      'lastEventAt + stuckThresholdMin < now AND NOT (phase=pr AND (ciStatus=pending OR mergeStatus IN (blocked_ci_pending, behind)))',
+      'lastEventAt + stuckThresholdMin < now AND NOT (phase=pr AND (ciStatus=pending OR mergeStatus IN (blocked_ci_pending, behind))) AND background_tasks_json IS NULL AND session_crons_json IS NULL',
+    hookEvent: null,
+  },
+  {
+    id: 'idle-stuck-suppressed-background',
+    from: 'idle',
+    to: 'idle',
+    trigger: 'timer',
+    triggerLabel: 'Stuck escalation suppressed — background work pending',
+    description:
+      'Idle threshold exceeded but the last Stop hook reported pending background_tasks or session_crons. The team remains idle until the background work completes or the agent emits a non-dormancy hook event, at which point the background flags are cleared (idle -> running) or the stuck timer can resume (issue #730).',
+    condition:
+      'lastEventAt + stuckThresholdMin < now AND (background_tasks_json IS NOT NULL OR session_crons_json IS NOT NULL)',
     hookEvent: null,
   },
   {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -251,6 +251,8 @@ export interface Team {
   lastEventAt: string | null;
   blockedByJson: string | null;
   pendingChildrenJson: string | null;
+  backgroundTasksJson: string | null;
+  sessionCronsJson: string | null;
   retryCount: number;
   createdAt: string;
   updatedAt: string;
@@ -652,6 +654,10 @@ export interface TeamDetail {
   } | null;
   recentEvents: Event[];
   outputTail: string | null;
+  /** Parsed background_tasks array from CC's last Stop hook (CC 2.1.145+). NULL when no work pending. */
+  backgroundTasks: unknown[] | null;
+  /** Parsed session_crons array from CC's last SubagentStop hook (CC 2.1.145+). NULL when no work pending. */
+  sessionCrons: unknown[] | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/api-endpoints.test.ts
+++ b/tests/integration/api-endpoints.test.ts
@@ -894,6 +894,111 @@ describe('Team lifecycle via events', () => {
     const after = afterRes.json();
     expect(after.lastEventAt).toBeTruthy();
   });
+
+  // Issue #730: persist CC 2.1.145+ background_tasks / session_crons from
+  // cc_stdin onto the team row so stuck-detector can suppress idle->stuck.
+  it('POST /api/events persists background_tasks_json from cc_stdin on stop event', async () => {
+    const team = seedTeam({
+      issueNumber: 730,
+      worktreeName: 'kea-730',
+      status: 'running',
+    });
+
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-bg-1',
+      background_tasks: [
+        { shell_command_id: 'sc_1', description: 'long-running build' },
+      ],
+    });
+
+    const eventRes = await server.inject({
+      method: 'POST',
+      url: '/api/events',
+      payload: {
+        event: 'stop',
+        team: 'kea-730',
+        timestamp: new Date().toISOString(),
+        cc_stdin: ccStdin,
+      },
+    });
+    expect(eventRes.statusCode).toBe(200);
+
+    // The team row should now have the normalized JSON string persisted.
+    const updated = getDatabase().getTeam(team.id);
+    expect(updated).toBeDefined();
+    expect(updated!.backgroundTasksJson).toBe(
+      JSON.stringify([{ shell_command_id: 'sc_1', description: 'long-running build' }]),
+    );
+  });
+
+  it('POST /api/events persists session_crons_json from cc_stdin on subagent_stop event', async () => {
+    const team = seedTeam({
+      issueNumber: 731,
+      worktreeName: 'kea-731',
+      status: 'running',
+    });
+
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-cron-1',
+      session_crons: [{ cron_id: 'c1', schedule: '*/5 * * * *' }],
+    });
+
+    const eventRes = await server.inject({
+      method: 'POST',
+      url: '/api/events',
+      payload: {
+        event: 'subagent_stop',
+        team: 'kea-731',
+        timestamp: new Date().toISOString(),
+        cc_stdin: ccStdin,
+      },
+    });
+    expect(eventRes.statusCode).toBe(200);
+
+    const updated = getDatabase().getTeam(team.id);
+    expect(updated).toBeDefined();
+    expect(updated!.sessionCronsJson).toBe(
+      JSON.stringify([{ cron_id: 'c1', schedule: '*/5 * * * *' }]),
+    );
+  });
+
+  it('POST /api/events normalizes an empty background_tasks array to null', async () => {
+    const team = seedTeam({
+      issueNumber: 732,
+      worktreeName: 'kea-732',
+      status: 'running',
+    });
+
+    // First seed a non-empty value so we can verify the null overwrite.
+    await server.inject({
+      method: 'POST',
+      url: '/api/events',
+      payload: {
+        event: 'stop',
+        team: 'kea-732',
+        timestamp: new Date().toISOString(),
+        cc_stdin: JSON.stringify({ background_tasks: [{ shell_command_id: 'sc_x' }] }),
+      },
+    });
+
+    let updated = getDatabase().getTeam(team.id);
+    expect(updated!.backgroundTasksJson).toBeTruthy();
+
+    // Now send an empty array — must normalize to NULL.
+    await server.inject({
+      method: 'POST',
+      url: '/api/events',
+      payload: {
+        event: 'stop',
+        team: 'kea-732',
+        timestamp: new Date().toISOString(),
+        cc_stdin: JSON.stringify({ background_tasks: [] }),
+      },
+    });
+
+    updated = getDatabase().getTeam(team.id);
+    expect(updated!.backgroundTasksJson).toBeNull();
+  });
 });
 
 // =============================================================================

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -2445,13 +2445,18 @@ describe('Transaction atomicity', () => {
       }),
     );
 
-    // Status update should be populated
+    // Status update should be populated. The resume transition (idle/stuck
+    // -> running) also clears the pending background_tasks / session_crons
+    // flags so a subsequent Stop hook can repopulate them cleanly (#730).
     expect(ops.statusUpdate).toEqual(
       expect.objectContaining({
         teamId: 1,
-        fields: { status: 'running' },
+        fields: expect.objectContaining({ status: 'running' }),
       }),
     );
+    const resumeFields = (ops.statusUpdate as { fields: Record<string, unknown> }).fields;
+    expect(resumeFields.backgroundTasksJson).toBeNull();
+    expect(resumeFields.sessionCronsJson).toBeNull();
 
     // Heartbeat always required
     expect(ops.heartbeatUpdate).toEqual(
@@ -3441,5 +3446,276 @@ describe('PR polling frequency detection', () => {
       (call: unknown[]) => call[3] === 'poll_warning',
     );
     expect(pollWarningCalls).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Background tasks and session crons (#730)
+// =============================================================================
+//
+// CC 2.1.145+ ships `background_tasks` and `session_crons` arrays inside
+// cc_stdin on Stop / SubagentStop hook input. The route handler stringifies
+// them onto the EventPayload, and processEvent persists them on the team row
+// so stuck-detector can suppress the idle->stuck escalation while either
+// array is non-empty.
+// =============================================================================
+
+describe('Background tasks and session crons (#730)', () => {
+  it('buildPayloadFromCcStdin extracts background_tasks array into JSON string', () => {
+    const ccData = {
+      session_id: 'sess-bg-1',
+      background_tasks: [
+        { shell_command_id: 'sc_1', description: 'building docs' },
+        { shell_command_id: 'sc_2', description: 'running tests' },
+      ],
+    };
+    const body = {
+      event: 'stop',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify(ccData),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.background_tasks).toBe(JSON.stringify(ccData.background_tasks));
+  });
+
+  it('buildPayloadFromCcStdin extracts session_crons array into JSON string', () => {
+    const ccData = {
+      session_id: 'sess-cron-1',
+      session_crons: [
+        { cron_id: 'c1', schedule: '*/5 * * * *' },
+      ],
+    };
+    const body = {
+      event: 'subagent_stop',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify(ccData),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.session_crons).toBe(JSON.stringify(ccData.session_crons));
+  });
+
+  it('buildPayloadFromCcStdin leaves background_tasks/session_crons undefined when absent', () => {
+    const body = {
+      event: 'stop',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-no-bg' }),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.background_tasks).toBeUndefined();
+    expect(payload.session_crons).toBeUndefined();
+  });
+
+  it('buildPayloadFromCcStdin ignores non-array background_tasks values', () => {
+    // Defense: CC may send a non-array shape in older / corrupted payloads.
+    // The guard must prevent us from forwarding garbage.
+    const body = {
+      event: 'stop',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ background_tasks: 'not an array' }),
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.background_tasks).toBeUndefined();
+  });
+
+  it('writes background_tasks_json onto team via statusUpdate when stop event has non-empty array', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const tasksArray = [{ shell_command_id: 'sc_1', description: 'long build' }];
+    const payload = makePayload({
+      event: 'stop',
+      background_tasks: JSON.stringify(tasksArray),
+    });
+
+    processEvent(payload, db, sse);
+
+    // The status update should include backgroundTasksJson with the normalized array.
+    const fieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        (call[1] as Record<string, unknown>).backgroundTasksJson !== undefined,
+    );
+    expect(fieldCalls.length).toBeGreaterThan(0);
+    const fields = fieldCalls[0]![1] as Record<string, unknown>;
+    expect(fields.backgroundTasksJson).toBe(JSON.stringify(tasksArray));
+  });
+
+  it('writes session_crons_json onto team via statusUpdate on subagent_stop with non-empty array', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const cronsArray = [{ cron_id: 'c1', schedule: '*/5 * * * *' }];
+    const payload = makePayload({
+      event: 'subagent_stop',
+      background_tasks: undefined,
+      session_crons: JSON.stringify(cronsArray),
+    });
+
+    processEvent(payload, db, sse);
+
+    const fieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        (call[1] as Record<string, unknown>).sessionCronsJson !== undefined,
+    );
+    expect(fieldCalls.length).toBeGreaterThan(0);
+    const fields = fieldCalls[0]![1] as Record<string, unknown>;
+    expect(fields.sessionCronsJson).toBe(JSON.stringify(cronsArray));
+  });
+
+  it('normalizes an empty background_tasks array to null on stop event', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'stop',
+      background_tasks: '[]',
+    });
+
+    processEvent(payload, db, sse);
+
+    const fieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        Object.prototype.hasOwnProperty.call(call[1], 'backgroundTasksJson'),
+    );
+    expect(fieldCalls.length).toBeGreaterThan(0);
+    const fields = fieldCalls[0]![1] as Record<string, unknown>;
+    expect(fields.backgroundTasksJson).toBeNull();
+  });
+
+  it('treats malformed background_tasks JSON as no work pending (null)', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'stop',
+      background_tasks: 'not valid json {{{',
+    });
+
+    processEvent(payload, db, sse);
+
+    const fieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        Object.prototype.hasOwnProperty.call(call[1], 'backgroundTasksJson'),
+    );
+    expect(fieldCalls.length).toBeGreaterThan(0);
+    const fields = fieldCalls[0]![1] as Record<string, unknown>;
+    expect(fields.backgroundTasksJson).toBeNull();
+  });
+
+  it('does NOT write background fields on non-dormancy events (e.g. tool_use)', () => {
+    // Background fields should only be written on dormancy events. A tool_use
+    // event must NOT carry these fields through to the DB row even if the
+    // payload happens to include them.
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({
+      event: 'tool_use',
+      background_tasks: JSON.stringify([{ shell_command_id: 'sc_1' }]),
+    });
+
+    processEvent(payload, db, sse);
+
+    const bgFieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        Object.prototype.hasOwnProperty.call(call[1], 'backgroundTasksJson'),
+    );
+    expect(bgFieldCalls).toHaveLength(0);
+  });
+
+  it('clears background fields when a non-dormancy event arrives on an idle team', () => {
+    // Issue #730: when an idle/stuck team resumes activity, the background
+    // flags must reset to null. If the agent is still genuinely awaiting
+    // background work it will re-emit them on the next Stop hook.
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'idle', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'tool_use' });
+
+    processEvent(payload, db, sse);
+
+    // The resume statusUpdate should clear both fields to null.
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        status: 'running',
+        backgroundTasksJson: null,
+        sessionCronsJson: null,
+      }),
+    );
+  });
+
+  it('clears background fields when a non-dormancy event arrives on a stuck team', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'stuck', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'notification' });
+
+    processEvent(payload, db, sse);
+
+    expect(db.updateTeam).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        status: 'running',
+        backgroundTasksJson: null,
+        sessionCronsJson: null,
+      }),
+    );
+  });
+
+  it('clears background fields defensively when a hook event arrives on a terminal team', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'done', phase: 'done' }),
+    });
+    const sse = createMockSse();
+    const payload = makePayload({ event: 'stop' });
+
+    processEvent(payload, db, sse);
+
+    // updateTeamSilent must be invoked with both fields set to null as part
+    // of the terminal-state cleanup.
+    expect(db.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        backgroundTasksJson: null,
+        sessionCronsJson: null,
+      }),
+    );
+  });
+
+  it('writes background_tasks_json on session_end event with non-empty array', () => {
+    const db = createMockDb({
+      getTeamByWorktree: vi.fn().mockReturnValue({ id: 1, status: 'running', phase: 'implementing' }),
+    });
+    const sse = createMockSse();
+    const tasksArray = [{ shell_command_id: 'sc_1' }];
+    const payload = makePayload({
+      event: 'session_end',
+      background_tasks: JSON.stringify(tasksArray),
+    });
+
+    processEvent(payload, db, sse);
+
+    const fieldCalls = (db.updateTeam as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        (call[1] as Record<string, unknown>).backgroundTasksJson !== undefined,
+    );
+    expect(fieldCalls.length).toBeGreaterThan(0);
+    const fields = fieldCalls[0]![1] as Record<string, unknown>;
+    expect(fields.backgroundTasksJson).toBe(JSON.stringify(tasksArray));
   });
 });

--- a/tests/server/stuck-detector-background.test.ts
+++ b/tests/server/stuck-detector-background.test.ts
@@ -1,0 +1,305 @@
+// =============================================================================
+// Fleet Commander — Stuck Detector Tests: background-aware suppression (#730)
+//
+// CC 2.1.145+ ships `background_tasks` and `session_crons` arrays on Stop /
+// SubagentStop hook input. When either array is non-empty the agent is
+// intentionally awaiting background work; FC must not escalate the team
+// to `stuck` via the idle-stuck timer. The control cases (no background
+// work) MUST still escalate normally.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Team } from '../../src/shared/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before import
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  getActiveTeams: vi.fn<() => Partial<Team>[]>().mockReturnValue([]),
+  updateTeam: vi.fn(),
+  updateTeamSilent: vi.fn(),
+  insertTransition: vi.fn(),
+  getPullRequest: vi.fn(),
+  hasActiveSubagent: vi.fn().mockReturnValue(false),
+};
+
+const mockSseBroker = {
+  broadcast: vi.fn(),
+};
+
+type SubagentActivityEntry = { lastEventAt: number; toolUseId: string; startedAt: number };
+
+const mockManager = {
+  stop: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn(),
+  syncStreamActivityToDb: vi.fn(),
+  getLastStreamAt: vi.fn().mockReturnValue(null),
+  thinkingTeams: new Set<number>(),
+  getSubagentActivity: vi.fn<(teamId: number) => Map<string, SubagentActivityEntry>>().mockReturnValue(new Map()),
+  clearSubagentActivity: vi.fn(),
+};
+
+vi.mock('../../src/server/db.js', () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock('../../src/server/services/sse-broker.js', () => ({
+  sseBroker: mockSseBroker,
+}));
+
+const mockGetTeamManager = vi.fn(() => mockManager);
+vi.mock('../../src/server/services/team-manager.js', () => ({
+  getTeamManager: (...args: unknown[]) => mockGetTeamManager(...args),
+}));
+
+vi.mock('../../src/server/utils/resolve-message.js', () => ({
+  resolveMessage: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/server/config.js', () => ({
+  default: {
+    stuckCheckIntervalMs: 60000,
+    idleThresholdMin: 5,
+    stuckThresholdMin: 10,
+    subagentStuckThresholdMin: 3,
+    launchTimeoutMin: 5,
+  },
+}));
+
+// Import after mocks are set up
+const { stuckDetector } = await import('../../src/server/services/stuck-detector.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTeam(overrides: Partial<Team>): Partial<Team> {
+  return {
+    id: 1,
+    issueNumber: 100,
+    issueKey: '100',
+    issueProvider: 'github',
+    issueTitle: 'Test issue',
+    projectId: 1,
+    status: 'running',
+    phase: 'implementing',
+    pid: 12345,
+    sessionId: 'sess-abc',
+    worktreeName: 'test-100',
+    branchName: 'feat/100-test',
+    prNumber: null,
+    customPrompt: null,
+    blockedByJson: null,
+    pendingChildrenJson: null,
+    backgroundTasksJson: null,
+    sessionCronsJson: null,
+    launchedAt: new Date(Date.now() - 60_000).toISOString(),
+    stoppedAt: null,
+    lastEventAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function minutesAgo(min: number): string {
+  return new Date(Date.now() - min * 60_000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.getActiveTeams.mockReturnValue([]);
+  mockDb.hasActiveSubagent.mockReturnValue(false);
+  mockDb.getPullRequest.mockReturnValue(undefined);
+  mockManager.thinkingTeams.clear();
+  mockManager.getSubagentActivity.mockReturnValue(new Map());
+  mockGetTeamManager.mockImplementation(() => mockManager);
+});
+
+// =============================================================================
+// Background-aware idle/stuck suppression (#730)
+// =============================================================================
+
+describe('Background-aware idle/stuck suppression (#730)', () => {
+  it('does NOT transition idle -> stuck when team has non-empty background_tasks_json', () => {
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11), // past the 10 min stuck threshold
+      backgroundTasksJson: JSON.stringify([{ shell_command_id: 'sc_1', description: 'long build' }]),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    // Stuck transition must be suppressed
+    const stuckCalls = mockDb.updateTeamSilent.mock.calls.filter(
+      (call: unknown[]) => {
+        const fields = call[1] as Record<string, unknown> | undefined;
+        return fields?.status === 'stuck';
+      },
+    );
+    expect(stuckCalls).toHaveLength(0);
+    const stuckTransitions = mockDb.insertTransition.mock.calls.filter(
+      (call: unknown[]) => {
+        const arg = call[0] as Record<string, unknown> | undefined;
+        return arg?.toStatus === 'stuck';
+      },
+    );
+    expect(stuckTransitions).toHaveLength(0);
+  });
+
+  it('does NOT transition idle -> stuck when team has non-empty session_crons_json', () => {
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      sessionCronsJson: JSON.stringify([{ cron_id: 'c1', schedule: '*/5 * * * *' }]),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(1, expect.objectContaining({ status: 'stuck' }));
+    expect(mockDb.insertTransition).not.toHaveBeenCalled();
+  });
+
+  it('does NOT transition idle -> stuck when BOTH background fields are non-empty', () => {
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: JSON.stringify([{ shell_command_id: 'sc_1' }]),
+      sessionCronsJson: JSON.stringify([{ cron_id: 'c1' }]),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(1, expect.objectContaining({ status: 'stuck' }));
+  });
+
+  it('DOES transition idle -> stuck when both background arrays are null (control case)', () => {
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: null,
+      sessionCronsJson: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'idle',
+        toStatus: 'stuck',
+        trigger: 'timer',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
+  });
+
+  it('DOES transition idle -> stuck when background_tasks_json is the literal string "[]" (empty array)', () => {
+    // Defense against a stray writer that stored "[]" instead of normalizing
+    // to NULL. The parser must treat empty arrays as "no work pending".
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: '[]',
+      sessionCronsJson: '[]',
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
+  });
+
+  it('DOES transition idle -> stuck when background_tasks_json is malformed JSON', () => {
+    // Corrupted column must not block stuck detection forever.
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: 'not valid json {',
+      sessionCronsJson: 'also not valid }',
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
+  });
+
+  it('DOES transition running -> idle even when background_tasks_json is set', () => {
+    // The suppression only affects idle->stuck, not running->idle. A team
+    // with pending background work should still report idle (it really is
+    // dormant), just never escalate to stuck.
+    const team = makeTeam({
+      status: 'running',
+      lastEventAt: minutesAgo(6),
+      backgroundTasksJson: JSON.stringify([{ shell_command_id: 'sc_1' }]),
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatus: 'running',
+        toStatus: 'idle',
+        trigger: 'timer',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'idle' });
+  });
+
+  it('background-pending team transitions to stuck on a later pass once arrays clear', () => {
+    // First pass: backgroundTasksJson set — suppressed.
+    const teamWithBg = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: JSON.stringify([{ shell_command_id: 'sc_1' }]),
+    });
+    mockDb.getActiveTeams.mockReturnValue([teamWithBg]);
+
+    stuckDetector.check();
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(1, expect.objectContaining({ status: 'stuck' }));
+
+    // Clear the mock and run a second pass with backgroundTasksJson=null.
+    vi.clearAllMocks();
+    mockDb.hasActiveSubagent.mockReturnValue(false);
+    mockDb.getPullRequest.mockReturnValue(undefined);
+
+    const teamClear = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: null,
+      sessionCronsJson: null,
+    });
+    mockDb.getActiveTeams.mockReturnValue([teamClear]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(1, { status: 'stuck' });
+  });
+
+  it('does NOT suppress idle->stuck when only an empty array is stored alongside a populated one... no — populated wins', () => {
+    // Sanity: if EITHER array is non-empty, the team is awaiting background
+    // work. An empty session_crons_json must not "rescue" the team from the
+    // suppression set by a non-empty background_tasks_json.
+    const team = makeTeam({
+      status: 'idle',
+      lastEventAt: minutesAgo(11),
+      backgroundTasksJson: JSON.stringify([{ shell_command_id: 'sc_1' }]),
+      sessionCronsJson: '[]', // empty, should not contribute
+    });
+    mockDb.getActiveTeams.mockReturnValue([team]);
+
+    stuckDetector.check();
+
+    expect(mockDb.updateTeamSilent).not.toHaveBeenCalledWith(1, expect.objectContaining({ status: 'stuck' }));
+  });
+});


### PR DESCRIPTION
## Summary
- Persist CC 2.1.145+ `background_tasks` / `session_crons` arrays from `cc_stdin` on the `teams` row (schema v21, two nullable JSON columns).
- Suppress the `idle -> stuck` escalation in `stuck-detector` while either array is non-empty, mirroring the existing CI-pending suppression pattern.
- Clear background flags on resume (any non-dormancy hook event) and defensively on terminal status.
- Surface a "Background:" badge in the TeamDetail UI with task / cron counts when work is pending.
- Update `src/shared/state-machine.ts` (CLAUDE.md rule #13): extend `idle-stuck` condition and add a new no-op `idle-stuck-suppressed-background` self-transition for the `/lifecycle` UI.

## Design notes
- **No new `TeamStatus`** — would have required ~15 sites of changes for a status functionally identical to `idle` + skip-stuck-escalation. Stored as two nullable `teams` columns instead.
- **Only `idle -> stuck` is suppressed** — `running -> idle` still fires honestly because the agent really is dormant when CC reports pending background work.
- **Defensive normalization in three layers** — route handler skips non-arrays, `normalizeJsonArray` collapses empty / malformed to `null`, `stuck-detector` wraps `JSON.parse` in try/catch.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `tests/server/stuck-detector-background.test.ts` — 9 new cases for suppression policy
- [x] `tests/server/event-collector.test.ts` — 12 new cases (extraction, writes, normalization, resume / terminal clears)
- [x] `tests/integration/api-endpoints.test.ts` — 3 new end-to-end round-trip cases
- [x] `tests/server/stuck-detector.test.ts` — 38 existing cases still pass
- [x] CI green on this PR

Closes #730