### PR TITLE
Issue #739: disable CC auto-memory in FC team-spawned sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,20 @@ The team lifecycle state machine is defined in `src/shared/state-machine.ts`. Th
 
 Message templates are stored in the `message_templates` DB table and can be edited from the `/lifecycle` UI view. The `resolveMessage()` utility in `src/server/utils/resolve-message.ts` reads templates from DB and replaces placeholders at runtime.
 
+## CC Auto-Memory & Spawned Teams
+
+Claude Code 2.1.59+ ships an auto-memory feature that stores per-project notes under `~/.claude/projects/<cwd-derived>/memory/` and silently injects them into the system prompt at session start.
+
+**Fleet Commander teams do NOT participate in auto-memory.** Every CC process Fleet Commander spawns — headless team agents, interactive terminal windows, and one-shot `-p` query calls — has auto-memory disabled unconditionally via both `autoMemoryEnabled: false` in the worktree's `.claude/settings.json` (deployed from `hooks/settings.json.example` by `team-manager.copyFCFiles`) and the `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` environment variable set in `src/server/utils/cc-spawn.ts` (`buildEnv()`).
+
+Two reasons this is always-off and not configurable:
+- FC teams are ephemeral single-issue workers — persistent context belongs in `CLAUDE.md`, the GitHub issue body, and the workflow prompt (`templates/workflow.md`), not in user-scoped memory.
+- Memory files written by one team's session would be silently injected into unrelated teams running later in the same worktree-path hash, leaking facts across issues.
+
+Configuration locations (defense-in-depth):
+- `hooks/settings.json.example` — template copied to every worktree's `.claude/settings.json` on team launch. Carries the top-level `"autoMemoryEnabled": false` key.
+- `src/server/utils/cc-spawn.ts` — the `buildEnv()` helper sets `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` on every spawned CC process. On Windows interactive launches, the var is also written into the temp `.cmd` launcher file by `writeLauncherCmdFile()` (which forwards every `CLAUDE_CODE_*` env key).
+
 ## MCP Server
 
 Fleet Commander exposes tools via the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio transport. This allows Claude Code (or any MCP client) to query fleet state programmatically.

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -2,6 +2,7 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "autoMemoryEnabled": false,
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true
   },

--- a/src/server/utils/cc-spawn.ts
+++ b/src/server/utils/cc-spawn.ts
@@ -97,6 +97,14 @@ export function buildEnv(fleetContext?: FleetEnvContext): SpawnEnv {
   // var instead of computing a fragile relative path from their own location.
   env['FLEET_HOOK_LOG'] = config.hookLogPath;
 
+  // FC teams are single-issue ephemeral agents — they must never read from or
+  // write to the user's auto-memory directory (~/.claude/projects/<cwd>/memory/).
+  // Belt-and-braces with `autoMemoryEnabled: false` in the worktree's
+  // .claude/settings.json (see hooks/settings.json.example, deployed via
+  // team-manager.copyFCFiles). Applies unconditionally to all spawn modes
+  // (headless team agents, interactive windows, and query mode).
+  env['CLAUDE_CODE_DISABLE_AUTO_MEMORY'] = '1';
+
   // Windows: CC requires git-bash for hook execution. Auto-detect the path
   // so CC can find bash.exe even when Fleet Commander is started from a
   // non-Git-Bash terminal (e.g. cmd.exe or PowerShell).

--- a/tests/server/cc-spawn.test.ts
+++ b/tests/server/cc-spawn.test.ts
@@ -225,6 +225,18 @@ describe('cc-spawn', () => {
 
       expect(env['ENABLE_PROMPT_CACHING_1H']).toBeUndefined();
     });
+
+    it("always sets CLAUDE_CODE_DISABLE_AUTO_MEMORY='1' (with fleet context)", () => {
+      const env = buildEnv(makeFleetContext());
+
+      expect(env['CLAUDE_CODE_DISABLE_AUTO_MEMORY']).toBe('1');
+    });
+
+    it("always sets CLAUDE_CODE_DISABLE_AUTO_MEMORY='1' (query mode, no context)", () => {
+      const env = buildEnv();
+
+      expect(env['CLAUDE_CODE_DISABLE_AUTO_MEMORY']).toBe('1');
+    });
   });
 
   // =========================================================================
@@ -734,6 +746,8 @@ describe('cc-spawn', () => {
       expect(opts.env['FLEET_TEAM_ID']).toBe('proj-42');
       expect(opts.env['FLEET_PROJECT_ID']).toBe('5');
       expect(opts.env['FLEET_GITHUB_REPO']).toBe('acme/lib');
+      // Auto-memory disable applies to headless spawns too
+      expect(opts.env['CLAUDE_CODE_DISABLE_AUTO_MEMORY']).toBe('1');
     });
 
     it('returns the subprocess (cast to ChildProcess)', () => {
@@ -1012,6 +1026,21 @@ describe('cc-spawn', () => {
       const [, content] = mockWriteFileSync.mock.calls[0];
       expect(content).toContain('SET "CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe"');
     });
+
+    it('includes CLAUDE_CODE_DISABLE_AUTO_MEMORY SET in launcher', async () => {
+      await spawnInteractive({
+        mode: 'interactive',
+        cwd: 'C:\\repos\\proj',
+        worktreeName: 'proj-42',
+        windowTitle: 'Team proj-42',
+        fleetContext: makeFleetContext(),
+        prompt: 'Fix it',
+        terminalPref: 'cmd',
+      });
+
+      const [, content] = mockWriteFileSync.mock.calls[0];
+      expect(content).toContain('SET "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"');
+    });
   });
 
   // =========================================================================
@@ -1246,6 +1275,8 @@ describe('cc-spawn', () => {
       expect(opts.env['FLEET_PROJECT_ID']).toBeUndefined();
       // But should still have agent teams flag
       expect(opts.env['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS']).toBe('1');
+      // And the auto-memory disable
+      expect(opts.env['CLAUDE_CODE_DISABLE_AUTO_MEMORY']).toBe('1');
     });
 
     it('skips taskkill when child.pid is undefined on timeout', async () => {


### PR DESCRIPTION
Closes #739

## Summary
- Empirical observation of `~/.claude/projects/` confirmed FC team sessions are NOT polluting CC auto-memory today (all 15 fleet-commander worktree-derived project dirs have zero `memory/` subdirs; only the main interactive-REPL dir has memory files).
- Adds defense-in-depth disable so FC teams never participate in auto-memory regardless of future CC version changes.

## Changes
- `hooks/settings.json.example` — new top-level key `"autoMemoryEnabled": false` (sibling of `env`/`enabledPlugins`/`hooks`); deployed to every worktree by `TeamManager.copyFCFiles()`.
- `src/server/utils/cc-spawn.ts` — `buildEnv()` unconditionally sets `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`; propagates to all 3 spawn modes (headless, interactive, query) and to Windows `.cmd` launcher via existing `CLAUDE_CODE_*` prefix loop.
- `CLAUDE.md` — new section `## CC Auto-Memory & Spawned Teams` documenting context, verdict, rationale, and configuration locations.
- `tests/server/cc-spawn.test.ts` — 4 new assertions covering `buildEnv()` (with and without fleet context), `spawnHeadless` execa env, and Windows interactive `.cmd` file emission.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — +3 passing, 0 new failures (3 pre-existing failures verified against baseline; they only repro inside an FC dogfooding run due to parent-env leakage, not in CI)
- [x] Empirical observation respected sensitive-context rule (only `C--Git-fleet-commander*` dirs inspected, no memory content quoted)
- [ ] Runtime verification deferred to next team launch: no new `memory/` dir should appear under `~/.claude/projects/C--Git-fleet-commander--claude-worktrees-fleet-commander-*` after the change lands