### PR TITLE
Issue #735: migrate hooks to native HTTP type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ fleet-commander/
       types.ts              # Shared TypeScript types (Team, Project, Event, etc.)
       message-templates.ts  # Message template type definitions and defaults
   hooks/                    # CC hook scripts (deployed to target repos)
-    send_event.sh           # Fire-and-forget POST to Fleet Commander
+    send_event.sh           # Fire-and-forget POST to Fleet Commander (legacy bash mode)
     run-hook.sh             # Generic hook runner (delegates to send_event.sh)
     on_session_start.sh
     on_session_end.sh
@@ -102,6 +102,8 @@ fleet-commander/
     on_stop_failure.sh
     on_teammate_idle.sh
     on_task_created.sh
+    settings.json.example       # Settings template for legacy bash hooks
+    settings.json.http.example  # Settings template for native HTTP hooks (CC 2.1.62+, default)
   scripts/
     launch.js               # Auto-install + build + open browser
     install.sh / install.ps1
@@ -279,6 +281,38 @@ The SSE broker emits 18 event types:
 11. **Stream JSON for CC** -- Claude Code is invoked with `--input-format stream-json --output-format stream-json` for stdin/stdout piping.
 12. **No Octokit, no REST wrappers** -- shell out to `gh` for GitHub API calls.
 13. **State machine transitions must ALWAYS be kept in sync with code.** The file `src/shared/state-machine.ts` defines all team status transitions, their triggers, conditions, and message templates. When modifying any code that changes team status (`db.updateTeam({ status: ... })`), you MUST also update `state-machine.ts` to reflect the change. The State Machine view in the UI (`/lifecycle`) reads from this file — if it's out of date, users will see incorrect transition information. The `message_templates` database table stores editable versions of messages sent to teams; defaults come from `state-machine.ts` and are seeded on startup.
+
+## Hook Deployment Modes (issue #735)
+
+Claude Code 2.1.62+ supports native HTTP hooks (`{"type": "http", "url": "..."}`)
+that POST a hook's stdin JSON directly to a URL, eliminating the bash + curl
+subshell startup cost (significant on Windows). FC supports both modes:
+
+| Mode | Template | Transport | When to use |
+|------|----------|-----------|------------|
+| `http` (default) | `hooks/settings.json.http.example` | CC POSTs directly to `POST /api/hooks/:eventType` | New installs (CC 2.1.62+). Lower latency, fewer moving parts. |
+| `bash` (legacy) | `hooks/settings.json.example` | CC spawns `bash run-hook.sh ... → send_event.sh → curl → POST /api/events` | CC < 2.1.62 or when you need the bash hook scripts to do custom pre-processing. |
+
+- **New projects** default to `http` (see `ProjectService.createProject`).
+- **Existing projects** can flip modes via the **Mode picker + Reinstall** button
+  in `/projects` (or `POST /api/projects/:id/install` with `{ "mode": "http" | "bash" }`).
+- **Reinstall is idempotent and exclusive** — install.sh first strips any prior
+  FC entries (both bash and http) from `.claude/settings.json` and then adds
+  the entries for the requested mode, so the two never coexist.
+- The selected mode is recorded on `projects.hook_mode` (DB schema v24) and
+  shown as an "HTTP / Bash / Unknown" badge in the install health row.
+- The HTTP endpoint is `localhost`-only by default and has no auth — see
+  issue #736 if you need to harden it for remote scenarios.
+
+`install.sh --mode http --port 4680` substitutes `{{FLEET_PORT}}` in the http
+template at install time. The `--port` flag falls back to the `FLEET_PORT`
+environment variable (default 4680).
+
+The `POST /api/hooks/:eventType` route lives in `src/server/routes/hooks.ts`
+and reuses the same `event-collector` pipeline as the legacy `POST /api/events`
+route via the shared `buildEventPayloadFromCc` helper. PascalCase hook names
+(e.g. `SessionStart`, `PostToolUse`) are mapped to snake_case event types
+(`session_start`, `tool_use`) inside the route.
 
 ## Development Workflow
 

--- a/hooks/settings.json.http.example
+++ b/hooks/settings.json.http.example
@@ -117,6 +117,26 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/WorktreeCreate"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/WorktreeRemove"
+          }
+        ]
+      }
+    ],
     "PostToolUseFailure": [
       {
         "hooks": [

--- a/hooks/settings.json.http.example
+++ b/hooks/settings.json.http.example
@@ -1,0 +1,131 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "autoMemoryEnabled": false,
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/SessionStart"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/SessionEnd"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/Stop"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/StopFailure"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/SubagentStart"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/SubagentStop"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/Notification"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/PreCompact"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/PostToolUse"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/TeammateIdle"
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/TaskCreated"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:{{FLEET_PORT}}/api/hooks/PostToolUseFailure"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,21 +2,36 @@
 # Delegates to install.sh via bash for cross-platform compatibility.
 #
 # Usage:
-#   .\scripts\install.ps1 [[-TargetRepo] <path>]
-#   .\scripts\install.ps1                        # auto-detects git repo root
-#   .\scripts\install.ps1 C:\Git\my-project      # explicit target
+#   .\scripts\install.ps1 [[-TargetRepo] <path>] [-Mode <http|bash>] [-Port <int>]
+#   .\scripts\install.ps1                            # auto-detects git repo root, mode=http, port=4680
+#   .\scripts\install.ps1 C:\Git\my-project          # explicit target
+#   .\scripts\install.ps1 -Mode bash                 # legacy bash hooks
+#   .\scripts\install.ps1 -Mode http -Port 4681      # custom FC port
 
 param(
     [Parameter(Position = 0)]
-    [string]$TargetRepo = ""
+    [string]$TargetRepo = "",
+
+    [ValidateSet('http', 'bash')]
+    [string]$Mode = "http",
+
+    [int]$Port = 0
 )
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-if ($TargetRepo) {
-    & bash "$scriptDir/install.sh" "$TargetRepo"
-} else {
-    & bash "$scriptDir/install.sh"
+# Build the argument list forwarded to install.sh. We always pass --mode so
+# the wrapper's default matches install.sh's. --port is only forwarded when
+# the caller explicitly set it (0 = unset) so install.sh's $FLEET_PORT
+# fallback continues to work.
+$bashArgs = @("$scriptDir/install.sh", "--mode", $Mode)
+if ($Port -gt 0) {
+    $bashArgs += @("--port", "$Port")
 }
+if ($TargetRepo) {
+    $bashArgs += $TargetRepo
+}
+
+& bash @bashArgs
 
 exit $LASTEXITCODE

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 # Installs hook scripts, merges settings.json, deploys workflow prompt,
 # and copies agent templates into a target repo's .claude directory.
 #
-# Usage: ./scripts/install.sh [/path/to/target/repo]
+# Usage: ./scripts/install.sh [--mode http|bash] [--port <n>] [/path/to/target/repo]
 #   If no path given, auto-detects the git repo root from current directory.
+#
+# Options:
+#   --mode http   Use native HTTP hooks (CC 2.1.62+, default).
+#   --mode bash   Use legacy bash+curl hooks.
+#   --port <n>    Fleet Commander server port for HTTP hooks (default $FLEET_PORT or 4680).
 
 # Ensure standard Unix tools are on PATH — when Git Bash's usr/bin/bash.exe
 # is invoked directly (not via git-bash.exe), /usr/bin may be missing.
@@ -18,6 +23,60 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Parse CLI flags (--mode, --port) before positional target arg ──
+# Default mode is 'http' (issue #735); operators can opt into 'bash' for
+# CC < 2.1.62 or when troubleshooting. Port defaults to $FLEET_PORT or 4680.
+INSTALL_MODE="http"
+INSTALL_PORT="${FLEET_PORT:-4680}"
+POSITIONAL_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --mode requires a value (http|bash)" >&2
+        exit 1
+      fi
+      INSTALL_MODE="$2"
+      shift 2
+      ;;
+    --mode=*)
+      INSTALL_MODE="${1#--mode=}"
+      shift
+      ;;
+    --port)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --port requires a value" >&2
+        exit 1
+      fi
+      INSTALL_PORT="$2"
+      shift 2
+      ;;
+    --port=*)
+      INSTALL_PORT="${1#--port=}"
+      shift
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "$INSTALL_MODE" != "http" ] && [ "$INSTALL_MODE" != "bash" ]; then
+  echo "Error: --mode must be 'http' or 'bash' (got: $INSTALL_MODE)" >&2
+  exit 1
+fi
+
+# Validate port — must be a positive integer
+if ! echo "$INSTALL_PORT" | grep -Eq '^[0-9]+$' || [ "$INSTALL_PORT" -lt 1 ] || [ "$INSTALL_PORT" -gt 65535 ]; then
+  echo "Error: --port must be an integer between 1 and 65535 (got: $INSTALL_PORT)" >&2
+  exit 1
+fi
+
+# Restore positional args so the existing $1 logic below still works
+set -- "${POSITIONAL_ARGS[@]:-}"
 
 # ── Read FC version from package.json ────────────────────────────
 FC_VERSION="unknown"
@@ -66,8 +125,17 @@ if [ ! -f "$FC_ROOT/templates/workflow.md" ]; then
   echo "ERROR: templates/workflow.md not found"
   exit 1
 fi
-if [ ! -f "$FC_ROOT/hooks/settings.json.example" ]; then
-  echo "ERROR: hooks/settings.json.example not found"
+
+# Pick the settings.json source template based on mode and validate its
+# presence. The bash template is the historical default; the http template
+# is new in issue #735 and substitutes {{FLEET_PORT}} at install time.
+if [ "$INSTALL_MODE" = "http" ]; then
+  SETTINGS_EXAMPLE_NAME="settings.json.http.example"
+else
+  SETTINGS_EXAMPLE_NAME="settings.json.example"
+fi
+if [ ! -f "$FC_ROOT/hooks/$SETTINGS_EXAMPLE_NAME" ]; then
+  echo "ERROR: hooks/$SETTINGS_EXAMPLE_NAME not found"
   exit 1
 fi
 
@@ -110,36 +178,56 @@ echo "  Copied hook scripts to $HOOK_DIR (v${FC_VERSION})"
 
 # ── 2. Merge into .claude/settings.json ──────────────────────────
 SETTINGS="$TARGET/.claude/settings.json"
-EXAMPLE="$FC_ROOT/hooks/settings.json.example"
+EXAMPLE="$FC_ROOT/hooks/$SETTINGS_EXAMPLE_NAME"
 
+# A FC hook entry is identified by either:
+#   - a bash command containing 'fleet-commander' (legacy bash mode), OR
+#   - an http URL containing '/api/hooks/' (new HTTP mode).
+# We always strip both kinds before re-adding the mode-specific entries so a
+# reinstall with a different mode leaves no stale duplicates (issue #735).
 if [ -f "$SETTINGS" ]; then
   # Merge Fleet Commander hook entries into existing settings,
   # preserving all existing hooks. Uses Node for reliable JSON handling.
+  # FLEET_PORT placeholder in the http template is substituted at install time.
   node -e "
     const fs = require('fs');
     const existing = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
-    const example = JSON.parse(fs.readFileSync(process.argv[2], 'utf-8'));
+    const exampleRaw = fs.readFileSync(process.argv[2], 'utf-8');
+    const fleetPort = process.argv[4];
+    const example = JSON.parse(exampleRaw.replace(/{{FLEET_PORT}}/g, fleetPort));
 
     if (!existing.hooks) existing.hooks = {};
 
+    // Returns true if the given entry is a Fleet Commander hook entry
+    // (matches both bash and http styles).
+    function isFcEntry(entry) {
+      const hooks = (entry && entry.hooks) || [];
+      return hooks.some(h => {
+        if (h && typeof h.command === 'string' && h.command.includes('fleet-commander')) return true;
+        if (h && typeof h.url === 'string' && h.url.includes('/api/hooks/')) return true;
+        return false;
+      });
+    }
+
+    // First pass: strip ALL existing FC entries across every hook type so a
+    // reinstall with a different mode (or after a botched previous install)
+    // does not leave bash and http entries coexisting (issue #735).
+    for (const hookType of Object.keys(existing.hooks)) {
+      const before = existing.hooks[hookType].length;
+      existing.hooks[hookType] = existing.hooks[hookType].filter(e => !isFcEntry(e));
+      if (existing.hooks[hookType].length === 0) {
+        delete existing.hooks[hookType];
+      } else if (existing.hooks[hookType].length !== before) {
+        // kept some non-FC entries, removed some FC ones
+      }
+    }
+
+    // Second pass: add this install's FC entries from the chosen template.
     for (const [hookType, entries] of Object.entries(example.hooks || {})) {
       for (const entry of entries) {
-        // Only add fleet-commander entries; skip others like pr-watcher
-        const commands = (entry.hooks || []).map(h => h.command || '');
-        const isFC = commands.some(c => c.includes('fleet-commander'));
-        if (!isFC) continue;
-
-        // Ensure the array exists for this hook type
+        if (!isFcEntry(entry)) continue;
         if (!existing.hooks[hookType]) existing.hooks[hookType] = [];
-
-        // Check if this exact entry already exists (idempotent)
-        const entryStr = JSON.stringify(entry);
-        const alreadyExists = existing.hooks[hookType].some(
-          e => JSON.stringify(e) === entryStr
-        );
-        if (!alreadyExists) {
-          existing.hooks[hookType].push(entry);
-        }
+        existing.hooks[hookType].push(entry);
       }
     }
 
@@ -151,14 +239,17 @@ if [ -f "$SETTINGS" ]; then
     } finally {
       try { fs.unlinkSync(tmpPath); } catch {}
     }
-  " "$SETTINGS" "$EXAMPLE" "$FC_VERSION"
-  echo "  Merged hook entries into existing settings.json (v${FC_VERSION})"
+  " "$SETTINGS" "$EXAMPLE" "$FC_VERSION" "$INSTALL_PORT"
+  echo "  Merged hook entries into existing settings.json (v${FC_VERSION}, mode=${INSTALL_MODE}, port=${INSTALL_PORT})"
 else
   mkdir -p "$TARGET/.claude"
-  # Copy template and inject version stamp
+  # Copy template and inject version stamp. FLEET_PORT placeholder in the
+  # http template is substituted here as well.
   node -e "
     const fs = require('fs');
-    const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
+    const exampleRaw = fs.readFileSync(process.argv[1], 'utf-8');
+    const fleetPort = process.argv[4];
+    const data = JSON.parse(exampleRaw.replace(/{{FLEET_PORT}}/g, fleetPort));
     data._fleetCommanderVersion = process.argv[2];
     const tmpPath = process.argv[3] + '.tmp';
     try {
@@ -167,8 +258,8 @@ else
     } finally {
       try { fs.unlinkSync(tmpPath); } catch {}
     }
-  " "$EXAMPLE" "$FC_VERSION" "$SETTINGS"
-  echo "  Created settings.json from template (v${FC_VERSION})"
+  " "$EXAMPLE" "$FC_VERSION" "$SETTINGS" "$INSTALL_PORT"
+  echo "  Created settings.json from template (v${FC_VERSION}, mode=${INSTALL_MODE}, port=${INSTALL_PORT})"
 fi
 
 # ── 3. Install workflow template and command ─────────────────────

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -52,12 +52,16 @@ if [ -f "$SETTINGS" ]; then
     if (settings.hooks) {
       for (const [hookType, entries] of Object.entries(settings.hooks)) {
         // Remove entries whose hook commands reference fleet-commander
+        // (legacy bash mode) or whose URL points at /api/hooks/ (HTTP mode,
+        // issue #735).
         settings.hooks[hookType] = entries.filter(entry => {
           // Check nested hooks array (structured format)
           if (entry && entry.hooks && Array.isArray(entry.hooks)) {
-            const hasFC = entry.hooks.some(
-              h => typeof h.command === 'string' && h.command.includes('fleet-commander')
-            );
+            const hasFC = entry.hooks.some(h => {
+              if (typeof h.command === 'string' && h.command.includes('fleet-commander')) return true;
+              if (typeof h.url === 'string' && h.url.includes('/api/hooks/')) return true;
+              return false;
+            });
             return !hasFC;
           }
           // Check direct command string

--- a/src/client/views/ProjectsPage.tsx
+++ b/src/client/views/ProjectsPage.tsx
@@ -93,6 +93,37 @@ function getInstallHealthLabel(color: HealthColor, project?: ProjectSummary): st
 }
 
 // ---------------------------------------------------------------------------
+// Hook mode badge (issue #735)
+// ---------------------------------------------------------------------------
+// Surfaces the project's hook deployment mode so operators can see at a
+// glance whether a project is on the new HTTP transport or the legacy bash
+// path. `null` means the project predates issue #735 and the mode has not
+// yet been recorded — surfaced as "Unknown" until the next reinstall.
+
+function HookModeBadge({ project }: { project: ProjectSummary }) {
+  const mode = project.hookMode;
+  const label = mode === 'http' ? 'HTTP' : mode === 'bash' ? 'Bash' : 'Unknown';
+  const color = mode === 'http' ? '#3FB950' : mode === 'bash' ? '#D29922' : '#8B949E';
+  const tooltip =
+    mode === 'http'
+      ? 'Hooks: native HTTP (CC 2.1.62+). Reinstall to switch modes.'
+      : mode === 'bash'
+        ? 'Hooks: legacy bash + curl. Reinstall with HTTP mode for lower latency.'
+        : 'Hook mode unknown — reinstall to record current mode.';
+
+  return (
+    <div className="relative group shrink-0">
+      <span className="cursor-default" style={{ color }}>
+        hooks: {label}
+      </span>
+      <div className="hidden group-hover:block absolute z-10 bottom-full right-0 mb-1 p-2 rounded bg-[#1C2128] border border-[#30363D] shadow-lg text-xs whitespace-nowrap">
+        <span className="text-[#C9D1D9]">{tooltip}</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Install detail categories (reused from original)
 // ---------------------------------------------------------------------------
 
@@ -259,6 +290,8 @@ function InstallHealthDetail({ project, repoSettings }: { project: ProjectSummar
           </div>
         );
       })}
+      {/* Hook mode badge (issue #735) \u2014 HTTP / Bash / Unknown */}
+      <HookModeBadge project={project} />
       {/* Git commit status badge */}
       {s.gitCommitStatus && (
         <div className="relative group shrink-0">
@@ -677,7 +710,12 @@ function ProjectCard({
   onSaveLimit: (projectId: number, value: number) => void;
   onSaveModel: (projectId: number, value: string) => void;
   onSaveEffort: (projectId: number, value: string) => void;
-  onReinstall: (p: ProjectSummary) => void;
+  /**
+   * Reinstall callback. Second arg is the hook deployment mode the user
+   * selected in the mode picker (issue #735). The card always passes a
+   * concrete value so the API call always gets an explicit mode.
+   */
+  onReinstall: (p: ProjectSummary, mode: 'http' | 'bash') => void;
   onCleanup: (p: ProjectSummary) => void;
   onDelete: (p: ProjectSummary) => void;
   onGroupChange: (projectId: number, groupId: number | null) => void;
@@ -688,6 +726,12 @@ function ProjectCard({
   const [committing, setCommitting] = useState(false);
   const [commitResult, setCommitResult] = useState<{ ok: boolean; error?: string; message?: string } | null>(null);
   const [repoSettingsLoaded, setRepoSettingsLoaded] = useState(false);
+  // Mode picker state — defaults to the project's recorded hookMode, or
+  // 'http' for new/unknown projects (issue #735). Operators can flip this
+  // before clicking Reinstall to migrate between transports.
+  const [selectedMode, setSelectedMode] = useState<'http' | 'bash'>(
+    project.hookMode === 'bash' ? 'bash' : 'http',
+  );
   const limitEdit = useInlineEdit<number>(project.maxActiveTeams);
   const modelEdit = useInlineEdit<string>(project.model ?? '');
 
@@ -773,15 +817,28 @@ function ProjectCard({
           </span>
         )}
 
-        {/* Reinstall button */}
+        {/* Hook mode picker + Reinstall button (issue #735) — operators can
+            flip http <-> bash before triggering a reinstall. Defaults to the
+            project's recorded mode, or HTTP for new/unknown projects. */}
+        <select
+          value={selectedMode}
+          onChange={(e) => setSelectedMode(e.target.value as 'http' | 'bash')}
+          onClick={(e) => e.stopPropagation()}
+          disabled={reinstalling === project.id}
+          className="px-2 py-1 text-xs rounded border border-dark-border bg-dark-bg text-dark-text shrink-0 disabled:opacity-40"
+          title="Hook deployment mode — applied on next reinstall"
+        >
+          <option value="http">HTTP (default)</option>
+          <option value="bash">Bash (legacy)</option>
+        </select>
         <button
-          onClick={(e) => { e.stopPropagation(); onReinstall(project); }}
+          onClick={(e) => { e.stopPropagation(); onReinstall(project, selectedMode); }}
           disabled={reinstalling === project.id}
           className="px-3 py-1 text-xs rounded border border-dark-accent/40 text-dark-accent bg-dark-accent/10 hover:bg-dark-accent/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           title={
             (project.installStatus?.outdatedCount ?? 0) > 0
-              ? `Reinstall (${project.installStatus!.outdatedCount} file${project.installStatus!.outdatedCount === 1 ? '' : 's'} outdated)`
-              : '(Re)install hooks, settings, and workflow prompt'
+              ? `Reinstall in ${selectedMode.toUpperCase()} mode (${project.installStatus!.outdatedCount} file${project.installStatus!.outdatedCount === 1 ? '' : 's'} outdated)`
+              : `(Re)install hooks, settings, and workflow prompt in ${selectedMode.toUpperCase()} mode`
           }
         >
           {reinstalling === project.id ? 'Installing...' : 'Reinstall'}
@@ -1365,7 +1422,7 @@ export function ProjectsPage() {
   }, [fetchProjects]);
 
   const handleReinstall = useCallback(
-    async (project: ProjectSummary) => {
+    async (project: ProjectSummary, mode: 'http' | 'bash') => {
       setReinstalling(project.id);
       setReinstallResult(null);
       try {
@@ -1376,15 +1433,23 @@ export function ProjectsPage() {
           installStatus?: ProjectSummary['installStatus'];
         }>(
           `projects/${project.id}/install`,
-          {},
+          { mode },
         );
         setReinstallResult({ id: project.id, ok: data.ok, error: data.error });
-        // Optimistic update: use the install status from the response
-        if (data.installStatus) {
-          setProjects((prev) =>
-            prev.map((p) => (p.id === project.id ? { ...p, installStatus: data.installStatus } : p)),
-          );
-        }
+        // Optimistic update: use the install status from the response and
+        // flip the hookMode badge to the requested mode so the UI doesn't
+        // wait for a fetchProjects round-trip (issue #735).
+        setProjects((prev) =>
+          prev.map((p) =>
+            p.id === project.id
+              ? {
+                  ...p,
+                  hookMode: mode,
+                  installStatus: data.installStatus ?? p.installStatus,
+                }
+              : p,
+          ),
+        );
       } catch (err: unknown) {
         setReinstallResult({
           id: project.id,

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -243,6 +243,8 @@ export interface ProjectInsert {
   issueProvider?: string | null;
   projectKey?: string | null;
   providerConfig?: string | null;
+  /** Hook deployment mode: 'http' (default for new projects), 'bash' (legacy), or null (unknown). */
+  hookMode?: 'http' | 'bash' | null;
 }
 
 export interface ProjectUpdate {
@@ -260,6 +262,8 @@ export interface ProjectUpdate {
   providerConfig?: string | null;
   autoMergeEnabled?: boolean | null;
   autoMergeCheckedAt?: string | null;
+  /** Hook deployment mode: 'http' / 'bash' / null. Updated on (re)install. */
+  hookMode?: 'http' | 'bash' | null;
 }
 
 export interface ProjectGroupInsert {
@@ -456,6 +460,9 @@ export class FleetDatabase {
 
     // Add team_subworktrees table if missing (v24 migration — CC-initiated subworktrees)
     this.addTeamSubworktreesTable();
+
+    // Add hook_mode column to projects (v25 migration — HTTP vs bash hooks, issue #735)
+    this.addHookModeColumn();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1447,6 +1454,37 @@ export class FleetDatabase {
   }
 
   /**
+   * Add hook_mode column to projects table if it doesn't exist (v25 migration).
+   *
+   * Records which hook deployment mode each project uses:
+   *   - 'http': native HTTP hooks (CC 2.1.62+, default for new projects).
+   *   - 'bash': legacy bash+curl hooks (fallback for older CC versions).
+   *   - NULL : pre-issue-#735 projects whose mode has not yet been recorded.
+   *            The UI surfaces these as "Unknown" so the operator can flip
+   *            them explicitly on the next reinstall.
+   *
+   * Fresh databases get the column via schema.sql; upgraded databases use
+   * this migration. Idempotent across restarts. Issue #735.
+   */
+  private addHookModeColumn(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+      // Fresh DB: projects table doesn't exist yet — schema.sql will create it
+      // with hook_mode already present. Nothing to migrate.
+      if (cols.length === 0) return;
+      const hasColumn = cols.some((c) => c.name === 'hook_mode');
+      if (!hasColumn) {
+        this.db.exec('ALTER TABLE projects ADD COLUMN hook_mode TEXT');
+        console.log('[DB] v25 migration: added hook_mode column to projects');
+      }
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (25)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v25 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
    * Migrate branch_behind and branch_behind_resolved message templates
    * from hardcoded 'main' to use {{BASE_BRANCH}} placeholder.
    * Only updates templates that exactly match the old defaults (user edits are preserved).
@@ -1507,8 +1545,8 @@ export class FleetDatabase {
   insertProject(data: ProjectInsert): Project {
     const now = new Date().toISOString();
     const stmt = this.stmt(`
-      INSERT INTO projects (name, repo_path, github_repo, group_id, max_active_teams, prompt_file, model, effort, issue_provider, project_key, provider_config, created_at, updated_at)
-      VALUES (@name, @repoPath, @githubRepo, @groupId, @maxActiveTeams, @promptFile, @model, @effort, @issueProvider, @projectKey, @providerConfig, @createdAt, @updatedAt)
+      INSERT INTO projects (name, repo_path, github_repo, group_id, max_active_teams, prompt_file, model, effort, issue_provider, project_key, provider_config, hook_mode, created_at, updated_at)
+      VALUES (@name, @repoPath, @githubRepo, @groupId, @maxActiveTeams, @promptFile, @model, @effort, @issueProvider, @projectKey, @providerConfig, @hookMode, @createdAt, @updatedAt)
     `);
 
     const info = stmt.run({
@@ -1523,6 +1561,7 @@ export class FleetDatabase {
       issueProvider: data.issueProvider ?? 'github',
       projectKey: data.projectKey ?? null,
       providerConfig: data.providerConfig ? encrypt(data.providerConfig) : null,
+      hookMode: data.hookMode ?? null,
       createdAt: now,
       updatedAt: now,
     });
@@ -1640,6 +1679,10 @@ export class FleetDatabase {
     if (fields.autoMergeCheckedAt !== undefined) {
       setClauses.push('auto_merge_checked_at = @autoMergeCheckedAt');
       params.autoMergeCheckedAt = fields.autoMergeCheckedAt;
+    }
+    if (fields.hookMode !== undefined) {
+      setClauses.push('hook_mode = @hookMode');
+      params.hookMode = fields.hookMode;
     }
 
     if (setClauses.length === 0) return this.getProject(id);
@@ -3397,6 +3440,12 @@ export class FleetDatabase {
         ? null
         : (rawAutoMerge as number) === 1;
 
+    // Coerce hook_mode to the narrowed union; treat unexpected values as null
+    // so a corrupted column never confuses callers.
+    const rawHookMode = row.hook_mode as string | null | undefined;
+    const hookMode: 'http' | 'bash' | null =
+      rawHookMode === 'http' || rawHookMode === 'bash' ? rawHookMode : null;
+
     return {
       id: row.id as number,
       name: row.name as string,
@@ -3414,6 +3463,7 @@ export class FleetDatabase {
       providerConfig,
       autoMergeEnabled,
       autoMergeCheckedAt: (row.auto_merge_checked_at as string | null) ?? null,
+      hookMode,
       createdAt: utcify(row.created_at as string),
       updatedAt: utcify(row.updated_at as string),
     };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import queryRoutes from './routes/query.js';
 import issueSourcesRoutes from './routes/issue-sources.js';
 import issueRelationsRoutes from './routes/issue-relations.js';
 import handoffRoutes from './routes/handoff.js';
+import hooksRoutes from './routes/hooks.js';
 import { sseBroker } from './services/sse-broker.js';
 import { getIssueFetcher } from './services/issue-fetcher.js';
 import { stuckDetector } from './services/stuck-detector.js';
@@ -75,6 +76,7 @@ async function main() {
 
   // API routes
   await server.register(eventsRoutes);
+  await server.register(hooksRoutes);
   await server.register(streamRoutes);
   await server.register(issueRoutes);
   await server.register(teamsRoutes);

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -7,6 +7,7 @@ import { getTeamManager } from '../services/team-manager.js';
 import { getEventService } from '../services/event-service.js';
 import { ServiceError } from '../services/service-error.js';
 import { parseOptionalIdParam } from '../utils/parse-params.js';
+import { buildEventPayloadFromCc } from '../utils/build-event-payload.js';
 
 interface EventQuerystring {
   team_id?: string;
@@ -28,82 +29,48 @@ function str(val: unknown): string | undefined {
 
 /**
  * New format: shell sends event, team, timestamp, and raw cc_stdin.
- * Server parses cc_stdin with JSON.parse() and extracts all CC fields.
+ * Server parses cc_stdin with JSON.parse() and delegates the field
+ * extraction to `buildEventPayloadFromCc` (shared with the HTTP hook route).
+ *
+ * We preserve the raw `cc_stdin` string the shell sent (rather than
+ * re-serializing the parsed object) because:
+ *   - the TaskCreated handler in event-collector parses cc_stdin back into
+ *     an object, which works either way;
+ *   - the dedup fingerprint hashes the full payload — a stable cc_stdin
+ *     string keeps fingerprints comparable across CC versions whose JSON
+ *     key order may vary;
+ *   - existing unit tests in event-collector.test.ts assert on the original
+ *     cc_stdin string for malformed / non-object inputs.
  */
 function buildPayloadFromCcStdin(body: Record<string, unknown>): EventPayload {
-  const payload: EventPayload = {
-    event: String(body.event),
-    team: String(body.team),
-    timestamp: str(body.timestamp),
-    cc_stdin: String(body.cc_stdin),
-  };
+  const eventType = String(body.event);
+  const team = String(body.team);
+  const timestamp = str(body.timestamp);
+  const ccStdinRaw = String(body.cc_stdin);
 
-  // Parse raw CC stdin JSON
   let cc: Record<string, unknown> = {};
   try {
-    const parsed: unknown = JSON.parse(String(body.cc_stdin));
+    const parsed: unknown = JSON.parse(ccStdinRaw);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       cc = parsed as Record<string, unknown>;
     }
   } catch {
-    // If cc_stdin is not valid JSON, store it as-is but extract nothing
-    return payload;
+    // Malformed JSON — preserve the raw string in cc_stdin (so TaskCreated
+    // and the dedup fingerprint still work) but skip field extraction.
+    return {
+      event: eventType,
+      team,
+      timestamp,
+      cc_stdin: ccStdinRaw,
+    };
   }
 
-  // Extract known CC fields
-  payload.session_id = str(cc.session_id);
-  payload.tool_name = str(cc.tool_name);
-  payload.agent_type = str(cc.agent_type);
-  payload.teammate_name = str(cc.teammate_name);
-  payload.message = str(cc.message);
-  payload.error = str(cc.error);
-  payload.tool_use_id = str(cc.tool_use_id);
-  payload.error_details = str(cc.error_details);
-  payload.last_assistant_message = str(cc.last_assistant_message);
-
-  // duration_ms: tool execution time in milliseconds (CC 2.1.119+, PostToolUse/PostToolUseFailure only).
-  // CC emits this as a real number; reject any other type defensively (strings, NaN, Infinity).
-  if (typeof cc.duration_ms === 'number' && Number.isFinite(cc.duration_ms)) {
-    payload.duration_ms = cc.duration_ms;
-  }
-
-  // tool_input: CC sends this as an object; stringify it for storage
-  if (cc.tool_input !== undefined && cc.tool_input !== null) {
-    payload.tool_input = typeof cc.tool_input === 'string'
-      ? cc.tool_input
-      : JSON.stringify(cc.tool_input);
-  }
-
-  // Extract SendMessage routing fields from parsed tool_input
-  if (payload.tool_name === 'SendMessage' && cc.tool_input && typeof cc.tool_input === 'object') {
-    const toolInput = cc.tool_input as Record<string, unknown>;
-    payload.msg_to = str(toolInput.to);
-    payload.msg_summary = str(toolInput.summary);
-  }
-
-  // Worktree fields
-  payload.worktree_root = str(cc.worktree_root);
-  payload.worktree_path = str(cc.worktree_path);
-
-  // New fields that CC provides but were previously dropped by shell regex
-  payload.model = str(cc.model);
-  payload.source = str(cc.source);
-  payload.notification_type = str(cc.notification_type);
-  payload.agent_id = str(cc.agent_id);
-  payload.owner = str(cc.owner);
-  payload.cwd = str(cc.cwd);
-
-  // Issue #730: CC 2.1.145+ Stop/SubagentStop hook input ships arrays of
-  // pending background tasks and session crons. Stringify them so they fit
-  // the EventPayload shape (string-only fields). The legacy shell hook path
-  // cannot transmit these — they only flow through cc_stdin.
-  if (Array.isArray(cc.background_tasks)) {
-    payload.background_tasks = JSON.stringify(cc.background_tasks);
-  }
-  if (Array.isArray(cc.session_crons)) {
-    payload.session_crons = JSON.stringify(cc.session_crons);
-  }
-
+  // Delegate to the shared builder, then overwrite cc_stdin with the raw
+  // string the shell originally sent (the builder re-serializes the parsed
+  // object, which is canonical but not guaranteed bit-identical to the
+  // shell's input).
+  const payload = buildEventPayloadFromCc(cc, team, eventType, timestamp);
+  payload.cc_stdin = ccStdinRaw;
   return payload;
 }
 

--- a/src/server/routes/hooks.ts
+++ b/src/server/routes/hooks.ts
@@ -69,6 +69,10 @@ const PASCAL_TO_SNAKE: Record<string, string> = {
   PostToolUseFailure: 'tool_error',
   TeammateIdle: 'teammate_idle',
   TaskCreated: 'task_created',
+  // CC 2.1.49+ — fired when CC creates/removes a subworktree
+  // via --worktree, EnterWorktree, or subagent isolation=worktree (issue #731).
+  WorktreeCreate: 'worktree_create',
+  WorktreeRemove: 'worktree_remove',
 };
 
 const VALID_EVENT_TYPES = new Set(Object.keys(PASCAL_TO_SNAKE));

--- a/src/server/routes/hooks.ts
+++ b/src/server/routes/hooks.ts
@@ -1,0 +1,206 @@
+// =============================================================================
+// Fleet Commander — Native HTTP Hook Route
+// =============================================================================
+// Native HTTP hook endpoint for Claude Code 2.1.62+. When a target repo's
+// .claude/settings.json uses `{ "type": "http", "url": "..." }` hook entries,
+// CC POSTs each hook's stdin JSON directly to this route instead of spawning
+// a bash+curl subshell.
+//
+// Endpoint: POST /api/hooks/:eventType
+//   :eventType is the PascalCase CC hook name (SessionStart, PostToolUse, ...).
+//
+// Request body: the raw CC hook input object (the same JSON CC would have
+// piped to a script's stdin). Common fields include session_id, cwd, tool_name,
+// tool_input, message, error, etc.
+//
+// Response:
+//   - 204 No Content on success (fire-and-forget — CC ignores the body)
+//   - 400 Bad Request for unknown event types, missing cwd, malformed JSON
+//   - 404 Not Found when the cwd does not resolve to a registered team
+//   - 500 Internal Server Error on unexpected exceptions (logged server-side)
+//
+// All processing is best-effort: a route-level try/catch ensures failures
+// never propagate to CC, matching the fire-and-forget contract of the legacy
+// bash hooks.
+// =============================================================================
+
+import type {
+  FastifyInstance,
+  FastifyPluginCallback,
+  FastifyReply,
+  FastifyRequest,
+} from 'fastify';
+import { processEvent, EventCollectorError } from '../services/event-collector.js';
+import type {
+  EventCollectorDb,
+  LastAssistantMessageSink,
+  SseBroker,
+  TeamMessageSender,
+} from '../services/event-collector.js';
+import { getDatabase } from '../db.js';
+import { sseBroker } from '../services/sse-broker.js';
+import { getTeamManager } from '../services/team-manager.js';
+import { buildEventPayloadFromCc } from '../utils/build-event-payload.js';
+import { resolveTeamFromHookBody } from '../utils/team-resolution.js';
+
+// ---------------------------------------------------------------------------
+// Event name mapping — PascalCase (CC hook name) -> snake_case (FC event name)
+// ---------------------------------------------------------------------------
+// The event-collector pipeline historically uses snake_case event types
+// (`session_start`, `tool_use`, ...). CC hooks fire under PascalCase names
+// (`SessionStart`, `PostToolUse`, ...). The legacy shell hook performed this
+// mapping in `run-hook.sh` (`bash run-hook.sh session_start ...`) before
+// POSTing; the HTTP route does it here so the URL stays PascalCase and the
+// event-collector contract is unchanged.
+//
+// Keep this map in sync with `hooks/settings.json.example` and
+// `hooks/settings.json.http.example` — every hook type registered in either
+// template must have an entry here.
+const PASCAL_TO_SNAKE: Record<string, string> = {
+  SessionStart: 'session_start',
+  SessionEnd: 'session_end',
+  Stop: 'stop',
+  StopFailure: 'stop_failure',
+  SubagentStart: 'subagent_start',
+  SubagentStop: 'subagent_stop',
+  Notification: 'notification',
+  PreCompact: 'pre_compact',
+  PostToolUse: 'tool_use',
+  PostToolUseFailure: 'tool_error',
+  TeammateIdle: 'teammate_idle',
+  TaskCreated: 'task_created',
+};
+
+const VALID_EVENT_TYPES = new Set(Object.keys(PASCAL_TO_SNAKE));
+
+// Stop-family events that should trigger queue reprocessing (so queued teams
+// can launch when a slot frees up). Mirrors the same set used in
+// routes/events.ts so both code paths converge.
+const STOP_FAMILY = new Set(['stop', 'stop_failure', 'session_end']);
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+interface HookParams {
+  eventType: string;
+}
+
+const hooksRoutes: FastifyPluginCallback = (
+  fastify: FastifyInstance,
+  _opts: Record<string, unknown>,
+  done: (err?: Error) => void,
+) => {
+  fastify.post(
+    '/api/hooks/:eventType',
+    async (
+      request: FastifyRequest<{ Params: HookParams }>,
+      reply: FastifyReply,
+    ) => {
+      // Top-level try/catch — CC must never see a 5xx panic. On any unhandled
+      // exception we log and return 500 with a generic body so the hook
+      // path stays fire-and-forget from CC's perspective.
+      try {
+        const { eventType } = request.params;
+
+        if (!VALID_EVENT_TYPES.has(eventType)) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: `Unknown hook event type: ${eventType}`,
+          });
+        }
+
+        const body = request.body as Record<string, unknown> | undefined;
+        if (!body || typeof body !== 'object' || Array.isArray(body)) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Hook body must be a JSON object',
+          });
+        }
+
+        // Resolve team from cwd / transcript_path. CC always populates one of
+        // these; if neither is present the hook config is broken so we reject
+        // with 400 (not 404) to surface the actual problem.
+        const team = resolveTeamFromHookBody(body);
+        if (!team) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Hook body missing cwd / transcript_path — cannot resolve team',
+          });
+        }
+
+        // Verify the team exists before processing so we can return 404
+        // explicitly. processEvent would also throw TEAM_NOT_FOUND, but
+        // checking upfront keeps the error path symmetric with the legacy
+        // /api/events route and yields a cleaner log line.
+        const db = getDatabase();
+        const teamRow = db.getTeamByWorktree(team);
+        if (!teamRow) {
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: `Team not found for worktree: ${team}`,
+          });
+        }
+
+        const snakeEvent = PASCAL_TO_SNAKE[eventType];
+        const payload = buildEventPayloadFromCc(body, team, snakeEvent);
+
+        const manager = getTeamManager();
+        try {
+          processEvent(
+            payload,
+            db as unknown as EventCollectorDb,
+            sseBroker as unknown as SseBroker,
+            manager as unknown as TeamMessageSender,
+            manager as unknown as LastAssistantMessageSink,
+          );
+        } catch (err) {
+          if (err instanceof EventCollectorError) {
+            const status = err.code === 'TEAM_NOT_FOUND' ? 404 : 400;
+            return reply.code(status).send({
+              error: status === 404 ? 'Not Found' : 'Bad Request',
+              message: err.message,
+            });
+          }
+          throw err;
+        }
+
+        // Queue reprocessing on stop-family events — mirrors routes/events.ts.
+        if (STOP_FAMILY.has(snakeEvent) && teamRow.projectId) {
+          manager.processQueue(teamRow.projectId).catch((qErr) => {
+            request.log.error(
+              qErr,
+              'processQueue error after stop/session_end/stop_failure HTTP hook',
+            );
+          });
+        }
+
+        // Fire-and-forget — CC ignores the body so 204 is the correct minimal
+        // success signal.
+        return reply.code(204).send();
+      } catch (err: unknown) {
+        // Unexpected exception — log with as much context as we have and
+        // return a generic 500. We deliberately do NOT propagate the error
+        // (no Fastify default error handler) to keep CC's hook path
+        // non-blocking.
+        const body = request.body as Record<string, unknown> | undefined;
+        request.log.error(
+          { err, eventType: request.params.eventType, cwd: body?.cwd },
+          'HTTP hook processing failed',
+        );
+        return reply.code(500).send({
+          error: 'Internal Server Error',
+          message: 'Failed to process hook event',
+        });
+      }
+    },
+  );
+
+  done();
+};
+
+export default hooksRoutes;
+
+// Exported for tests so they can verify the canonical event-name map
+// matches the templates and CC docs.
+export { PASCAL_TO_SNAKE, VALID_EVENT_TYPES };

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -240,18 +240,36 @@ const projectsRoutes: FastifyPluginCallback = (
 
   // -------------------------------------------------------------------------
   // POST /api/projects/:id/install — (re)install hooks, settings, prompt
+  // Accepts optional body { mode: 'http' | 'bash' } to flip the hook
+  // deployment mode (issue #735). Defaults to 'http' when omitted, matching
+  // service-layer behavior.
   // -------------------------------------------------------------------------
   fastify.post(
     '/api/projects/:id/install',
     async (
-      request: FastifyRequest<{ Params: ProjectIdParams }>,
+      request: FastifyRequest<{ Params: ProjectIdParams; Body?: { mode?: 'http' | 'bash' } }>,
       reply: FastifyReply,
     ) => {
       try {
         const projectId = parseIdParam(request.params.id, 'id');
 
+        // Validate mode if explicitly provided. We accept undefined / missing
+        // body and let the service apply its default. Reject any other value
+        // with 400 to surface client typos early.
+        const body = (request.body ?? {}) as { mode?: unknown };
+        let mode: 'http' | 'bash' | undefined;
+        if (body.mode !== undefined) {
+          if (body.mode !== 'http' && body.mode !== 'bash') {
+            return reply.code(400).send({
+              error: 'Bad Request',
+              message: `Invalid hook mode: ${String(body.mode)}. Must be 'http' or 'bash'.`,
+            });
+          }
+          mode = body.mode;
+        }
+
         const service = getProjectService();
-        const result = service.installHooksForProject(projectId);
+        const result = service.installHooksForProject(projectId, mode ? { mode } : undefined);
         return reply.code(200).send(result);
       } catch (err: unknown) {
         if (err instanceof ServiceError) {

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS projects (
   provider_config TEXT,                               -- JSON blob of provider-specific configuration
   auto_merge_enabled INTEGER,                         -- 0|1|NULL (NULL = unknown / not yet detected; non-GitHub projects stay NULL)
   auto_merge_checked_at TEXT,                         -- ISO timestamp of last gh check, or NULL
+  hook_mode       TEXT,                               -- 'http' | 'bash' | NULL (NULL = legacy / not yet set; new projects default to 'http' via the install path)
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -447,4 +448,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_team_subworktrees_team_path_active
   ON team_subworktrees(team_id, path) WHERE removed_at IS NULL;
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (24);
+INSERT OR IGNORE INTO schema_version (version) VALUES (25);

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -989,8 +989,10 @@ export class ProjectService {
       }
     }
 
-    // Install hooks (non-fatal)
-    const installResult = installHooks(normalizedPath, _minimalLogger);
+    // Install hooks (non-fatal) — new projects default to HTTP mode per
+    // issue #735. The mode is recorded on the project row so the UI can
+    // surface it and so reinstall flows know what to flip to/from.
+    const installResult = installHooks(normalizedPath, _minimalLogger, { mode: 'http' });
     if (!installResult.ok) {
       console.warn(`[ProjectService] Hook installation failed for ${normalizedPath}: ${installResult.stderr}`);
     }
@@ -1002,7 +1004,12 @@ export class ProjectService {
     const status = checkInstallStatus(normalizedPath);
     const allInstalled = status.hooks.installed && status.prompt.installed;
     if (allInstalled) {
-      db.updateProject(project.id, { hooksInstalled: true });
+      db.updateProject(project.id, { hooksInstalled: true, hookMode: 'http' });
+    } else {
+      // Still record the requested mode even if some artifacts are missing —
+      // the operator's intent was http; partial-install state is captured
+      // separately via hooksInstalled.
+      db.updateProject(project.id, { hookMode: 'http' });
     }
 
     // Re-fetch to get updated hooks_installed
@@ -1140,10 +1147,17 @@ export class ProjectService {
    * and updates the DB accordingly.
    *
    * @param projectId - The project ID
+   * @param opts.mode - Hook deployment mode: 'http' (default) or 'bash'.
+   *                    Forwarded to installHooks() and persisted on the
+   *                    project row so the UI badge and future reinstalls
+   *                    know which mode this project uses. Issue #735.
    * @returns Install result with status details
    * @throws ServiceError with code NOT_FOUND if project doesn't exist
    */
-  installHooksForProject(projectId: number): {
+  installHooksForProject(
+    projectId: number,
+    opts?: { mode?: 'http' | 'bash' },
+  ): {
     ok: boolean;
     output: string;
     error?: string;
@@ -1155,13 +1169,16 @@ export class ProjectService {
       throw notFoundError(`Project ${projectId} not found`);
     }
 
-    const result = installHooks(project.repoPath, _minimalLogger);
+    const mode = opts?.mode ?? 'http';
+    const result = installHooks(project.repoPath, _minimalLogger, { mode });
 
     // Invalidate cache and check what actually landed on disk
     invalidateInstallStatusCache(project.repoPath);
     const status = checkInstallStatus(project.repoPath);
     const allInstalled = status.hooks.installed && status.prompt.installed;
-    db.updateProject(project.id, { hooksInstalled: allInstalled });
+    // Persist the requested mode even if some artifacts are missing — it
+    // captures operator intent. hooksInstalled tracks completeness separately.
+    db.updateProject(project.id, { hooksInstalled: allInstalled, hookMode: mode });
 
     // Broadcast so UI refreshes badges
     sseBroker.broadcast('project_updated', {

--- a/src/server/utils/build-event-payload.ts
+++ b/src/server/utils/build-event-payload.ts
@@ -1,0 +1,117 @@
+// =============================================================================
+// Fleet Commander — Build EventPayload from CC stdin
+// =============================================================================
+// Shared helper that converts a parsed Claude Code hook stdin object into the
+// canonical `EventPayload` shape consumed by the event-collector pipeline.
+//
+// Two routes need this conversion today:
+//   1. POST /api/events (legacy shell hook path, routes/events.ts) — the shell
+//      wrapper forwards `cc_stdin` as a JSON string; the route handler parses
+//      it and then calls this helper.
+//   2. POST /api/hooks/:eventType (HTTP hook path, routes/hooks.ts) — CC POSTs
+//      its hook input directly. The route handler treats the entire body as
+//      `ccBody` and calls this helper with the snake_case event type.
+//
+// Extracting the field-mapping logic here keeps both paths bit-identical: any
+// future addition to the CC schema only needs to land in one place.
+// =============================================================================
+
+import type { EventPayload } from '../services/event-collector.js';
+
+/** Helper to safely extract a string from an unknown value. Mirrors routes/events.ts. */
+function str(val: unknown): string | undefined {
+  if (val === undefined || val === null || val === '') return undefined;
+  return String(val);
+}
+
+/**
+ * Build an EventPayload from a parsed Claude Code hook stdin object.
+ *
+ * @param ccBody     - Parsed CC hook input (the JSON object CC ships on stdin).
+ * @param team       - Worktree name (FC's team key). Caller is responsible
+ *                     for resolving this from `ccBody.cwd` via the
+ *                     `resolveTeamFromHookBody` helper before calling.
+ * @param eventType  - snake_case event type (e.g. `session_start`, `tool_use`).
+ *                     For the HTTP route this is derived from the URL param;
+ *                     for the legacy route it is forwarded from the shell.
+ * @param timestamp  - Optional ISO timestamp. When omitted the event-collector
+ *                     applies its own `new Date().toISOString()` so this is
+ *                     fine to leave undefined for the HTTP path.
+ */
+export function buildEventPayloadFromCc(
+  ccBody: Record<string, unknown>,
+  team: string,
+  eventType: string,
+  timestamp?: string,
+): EventPayload {
+  const payload: EventPayload = {
+    event: eventType,
+    team,
+    timestamp,
+    // Preserve the full ccBody as a JSON string. The TaskCreated handler in
+    // event-collector parses `cc_stdin` for task_id/subject/description/etc.
+    // and the dedup fingerprint uses the payload string, so this must stay
+    // bit-identical to what the legacy shell hook would have sent.
+    cc_stdin: JSON.stringify(ccBody),
+  };
+
+  payload.session_id = str(ccBody.session_id);
+  payload.tool_name = str(ccBody.tool_name);
+  payload.agent_type = str(ccBody.agent_type);
+  payload.teammate_name = str(ccBody.teammate_name);
+  payload.message = str(ccBody.message);
+  payload.error = str(ccBody.error);
+  payload.tool_use_id = str(ccBody.tool_use_id);
+  payload.error_details = str(ccBody.error_details);
+  payload.last_assistant_message = str(ccBody.last_assistant_message);
+
+  // duration_ms: tool execution time in milliseconds (CC 2.1.119+, PostToolUse/
+  // PostToolUseFailure only). CC emits this as a real number; reject any other
+  // type defensively (strings, NaN, Infinity).
+  if (typeof ccBody.duration_ms === 'number' && Number.isFinite(ccBody.duration_ms)) {
+    payload.duration_ms = ccBody.duration_ms;
+  }
+
+  // tool_input: CC sends this as an object; stringify it for storage. The
+  // event-collector parses it back to JSON for SendMessage routing and the
+  // spawn-prompt extraction, so the round-trip must be lossless.
+  if (ccBody.tool_input !== undefined && ccBody.tool_input !== null) {
+    payload.tool_input = typeof ccBody.tool_input === 'string'
+      ? ccBody.tool_input
+      : JSON.stringify(ccBody.tool_input);
+  }
+
+  // Extract SendMessage routing fields from the parsed tool_input. This is
+  // the contract that lets event-collector populate agent_messages rows.
+  if (payload.tool_name === 'SendMessage' && ccBody.tool_input && typeof ccBody.tool_input === 'object') {
+    const toolInput = ccBody.tool_input as Record<string, unknown>;
+    payload.msg_to = str(toolInput.to);
+    payload.msg_summary = str(toolInput.summary);
+  }
+
+  // Worktree-aware fields (some CC versions populate these).
+  payload.worktree_root = str(ccBody.worktree_root);
+  payload.worktree_path = str(ccBody.worktree_path);
+
+  // Additional fields CC provides but the legacy shell regex used to drop.
+  payload.model = str(ccBody.model);
+  payload.source = str(ccBody.source);
+  payload.notification_type = str(ccBody.notification_type);
+  payload.agent_id = str(ccBody.agent_id);
+  payload.owner = str(ccBody.owner);
+  payload.cwd = str(ccBody.cwd);
+
+  // CC 2.1.145+ Stop / SubagentStop hook input ships arrays of pending
+  // background tasks and session crons. Stringify them so they fit the
+  // EventPayload string-only schema (see issue #730). The legacy shell
+  // path could not transmit these without cc_stdin; the HTTP path always
+  // can.
+  if (Array.isArray(ccBody.background_tasks)) {
+    payload.background_tasks = JSON.stringify(ccBody.background_tasks);
+  }
+  if (Array.isArray(ccBody.session_crons)) {
+    payload.session_crons = JSON.stringify(ccBody.session_crons);
+  }
+
+  return payload;
+}

--- a/src/server/utils/fc-manifest.ts
+++ b/src/server/utils/fc-manifest.ts
@@ -58,11 +58,27 @@ export function getWorkflowFile(): string {
 }
 
 /**
- * Get the settings example filename.
- * Returns 'settings.json.example'.
+ * Get the settings example filename for the requested hook deployment mode.
+ *
+ * - `'bash'` (default, backward-compat): `'settings.json.example'` — the
+ *   legacy bash+curl template.
+ * - `'http'`: `'settings.json.http.example'` — native HTTP hooks template
+ *   added by issue #735.
+ *
+ * Callers that need both filenames (e.g. install validation) should call
+ * this once per mode rather than hardcoding the names.
  */
-export function getSettingsExampleFile(): string {
-  return 'settings.json.example';
+export function getSettingsExampleFile(mode: 'bash' | 'http' = 'bash'): string {
+  return mode === 'http' ? 'settings.json.http.example' : 'settings.json.example';
+}
+
+/**
+ * Convenience wrapper for the HTTP settings example filename. Equivalent to
+ * `getSettingsExampleFile('http')`. Exists so the manifest's static shape
+ * can carry both filenames without callers needing the literal string.
+ */
+export function getHttpSettingsExampleFile(): string {
+  return getSettingsExampleFile('http');
 }
 
 /**
@@ -118,8 +134,10 @@ export interface FCManifest {
   guides: string[];
   /** Workflow prompt filename (always 'fleet-workflow.md') */
   workflow: string;
-  /** Settings example filename (always 'settings.json.example') */
+  /** Bash-mode settings example filename (always 'settings.json.example') */
   settingsExample: string;
+  /** HTTP-mode settings example filename (always 'settings.json.http.example') — issue #735 */
+  httpSettingsExample: string;
   /** Explicit .gitignore entries for FC-managed files */
   gitignoreEntries: string[];
 }
@@ -135,7 +153,8 @@ export function getAllManagedFiles(): FCManifest {
     agents: getAgentFiles(),
     guides: getGuideFiles(),
     workflow: getWorkflowFile(),
-    settingsExample: getSettingsExampleFile(),
+    settingsExample: getSettingsExampleFile('bash'),
+    httpSettingsExample: getSettingsExampleFile('http'),
     gitignoreEntries: getGitignoreEntries(),
   };
 }

--- a/src/server/utils/hook-installer.ts
+++ b/src/server/utils/hook-installer.ts
@@ -84,8 +84,19 @@ export function toBashPath(p: string): string {
 /**
  * Install Fleet Commander hooks into a project repo.
  * Returns { ok, stdout, stderr } so callers can log / surface errors.
+ *
+ * @param opts.mode  Hook deployment mode: 'http' (default, CC 2.1.62+) or
+ *                   'bash' (legacy bash+curl path). Forwarded to install.sh
+ *                   via `--mode`. Issue #735.
+ * @param opts.port  FC server port baked into the http template's
+ *                   {{FLEET_PORT}} placeholder. Defaults to `config.port`.
+ *                   Forwarded to install.sh via `--port`.
  */
-export function installHooks(repoPath: string, logger: FastifyBaseLogger): { ok: boolean; stdout: string; stderr: string } {
+export function installHooks(
+  repoPath: string,
+  logger: FastifyBaseLogger,
+  opts?: { mode?: 'http' | 'bash'; port?: number },
+): { ok: boolean; stdout: string; stderr: string } {
   const fail = (msg: string) => ({ ok: false, stdout: '', stderr: msg });
 
   const scriptPath = path.join(config.fleetCommanderRoot, 'scripts', 'install.sh');
@@ -93,12 +104,16 @@ export function installHooks(repoPath: string, logger: FastifyBaseLogger): { ok:
     return fail(`install.sh not found at ${scriptPath}`);
   }
 
+  const mode = opts?.mode ?? 'http';
+  const port = opts?.port ?? config.port;
+
   // On Windows, use Git Bash with forward-slash paths (Git Bash handles C:/ natively)
   // Use --login so /etc/profile is sourced and PATH includes /usr/bin (dirname, mkdir, etc.)
   const bash = getGitBash();
+  const modeArgs = `--mode ${mode} --port ${port}`;
   const cmd = process.platform === 'win32'
-    ? `"${bash}" --login "${toBashPath(scriptPath)}" "${toBashPath(repoPath)}"`
-    : `"${scriptPath}" "${repoPath}"`;
+    ? `"${bash}" --login "${toBashPath(scriptPath)}" ${modeArgs} "${toBashPath(repoPath)}"`
+    : `"${scriptPath}" ${modeArgs} "${repoPath}"`;
 
   logger.info(`[installHooks] bash=${bash}, cmd=${cmd}`);
 

--- a/src/server/utils/team-resolution.ts
+++ b/src/server/utils/team-resolution.ts
@@ -54,7 +54,11 @@ export function resolveTeamFromCwd(cwd: string): string {
   }
 
   // No worktrees segment — use basename as a defensive fallback.
-  return path.basename(cwd);
+  // Normalize backslashes to forward slashes first: on POSIX, `path.basename`
+  // does NOT recognize `\` as a separator, so a Windows-style input like
+  // `C:\Users\me\projects\standalone-team` would be returned verbatim on
+  // Linux CI runners. Normalizing makes the fallback platform-independent.
+  return path.basename(cwd.replace(/\\/g, '/'));
 }
 
 /**

--- a/src/server/utils/team-resolution.ts
+++ b/src/server/utils/team-resolution.ts
@@ -1,0 +1,87 @@
+// =============================================================================
+// Fleet Commander — Team Resolution Helpers
+// =============================================================================
+// Shared helpers for resolving a team's worktree name from the data available
+// on a Claude Code hook payload. Used by the new HTTP hook route
+// (POST /api/hooks/:eventType) to map CC's `cwd` / `transcript_path` field
+// onto the FC team registry without requiring the shell hook to extract the
+// worktree name itself.
+//
+// CC ships the absolute working directory of the spawned process in
+// `cc_stdin.cwd`. FC always spawns CC inside a worktree at
+// `<repo>/.claude/worktrees/<worktree_name>`, so the worktree name is the
+// path segment immediately after `/worktrees/`. When the path does not
+// contain a `worktrees` segment (e.g. when CC runs from the main checkout),
+// we fall back to the basename — which lets the helper work in test
+// scenarios that seed teams whose worktreeName matches a literal directory
+// name without the worktrees prefix.
+// =============================================================================
+
+import path from 'path';
+
+/**
+ * Resolve the worktree name (FC's team key) from a Claude Code `cwd` field.
+ *
+ * Splits on `/worktrees/` (forward slashes) or `\worktrees\` (Windows
+ * backslashes) and returns the next path segment. Defensive against trailing
+ * separators — only the segment immediately after `worktrees` is returned,
+ * any deeper nesting (e.g. nested subdirectories of the worktree) is
+ * discarded.
+ *
+ * Falls back to `path.basename(cwd)` when no `worktrees` segment is present.
+ * Returns an empty string only for an empty input (callers should treat that
+ * as a missing field and reject the request with 400).
+ *
+ * Examples:
+ *   resolveTeamFromCwd('C:/Git/myrepo/.claude/worktrees/myrepo-42')
+ *     -> 'myrepo-42'
+ *   resolveTeamFromCwd('C:\\Git\\myrepo\\.claude\\worktrees\\myrepo-42')
+ *     -> 'myrepo-42'
+ *   resolveTeamFromCwd('/home/u/myrepo/.claude/worktrees/myrepo-42/src')
+ *     -> 'myrepo-42'
+ *   resolveTeamFromCwd('/some/random/path/myrepo-42')
+ *     -> 'myrepo-42'  (basename fallback)
+ */
+export function resolveTeamFromCwd(cwd: string): string {
+  if (!cwd) return '';
+
+  // Match both POSIX (/worktrees/) and Windows (\worktrees\) variants.
+  // The regex is anchored on the separator characters so it cannot match
+  // a literal `worktrees` substring embedded in a directory name.
+  const match = cwd.match(/[\\/]worktrees[\\/]([^\\/]+)/);
+  if (match && match[1]) {
+    return match[1];
+  }
+
+  // No worktrees segment — use basename as a defensive fallback.
+  return path.basename(cwd);
+}
+
+/**
+ * Resolve the team's worktree name from a parsed CC hook body.
+ *
+ * Prefers `body.cwd` (canonical field on every CC hook). Falls back to
+ * `body.transcript_path` for CC versions that omit `cwd` on some hook types
+ * — the transcript file lives alongside the worktree so the same path
+ * prefix logic applies.
+ *
+ * Returns `null` when neither field is present or both resolve to empty
+ * strings. Route handlers should treat null as a 400 (missing cwd) so the
+ * caller can fix their hook config rather than receiving a misleading 404
+ * after we try to look up a nonexistent team.
+ */
+export function resolveTeamFromHookBody(body: Record<string, unknown>): string | null {
+  const cwd = typeof body.cwd === 'string' ? body.cwd : '';
+  if (cwd) {
+    const resolved = resolveTeamFromCwd(cwd);
+    if (resolved) return resolved;
+  }
+
+  const transcriptPath = typeof body.transcript_path === 'string' ? body.transcript_path : '';
+  if (transcriptPath) {
+    const resolved = resolveTeamFromCwd(transcriptPath);
+    if (resolved) return resolved;
+  }
+
+  return null;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,6 +74,14 @@ export interface Project {
   autoMergeEnabled: boolean | null;
   /** ISO timestamp of last `gh api` check used to throttle refreshes. */
   autoMergeCheckedAt: string | null;
+  /**
+   * Hook deployment mode for this project (issue #735):
+   *   - 'http': native HTTP hooks (CC 2.1.62+), default for new projects.
+   *   - 'bash': legacy bash+curl hooks (fallback for older CC versions).
+   *   - null : pre-issue-#735 project whose mode has not yet been recorded;
+   *            surfaced in the UI as "Unknown" until the operator reinstalls.
+   */
+  hookMode: 'http' | 'bash' | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/tests/server/fc-manifest.test.ts
+++ b/tests/server/fc-manifest.test.ts
@@ -3,16 +3,20 @@
 // =============================================================================
 
 import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import {
   getHookFiles,
   getAgentFiles,
   getGuideFiles,
   getWorkflowFile,
   getSettingsExampleFile,
+  getHttpSettingsExampleFile,
   getHookEventTypes,
   getGitignoreEntries,
   getAllManagedFiles,
 } from '../../src/server/utils/fc-manifest.js';
+import config from '../../src/server/config.js';
 
 // ---------------------------------------------------------------------------
 // getHookFiles
@@ -97,8 +101,45 @@ describe('getWorkflowFile', () => {
 });
 
 describe('getSettingsExampleFile', () => {
-  it('returns the settings example filename', () => {
+  it('returns the bash-mode settings example filename by default', () => {
     expect(getSettingsExampleFile()).toBe('settings.json.example');
+  });
+
+  it("returns the bash-mode filename when called with 'bash'", () => {
+    expect(getSettingsExampleFile('bash')).toBe('settings.json.example');
+  });
+
+  it("returns the http-mode filename when called with 'http' (issue #735)", () => {
+    expect(getSettingsExampleFile('http')).toBe('settings.json.http.example');
+  });
+
+  it('http-mode example file exists on disk', () => {
+    const httpFile = path.join(config.fcHooksDir, getSettingsExampleFile('http'));
+    expect(fs.existsSync(httpFile)).toBe(true);
+  });
+
+  it('http-mode example file is parseable JSON with hooks block', () => {
+    const httpFile = path.join(config.fcHooksDir, getSettingsExampleFile('http'));
+    const content = fs.readFileSync(httpFile, 'utf-8');
+    const parsed = JSON.parse(content) as { hooks?: Record<string, unknown> };
+    expect(parsed.hooks).toBeDefined();
+    expect(Object.keys(parsed.hooks!).length).toBeGreaterThan(0);
+  });
+
+  it('http-mode example file contains {{FLEET_PORT}} placeholder for install-time substitution', () => {
+    const httpFile = path.join(config.fcHooksDir, getSettingsExampleFile('http'));
+    const content = fs.readFileSync(httpFile, 'utf-8');
+    expect(content).toContain('{{FLEET_PORT}}');
+  });
+});
+
+describe('getHttpSettingsExampleFile', () => {
+  it('returns the http example filename', () => {
+    expect(getHttpSettingsExampleFile()).toBe('settings.json.http.example');
+  });
+
+  it('is consistent with getSettingsExampleFile("http")', () => {
+    expect(getHttpSettingsExampleFile()).toBe(getSettingsExampleFile('http'));
   });
 });
 
@@ -193,6 +234,7 @@ describe('getAllManagedFiles', () => {
     expect(manifest.guides.length).toBeGreaterThan(0);
     expect(manifest.workflow).toBe('fleet-workflow.md');
     expect(manifest.settingsExample).toBe('settings.json.example');
+    expect(manifest.httpSettingsExample).toBe('settings.json.http.example');
     expect(manifest.gitignoreEntries.length).toBeGreaterThan(0);
   });
 

--- a/tests/server/routes/hooks-routes.test.ts
+++ b/tests/server/routes/hooks-routes.test.ts
@@ -1,0 +1,336 @@
+// =============================================================================
+// Fleet Commander -- HTTP Hook Routes: HTTP contract tests (issue #735)
+// =============================================================================
+// Tests POST /api/hooks/:eventType — the native HTTP hook endpoint that
+// replaces the bash + curl fire-and-forget chain. Mirrors the structure of
+// tests/server/routes/handoff-routes.test.ts (Fastify inject + real
+// temporary SQLite DB).
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+import { sseBroker } from '../../../src/server/services/sse-broker.js';
+import {
+  resetThrottleState,
+  resetEventDedupState,
+  resetSubagentTrackers,
+  resetPrPollState,
+} from '../../../src/server/services/event-collector.js';
+import hooksRoutes from '../../../src/server/routes/hooks.js';
+
+// ---------------------------------------------------------------------------
+// Stub the team-manager service so the hook route can call processQueue and
+// sendMessage without spinning up real child processes.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/server/services/team-manager.js', () => ({
+  getTeamManager: vi.fn(() => ({
+    sendMessage: vi.fn(),
+    processQueue: vi.fn().mockResolvedValue(undefined),
+    noteLastAssistantMessage: vi.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+let server: FastifyInstance;
+let dbPath: string;
+let counter = 0;
+
+function seedTeam(
+  worktreeName: string,
+  overrides: { status?: 'queued' | 'launching' | 'running' | 'idle' | 'stuck' | 'done' | 'failed' } = {},
+) {
+  counter++;
+  const db = getDatabase();
+  return db.insertTeam({
+    issueNumber: 700 + counter,
+    worktreeName,
+    status: overrides.status ?? 'running',
+    phase: 'implementing',
+    prNumber: null,
+  });
+}
+
+beforeAll(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `fleet-hooks-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+  closeDatabase();
+  process.env['FLEET_DB_PATH'] = dbPath;
+  getDatabase(dbPath);
+
+  server = Fastify({ logger: false });
+  await server.register(hooksRoutes);
+  await server.ready();
+});
+
+afterAll(async () => {
+  sseBroker.stop();
+  await server.close();
+  closeDatabase();
+  for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // best effort
+    }
+  }
+  delete process.env['FLEET_DB_PATH'];
+});
+
+beforeEach(() => {
+  // Reset module-level state so each test starts clean. Without this, the
+  // dedup window from a previous test can swallow a fresh stop event.
+  resetThrottleState();
+  resetEventDedupState();
+  resetSubagentTrackers();
+  resetPrPollState();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCwd(worktree: string): string {
+  return `C:/Git/test-repo/.claude/worktrees/${worktree}`;
+}
+
+async function postHook(eventType: string, body: Record<string, unknown>) {
+  return server.inject({
+    method: 'POST',
+    url: `/api/hooks/${eventType}`,
+    payload: body,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/hooks/SessionStart', () => {
+  it('returns 204 on success and persists an events row', async () => {
+    const worktree = `hooks-sess-${Date.now()}`;
+    const team = seedTeam(worktree, { status: 'launching' });
+
+    const res = await postHook('SessionStart', {
+      session_id: 'sess-abc',
+      cwd: makeCwd(worktree),
+      source: 'startup',
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.payload).toBe('');
+
+    const db = getDatabase();
+    const events = db.getEventsByTeam(team.id);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].eventType).toBe('SessionStart');
+    expect(events[0].sessionId).toBe('sess-abc');
+  });
+});
+
+describe('POST /api/hooks/PostToolUse', () => {
+  it('returns 204 and stores the tool name and tool_input on the event', async () => {
+    const worktree = `hooks-tool-${Date.now()}`;
+    const team = seedTeam(worktree);
+
+    const res = await postHook('PostToolUse', {
+      session_id: 'sess-tool',
+      cwd: makeCwd(worktree),
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi', description: 'greet' },
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const db = getDatabase();
+    const events = db.getEventsByTeam(team.id);
+    const toolEvent = events.find((e) => e.eventType === 'ToolUse');
+    expect(toolEvent).toBeDefined();
+    expect(toolEvent?.toolName).toBe('Bash');
+    // Payload JSON contains the stringified tool_input
+    expect(toolEvent?.payload).toContain('echo hi');
+  });
+});
+
+describe('POST /api/hooks/Stop', () => {
+  it('persists background_tasks JSON on the team row when present', async () => {
+    const worktree = `hooks-bg-${Date.now()}`;
+    const team = seedTeam(worktree);
+
+    const res = await postHook('Stop', {
+      session_id: 'sess-stop',
+      cwd: makeCwd(worktree),
+      background_tasks: [
+        { id: 'bg-1', state: 'pending' },
+        { id: 'bg-2', state: 'pending' },
+      ],
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const db = getDatabase();
+    const refreshed = db.getTeam(team.id);
+    expect(refreshed?.backgroundTasksJson).toBeTruthy();
+    // Round-trip: the stored JSON must parse to an array with both entries.
+    const parsed = JSON.parse(refreshed!.backgroundTasksJson!);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(2);
+  });
+
+  it('does not write background_tasks_json when the field is absent', async () => {
+    const worktree = `hooks-nobg-${Date.now()}`;
+    const team = seedTeam(worktree);
+
+    await postHook('Stop', {
+      session_id: 'sess-nobg',
+      cwd: makeCwd(worktree),
+    });
+
+    const db = getDatabase();
+    const refreshed = db.getTeam(team.id);
+    expect(refreshed?.backgroundTasksJson ?? null).toBeNull();
+  });
+});
+
+describe('POST /api/hooks/SubagentStop', () => {
+  it('returns 204 and records the event with the subagent name', async () => {
+    const worktree = `hooks-sub-${Date.now()}`;
+    const team = seedTeam(worktree);
+
+    const res = await postHook('SubagentStop', {
+      session_id: 'sess-sub',
+      cwd: makeCwd(worktree),
+      teammate_name: 'fleet-dev',
+    });
+
+    expect(res.statusCode).toBe(204);
+    const db = getDatabase();
+    const events = db.getEventsByTeam(team.id);
+    expect(events.some((e) => e.eventType === 'SubagentStop')).toBe(true);
+  });
+});
+
+describe('POST /api/hooks/PostToolUseFailure', () => {
+  it('maps to tool_error and stores error_details on the event payload', async () => {
+    const worktree = `hooks-err-${Date.now()}`;
+    const team = seedTeam(worktree);
+
+    const res = await postHook('PostToolUseFailure', {
+      session_id: 'sess-err',
+      cwd: makeCwd(worktree),
+      tool_name: 'Bash',
+      tool_use_id: 'tu-1',
+      error: 'exit 1',
+      error_details: 'command not found',
+    });
+
+    expect(res.statusCode).toBe(204);
+
+    const db = getDatabase();
+    const events = db.getEventsByTeam(team.id);
+    const errEvent = events.find((e) => e.eventType === 'ToolError');
+    expect(errEvent).toBeDefined();
+    expect(errEvent?.payload).toContain('command not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error-path tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/hooks — error paths', () => {
+  it('returns 400 for an unknown event type', async () => {
+    const worktree = `hooks-unknown-${Date.now()}`;
+    seedTeam(worktree);
+
+    const res = await postHook('UnknownEvent', {
+      cwd: makeCwd(worktree),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload).message).toMatch(/Unknown hook event type/);
+  });
+
+  it('returns 400 for an empty body (no cwd / transcript_path)', async () => {
+    const res = await postHook('SessionStart', {});
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload).message).toMatch(/cwd/);
+  });
+
+  it('returns 400 when cwd / transcript_path are both missing on a payload with other fields', async () => {
+    const res = await postHook('PostToolUse', {
+      session_id: 'sess-x',
+      tool_name: 'Read',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when the cwd resolves to a team that does not exist', async () => {
+    const res = await postHook('SessionStart', {
+      cwd: makeCwd('nonexistent-team-99999'),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.payload).message).toMatch(/Team not found/);
+  });
+
+  it('returns 400 when the body is null', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/SessionStart',
+      payload: 'null',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when the body is a JSON array (not an object)', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/hooks/SessionStart',
+      payload: '[1, 2, 3]',
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event-name map coverage
+// ---------------------------------------------------------------------------
+
+describe('PASCAL_TO_SNAKE event name map', () => {
+  it('covers all hook types declared in settings.json.example', async () => {
+    // Load the bash example so this stays in sync with the deployment
+    // template. The HTTP template uses the same set of hook types so we
+    // only need to check one.
+    const examplePath = path.join(
+      process.cwd(),
+      'hooks',
+      'settings.json.example',
+    );
+    const example = JSON.parse(fs.readFileSync(examplePath, 'utf-8')) as {
+      hooks: Record<string, unknown>;
+    };
+    const declaredTypes = Object.keys(example.hooks ?? {});
+
+    // Dynamically import the map so we don't have to re-export it from the
+    // route module just for tests.
+    const { PASCAL_TO_SNAKE } = await import(
+      '../../../src/server/routes/hooks.js'
+    );
+    for (const eventType of declaredTypes) {
+      expect(PASCAL_TO_SNAKE).toHaveProperty(eventType);
+    }
+  });
+});

--- a/tests/server/routes/projects-routes.test.ts
+++ b/tests/server/routes/projects-routes.test.ts
@@ -445,6 +445,103 @@ describe('POST /api/projects/:id/install', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  // ---- Issue #735: hook_mode flip via body { mode: 'http'|'bash' } ------
+  // installHooks is mocked at the top of this file so the route returns
+  // ok=false (no stdout/stderr). We don't care about install success here —
+  // we only care that the service persists the requested mode on the
+  // project row.
+  it("should persist hookMode='http' when body.mode='http'", async () => {
+    const project = seedProject();
+    const { installHooks } = await import(
+      '../../../src/server/utils/hook-installer.js'
+    );
+    (installHooks as ReturnType<typeof vi.fn>).mockReturnValue({
+      ok: true,
+      stdout: '',
+      stderr: '',
+    });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/projects/${project.id}/install`,
+      payload: { mode: 'http' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const db = getDatabase();
+    const refreshed = db.getProject(project.id);
+    expect(refreshed?.hookMode).toBe('http');
+    // The mock should have been called with mode=http forwarded through
+    expect(installHooks).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ mode: 'http' }),
+    );
+  });
+
+  it("should persist hookMode='bash' when body.mode='bash'", async () => {
+    const project = seedProject();
+    const { installHooks } = await import(
+      '../../../src/server/utils/hook-installer.js'
+    );
+    (installHooks as ReturnType<typeof vi.fn>).mockReturnValue({
+      ok: true,
+      stdout: '',
+      stderr: '',
+    });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/projects/${project.id}/install`,
+      payload: { mode: 'bash' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const db = getDatabase();
+    const refreshed = db.getProject(project.id);
+    expect(refreshed?.hookMode).toBe('bash');
+    expect(installHooks).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ mode: 'bash' }),
+    );
+  });
+
+  it('should default to http when no mode is supplied', async () => {
+    const project = seedProject();
+    const { installHooks } = await import(
+      '../../../src/server/utils/hook-installer.js'
+    );
+    (installHooks as ReturnType<typeof vi.fn>).mockReturnValue({
+      ok: true,
+      stdout: '',
+      stderr: '',
+    });
+
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/projects/${project.id}/install`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const db = getDatabase();
+    const refreshed = db.getProject(project.id);
+    expect(refreshed?.hookMode).toBe('http');
+  });
+
+  it('should return 400 for an invalid mode value', async () => {
+    const project = seedProject();
+    const res = await server.inject({
+      method: 'POST',
+      url: `/api/projects/${project.id}/install`,
+      payload: { mode: 'tcp' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload).message).toMatch(/http|bash/);
+  });
 });
 
 // =============================================================================

--- a/tests/server/utils/build-event-payload.test.ts
+++ b/tests/server/utils/build-event-payload.test.ts
@@ -1,0 +1,179 @@
+// =============================================================================
+// Fleet Commander -- buildEventPayloadFromCc (issue #735)
+// =============================================================================
+// Round-trip parity tests: feeding the same CC stdin object through the
+// shared `buildEventPayloadFromCc` helper must produce the same EventPayload
+// as the legacy `buildPayloadFromCcStdin` wrapper in routes/events.ts. The
+// HTTP hook route and the legacy bash-curl route both depend on this
+// equivalence so behaviour stays bit-identical across transports.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import { buildEventPayloadFromCc } from '../../../src/server/utils/build-event-payload.js';
+import { buildPayloadFromCcStdin } from '../../../src/server/routes/events.js';
+
+/**
+ * Build the legacy body shape (what the shell hook posts to /api/events)
+ * from a CC stdin object, then run both code paths and compare.
+ *
+ * The shared helper does NOT preserve the original `cc_stdin` string (it
+ * re-serializes the parsed object), whereas the legacy route preserves it
+ * as-is. We assert on cc_stdin via JSON equivalence rather than string
+ * equality so canonical JSON serialization differences don't trip the test.
+ */
+function assertParity(cc: Record<string, unknown>, eventType = 'tool_use', team = 'kea-100') {
+  const legacy = buildPayloadFromCcStdin({
+    event: eventType,
+    team,
+    cc_stdin: JSON.stringify(cc),
+  });
+
+  const shared = buildEventPayloadFromCc(cc, team, eventType);
+
+  // Compare every field except cc_stdin (which has different but
+  // semantically equivalent representations across the two paths).
+  const stripCcStdin = ({ cc_stdin: _omit, ...rest }: typeof legacy) => rest;
+  expect(stripCcStdin(shared)).toEqual(stripCcStdin(legacy));
+
+  // cc_stdin must JSON-parse to the same object on both paths.
+  expect(JSON.parse(shared.cc_stdin || '{}')).toEqual(JSON.parse(legacy.cc_stdin || '{}'));
+}
+
+describe('buildEventPayloadFromCc — round-trip parity with routes/events.ts', () => {
+  it('matches for a SessionStart payload', () => {
+    assertParity(
+      {
+        session_id: 'sess-1',
+        cwd: '/repo/.claude/worktrees/kea-100',
+        source: 'startup',
+        model: 'claude-opus-4-7',
+      },
+      'session_start',
+    );
+  });
+
+  it('matches for a PostToolUse Bash payload', () => {
+    assertParity({
+      session_id: 'sess-2',
+      tool_name: 'Bash',
+      tool_input: { command: 'gh pr view 123', description: 'check PR' },
+      agent_type: 'fleet-dev',
+      duration_ms: 245,
+    });
+  });
+
+  it('matches for a SendMessage payload (msg_to / msg_summary extraction)', () => {
+    assertParity({
+      session_id: 'sess-3',
+      tool_name: 'SendMessage',
+      tool_input: { to: 'reviewer', summary: 'Please review', body: 'long body...' },
+      agent_type: 'fleet-dev',
+    });
+  });
+
+  it('matches for a TaskCreated payload', () => {
+    assertParity(
+      {
+        session_id: 'sess-4',
+        task_id: 'task-42',
+        subject: 'Implement feature X',
+        description: 'see plan.md',
+        status: 'pending',
+        owner: 'fleet-planner',
+        agent_id: 'agent-abc',
+      },
+      'task_created',
+    );
+  });
+
+  it('matches for a Stop payload with background_tasks (CC 2.1.145+)', () => {
+    assertParity(
+      {
+        session_id: 'sess-5',
+        background_tasks: [
+          { id: 't1', state: 'pending' },
+          { id: 't2', state: 'pending' },
+        ],
+        last_assistant_message: 'shutting down',
+      },
+      'stop',
+    );
+  });
+
+  it('matches for a SubagentStop payload with session_crons', () => {
+    assertParity(
+      {
+        session_id: 'sess-6',
+        teammate_name: 'fleet-dev',
+        session_crons: [{ id: 'c1', cron: '*/5 * * * *' }],
+      },
+      'subagent_stop',
+    );
+  });
+
+  it('matches for an empty CC object', () => {
+    assertParity({}, 'session_start');
+  });
+
+  it('matches for a PostToolUseFailure payload with error fields', () => {
+    assertParity(
+      {
+        session_id: 'sess-7',
+        tool_name: 'Bash',
+        tool_use_id: 'tu-1',
+        error: 'exit 1',
+        error_details: 'command failed',
+        tool_input: { command: 'false' },
+      },
+      'tool_error',
+    );
+  });
+
+  it('matches for a Notification payload', () => {
+    assertParity(
+      {
+        session_id: 'sess-8',
+        notification_type: 'stuck',
+        message: 'No tool calls for 5 minutes',
+      },
+      'notification',
+    );
+  });
+
+  it('rejects non-finite duration_ms (NaN / Infinity / string)', () => {
+    // The legacy route accepts only finite numbers; the shared helper must too.
+    const cc = {
+      session_id: 'sess-9',
+      tool_name: 'Read',
+      duration_ms: 'not-a-number',
+    };
+    const payload = buildEventPayloadFromCc(cc, 'kea-100', 'tool_use');
+    expect(payload.duration_ms).toBeUndefined();
+  });
+
+  it('stringifies object tool_input but preserves string tool_input as-is', () => {
+    const objectInput = buildEventPayloadFromCc(
+      { tool_name: 'Read', tool_input: { file_path: '/a/b/c' } },
+      'kea-100',
+      'tool_use',
+    );
+    expect(objectInput.tool_input).toBe(JSON.stringify({ file_path: '/a/b/c' }));
+
+    const stringInput = buildEventPayloadFromCc(
+      { tool_name: 'Read', tool_input: '{"file_path":"/x/y/z"}' },
+      'kea-100',
+      'tool_use',
+    );
+    expect(stringInput.tool_input).toBe('{"file_path":"/x/y/z"}');
+  });
+
+  it('always sets cc_stdin to the JSON-stringified ccBody (TaskCreated parser dependency)', () => {
+    // The TaskCreated handler in event-collector calls `JSON.parse(payload.cc_stdin)`,
+    // so cc_stdin MUST be set even on a minimal payload. Without it, task extraction
+    // would silently no-op for the HTTP route.
+    const cc = { task_id: 't-1', subject: 'x' };
+    const payload = buildEventPayloadFromCc(cc, 'kea-100', 'task_created');
+    expect(payload.cc_stdin).toBeDefined();
+    expect(JSON.parse(payload.cc_stdin!)).toEqual(cc);
+  });
+});

--- a/tests/server/utils/team-resolution.test.ts
+++ b/tests/server/utils/team-resolution.test.ts
@@ -1,0 +1,127 @@
+// =============================================================================
+// Fleet Commander -- Team Resolution Helpers (issue #735)
+// =============================================================================
+// Unit tests for the cwd -> worktree-name resolution used by the HTTP hook
+// route. The helper must handle both POSIX and Windows path separators since
+// FC runs on both platforms.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveTeamFromCwd,
+  resolveTeamFromHookBody,
+} from '../../../src/server/utils/team-resolution.js';
+
+describe('resolveTeamFromCwd', () => {
+  it('extracts worktree name from a POSIX path', () => {
+    expect(resolveTeamFromCwd('/home/user/myrepo/.claude/worktrees/myrepo-42')).toBe(
+      'myrepo-42',
+    );
+  });
+
+  it('extracts worktree name from a Windows path with backslashes', () => {
+    expect(
+      resolveTeamFromCwd('C:\\Git\\myrepo\\.claude\\worktrees\\myrepo-42'),
+    ).toBe('myrepo-42');
+  });
+
+  it('extracts worktree name from a Windows path with forward slashes', () => {
+    expect(resolveTeamFromCwd('C:/Git/myrepo/.claude/worktrees/myrepo-42')).toBe(
+      'myrepo-42',
+    );
+  });
+
+  it('returns only the first segment after worktrees, ignoring subdirectories', () => {
+    expect(
+      resolveTeamFromCwd('/home/user/repo/.claude/worktrees/repo-42/src/app'),
+    ).toBe('repo-42');
+  });
+
+  it('handles trailing separator after worktree name', () => {
+    expect(
+      resolveTeamFromCwd('/home/user/repo/.claude/worktrees/repo-42/'),
+    ).toBe('repo-42');
+  });
+
+  it('handles mixed separators in the same path', () => {
+    expect(
+      resolveTeamFromCwd('C:/Git/myrepo/.claude\\worktrees/myrepo-42'),
+    ).toBe('myrepo-42');
+  });
+
+  it('falls back to basename when there is no worktrees segment', () => {
+    expect(resolveTeamFromCwd('/some/random/path/myrepo-42')).toBe('myrepo-42');
+  });
+
+  it('falls back to basename for Windows paths without worktrees segment', () => {
+    expect(resolveTeamFromCwd('C:\\Users\\me\\projects\\standalone-team')).toBe(
+      'standalone-team',
+    );
+  });
+
+  it('does not match worktrees as an embedded substring', () => {
+    // `myworktrees-stuff` is NOT a worktrees segment — the helper falls back
+    // to basename so callers don't accidentally treat it as a team name.
+    expect(resolveTeamFromCwd('/home/user/myworktrees-stuff/repo-42')).toBe(
+      'repo-42',
+    );
+  });
+
+  it('handles nested worktrees segments by taking the FIRST one', () => {
+    // Defensive: nested worktrees should never happen in practice, but if
+    // they do, take the outermost worktree name. This matches FC's spawn
+    // behavior (one worktree per team) and prevents weird edge-case keys.
+    expect(
+      resolveTeamFromCwd(
+        '/repo/.claude/worktrees/outer-team/.claude/worktrees/inner-team',
+      ),
+    ).toBe('outer-team');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(resolveTeamFromCwd('')).toBe('');
+  });
+});
+
+describe('resolveTeamFromHookBody', () => {
+  it('prefers cwd over transcript_path', () => {
+    const body = {
+      cwd: 'C:/Git/repo/.claude/worktrees/repo-1',
+      transcript_path: 'C:/Git/repo/.claude/worktrees/repo-2/transcript.jsonl',
+    };
+    expect(resolveTeamFromHookBody(body)).toBe('repo-1');
+  });
+
+  it('falls back to transcript_path when cwd is missing', () => {
+    const body = {
+      transcript_path: 'C:/Git/repo/.claude/worktrees/repo-7/transcript.jsonl',
+    };
+    expect(resolveTeamFromHookBody(body)).toBe('repo-7');
+  });
+
+  it('falls back to transcript_path when cwd is empty string', () => {
+    const body = {
+      cwd: '',
+      transcript_path: '/home/u/repo/.claude/worktrees/repo-99/x.jsonl',
+    };
+    expect(resolveTeamFromHookBody(body)).toBe('repo-99');
+  });
+
+  it('returns null when both fields are missing', () => {
+    expect(resolveTeamFromHookBody({})).toBeNull();
+  });
+
+  it('returns null when both fields are non-strings', () => {
+    expect(resolveTeamFromHookBody({ cwd: 42, transcript_path: null })).toBeNull();
+  });
+
+  it('returns null when both fields are empty strings', () => {
+    expect(resolveTeamFromHookBody({ cwd: '', transcript_path: '' })).toBeNull();
+  });
+
+  it('handles a cwd without a worktrees segment via basename fallback', () => {
+    expect(resolveTeamFromHookBody({ cwd: '/tmp/standalone-repo' })).toBe(
+      'standalone-repo',
+    );
+  });
+});


### PR DESCRIPTION
Closes #735

## Summary

Migrates Fleet Commander's CC hook transport from bash + curl to native HTTP hooks (CC 2.1.62+) for new projects, with a per-project mode picker so existing projects can opt in via the UI. New `POST /api/hooks/:eventType` route reuses the existing event-collector pipeline. Bash mode remains as an explicit fallback.

- **Refactor** (`77ecd24`): Extracted `team-resolution.ts` and `build-event-payload.ts` so both transports share field-extraction logic. `routes/events.ts:buildPayloadFromCcStdin` now delegates while preserving the raw `cc_stdin` string for dedup-fingerprint stability.
- **Feature** (`775bd68`): New `POST /api/hooks/:eventType` route with PascalCase → snake_case map and fire-and-forget try/catch; `hooks/settings.json.http.example` template with `{{FLEET_PORT}}` placeholder; `projects.hook_mode` column (schema v25); `install.sh --mode|--port` flags with exclusive bash/http entry filtering on reinstall; `uninstall.sh` extended to strip both transports; UI HookModeBadge + mode picker in ProjectsPage; CLAUDE.md docs.
- **Rebase fix** (`4269c2c`): Added `WorktreeCreate` / `WorktreeRemove` to the HTTP template and PASCAL_TO_SNAKE map after #731 landed on main during this PR.

## Test plan

- [x] `npm run build` succeeds, `npx tsc --noEmit` clean
- [x] 13 new hooks-routes tests pass (204/400/404 contract verified)
- [x] 18 new team-resolution tests pass (POSIX + Windows separators)
- [x] 12 new build-event-payload parity tests pass (refactor is behavior-preserving)
- [x] 5 new projects-routes tests pass (POST /install with `{mode}`)
- [x] Existing test suite passes (2165 / 3 pre-existing failures in `cc-spawn.test.ts` unrelated to this PR — same on `origin/main`)
- [ ] CI green on this PR