### PR TITLE
Issue #734: drop 'max' effort level (CC 2.1.68 removed it)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ The SSE broker emits 18 event types:
 | `FLEET_MAX_PR_POLL_CALLS` | `5` | Max gh pr view/checks calls per team per 10-minute window before sending a poll_warning |
 | `FLEET_MERGE_SHUTDOWN_GRACE_MS` | `600000` | Grace period (ms) after PR merge before stopping the team |
 | `FLEET_DEFAULT_MODEL` | `opus` | Default model name shown when neither the team nor the project specifies a model |
-| `FLEET_DEFAULT_EFFORT` | (unset) | Default adaptive-reasoning effort level (`low\|medium\|high\|xhigh\|max`) applied when a project has no `effort` set. Unset = let CC decide. |
+| `FLEET_DEFAULT_EFFORT` | (unset) | Default adaptive-reasoning effort level (`low\|medium\|high\|xhigh`) applied when a project has no `effort` set. Unset = let CC decide. Claude Code removed the legacy `max` level in 2.1.68 (`xhigh`, added in 2.1.111, is the new top tier and Opus 4.7 default); existing `effort='max'` project rows are auto-migrated to `xhigh` on startup. |
 | `FLEET_CC_QUERY_MODEL` | `sonnet` | Claude model for CC query operations (e.g. `sonnet`, `opus`) |
 | `FLEET_CC_QUERY_TIMEOUT_MS` | `30000` | Timeout (ms) for individual CC query calls |
 | `FLEET_CC_QUERY_PRIORITIZE_TIMEOUT_MS` | `300000` | Timeout (ms) for AI issue prioritization |

--- a/src/client/components/AddProjectDialog.tsx
+++ b/src/client/components/AddProjectDialog.tsx
@@ -681,10 +681,9 @@ export function AddProjectDialog({ open, onClose, onAdded }: AddProjectDialogPro
               <option value="medium">medium</option>
               <option value="high">high</option>
               <option value="xhigh">xhigh (Opus 4.7 default)</option>
-              <option value="max">max (Opus 4.7 only)</option>
             </select>
             <p className="mt-1 text-xs text-dark-muted/60">
-              Adaptive-reasoning effort level. xhigh/max apply only to Opus 4.7+; other models silently fall back.
+              Adaptive-reasoning effort level. xhigh applies only to Opus 4.7+; other models silently fall back.
             </p>
           </div>
 

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -953,14 +953,13 @@ function ProjectCard({
                   onChange={(e) => onSaveEffort(project.id, e.target.value)}
                   onClick={(e) => e.stopPropagation()}
                   className="shrink-0 px-1 py-0 text-xs rounded border border-dark-border bg-dark-base text-dark-muted hover:text-dark-text focus:outline-none cursor-pointer"
-                  title="Effort level (Opus 4.7 adaptive reasoning)"
+                  title="Effort level (Opus 4.7 adaptive reasoning; xhigh is Opus 4.7 only)"
                 >
                   <option value="">default</option>
                   <option value="low">low</option>
                   <option value="medium">medium</option>
                   <option value="high">high</option>
                   <option value="xhigh">xhigh</option>
-                  <option value="max">max</option>
                 </select>
               </span>
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -441,6 +441,9 @@ export class FleetDatabase {
     // Add background_tasks_json / session_crons_json columns to teams (v21 migration)
     this.addBackgroundTaskColumns();
 
+    // Rewrite any effort='max' rows to 'xhigh' (v22 migration — CC removed 'max' in 2.1.68)
+    this.migrateMaxEffortToXhigh();
+
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
 
@@ -1305,6 +1308,47 @@ export class FleetDatabase {
     } catch (err) {
       // Table may not exist yet (fresh database) — schema.sql will create it
       console.warn('[DB] v21 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Rewrite any projects with effort='max' to 'xhigh' (v22 migration).
+   *
+   * Claude Code removed the `max` effort level in 2.1.68 and added `xhigh` in
+   * 2.1.111 (Opus 4.7 default). Existing FC databases may carry rows with
+   * effort='max' from before this change; CC will reject them. We rewrite all
+   * 'max' rows to 'xhigh' — the highest still-valid effort level — so users
+   * preserve their explicit "high effort" intent without manual cleanup.
+   *
+   * Note: we cannot differentiate Opus 4.7 from other Opus models when picking
+   * a fallback because the `model` column is a free-form string (e.g. "opus"
+   * alone is ambiguous), and effort is silently ignored on non-Opus-4.7 models
+   * anyway, so the single mapping `max -> xhigh` is the safest user-facing
+   * fallback.
+   *
+   * Idempotent: on restart after the migration runs, the UPDATE matches zero
+   * rows and is a no-op (no log message emitted).
+   *
+   * Fresh databases (projects table doesn't exist yet) are no-ops here —
+   * schema.sql will create the table with the new CHECK constraint that
+   * excludes 'max' entirely.
+   */
+  private migrateMaxEffortToXhigh(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+      // Fresh DB: projects table doesn't exist yet — schema.sql will create it
+      if (cols.length === 0) return;
+      if (!cols.some((c) => c.name === 'effort')) return;
+      const result = this.db.prepare(
+        "UPDATE projects SET effort = 'xhigh', updated_at = datetime('now') WHERE effort = 'max'"
+      ).run();
+      if (result.changes > 0) {
+        console.log(`[DB] v22 migration: rewrote ${result.changes} project(s) with effort='max' to 'xhigh' (CC removed 'max' in 2.1.68)`);
+      }
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (22)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v22 migration skipped:', err instanceof Error ? err.message : err);
     }
   }
 

--- a/src/server/mcp/tools/add-project.ts
+++ b/src/server/mcp/tools/add-project.ts
@@ -31,8 +31,8 @@ export function registerAddProjectTool(server: McpServer): void {
       githubRepo: z.string().optional().describe('GitHub repo in owner/name format (auto-detected if omitted)'),
       maxActiveTeams: z.number().optional().describe('Maximum concurrent active teams (default 5)'),
       model: z.string().optional().describe('Claude model to use for this project'),
-      effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional()
-        .describe('Adaptive-reasoning effort level (Opus 4.7+). xhigh/max are Opus-4.7-only.'),
+      effort: z.enum(['low', 'medium', 'high', 'xhigh']).optional()
+        .describe("Adaptive-reasoning effort level. 'xhigh' is the Opus 4.7 default (other models silently fall back). 'max' was removed by Claude Code in 2.1.68 — use 'xhigh' instead."),
     },
     async ({ repoPath, name, githubRepo, maxActiveTeams, model, effort }) => {
       try {

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS projects (
   max_active_teams INTEGER NOT NULL DEFAULT 5,        -- max concurrent active teams before queueing
   prompt_file     TEXT,                               -- relative path to launch prompt .md file
   model           TEXT,                               -- Claude model override e.g. "opus", "sonnet", "claude-opus-4-6"
-  effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh','max')),  -- CC adaptive-reasoning effort level
+  effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh')),  -- CC adaptive-reasoning effort level (xhigh is Opus 4.7 only; 'max' removed in CC 2.1.68)
   issue_provider  TEXT DEFAULT 'github',              -- issue provider: github | jira | linear
   project_key     TEXT,                               -- provider-specific project key (e.g. Jira project key)
   provider_config TEXT,                               -- JSON blob of provider-specific configuration
@@ -421,4 +421,4 @@ CREATE TABLE IF NOT EXISTS provider_state (
 );
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (21);
+INSERT OR IGNORE INTO schema_version (version) VALUES (22);

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -946,11 +946,16 @@ export class ProjectService {
       }
     }
 
-    // Validate effort if provided (empty string coerces to null below)
+    // Validate effort if provided (empty string coerces to null below).
+    // 'max' was removed by Claude Code in 2.1.68; 'xhigh' is the highest valid
+    // level (Opus 4.7 default since CC 2.1.111).
     const normalizedEffort = effort?.trim() || null;
     if (normalizedEffort !== null &&
-        !['low', 'medium', 'high', 'xhigh', 'max'].includes(normalizedEffort)) {
-      throw validationError('Invalid effort. Must be one of: low, medium, high, xhigh, max');
+        !['low', 'medium', 'high', 'xhigh'].includes(normalizedEffort)) {
+      throw validationError(
+        "Invalid effort. Must be one of: low, medium, high, xhigh. " +
+        "(Claude Code removed 'max' in 2.1.68 — use 'xhigh' instead.)"
+      );
     }
 
     // Insert the project (no per-project prompt file — always use prompts/default-prompt.md)
@@ -1347,13 +1352,18 @@ export class ProjectService {
       }
     }
 
-    // Validate effort if provided (empty string coerces to null below)
+    // Validate effort if provided (empty string coerces to null below).
+    // 'max' was removed by Claude Code in 2.1.68; 'xhigh' is the highest valid
+    // level (Opus 4.7 default since CC 2.1.111).
     let normalizedEffort: string | null | undefined = undefined;
     if (effort !== undefined) {
       normalizedEffort = effort?.trim() || null;
       if (normalizedEffort !== null &&
-          !['low', 'medium', 'high', 'xhigh', 'max'].includes(normalizedEffort)) {
-        throw validationError('Invalid effort. Must be one of: low, medium, high, xhigh, max');
+          !['low', 'medium', 'high', 'xhigh'].includes(normalizedEffort)) {
+        throw validationError(
+          "Invalid effort. Must be one of: low, medium, high, xhigh. " +
+          "(Claude Code removed 'max' in 2.1.68 — use 'xhigh' instead.)"
+        );
       }
     }
 

--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -112,6 +112,26 @@ export function buildEnv(fleetContext?: FleetEnvContext): SpawnEnv {
 // Arg builders — pure functions, one per spawn mode
 // ---------------------------------------------------------------------------
 
+/**
+ * Log a one-shot warning when an `effort='max'` value reaches the spawn layer.
+ *
+ * Claude Code removed the `max` effort level in 2.1.68 and added `xhigh` in
+ * 2.1.111 (Opus 4.7 default). Application-level validation in project-service
+ * and the MCP `fleet_add_project` tool should normally reject `max` before it
+ * reaches this point, but a stale `FLEET_DEFAULT_EFFORT=max` env var or a
+ * database row that escaped the v21 migration could still slip through. Log
+ * a clear warning so operators can clean up; do NOT silently drop the flag
+ * (CC will surface its own error).
+ */
+function warnIfDeprecatedEffort(effort: string, worktreeName: string): void {
+  if (effort === 'max') {
+    console.warn(
+      `[cc-spawn] effort='max' is no longer accepted by Claude Code (removed in 2.1.68). ` +
+      `Update the project's effort to 'xhigh' or FLEET_DEFAULT_EFFORT. worktree=${worktreeName}`,
+    );
+  }
+}
+
 /** Options for building headless (stream-json) CLI args. */
 export interface HeadlessArgsOptions {
   worktreeName: string;
@@ -166,6 +186,7 @@ export function buildHeadlessArgs(options: HeadlessArgsOptions): string[] {
   }
 
   if (options.effort) {
+    warnIfDeprecatedEffort(options.effort, options.worktreeName);
     args.push('--effort', options.effort);
   }
 
@@ -203,6 +224,7 @@ export function buildInteractiveArgs(options: InteractiveArgsOptions): string[] 
   }
 
   if (options.effort) {
+    warnIfDeprecatedEffort(options.effort, options.worktreeName);
     args.push('--effort', options.effort);
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,8 +27,10 @@ export type MergeStatus = 'unknown' | 'clean' | 'behind' | 'blocked' | 'blocked_
 /** Project status */
 export type ProjectStatus = 'active' | 'archived';
 
-/** Claude Code adaptive-reasoning effort level (Opus 4.7+) */
-export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+/** Claude Code adaptive-reasoning effort level (Opus 4.7+).
+ * 'max' was removed by Claude Code in 2.1.68; 'xhigh' (added in 2.1.111) is now
+ * the highest level and the Opus 4.7 default. */
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh';
 
 /** Usage zone for queue gating */
 export type UsageZone = 'green' | 'red' | 'hard_red';

--- a/tests/server/cc-spawn.test.ts
+++ b/tests/server/cc-spawn.test.ts
@@ -298,11 +298,11 @@ describe('cc-spawn', () => {
     });
 
     it('includes --effort when provided', () => {
-      const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'max' });
+      const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'xhigh' });
 
       expect(args).toContain('--effort');
       const effortIdx = args.indexOf('--effort');
-      expect(args[effortIdx + 1]).toBe('max');
+      expect(args[effortIdx + 1]).toBe('xhigh');
     });
 
     it('excludes --effort when not provided', () => {
@@ -315,6 +315,42 @@ describe('cc-spawn', () => {
       const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: null });
 
       expect(args).not.toContain('--effort');
+    });
+
+    it("logs a deprecation warning when effort='max' reaches the spawn layer (headless)", () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* swallow */ });
+      try {
+        const args = buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'max' });
+
+        // Argument is still forwarded — CC will surface its own error; we just warn.
+        expect(args).toContain('--effort');
+        expect(args[args.indexOf('--effort') + 1]).toBe('max');
+
+        // Warning fires exactly once and mentions 'max', 'xhigh', and the worktree name.
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const firstCall = warnSpy.mock.calls[0]?.[0];
+        expect(firstCall).toBeTypeOf('string');
+        const msg = String(firstCall);
+        expect(msg).toContain("effort='max'");
+        expect(msg).toContain("xhigh");
+        expect(msg).toContain('test-wt');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does NOT log a deprecation warning for non-'max' effort values", () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* swallow */ });
+      try {
+        buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'xhigh' });
+        buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'high' });
+        buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'medium' });
+        buildHeadlessArgs({ worktreeName: 'test-wt', effort: 'low' });
+
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('includes --resume when resume is true', () => {
@@ -408,6 +444,24 @@ describe('cc-spawn', () => {
       const args = buildInteractiveArgs({ worktreeName: 'proj-99', effort: null });
 
       expect(args).not.toContain('--effort');
+    });
+
+    it("logs a deprecation warning when effort='max' reaches the spawn layer (interactive)", () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* swallow */ });
+      try {
+        const args = buildInteractiveArgs({ worktreeName: 'proj-99', effort: 'max' });
+
+        expect(args).toContain('--effort');
+        expect(args[args.indexOf('--effort') + 1]).toBe('max');
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const msg = String(warnSpy.mock.calls[0]?.[0]);
+        expect(msg).toContain("effort='max'");
+        expect(msg).toContain("xhigh");
+        expect(msg).toContain('proj-99');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('does NOT include stream-json flags (interactive mode)', () => {

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -2,11 +2,12 @@
 // Fleet Commander — Database Layer Tests
 // =============================================================================
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import Database from 'better-sqlite3';
 import { FleetDatabase, utcify } from '../../src/server/db.js';
 import { isEncrypted, resetEncryptionKey } from '../../src/server/utils/crypto.js';
 
@@ -2082,6 +2083,152 @@ describe('Auto-merge cache columns', () => {
       .prepare('SELECT MAX(version) AS version FROM schema_version')
       .get() as { version: number };
     expect(row.version).toBeGreaterThanOrEqual(20);
+  });
+});
+
+// =============================================================================
+// max -> xhigh effort migration (issue #734)
+// =============================================================================
+
+describe("v21 migration: effort='max' -> 'xhigh'", () => {
+  /**
+   * Build a temp DB containing a projects table with the legacy CHECK
+   * constraint that still permits 'max', insert a row with effort='max',
+   * then re-open via FleetDatabase so initSchema()'s v21 migration runs and
+   * rewrites the row. This mirrors the upgrade path from a pre-issue-#734
+   * database.
+   */
+  function seedLegacyDbWithMaxEffort(): { dbPath: string; rowId: number } {
+    const seedPath = path.join(
+      os.tmpdir(),
+      `fleet-test-max-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    const seed = new Database(seedPath);
+    // Mimic the v19-era projects table (CHECK still allows 'max').
+    seed.exec(`
+      CREATE TABLE projects (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        name            TEXT NOT NULL,
+        repo_path       TEXT NOT NULL UNIQUE,
+        github_repo     TEXT,
+        group_id        INTEGER,
+        status          TEXT NOT NULL DEFAULT 'active',
+        hooks_installed INTEGER NOT NULL DEFAULT 0,
+        max_active_teams INTEGER NOT NULL DEFAULT 5,
+        prompt_file     TEXT,
+        model           TEXT,
+        effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh','max')),
+        issue_provider  TEXT DEFAULT 'github',
+        project_key     TEXT,
+        provider_config TEXT,
+        created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE schema_version (
+        version     INTEGER PRIMARY KEY,
+        applied_at  TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO schema_version (version) VALUES (20);
+    `);
+    const info = seed.prepare(
+      "INSERT INTO projects (name, repo_path, effort) VALUES (?, ?, 'max')",
+    ).run('legacy-max', `/tmp/legacy-max-${Date.now()}`);
+    seed.close();
+    return { dbPath: seedPath, rowId: Number(info.lastInsertRowid) };
+  }
+
+  function cleanupSeedDb(p: string): void {
+    for (const f of [p, p + '-wal', p + '-shm']) {
+      try { if (fs.existsSync(f)) fs.unlinkSync(f); } catch { /* best effort */ }
+    }
+  }
+
+  it("rewrites existing effort='max' rows to 'xhigh' on initSchema()", () => {
+    const { dbPath: seedPath, rowId } = seedLegacyDbWithMaxEffort();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      const row = upgraded.raw
+        .prepare('SELECT effort FROM projects WHERE id = ?')
+        .get(rowId) as { effort: string };
+      expect(row.effort).toBe('xhigh');
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('bumps schema_version to >= 21 after running the migration', () => {
+    const { dbPath: seedPath } = seedLegacyDbWithMaxEffort();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      const row = upgraded.raw
+        .prepare('SELECT MAX(version) AS version FROM schema_version')
+        .get() as { version: number };
+      expect(row.version).toBeGreaterThanOrEqual(21);
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('is idempotent on restart (second initSchema is a no-op)', () => {
+    const { dbPath: seedPath, rowId } = seedLegacyDbWithMaxEffort();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      // First run — migrates the 'max' row to 'xhigh'.
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+      const firstUpdatedAt = (upgraded.raw
+        .prepare('SELECT updated_at FROM projects WHERE id = ?')
+        .get(rowId) as { updated_at: string }).updated_at;
+
+      // Capture log output for the second run so we can confirm no migration
+      // log line is emitted (no 'max' rows remain).
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { /* swallow */ });
+      try {
+        upgraded.initSchema();
+      } finally {
+        logSpy.mockRestore();
+      }
+
+      // Row should still be 'xhigh' and the updated_at should not have moved
+      // (no UPDATE ran because no row matched effort='max').
+      const after = upgraded.raw
+        .prepare('SELECT effort, updated_at FROM projects WHERE id = ?')
+        .get(rowId) as { effort: string; updated_at: string };
+      expect(after.effort).toBe('xhigh');
+      expect(after.updated_at).toBe(firstUpdatedAt);
+
+      // No v21 migration log line should have been emitted on the second run.
+      const v21Logs = logSpy.mock.calls
+        .map((c) => String(c[0] ?? ''))
+        .filter((s) => s.includes('v21 migration'));
+      expect(v21Logs).toEqual([]);
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('is a no-op on a fresh database (no max rows to migrate)', () => {
+    // The standard test db (created by beforeEach) is fresh — no 'max' rows
+    // exist; the migration runs but updates 0 rows. schema_version still
+    // reaches >= 21 via the trailing INSERT OR IGNORE in schema.sql.
+    const count = db.raw
+      .prepare("SELECT COUNT(*) AS n FROM projects WHERE effort = 'max'")
+      .get() as { n: number };
+    expect(count.n).toBe(0);
+
+    const row = db.raw
+      .prepare('SELECT MAX(version) AS version FROM schema_version')
+      .get() as { version: number };
+    expect(row.version).toBeGreaterThanOrEqual(21);
   });
 });
 

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -2090,11 +2090,11 @@ describe('Auto-merge cache columns', () => {
 // max -> xhigh effort migration (issue #734)
 // =============================================================================
 
-describe("v21 migration: effort='max' -> 'xhigh'", () => {
+describe("v22 migration: effort='max' -> 'xhigh'", () => {
   /**
    * Build a temp DB containing a projects table with the legacy CHECK
    * constraint that still permits 'max', insert a row with effort='max',
-   * then re-open via FleetDatabase so initSchema()'s v21 migration runs and
+   * then re-open via FleetDatabase so initSchema()'s v22 migration runs and
    * rewrites the row. This mirrors the upgrade path from a pre-issue-#734
    * database.
    */
@@ -2160,7 +2160,7 @@ describe("v21 migration: effort='max' -> 'xhigh'", () => {
     }
   });
 
-  it('bumps schema_version to >= 21 after running the migration', () => {
+  it('bumps schema_version to >= 22 after running the migration', () => {
     const { dbPath: seedPath } = seedLegacyDbWithMaxEffort();
     let upgraded: FleetDatabase | null = null;
     try {
@@ -2170,7 +2170,7 @@ describe("v21 migration: effort='max' -> 'xhigh'", () => {
       const row = upgraded.raw
         .prepare('SELECT MAX(version) AS version FROM schema_version')
         .get() as { version: number };
-      expect(row.version).toBeGreaterThanOrEqual(21);
+      expect(row.version).toBeGreaterThanOrEqual(22);
     } finally {
       try { upgraded?.close(); } catch { /* ignore */ }
       cleanupSeedDb(seedPath);
@@ -2205,11 +2205,11 @@ describe("v21 migration: effort='max' -> 'xhigh'", () => {
       expect(after.effort).toBe('xhigh');
       expect(after.updated_at).toBe(firstUpdatedAt);
 
-      // No v21 migration log line should have been emitted on the second run.
-      const v21Logs = logSpy.mock.calls
+      // No v22 migration log line should have been emitted on the second run.
+      const v22Logs = logSpy.mock.calls
         .map((c) => String(c[0] ?? ''))
-        .filter((s) => s.includes('v21 migration'));
-      expect(v21Logs).toEqual([]);
+        .filter((s) => s.includes("v22 migration: rewrote"));
+      expect(v22Logs).toEqual([]);
     } finally {
       try { upgraded?.close(); } catch { /* ignore */ }
       cleanupSeedDb(seedPath);
@@ -2219,7 +2219,7 @@ describe("v21 migration: effort='max' -> 'xhigh'", () => {
   it('is a no-op on a fresh database (no max rows to migrate)', () => {
     // The standard test db (created by beforeEach) is fresh — no 'max' rows
     // exist; the migration runs but updates 0 rows. schema_version still
-    // reaches >= 21 via the trailing INSERT OR IGNORE in schema.sql.
+    // reaches >= 22 via the trailing INSERT OR IGNORE in schema.sql.
     const count = db.raw
       .prepare("SELECT COUNT(*) AS n FROM projects WHERE effort = 'max'")
       .get() as { n: number };
@@ -2228,7 +2228,7 @@ describe("v21 migration: effort='max' -> 'xhigh'", () => {
     const row = db.raw
       .prepare('SELECT MAX(version) AS version FROM schema_version')
       .get() as { version: number };
-    expect(row.version).toBeGreaterThanOrEqual(21);
+    expect(row.version).toBeGreaterThanOrEqual(22);
   });
 });
 

--- a/tests/server/routes/projects-routes.test.ts
+++ b/tests/server/routes/projects-routes.test.ts
@@ -319,13 +319,42 @@ describe('PUT /api/projects/:id', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("should reject deprecated effort='max' with 400 (CC removed it in 2.1.68)", async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'max' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    // Error message must point users at the replacement so they know what to do.
+    const body = res.json();
+    const message = body?.message ?? body?.error?.message ?? JSON.stringify(body);
+    expect(String(message)).toContain('xhigh');
+  });
+
+  it("should accept effort='xhigh' (replacement for 'max')", async () => {
+    const project = seedProject();
+
+    const res = await server.inject({
+      method: 'PUT',
+      url: `/api/projects/${project.id}`,
+      payload: { effort: 'xhigh' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().effort).toBe('xhigh');
+  });
+
   it('should coerce empty-string effort to null', async () => {
     const project = seedProject();
     // First set it to something non-null
     await server.inject({
       method: 'PUT',
       url: `/api/projects/${project.id}`,
-      payload: { effort: 'max' },
+      payload: { effort: 'xhigh' },
     });
 
     // Now clear with empty string


### PR DESCRIPTION
Closes #734.

## Summary
Claude Code removed the `max` adaptive-reasoning effort level in 2.1.68 and added `xhigh` (Opus 4.7 default) in 2.1.111. Fleet Commander's schema, validators, UI, docs and tests still referenced `max`. This PR removes `max` from every validation surface and auto-migrates existing `effort='max'` rows to `'xhigh'` on startup.

## Changes
- `src/server/schema.sql` — drop `'max'` from the `projects.effort` CHECK constraint; bump trailing `INSERT OR IGNORE INTO schema_version` to `(22)`.
- `src/server/db.ts` — new `migrateMaxEffortToXhigh()` v22 migration invoked from `initSchema()`. Idempotent on restart; logs once when it rewrites rows.
- `src/server/services/project-service.ts` — drop `'max'` from create + update effort allow-lists; error messages name `xhigh` and reference CC 2.1.68.
- `src/server/mcp/tools/add-project.ts` — Zod enum drops `'max'`; describe text updated.
- `src/server/utils/cc-spawn.ts` — new `warnIfDeprecatedEffort()` helper; called from `buildHeadlessArgs()` and `buildInteractiveArgs()` before pushing `--effort`. Flag is still forwarded so CC surfaces its own error.
- `src/client/views/ProjectsPage.tsx` and `src/client/components/AddProjectDialog.tsx` — remove `<option value="max">` from both effort dropdowns; help text updated.
- `src/shared/types.ts` — `EffortLevel` union drops `'max'`.
- `CLAUDE.md` — `FLEET_DEFAULT_EFFORT` row lists `low|medium|high|xhigh` and documents the auto-migration.
- Tests: `cc-spawn.test.ts`, `routes/projects-routes.test.ts`, `db.test.ts` — new coverage for the spawn warning, the PUT 400 rejection with `xhigh` in the message, and the v22 migration (rewrite, version bump, idempotency, fresh-DB no-op).

## Notes
- Originally drafted as v21, bumped to v22 during rebase because issue #730 landed a v21 migration first. Tests and version inserts updated accordingly.
- Single mapping `max -> xhigh` (not model-aware): the `model` column is a free-form string and effort is silently ignored on non-Opus-4.7 models, so `xhigh` is the safest fallback for an existing explicit "max effort" intent.
- v19's `addEffortColumn()` legacy CHECK string still permits `'max'` on upgraded DBs — SQLite cannot rewrite a CHECK in place without a full table rebuild. Application-level validators (server, MCP, UI) are the enforcement layer for new writes.

## Test plan
- [ ] `npm run build` — clean
- [ ] `npm test` — relevant suites green (`db.test.ts`, `routes/projects-routes.test.ts`, `cc-spawn.test.ts`); 3 unrelated pre-existing env-leak failures remain
- [ ] CI green on PR