### PR TITLE
Issue #731: handle WorktreeCreate/WorktreeRemove events for CC-managed worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ fleet-commander/
       index.ts              # Fastify app entry, route registration, service startup
       config.ts             # Environment variable parsing and validation
       db.ts                 # SQLite connection (WAL mode), schema init, query helpers
-      schema.sql            # 14 tables: projects, project_groups, project_issue_sources, teams, pull_requests, events, commands, usage_snapshots, schema_version, message_templates, team_transitions, agent_messages, stream_events, team_tasks
+      schema.sql            # 15 tables: projects, project_groups, project_issue_sources, teams, pull_requests, events, commands, usage_snapshots, schema_version, message_templates, team_transitions, agent_messages, stream_events, team_tasks, team_subworktrees
       routes/               # REST API route handlers
         teams.ts            # CRUD + launch/stop/message
         projects.ts         # CRUD + install/uninstall/cleanup
@@ -126,7 +126,7 @@ fleet-commander/
 | `src/server/index.ts` | App entry point, registers routes, starts services |
 | `src/server/config.ts` | All env var parsing, validation, frozen config object |
 | `src/server/db.ts` | SQLite connection, WAL mode, schema initialization |
-| `src/server/schema.sql` | Full database schema (14 tables + 1 view) |
+| `src/server/schema.sql` | Full database schema (15 tables + 1 view) |
 | `src/server/services/team-manager.ts` | Spawns CC processes, manages stdin/stdout pipes |
 | `src/server/services/event-collector.ts` | Receives hook events, writes to DB, broadcasts SSE |
 | `src/server/services/github-poller.ts` | Polls GitHub via `gh` CLI for PR/CI/merge status |
@@ -155,7 +155,7 @@ npm run launch       # Full launch: install + build + open browser
 
 ## Database
 
-SQLite with WAL mode, 14 tables:
+SQLite with WAL mode, 15 tables:
 
 | Table | Purpose |
 |-------|---------|
@@ -173,6 +173,7 @@ SQLite with WAL mode, 14 tables:
 | `agent_messages` | Inter-agent message tracking |
 | `stream_events` | Raw CC stream events for output replay |
 | `team_tasks` | Task tracking per team (from TaskCreated hooks) |
+| `team_subworktrees` | CC-initiated subworktrees per team (path, branch, created_via, removed_at) from WorktreeCreate/WorktreeRemove hooks |
 
 Plus one view: `v_team_dashboard` (joins teams + projects + PRs for the grid).
 

--- a/hooks/on_worktree_create.sh
+++ b/hooks/on_worktree_create.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# fleet-commander v0.0.24
+# Fleet Commander hook: WorktreeCreate
+# Fires when CC creates a worktree via --worktree, EnterWorktree, or subagent isolation=worktree.
+# stdin JSON example: {"session_id":"abc123","cwd":"/path/to/worktree","hookSpecificOutput":{"worktreePath":"/path/to/worktree"}}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | worktree_create | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "worktree_create"
+exit 0

--- a/hooks/on_worktree_remove.sh
+++ b/hooks/on_worktree_remove.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# fleet-commander v0.0.24
+# Fleet Commander hook: WorktreeRemove
+# Fires when CC removes a worktree via ExitWorktree or subagent isolation teardown.
+# stdin JSON example: {"session_id":"abc123","cwd":"/path/to/worktree","hookSpecificOutput":{"worktreePath":"/path/to/worktree"}}
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+_LOG="${FLEET_HOOK_LOG:-/tmp/fleet-hooks.log}"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) | HOOK  | worktree_remove | ${FLEET_TEAM_ID:-?} | cwd=$(pwd)" >> "$_LOG" 2>/dev/null || true
+input=$(cat)
+echo "$input" | "$HOOK_DIR/send_event.sh" "worktree_remove"
+exit 0

--- a/hooks/settings.json.example
+++ b/hooks/settings.json.example
@@ -117,6 +117,26 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_create on_worktree_create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fleet-commander/run-hook.sh worktree_remove on_worktree_remove.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUseFailure": [
       {
         "hooks": [

--- a/src/client/components/CleanupModal.tsx
+++ b/src/client/components/CleanupModal.tsx
@@ -19,13 +19,15 @@ interface CleanupModalProps {
 
 const TYPE_ORDER: Record<CleanupItem['type'], number> = {
   worktree: 0,
-  signal_file: 1,
-  stale_branch: 2,
-  team_record: 3,
+  cc_subworktree: 1,
+  signal_file: 2,
+  stale_branch: 3,
+  team_record: 4,
 };
 
 const TYPE_LABELS: Record<CleanupItem['type'], string> = {
   worktree: 'Worktrees',
+  cc_subworktree: 'CC Subworktrees',
   signal_file: 'Signal Files',
   stale_branch: 'Branches',
   team_record: 'Database Records',
@@ -33,6 +35,7 @@ const TYPE_LABELS: Record<CleanupItem['type'], string> = {
 
 const TYPE_ICONS: Record<CleanupItem['type'], string> = {
   worktree: '\uD83D\uDCC1',   // folder icon
+  cc_subworktree: '\uD83D\uDCC1', // folder icon (same kind of artifact, nested)
   signal_file: '\uD83D\uDCC4', // page icon
   stale_branch: '\uD83C\uDF3F', // leaf icon
   team_record: '\uD83D\uDDD1\uFE0F',  // database/wastebasket icon

--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -13,7 +13,7 @@ import { SpawnPromptPanel } from './SpawnPromptPanel';
 import { STATUS_COLORS } from '../utils/constants';
 import { getMergeStatusLabel } from '../utils/merge-status';
 import { formatIssueKey } from '../../shared/issue-provider';
-import type { TeamTask, HandoffFile } from '../../shared/types';
+import type { TeamTask, HandoffFile, TeamSubworktree } from '../../shared/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -125,6 +125,9 @@ export function TeamDetail() {
   const [tasksLoading, setTasksLoading] = useState(false);
   const [handoffFiles, setHandoffFiles] = useState<HandoffFile[]>([]);
   const [handoffFilesLoading, setHandoffFilesLoading] = useState(false);
+  // Issue #731: CC-initiated subworktrees displayed under the Team tab.
+  const [subworktrees, setSubworktrees] = useState<TeamSubworktree[]>([]);
+  const [subworktreesLoading, setSubworktreesLoading] = useState(false);
   const [metadataCollapsed, setMetadataCollapsed] = useState(false);
   const [agentFilters, setAgentFilters] = useState<Set<string>>(new Set());
   // Issue #713: which agent's spawn prompts are open in the side panel.
@@ -256,6 +259,28 @@ export function TeamDetail() {
   }, [api]);
 
   useFleetSSE('team_handoff_file', handleHandoffFile);
+
+  // Issue #731: fetch CC subworktrees when the Team tab is selected.
+  // No SSE refresh in v1 — subworktree create/remove is a rare event and
+  // the 5s polling in useTeamDetailData would catch the wider state
+  // anyway. If dogfooding shows latency is an issue, add a dedicated
+  // SSE event in a follow-up.
+  useEffect(() => {
+    if (activeTab !== 'team' || !selectedTeamId) return;
+    let cancelled = false;
+    setSubworktreesLoading(true);
+    api.get<TeamSubworktree[]>(`teams/${selectedTeamId}/subworktrees`)
+      .then((data) => {
+        if (!cancelled) setSubworktrees(data);
+      })
+      .catch(() => {
+        if (!cancelled) setSubworktrees([]);
+      })
+      .finally(() => {
+        if (!cancelled) setSubworktreesLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [activeTab, selectedTeamId, api]);
 
   // Close panel handler
   const handleClose = useCallback(() => {
@@ -903,20 +928,77 @@ export function TeamDetail() {
                 )}
 
                 {activeTab === 'team' && (
-                  <div className="flex-1 min-h-0 px-5 py-3 relative">
-                    <CommGraph
-                      edges={messageEdges}
-                      agents={roster}
-                      onNodeClick={setSelectedSpawnAgent}
-                      clickableAgents={clickableAgents}
-                    />
-                    {selectedSpawnAgent !== null && (
-                      <SpawnPromptPanel
-                        agentName={selectedSpawnAgent}
-                        spawns={filteredSpawns}
-                        onClose={() => setSelectedSpawnAgent(null)}
+                  <div className="flex-1 min-h-0 flex flex-col px-5 py-3 relative">
+                    <div className="flex-1 min-h-0 relative">
+                      <CommGraph
+                        edges={messageEdges}
+                        agents={roster}
+                        onNodeClick={setSelectedSpawnAgent}
+                        clickableAgents={clickableAgents}
                       />
-                    )}
+                      {selectedSpawnAgent !== null && (
+                        <SpawnPromptPanel
+                          agentName={selectedSpawnAgent}
+                          spawns={filteredSpawns}
+                          onClose={() => setSelectedSpawnAgent(null)}
+                        />
+                      )}
+                    </div>
+
+                    {/* Issue #731: CC-managed subworktrees panel. Sits below
+                        CommGraph in the Team tab so it never crowds the graph;
+                        bounded height with internal scroll. */}
+                    <div className="shrink-0 mt-3 border-t border-dark-border pt-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <h3 className="text-xs font-semibold uppercase tracking-wide text-dark-muted">
+                          CC-managed subworktrees
+                        </h3>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-dark-border/30 text-dark-muted">
+                          {subworktrees.length}
+                        </span>
+                      </div>
+                      <div className="max-h-48 overflow-y-auto custom-scrollbar">
+                        {subworktreesLoading && subworktrees.length === 0 && (
+                          <p className="text-xs text-dark-muted py-2">Loading subworktrees...</p>
+                        )}
+                        {!subworktreesLoading && subworktrees.length === 0 && (
+                          <p className="text-xs text-dark-muted py-2">No CC-managed subworktrees yet.</p>
+                        )}
+                        {subworktrees.length > 0 && (
+                          <ul className="space-y-1.5">
+                            {subworktrees.map((sw) => {
+                              const displayPath = sw.path.replace(/\/+$/, '');
+                              const isRemoved = sw.removedAt !== null;
+                              return (
+                                <li
+                                  key={sw.id}
+                                  className={`flex items-center gap-2 px-2 py-1.5 rounded border border-dark-border/40 ${
+                                    isRemoved ? 'bg-dark-border/10 opacity-60' : 'bg-dark-border/5'
+                                  }`}
+                                >
+                                  <code
+                                    className="flex-1 min-w-0 text-xs text-dark-text truncate font-mono"
+                                    title={displayPath}
+                                  >
+                                    {displayPath}
+                                  </code>
+                                  {sw.branch && (
+                                    <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-dark-border/30 text-dark-muted font-mono">
+                                      {sw.branch}
+                                    </span>
+                                  )}
+                                  {isRemoved && (
+                                    <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-[#F85149]/40 text-[#F85149]">
+                                      removed
+                                    </span>
+                                  )}
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -33,6 +33,7 @@ import type {
   HandoffFileType,
   SpawnRecord,
   SpawnTerminalStatus,
+  TeamSubworktree,
 } from '../shared/types.js';
 import { encrypt, decrypt, isEncrypted, decryptWithKey } from './utils/crypto.js';
 import config from './config.js';
@@ -452,6 +453,9 @@ export class FleetDatabase {
 
     // Add duration_ms column to events (v23 migration — per-tool timing capture)
     this.addEventsDurationMsColumn();
+
+    // Add team_subworktrees table if missing (v24 migration — CC-initiated subworktrees)
+    this.addTeamSubworktreesTable();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1385,6 +1389,60 @@ export class FleetDatabase {
     } catch (err) {
       // Table may not exist yet (fresh database) — schema.sql will create it
       console.warn('[DB] v23 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Add team_subworktrees table if it doesn't exist (v24 migration).
+   *
+   * Tracks subworktrees created by CC (via --worktree, EnterWorktree, or
+   * subagent isolation=worktree) so cleanup can remove them when the parent
+   * team finishes. `created_via='cc'` rows are inserted from the
+   * WorktreeCreate hook; `created_via='fc'` is reserved for any future
+   * FC-side worktree-tracking integration. Removal updates `removed_at`
+   * instead of deleting the row to preserve the audit trail.
+   *
+   * The partial unique index prevents double-inserts when CC re-emits
+   * WorktreeCreate for an already-tracked path (e.g., crash-recovery),
+   * while still allowing historical re-creates after a removal.
+   *
+   * Fresh databases get the table via schema.sql; upgraded databases use
+   * this migration. Idempotent across restarts.
+   */
+  private addTeamSubworktreesTable(): void {
+    // Skip on truly fresh DBs — schema.sql will create the table and bump
+    // schema_version. This migration only fires on existing (v23 or older)
+    // databases where the table needs to be added in place.
+    try {
+      const versionRow = this.db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'")
+        .get();
+      if (!versionRow) return;
+    } catch {
+      return;
+    }
+
+    try {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS team_subworktrees (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          team_id         INTEGER NOT NULL REFERENCES teams(id),
+          path            TEXT NOT NULL,
+          branch          TEXT,
+          created_via     TEXT NOT NULL DEFAULT 'cc',
+          created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          removed_at      TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_team_subworktrees_team ON team_subworktrees(team_id);
+        CREATE INDEX IF NOT EXISTS idx_team_subworktrees_team_active ON team_subworktrees(team_id, removed_at);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_team_subworktrees_team_path_active
+          ON team_subworktrees(team_id, path) WHERE removed_at IS NULL;
+      `);
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (24)');
+    } catch (err) {
+      // Table may already exist or referenced teams table may not yet exist —
+      // schema.sql will reconcile. Safe to ignore.
+      console.warn('[DB] v24 migration skipped:', err instanceof Error ? err.message : err);
     }
   }
 
@@ -3138,6 +3196,7 @@ export class FleetDatabase {
       this.stmt('DELETE FROM usage_snapshots WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM team_tasks WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM handoff_files WHERE team_id = ?').run(id);
+      this.stmt('DELETE FROM team_subworktrees WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM pull_requests WHERE team_id = ?').run(id);
       this.stmt('DELETE FROM teams WHERE id = ?').run(id);
     })(teamId);
@@ -3160,6 +3219,7 @@ export class FleetDatabase {
       this.stmt('DELETE FROM events').run();
       this.stmt('DELETE FROM commands').run();
       this.stmt('DELETE FROM usage_snapshots').run();
+      this.stmt('DELETE FROM team_subworktrees').run();
       this.stmt('DELETE FROM pull_requests').run();
       this.stmt('DELETE FROM teams').run();
       this.stmt('DELETE FROM message_templates').run();
@@ -3729,6 +3789,123 @@ export class FleetDatabase {
       content: row.content as string,
       agentName: (row.agent_name as string | null) ?? null,
       capturedAt: utcify(row.captured_at as string),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Team Subworktrees (CC-initiated nested worktrees — issue #731)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Record a CC-initiated subworktree create (or revive a previously-removed
+   * row for the same path). Idempotent: if a row already exists for the same
+   * (team_id, path), refresh its `branch`, bump `created_at`, and clear
+   * `removed_at` to NULL. This handles both crash-recovery re-emits and the
+   * rare case where a path is re-created after removal.
+   *
+   * Uses the partial unique index `idx_team_subworktrees_team_path_active`
+   * (which only covers rows with `removed_at IS NULL`) as the conflict
+   * target. When a removed row exists for the same path, the partial index
+   * does NOT match it, so we fall through to a plain INSERT and produce a
+   * new row — that's the "historical re-create" case.
+   */
+  recordCcSubworktreeCreate(data: {
+    teamId: number;
+    path: string;
+    branch?: string | null;
+    createdVia?: 'cc' | 'fc';
+  }): TeamSubworktree {
+    const createdVia: 'cc' | 'fc' = data.createdVia ?? 'cc';
+
+    // Try to revive an existing active row first (matches on the partial
+    // unique index). Returns the row id when one already exists.
+    const existing = this.stmt(
+      'SELECT id FROM team_subworktrees WHERE team_id = ? AND path = ? AND removed_at IS NULL'
+    ).get(data.teamId, data.path) as { id: number } | undefined;
+
+    let rowId: number;
+    if (existing) {
+      this.stmt(
+        `UPDATE team_subworktrees
+            SET branch = @branch,
+                created_via = @createdVia,
+                created_at = datetime('now'),
+                removed_at = NULL
+          WHERE id = @id`,
+      ).run({
+        id: existing.id,
+        branch: data.branch ?? null,
+        createdVia,
+      });
+      rowId = existing.id;
+    } else {
+      const result = this.stmt(
+        `INSERT INTO team_subworktrees (team_id, path, branch, created_via)
+         VALUES (@teamId, @path, @branch, @createdVia)`,
+      ).run({
+        teamId: data.teamId,
+        path: data.path,
+        branch: data.branch ?? null,
+        createdVia,
+      });
+      rowId = Number(result.lastInsertRowid);
+    }
+
+    const row = this.stmt(
+      'SELECT * FROM team_subworktrees WHERE id = ?'
+    ).get(rowId) as Record<string, unknown>;
+
+    return this.mapTeamSubworktreeRow(row);
+  }
+
+  /**
+   * Mark a CC-initiated subworktree row as removed (sets `removed_at` to now).
+   * Matches by `team_id` + `path` where `removed_at IS NULL`. Returns the
+   * updated row, or undefined when no matching active row exists. Never
+   * inserts a phantom row — late WorktreeRemove events for unknown paths
+   * are silently dropped.
+   */
+  recordCcSubworktreeRemove(data: { teamId: number; path: string }): TeamSubworktree | undefined {
+    const existing = this.stmt(
+      'SELECT id FROM team_subworktrees WHERE team_id = ? AND path = ? AND removed_at IS NULL'
+    ).get(data.teamId, data.path) as { id: number } | undefined;
+
+    if (!existing) return undefined;
+
+    this.stmt(
+      "UPDATE team_subworktrees SET removed_at = datetime('now') WHERE id = ?",
+    ).run(existing.id);
+
+    const row = this.stmt(
+      'SELECT * FROM team_subworktrees WHERE id = ?'
+    ).get(existing.id) as Record<string, unknown>;
+
+    return this.mapTeamSubworktreeRow(row);
+  }
+
+  /**
+   * Get all subworktree rows for a team, ordered by id ascending (oldest
+   * first). Pass `{ activeOnly: true }` to filter out rows that have a
+   * non-null `removed_at`.
+   */
+  getTeamSubworktrees(teamId: number, opts?: { activeOnly?: boolean }): TeamSubworktree[] {
+    const sql = opts?.activeOnly
+      ? 'SELECT * FROM team_subworktrees WHERE team_id = ? AND removed_at IS NULL ORDER BY id ASC'
+      : 'SELECT * FROM team_subworktrees WHERE team_id = ? ORDER BY id ASC';
+
+    const rows = this.stmt(sql).all(teamId) as Record<string, unknown>[];
+    return rows.map((r) => this.mapTeamSubworktreeRow(r));
+  }
+
+  private mapTeamSubworktreeRow(row: Record<string, unknown>): TeamSubworktree {
+    return {
+      id: row.id as number,
+      teamId: row.team_id as number,
+      path: row.path as string,
+      branch: (row.branch as string | null) ?? null,
+      createdVia: row.created_via as 'cc' | 'fc',
+      createdAt: utcify(row.created_at as string),
+      removedAt: row.removed_at ? utcify(row.removed_at as string) : null,
     };
   }
 

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -837,6 +837,37 @@ const teamsRoutes: FastifyPluginCallback = (
   );
 
   // -------------------------------------------------------------------------
+  // GET /api/teams/:id/subworktrees — CC-initiated subworktrees for this team
+  // -------------------------------------------------------------------------
+  // Issue #731: returns rows from team_subworktrees for the given team,
+  // including both active and historical (removed_at non-null) entries.
+  // Consumed by the TeamDetail "Worktrees" panel.
+  fastify.get(
+    '/api/teams/:id/subworktrees',
+    async (
+      request: FastifyRequest<{ Params: TeamIdParams }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const teamId = parseIdParam(request.params.id, 'id');
+
+        const service = getTeamService();
+        const subworktrees = service.getSubworktrees(teamId);
+        return reply.code(200).send(subworktrees);
+      } catch (err: unknown) {
+        if (err instanceof ServiceError) {
+          return reply.code(err.statusCode).send({ error: err.code, message: err.message });
+        }
+        request.log.error(err, 'Failed to get team subworktrees');
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // GET /api/teams/:id/messages — agent messages for this team
   // -------------------------------------------------------------------------
   // Query params:

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -422,5 +422,29 @@ CREATE TABLE IF NOT EXISTS provider_state (
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- ---------------------------------------------------------------------------
+-- TEAM SUBWORKTREES — CC-initiated subworktrees from WorktreeCreate hook
+-- ---------------------------------------------------------------------------
+-- Tracks subworktrees CC creates within a team's main worktree (or anywhere
+-- CC chose), so cleanup can remove them when the team finishes and so the UI
+-- can surface nested worktrees per team. `created_via='cc'` rows come from
+-- the WorktreeCreate hook handler; `created_via='fc'` is reserved for any
+-- future FC-side worktree-tracking integration. Removal updates `removed_at`
+-- instead of deleting the row so the audit trail survives.
+CREATE TABLE IF NOT EXISTS team_subworktrees (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  team_id         INTEGER NOT NULL REFERENCES teams(id),
+  path            TEXT NOT NULL,
+  branch          TEXT,
+  created_via     TEXT NOT NULL DEFAULT 'cc',
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  removed_at      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_subworktrees_team ON team_subworktrees(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_subworktrees_team_active ON team_subworktrees(team_id, removed_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_subworktrees_team_path_active
+  ON team_subworktrees(team_id, path) WHERE removed_at IS NULL;
+
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (23);
+INSERT OR IGNORE INTO schema_version (version) VALUES (24);

--- a/src/server/services/cleanup.ts
+++ b/src/server/services/cleanup.ts
@@ -165,7 +165,39 @@ export function getCleanupPreview(projectId: number, resetTeams: boolean = false
   }
 
   // -------------------------------------------------------------------
-  // 4. If resetTeams, include all team DB records for this project
+  // 4. CC-initiated subworktrees from done/failed teams (issue #731)
+  // -------------------------------------------------------------------
+  // For each terminal team in this project, list its active CC-tracked
+  // subworktrees. These are nested worktrees CC created via WorktreeCreate
+  // (--worktree, EnterWorktree, isolation=worktree) inside or alongside
+  // the team's main worktree. Skipped when the team is still active.
+  if (typeof db.getTeamSubworktrees === 'function') {
+    for (const team of allTeams) {
+      if (!['done', 'failed'].includes(team.status)) continue;
+      const subworktrees = db.getTeamSubworktrees(team.id) as Array<{
+        path: string;
+        createdVia: 'cc' | 'fc';
+        removedAt: string | null;
+      }>;
+      for (const sw of subworktrees) {
+        if (sw.removedAt !== null) continue;
+        if (sw.createdVia !== 'cc') continue;
+        // Derive a display name from the trailing path segment so the UI
+        // shows something readable rather than the full absolute path.
+        const segments = sw.path.replace(/\\/g, '/').replace(/\/+$/, '').split('/');
+        const displayName = segments[segments.length - 1] || sw.path;
+        items.push({
+          type: 'cc_subworktree',
+          name: displayName,
+          path: sw.path,
+          reason: `CC-created subworktree, team ${team.status}`,
+        });
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // 5. If resetTeams, include all team DB records for this project
   // -------------------------------------------------------------------
   if (resetTeams) {
     const teams = db.getTeams({ projectId });
@@ -272,6 +304,82 @@ export function executeCleanup(
           continue;
         }
         db.deleteTeamAndRelated(teamId);
+        removed.push(item.name);
+      } else if (item.type === 'cc_subworktree') {
+        // Locate the matching active subworktree row to know which team
+        // owns it (so we can mark it removed in DB). Walk the project's
+        // teams once; the per-team list is small (one row per active
+        // CC subworktree) so the cost is negligible.
+        let ownerTeamId: number | null = null;
+        if (typeof db.getTeamSubworktrees === 'function') {
+          for (const team of db.getTeams({ projectId })) {
+            const rows = db.getTeamSubworktrees(team.id) as Array<{
+              path: string;
+              removedAt: string | null;
+              createdVia: 'cc' | 'fc';
+            }>;
+            const match = rows.find(
+              (r) => r.path === item.path && r.removedAt === null && r.createdVia === 'cc',
+            );
+            if (match) {
+              ownerTeamId = team.id;
+              break;
+            }
+          }
+        }
+
+        if (ownerTeamId === null) {
+          // Row vanished between preview and execute — silently skip.
+          console.log(`[Cleanup] CC subworktree no longer tracked: ${item.path}`);
+          continue;
+        }
+
+        // Try git worktree remove first; fall back to fs.rmSync.
+        try {
+          execSync(
+            `git -C "${project.repoPath}" worktree remove --force "${item.path}"`,
+            { encoding: 'utf-8', stdio: 'pipe', timeout: 15000 },
+          );
+        } catch (e) {
+          console.error(
+            `[Cleanup] CC subworktree remove failed for ${item.path}:`,
+            e instanceof Error ? e.message : e,
+          );
+          try {
+            fs.rmSync(item.path, { recursive: true, force: true });
+          } catch (rmErr) {
+            // Both git and fs failed — still mark removed_at so we don't
+            // keep retrying this path on every subsequent cleanup.
+            console.error(
+              `[Cleanup] CC subworktree fs.rmSync failed for ${item.path}:`,
+              rmErr instanceof Error ? rmErr.message : rmErr,
+            );
+          }
+        }
+
+        // Prune stale worktree references (best-effort, like main worktree path).
+        try {
+          execSync(`git -C "${project.repoPath}" worktree prune`, {
+            stdio: 'pipe',
+            timeout: 5000,
+          });
+        } catch (e) {
+          console.error(`[Cleanup] worktree prune failed:`, e instanceof Error ? e.message : e);
+        }
+
+        // Mark the row removed in DB regardless of git/fs outcome — we don't
+        // want repeated retries against an already-vanished directory.
+        if (typeof db.recordCcSubworktreeRemove === 'function') {
+          try {
+            db.recordCcSubworktreeRemove({ teamId: ownerTeamId, path: item.path });
+          } catch (e) {
+            console.error(
+              `[Cleanup] recordCcSubworktreeRemove failed for ${item.path}:`,
+              e instanceof Error ? e.message : e,
+            );
+          }
+        }
+
         removed.push(item.name);
       }
     } catch (err) {

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -122,6 +122,30 @@ export interface EventCollectorDb {
     taskSubagentType: string | null;
     prompt: string;
   }): boolean;
+  /**
+   * Record a CC-initiated subworktree create. Optional so mock DBs in
+   * existing tests continue to work. Implemented in FleetDatabase for
+   * issue #731 (WorktreeCreate hook).
+   */
+  recordCcSubworktreeCreate?(data: {
+    teamId: number;
+    path: string;
+    branch?: string | null;
+    createdVia?: 'cc' | 'fc';
+  }): { id: number };
+  /**
+   * Mark a CC-initiated subworktree row as removed. Returns the updated
+   * row identifier, or undefined if no matching active row exists.
+   * Optional so mock DBs in existing tests continue to work. Implemented
+   * in FleetDatabase for issue #731 (WorktreeRemove hook).
+   */
+  recordCcSubworktreeRemove?(data: { teamId: number; path: string }): { id: number } | undefined;
+  /**
+   * List subworktree rows for a team. Optional for mock-DB compatibility.
+   * Used by the API route for the TeamDetail "Worktrees" panel
+   * (issue #731).
+   */
+  getTeamSubworktrees?(teamId: number, opts?: { activeOnly?: boolean }): unknown[];
 }
 
 /** SSE broker interface for broadcasting events */
@@ -300,6 +324,111 @@ export function extractSpawnPrompt(payload: EventPayload): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Extract the worktree path from a WorktreeCreate/WorktreeRemove hook payload.
+ *
+ * Priority chain (first non-empty wins):
+ *   1. `cc_stdin.hookSpecificOutput.worktreePath` (CC's documented override field).
+ *   2. `cc_stdin.cwd` (CC's working directory on hook fire).
+ *   3. `payload.worktree_path` (lifted by events.ts from `cc_stdin.worktree_path`).
+ *   4. `payload.tool_input.path` or `tool_input.worktreePath` (EnterWorktree /
+ *      ExitWorktree tool input).
+ *
+ * Returns `null` when no path can be resolved. Normalizes backslashes to forward
+ * slashes for cross-platform consistency. Trailing slashes are preserved.
+ *
+ * Exported for unit testing of the priority chain.
+ */
+export function extractWorktreePath(payload: EventPayload): string | null {
+  const normalize = (raw: unknown): string | null => {
+    if (typeof raw !== 'string' || raw.trim() === '') return null;
+    return raw.trim().replace(/\\/g, '/');
+  };
+
+  // 1. cc_stdin.hookSpecificOutput.worktreePath
+  // 2. cc_stdin.cwd
+  if (payload.cc_stdin && typeof payload.cc_stdin === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(payload.cc_stdin);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const obj = parsed as Record<string, unknown>;
+
+        const hso = obj.hookSpecificOutput;
+        if (hso && typeof hso === 'object' && !Array.isArray(hso)) {
+          const candidate = normalize((hso as Record<string, unknown>).worktreePath);
+          if (candidate) return candidate;
+        }
+
+        const cwdCandidate = normalize(obj.cwd);
+        if (cwdCandidate) return cwdCandidate;
+      }
+    } catch {
+      // Malformed cc_stdin — fall through to other sources.
+    }
+  }
+
+  // 3. payload.worktree_path (already lifted by events.ts)
+  const lifted = normalize(payload.worktree_path);
+  if (lifted) return lifted;
+
+  // 4. payload.tool_input (EnterWorktree/ExitWorktree tool input)
+  if (payload.tool_input && typeof payload.tool_input === 'string' && payload.tool_input.trim() !== '') {
+    try {
+      const parsed: unknown = JSON.parse(payload.tool_input);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const obj = parsed as Record<string, unknown>;
+        const candidate = normalize(obj.path) ?? normalize(obj.worktreePath);
+        if (candidate) return candidate;
+      }
+    } catch {
+      // Non-JSON tool_input — no path available.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract a best-effort branch name from a WorktreeCreate/WorktreeRemove
+ * payload. Checks `cc_stdin.branch` then `tool_input.branch`. Returns `null`
+ * when no branch field is present. Branch is purely informational — we never
+ * fail the handler when it's missing.
+ */
+export function extractWorktreeBranch(payload: EventPayload): string | null {
+  const normalize = (raw: unknown): string | null => {
+    if (typeof raw !== 'string' || raw.trim() === '') return null;
+    return raw.trim();
+  };
+
+  if (payload.cc_stdin && typeof payload.cc_stdin === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(payload.cc_stdin);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const obj = parsed as Record<string, unknown>;
+        const fromStdin = normalize(obj.branch);
+        if (fromStdin) return fromStdin;
+      }
+    } catch {
+      // Fall through to tool_input.
+    }
+  }
+
+  if (payload.tool_input && typeof payload.tool_input === 'string' && payload.tool_input.trim() !== '') {
+    try {
+      const parsed: unknown = JSON.parse(payload.tool_input);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const obj = parsed as Record<string, unknown>;
+        const fromToolInput = normalize(obj.branch);
+        if (fromToolInput) return fromToolInput;
+      }
+    } catch {
+      // Ignore.
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -1078,6 +1207,52 @@ export function processEvent(
       }, teamId);
     } catch {
       // Non-critical — task extraction failure should not break event processing
+    }
+  }
+
+  // ── CC-initiated worktree tracking (issue #731) ─────────────────
+  // WorktreeCreate and WorktreeRemove hooks (CC 2.1.49+) fire when CC
+  // creates or tears down a worktree via --worktree, EnterWorktree, or
+  // subagent isolation=worktree. We record an entry per (team, path) so
+  // cleanup can remove the subworktree when the team finishes and so the
+  // UI can show nested worktrees per team. Path extraction tolerates
+  // multiple stdin shapes via extractWorktreePath.
+  if (eventType === 'WorktreeCreate' && db.recordCcSubworktreeCreate) {
+    try {
+      const wtPath = extractWorktreePath(payload);
+      if (wtPath) {
+        const branch = extractWorktreeBranch(payload);
+        db.recordCcSubworktreeCreate({ teamId, path: wtPath, branch, createdVia: 'cc' });
+      } else {
+        console.warn(
+          `[EventCollector] WorktreeCreate without resolvable path for team=${payload.team}`,
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[EventCollector] WorktreeCreate handler failed for team=${payload.team}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (eventType === 'WorktreeRemove' && db.recordCcSubworktreeRemove) {
+    try {
+      const wtPath = extractWorktreePath(payload);
+      if (wtPath) {
+        // recordCcSubworktreeRemove returns undefined when no matching active
+        // row exists (e.g., WorktreeRemove arriving for a path FC never saw a
+        // Create for). This is expected when hooks were installed mid-lifecycle
+        // — silently no-op rather than insert a phantom row.
+        db.recordCcSubworktreeRemove({ teamId, path: wtPath });
+      } else {
+        console.warn(
+          `[EventCollector] WorktreeRemove without resolvable path for team=${payload.team}`,
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[EventCollector] WorktreeRemove handler failed for team=${payload.team}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -1311,6 +1311,28 @@ export class TeamService {
 
     return db.getHandoffFiles(teamId);
   }
+
+  /**
+   * Get all CC-initiated subworktrees tracked for a team. Includes both
+   * active and previously-removed rows so the UI can show historical
+   * worktrees as well as live ones (issue #731).
+   *
+   * @throws ServiceError with code VALIDATION if teamId is invalid
+   * @throws ServiceError with code NOT_FOUND if team doesn't exist
+   */
+  getSubworktrees(teamId: number): unknown[] {
+    if (isNaN(teamId) || teamId < 1) {
+      throw validationError('Invalid team ID');
+    }
+
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    if (!team) {
+      throw notFoundError(`Team ${teamId} not found`);
+    }
+
+    return db.getTeamSubworktrees(teamId);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -338,7 +338,7 @@ export interface UsageSnapshot {
 
 /** A single item that could be cleaned up */
 export interface CleanupItem {
-  type: 'worktree' | 'signal_file' | 'stale_branch' | 'team_record';
+  type: 'worktree' | 'signal_file' | 'stale_branch' | 'team_record' | 'cc_subworktree';
   name: string;
   path: string;
   reason: string;
@@ -479,6 +479,25 @@ export interface HandoffFile {
   content: string;
   agentName: string | null;
   capturedAt: string;
+}
+
+/**
+ * A CC-initiated subworktree created via WorktreeCreate hook (--worktree,
+ * EnterWorktree, or subagent isolation=worktree). FC tracks these so they
+ * can be cleaned up alongside the team's main worktree when the team
+ * finishes. `removedAt` is set when CC fires WorktreeRemove for the path
+ * (or when cleanup explicitly removes it); the row is never deleted so
+ * the audit trail survives.
+ */
+export interface TeamSubworktree {
+  id: number;
+  teamId: number;
+  path: string;
+  branch: string | null;
+  /** `'cc'` for hook-tracked CC subworktrees, `'fc'` reserved for future FC-side tracking. */
+  createdVia: 'cc' | 'fc';
+  createdAt: string;
+  removedAt: string | null;
 }
 
 /** Aggregated edge for the communication graph (sender -> recipient) */

--- a/tests/server/cleanup.test.ts
+++ b/tests/server/cleanup.test.ts
@@ -18,6 +18,10 @@ const mockDb = {
   getTeams: vi.fn().mockReturnValue([]),
   getTeamByWorktree: vi.fn(),
   deleteTeamAndRelated: vi.fn(),
+  // Issue #731: CC subworktree tracking. Default returns [] so existing tests
+  // see no cc_subworktree items in the preview unless they opt in.
+  getTeamSubworktrees: vi.fn().mockReturnValue([]),
+  recordCcSubworktreeRemove: vi.fn(),
 };
 
 vi.mock('../../src/server/db.js', () => ({
@@ -609,5 +613,221 @@ describe('executeCleanup', () => {
 
     expect(result.removed).toContain('test-project-1');
     expect(result.removed).not.toContain('test-project-2');
+  });
+});
+
+// =============================================================================
+// CC subworktree cleanup (Issue #731)
+// =============================================================================
+
+describe('cc_subworktree preview', () => {
+  it('includes a cc_subworktree item when a done team has an active CC subworktree', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 1,
+        teamId: 10,
+        path: '/tmp/repo/.claude/worktrees/test-project-10/sub-1',
+        branch: 'feat/x',
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const ccItems = result.items.filter((i) => i.type === 'cc_subworktree');
+    expect(ccItems.length).toBe(1);
+    expect(ccItems[0]!.name).toBe('sub-1');
+    expect(ccItems[0]!.path).toBe('/tmp/repo/.claude/worktrees/test-project-10/sub-1');
+    expect(ccItems[0]!.reason).toContain('done');
+  });
+
+  it('skips cc_subworktree rows that are already removed', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 1,
+        teamId: 10,
+        path: '/tmp/repo/sub-1',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: '2025-01-02T00:00:00Z',
+      },
+    ]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const ccItems = result.items.filter((i) => i.type === 'cc_subworktree');
+    expect(ccItems.length).toBe(0);
+  });
+
+  it('skips cc_subworktree rows with createdVia=fc (FC-owned, not in this branch)', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 1,
+        teamId: 10,
+        path: '/tmp/repo/sub-1',
+        branch: null,
+        createdVia: 'fc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const ccItems = result.items.filter((i) => i.type === 'cc_subworktree');
+    expect(ccItems.length).toBe(0);
+  });
+
+  it('skips cc_subworktrees on active teams', () => {
+    const project = makeProject();
+    const activeTeam = makeTeam({ id: 10, status: 'running', worktreeName: 'test-project-10' });
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([activeTeam]);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 1,
+        teamId: 10,
+        path: '/tmp/repo/sub-active',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = getCleanupPreview(1);
+
+    const ccItems = result.items.filter((i) => i.type === 'cc_subworktree');
+    expect(ccItems.length).toBe(0);
+  });
+});
+
+describe('cc_subworktree execute', () => {
+  it('runs git worktree remove --force and marks removed_at in DB', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    const subworktreeRow = {
+      id: 1,
+      teamId: 10,
+      path: '/tmp/repo/sub-1',
+      branch: null,
+      createdVia: 'cc' as const,
+      createdAt: '2025-01-01T00:00:00Z',
+      removedAt: null,
+    };
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamSubworktrees.mockReturnValue([subworktreeRow]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = executeCleanup(1, ['/tmp/repo/sub-1']);
+
+    expect(result.removed).toContain('sub-1');
+
+    // Verify git worktree remove was called with the subworktree path
+    const removeCalls = mockExecSync.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('worktree remove') &&
+        call[0].includes('/tmp/repo/sub-1'),
+    );
+    expect(removeCalls.length).toBe(1);
+
+    // Verify recordCcSubworktreeRemove was called with team and path
+    expect(mockDb.recordCcSubworktreeRemove).toHaveBeenCalledWith({
+      teamId: 10,
+      path: '/tmp/repo/sub-1',
+    });
+  });
+
+  it('falls back to fs.rmSync when git worktree remove fails', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    const subworktreeRow = {
+      id: 1,
+      teamId: 10,
+      path: '/tmp/repo/sub-locked',
+      branch: null,
+      createdVia: 'cc' as const,
+      createdAt: '2025-01-01T00:00:00Z',
+      removedAt: null,
+    };
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    mockDb.getTeamSubworktrees.mockReturnValue([subworktreeRow]);
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
+        throw new Error('worktree locked');
+      }
+      return '';
+    });
+
+    const result = executeCleanup(1, ['/tmp/repo/sub-locked']);
+
+    expect(result.removed).toContain('sub-locked');
+    expect(mockFs.rmSync).toHaveBeenCalled();
+    // Even on git failure, the DB row should be marked removed so retries are bounded
+    expect(mockDb.recordCcSubworktreeRemove).toHaveBeenCalled();
+  });
+
+  it('skips when the row is no longer tracked between preview and execute', () => {
+    const project = makeProject();
+    const team = makeTeam({ id: 10, status: 'done', worktreeName: 'test-project-10' });
+    const subworktreeRow = {
+      id: 1,
+      teamId: 10,
+      path: '/tmp/repo/sub-vanished',
+      branch: null,
+      createdVia: 'cc' as const,
+      createdAt: '2025-01-01T00:00:00Z',
+      removedAt: null,
+    };
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeams.mockReturnValue([team]);
+    // First call (during preview) returns the active row; second call (during
+    // execute lookup) returns an empty list — simulates the row being removed
+    // outside FC between preview and execute.
+    let lookupCount = 0;
+    mockDb.getTeamSubworktrees.mockImplementation(() => {
+      lookupCount++;
+      return lookupCount === 1 ? [subworktreeRow] : [];
+    });
+    mockFs.existsSync.mockReturnValue(false);
+    mockExecSync.mockReturnValue('');
+
+    const result = executeCleanup(1, ['/tmp/repo/sub-vanished']);
+
+    expect(result.removed).not.toContain('sub-vanished');
+    // git worktree remove should NOT have been called
+    const removeCalls = mockExecSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('worktree remove'),
+    );
+    expect(removeCalls.length).toBe(0);
+    expect(mockDb.recordCcSubworktreeRemove).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -2232,6 +2232,186 @@ describe("v22 migration: effort='max' -> 'xhigh'", () => {
   });
 });
 
+describe('team_subworktrees', () => {
+  let teamId: number;
+
+  beforeEach(() => {
+    const team = db.insertTeam({
+      issueNumber: 731,
+      worktreeName: 'sw-test-731',
+    });
+    teamId = team.id;
+  });
+
+  it('creates the team_subworktrees table on fresh init', () => {
+    const rows = db.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='team_subworktrees'")
+      .all() as Array<{ name: string }>;
+    expect(rows.length).toBe(1);
+  });
+
+  it('includes schema version >= 23 for the team_subworktrees migration', () => {
+    const row = db.raw
+      .prepare('SELECT MAX(version) AS version FROM schema_version')
+      .get() as { version: number };
+    expect(row.version).toBeGreaterThanOrEqual(23);
+  });
+
+  it('recordCcSubworktreeCreate inserts a row with correct fields and default createdVia=cc', () => {
+    const sw = db.recordCcSubworktreeCreate({
+      teamId,
+      path: '/tmp/foo',
+      branch: 'feat/x',
+    });
+
+    expect(sw.id).toBeGreaterThan(0);
+    expect(sw.teamId).toBe(teamId);
+    expect(sw.path).toBe('/tmp/foo');
+    expect(sw.branch).toBe('feat/x');
+    expect(sw.createdVia).toBe('cc');
+    expect(sw.createdAt).toBeTruthy();
+    expect(sw.removedAt).toBeNull();
+  });
+
+  it('recordCcSubworktreeCreate accepts null branch', () => {
+    const sw = db.recordCcSubworktreeCreate({ teamId, path: '/tmp/no-branch' });
+    expect(sw.branch).toBeNull();
+  });
+
+  it('calling recordCcSubworktreeCreate twice for the same (team, path) does not duplicate', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/dup', branch: 'one' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/dup', branch: 'two' });
+
+    const rows = db.getTeamSubworktrees(teamId);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.branch).toBe('two'); // updated, not duplicated
+  });
+
+  it('recordCcSubworktreeRemove sets removed_at and returns the updated row', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/bar' });
+
+    const result = db.recordCcSubworktreeRemove({ teamId, path: '/tmp/bar' });
+    expect(result).toBeDefined();
+    expect(result!.path).toBe('/tmp/bar');
+    expect(result!.removedAt).toBeTruthy();
+  });
+
+  it('recordCcSubworktreeRemove returns undefined for a non-existent (team, path)', () => {
+    const result = db.recordCcSubworktreeRemove({ teamId, path: '/tmp/never-created' });
+    expect(result).toBeUndefined();
+  });
+
+  it('recordCcSubworktreeRemove does not match already-removed rows', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/once' });
+    const first = db.recordCcSubworktreeRemove({ teamId, path: '/tmp/once' });
+    expect(first).toBeDefined();
+
+    // Second call should not find an active row to update.
+    const second = db.recordCcSubworktreeRemove({ teamId, path: '/tmp/once' });
+    expect(second).toBeUndefined();
+  });
+
+  it('re-creating a previously-removed path inserts a fresh row (audit trail preserved)', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/revive' });
+    db.recordCcSubworktreeRemove({ teamId, path: '/tmp/revive' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/revive', branch: 'newbranch' });
+
+    const all = db.getTeamSubworktrees(teamId);
+    expect(all.length).toBe(2);
+    expect(all[0]!.removedAt).toBeTruthy();
+    expect(all[1]!.removedAt).toBeNull();
+    expect(all[1]!.branch).toBe('newbranch');
+  });
+
+  it('getTeamSubworktrees returns rows ordered by id ASC', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/a' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/b' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/c' });
+
+    const rows = db.getTeamSubworktrees(teamId);
+    expect(rows.map((r) => r.path)).toEqual(['/tmp/a', '/tmp/b', '/tmp/c']);
+  });
+
+  it('getTeamSubworktrees with activeOnly filters out removed rows', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/active' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/gone' });
+    db.recordCcSubworktreeRemove({ teamId, path: '/tmp/gone' });
+
+    const all = db.getTeamSubworktrees(teamId);
+    expect(all.length).toBe(2);
+
+    const active = db.getTeamSubworktrees(teamId, { activeOnly: true });
+    expect(active.length).toBe(1);
+    expect(active[0]!.path).toBe('/tmp/active');
+  });
+
+  it('deleteTeamAndRelated removes team_subworktrees rows', () => {
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/x' });
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/y' });
+    expect(db.getTeamSubworktrees(teamId).length).toBe(2);
+
+    db.deleteTeamAndRelated(teamId);
+
+    // After cascade delete, no rows should remain for this team.
+    const remaining = db.raw
+      .prepare('SELECT COUNT(*) AS count FROM team_subworktrees WHERE team_id = ?')
+      .get(teamId) as { count: number };
+    expect(remaining.count).toBe(0);
+  });
+
+  it('isolates rows by team_id', () => {
+    const other = db.insertTeam({ issueNumber: 999, worktreeName: 'sw-test-999' });
+
+    db.recordCcSubworktreeCreate({ teamId, path: '/tmp/mine' });
+    db.recordCcSubworktreeCreate({ teamId: other.id, path: '/tmp/yours' });
+
+    const mine = db.getTeamSubworktrees(teamId);
+    const yours = db.getTeamSubworktrees(other.id);
+
+    expect(mine.map((r) => r.path)).toEqual(['/tmp/mine']);
+    expect(yours.map((r) => r.path)).toEqual(['/tmp/yours']);
+  });
+
+  it('createdVia=fc passes through when explicitly set', () => {
+    const sw = db.recordCcSubworktreeCreate({
+      teamId,
+      path: '/tmp/fc-row',
+      createdVia: 'fc',
+    });
+    expect(sw.createdVia).toBe('fc');
+  });
+
+  it('migrates an existing v22 DB to v23 on initSchema', () => {
+    // Simulate an existing DB that's already at v22 (before this issue):
+    // drop the team_subworktrees table this test setup created, reset
+    // schema_version to 22, then re-run initSchema. The migration
+    // should re-create the table and bump version to 23.
+    db.raw.exec('DROP TABLE IF EXISTS team_subworktrees');
+    db.raw.prepare("DELETE FROM schema_version WHERE version >= 23").run();
+    db.raw.prepare("INSERT OR REPLACE INTO schema_version (version) VALUES (22)").run();
+
+    // Sanity-check pre-condition
+    const beforeRow = db.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='team_subworktrees'")
+      .get();
+    expect(beforeRow).toBeUndefined();
+
+    db.initSchema();
+
+    // Table should exist after re-init
+    const afterRow = db.raw
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='team_subworktrees'")
+      .get();
+    expect(afterRow).toBeDefined();
+
+    // Schema version should be bumped
+    const ver = db.raw
+      .prepare('SELECT MAX(version) AS version FROM schema_version')
+      .get() as { version: number };
+    expect(ver.version).toBeGreaterThanOrEqual(23);
+  });
+});
+
 describe('Connection management', () => {
   it('closes the database', () => {
     db.close();

--- a/tests/server/event-collector.test.ts
+++ b/tests/server/event-collector.test.ts
@@ -17,6 +17,8 @@ import {
   PHASE_ORDER,
   EventCollectorError,
   extractSpawnPrompt,
+  extractWorktreePath,
+  extractWorktreeBranch,
   type EventPayload,
   type EventCollectorDb,
   type SseBroker,
@@ -3717,5 +3719,351 @@ describe('Background tasks and session crons (#730)', () => {
     expect(fieldCalls.length).toBeGreaterThan(0);
     const fields = fieldCalls[0]![1] as Record<string, unknown>;
     expect(fields.backgroundTasksJson).toBe(JSON.stringify(tasksArray));
+  });
+});
+
+// =============================================================================
+// Worktree path extraction helpers (Issue #731)
+// =============================================================================
+
+describe('extractWorktreePath', () => {
+  it('prefers cc_stdin.hookSpecificOutput.worktreePath over other fields', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({
+        cwd: '/tmp/cwd',
+        worktree_path: '/tmp/lifted',
+        hookSpecificOutput: { worktreePath: '/tmp/preferred' },
+      }),
+      worktree_path: '/tmp/payload-field',
+      tool_input: JSON.stringify({ path: '/tmp/tool-input' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/preferred');
+  });
+
+  it('falls back to cc_stdin.cwd when hookSpecificOutput is absent', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/cwd' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/cwd');
+  });
+
+  it('falls back to payload.worktree_path when cc_stdin has neither', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-1' }),
+      worktree_path: '/tmp/from-payload',
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/from-payload');
+  });
+
+  it('falls back to tool_input.path as the lowest-priority source', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      tool_input: JSON.stringify({ path: '/tmp/from-tool-input' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/from-tool-input');
+  });
+
+  it('falls back to tool_input.worktreePath as an alias', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      tool_input: JSON.stringify({ worktreePath: '/tmp/wt-alias' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/wt-alias');
+  });
+
+  it('normalizes backslashes to forward slashes', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: 'C:\\Users\\me\\proj' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBe('C:/Users/me/proj');
+  });
+
+  it('returns null when no source has a path', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-1' }),
+    };
+
+    expect(extractWorktreePath(payload)).toBeNull();
+  });
+
+  it('returns null on malformed cc_stdin (falls through, no throw)', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: 'not-valid-json',
+    };
+
+    expect(extractWorktreePath(payload)).toBeNull();
+  });
+
+  it('ignores empty strings in path fields', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({
+        cwd: '',
+        hookSpecificOutput: { worktreePath: '   ' },
+      }),
+      worktree_path: '/tmp/real',
+    };
+
+    expect(extractWorktreePath(payload)).toBe('/tmp/real');
+  });
+});
+
+describe('extractWorktreeBranch', () => {
+  it('reads cc_stdin.branch when present', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ branch: 'feat/x' }),
+    };
+
+    expect(extractWorktreeBranch(payload)).toBe('feat/x');
+  });
+
+  it('falls back to tool_input.branch when cc_stdin is missing branch', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-1' }),
+      tool_input: JSON.stringify({ branch: 'feat/from-input' }),
+    };
+
+    expect(extractWorktreeBranch(payload)).toBe('feat/from-input');
+  });
+
+  it('returns null when no branch is present', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-1' }),
+    };
+
+    expect(extractWorktreeBranch(payload)).toBeNull();
+  });
+
+  it('returns null on malformed cc_stdin without throwing', () => {
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: '{invalid json',
+    };
+
+    expect(extractWorktreeBranch(payload)).toBeNull();
+  });
+});
+
+// =============================================================================
+// WorktreeCreate / WorktreeRemove hook handlers (Issue #731)
+// =============================================================================
+
+describe('WorktreeCreate / WorktreeRemove hook handlers', () => {
+  it('WorktreeCreate calls recordCcSubworktreeCreate with extracted cwd', () => {
+    const recordCcSubworktreeCreate = vi.fn().mockReturnValue({ id: 1 });
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/sub-1', branch: 'feat/wt' }),
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeCreate).toHaveBeenCalledTimes(1);
+    expect(recordCcSubworktreeCreate).toHaveBeenCalledWith({
+      teamId: 1,
+      path: '/tmp/sub-1',
+      branch: 'feat/wt',
+      createdVia: 'cc',
+    });
+  });
+
+  it('WorktreeCreate prefers hookSpecificOutput.worktreePath over cwd', () => {
+    const recordCcSubworktreeCreate = vi.fn().mockReturnValue({ id: 1 });
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({
+        cwd: '/tmp/cwd-value',
+        hookSpecificOutput: { worktreePath: '/tmp/preferred' },
+      }),
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/tmp/preferred' }),
+    );
+  });
+
+  it('WorktreeCreate works with only payload.worktree_path set', () => {
+    const recordCcSubworktreeCreate = vi.fn().mockReturnValue({ id: 1 });
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      worktree_path: '/tmp/from-lifted-field',
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/tmp/from-lifted-field' }),
+    );
+  });
+
+  it('WorktreeCreate normalizes backslashes to forward slashes', () => {
+    const recordCcSubworktreeCreate = vi.fn().mockReturnValue({ id: 1 });
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: 'C:\\Users\\me\\sub-wt' }),
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'C:/Users/me/sub-wt' }),
+    );
+  });
+
+  it('WorktreeCreate with no resolvable path warns and does NOT call recordCcSubworktreeCreate', () => {
+    const recordCcSubworktreeCreate = vi.fn();
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ session_id: 'sess-1' }),
+    };
+
+    expect(() => processEvent(payload, db, sse)).not.toThrow();
+    expect(recordCcSubworktreeCreate).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('WorktreeCreate is a no-op when db.recordCcSubworktreeCreate is absent', () => {
+    // Mock DB without the optional method (mimics older test setups).
+    const db = createMockDb();
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/wt' }),
+    };
+
+    // Should not throw — silently no-ops when method is undefined.
+    expect(() => processEvent(payload, db, sse)).not.toThrow();
+  });
+
+  it('WorktreeRemove with resolvable path calls recordCcSubworktreeRemove', () => {
+    const recordCcSubworktreeRemove = vi.fn().mockReturnValue({ id: 1 });
+    const db = createMockDb({ recordCcSubworktreeRemove });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_remove',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/gone' }),
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeRemove).toHaveBeenCalledTimes(1);
+    expect(recordCcSubworktreeRemove).toHaveBeenCalledWith({
+      teamId: 1,
+      path: '/tmp/gone',
+    });
+  });
+
+  it('WorktreeRemove tolerates undefined return from recordCcSubworktreeRemove (no error)', () => {
+    const recordCcSubworktreeRemove = vi.fn().mockReturnValue(undefined);
+    const db = createMockDb({ recordCcSubworktreeRemove });
+    const sse = createMockSse();
+
+    const payload: EventPayload = {
+      event: 'worktree_remove',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/never-created' }),
+    };
+
+    expect(() => processEvent(payload, db, sse)).not.toThrow();
+    expect(recordCcSubworktreeRemove).toHaveBeenCalled();
+  });
+
+  it('WorktreeRemove with no resolvable path warns without calling the recorder', () => {
+    const recordCcSubworktreeRemove = vi.fn();
+    const db = createMockDb({ recordCcSubworktreeRemove });
+    const sse = createMockSse();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const payload: EventPayload = {
+      event: 'worktree_remove',
+      team: 'kea-100',
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(recordCcSubworktreeRemove).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('handler errors are logged but do not break event processing', () => {
+    const recordCcSubworktreeCreate = vi.fn().mockImplementation(() => {
+      throw new Error('synthetic db failure');
+    });
+    const db = createMockDb({ recordCcSubworktreeCreate });
+    const sse = createMockSse();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const payload: EventPayload = {
+      event: 'worktree_create',
+      team: 'kea-100',
+      cc_stdin: JSON.stringify({ cwd: '/tmp/oops' }),
+    };
+
+    // Should not throw — handler swallows errors and emits a warning.
+    const result = processEvent(payload, db, sse);
+
+    expect(result.processed).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });

--- a/tests/server/fc-manifest.test.ts
+++ b/tests/server/fc-manifest.test.ts
@@ -34,6 +34,9 @@ describe('getHookFiles', () => {
     expect(hooks).toContain('on_session_end.sh');
     expect(hooks).toContain('on_stop.sh');
     expect(hooks).toContain('on_task_created.sh');
+    // Issue #731: WorktreeCreate / WorktreeRemove hook scripts
+    expect(hooks).toContain('on_worktree_create.sh');
+    expect(hooks).toContain('on_worktree_remove.sh');
   });
 
   it('returns filenames sorted alphabetically', () => {
@@ -115,6 +118,9 @@ describe('getHookEventTypes', () => {
     expect(types).toContain('SessionEnd');
     expect(types).toContain('Stop');
     expect(types).toContain('TaskCreated');
+    // Issue #731: WorktreeCreate / WorktreeRemove hook events
+    expect(types).toContain('WorktreeCreate');
+    expect(types).toContain('WorktreeRemove');
   });
 
   it('returns event types sorted alphabetically', () => {


### PR DESCRIPTION
## Summary

Implements CC-managed worktree tracking end-to-end:

- **Hooks**: new `on_worktree_create.sh` / `on_worktree_remove.sh` (fire-and-forget, POSIX, LF endings) + `WorktreeCreate` / `WorktreeRemove` entries in `hooks/settings.json.example`.
- **Schema (v24)**: new `team_subworktrees` table with `(team_id, path)` partial unique index for upsert idempotency; cascade DELETE in `deleteTeamAndRelated`; purge in `factoryReset`. Both fresh-install and v23→v24 upgrade paths land at v24.
- **Event handling**: `extractWorktreePath` four-step priority chain (`hookSpecificOutput.worktreePath` → `cc_stdin.cwd` → `payload.worktree_path` → `tool_input.path/worktreePath`), backslash normalization, `extractWorktreeBranch` best-effort fallback. Handlers guarded by optional db method check so existing mocks keep working.
- **Cleanup**: `getCleanupPreview` lists `cc_subworktree` items for terminal teams; `executeCleanup` re-checks ownership, runs `git worktree remove --force` with `fs.rmSync` fallback, unconditionally marks `removed_at` to bound retries.
- **API**: `GET /api/teams/:id/subworktrees` returns `TeamSubworktree[]` (mirrors `handoff-files` endpoint).
- **UI**: new "CC-managed subworktrees" panel inside the Team tab in `TeamDetail.tsx` (bounded height, internal scroll, empty/loading/removed states; refreshes on tab activation via existing 5s detail-poll).
- **Tests**: 46 new tests across `db.test.ts` (15), `event-collector.test.ts` (22), `cleanup.test.ts` (7), `fc-manifest.test.ts` (assertions). 428/428 targeted tests pass; 2087/2090 full server suite (3 pre-existing cc-spawn env-pollution failures unrelated to this PR).
- **Docs**: `CLAUDE.md` Database table updated (15 tables).

Schema bumped from planned v21 → v24 to absorb PR #743 (v21), PR #744 (v22), and PR #745 (v23) which all landed during dev/rebase. Acceptance criteria from the issue and from `plan.md` all met (verified by reviewer).

Closes #731

## Test plan

- [ ] CI passes (build + server tests + client tests + lint)
- [ ] Fresh-install: a clean DB initializes at schema_version 24 with `team_subworktrees` table present
- [ ] Upgrade: a v23 DB upgrades cleanly to v24 with `team_subworktrees` created in place
- [ ] Posting `worktree_create` with `cc_stdin = '{"cwd": "/tmp/foo"}'` inserts a tracked row
- [ ] Posting `worktree_remove` for the same path sets `removed_at`
- [ ] `GET /api/teams/:id/subworktrees` returns the rows
- [ ] Team tab in TeamDetail shows the subworktrees panel (with empty state when none)