### PR TITLE
Issue #737: document CC subagent worktree isolation policy + auto-cleanup orphan subworktrees

### DIFF
--- a/.claude/prompts/fleet-workflow.md
+++ b/.claude/prompts/fleet-workflow.md
@@ -1,8 +1,8 @@
 <!-- fleet-commander v0.0.24 -->
 <!-- Fleet Commander workflow template. Installed by Fleet Commander into your project. -->
-<!-- Placeholders fleet-commander, fleet-commander, main, {{ISSUE_NUMBER}} are replaced during installation. -->
+<!-- Placeholders {{PROJECT_NAME}}, {{project_slug}}, {{BASE_BRANCH}}, {{ISSUE_NUMBER}} are replaced during installation. -->
 
-# Diamond Workflow — fleet-commander
+# Diamond Workflow — {{PROJECT_NAME}}
 
 ## About Fleet Commander
 
@@ -18,15 +18,15 @@ Fleet Commander (FC) is the orchestration layer that manages your team. Key fact
 
 You are running inside a **git worktree**, not the main repository checkout. This has critical implications:
 
-- **NEVER run `git checkout main`** — the base branch is already checked out in the main worktree. Attempting to check it out here will fail with "already used by worktree."
-- **Use `git fetch origin main` and reference `origin/main`** whenever you need the latest base branch state. Do not try to switch to it.
-- **Your branch is your branch.** Create it, work on it, push it. Never switch away from it to main.
-- This applies to ALL agents (planner, dev, reviewer) — none of them should ever attempt to checkout main.
+- **NEVER run `git checkout {{BASE_BRANCH}}`** — the base branch is already checked out in the main worktree. Attempting to check it out here will fail with "already used by worktree."
+- **Use `git fetch origin {{BASE_BRANCH}}` and reference `origin/{{BASE_BRANCH}}`** whenever you need the latest base branch state. Do not try to switch to it.
+- **Your branch is your branch.** Create it, work on it, push it. Never switch away from it to {{BASE_BRANCH}}.
+- This applies to ALL agents (planner, dev, reviewer) — none of them should ever attempt to checkout {{BASE_BRANCH}}.
 
 ## Entry Point
 
 ```
-User: claude --worktree fleet-commander-{N}
+User: claude --worktree {{project_slug}}-{N}
 (prompt is sent via stdin from Fleet Commander's prompt file)
 ```
 
@@ -125,6 +125,19 @@ All implementation work is assigned to the single `fleet-dev` agent. The Planner
 | Infrastructure / CI | `devops-conventions.md` |
 | Generic / unknown | CLAUDE.md only (no language-specific guidebook) |
 | Mixed (A + B) | Multiple guidebooks — dev reads all relevant ones |
+
+## Parallel research subagents (optional)
+
+The Diamond team (planner + dev + reviewer) is strictly sequential. None of those three agents use `isolation: "worktree"` — see CLAUDE.md "CC Subagent Worktree Isolation" for why.
+
+You MAY, however, spawn ad-hoc **read-only research subagents in parallel** if you need to scan a large codebase or gather diverse perspectives quickly. When you do, pass `isolation: "worktree"` to the `Agent` tool so the parallel subagents each get their own throwaway worktree and cannot collide on shared files:
+
+- Use this ONLY for subagents that **read** code/docs and return findings — never for code-writing work.
+- Do NOT isolate any of `fleet-planner`, `fleet-dev`, or `fleet-reviewer` — they need access to the team's main worktree to read/write `plan.md`, source files, `changes.md`, and `review.md`.
+- Isolated subagents see `origin/{{BASE_BRANCH}}`, not the dev's in-flight commits or uncommitted work — do not isolate any subagent that must inspect work-in-progress.
+- Fleet Commander auto-cleans CC subworktrees when the team finishes (see `cleanupTeamCcSubworktrees` in `src/server/services/cleanup.ts`), so you do not need to worry about leaked directories if a parallel subagent crashes.
+
+Default behavior: **do not spawn parallel subagents at all.** The Diamond agents cover every standard implementation flow. Only reach for parallel research when the task explicitly calls for breadth (e.g., a multi-area refactor scoping exercise).
 
 ## Workflow State Machine
 
@@ -241,7 +254,7 @@ If `.fleet-issue-context.md` was NOT available, omit the context fields and inst
 
 ### Dev Task Format (sent via TaskCreate at spawn)
 
-Include these fields: ISSUE (`#{N} {title}`), BRANCH (`{feat|fix|test}/{N}-{short-desc}`), BASE (`main`), ISSUE SUMMARY (1-3 sentences), ACCEPTANCE CRITERIA (bulleted), PLAN (full planner plan), GUIDEBOOKS (list of paths from plan). Dev reads CLAUDE.md + guidebooks, implements per plan, runs build + tests, commits atomically (`Issue #{N}: {desc}`), pushes, and pings TL.
+Include these fields: ISSUE (`#{N} {title}`), BRANCH (`{feat|fix|test}/{N}-{short-desc}`), BASE (`{{BASE_BRANCH}}`), ISSUE SUMMARY (1-3 sentences), ACCEPTANCE CRITERIA (bulleted), PLAN (full planner plan), GUIDEBOOKS (list of paths from plan). Dev reads CLAUDE.md + guidebooks, implements per plan, runs build + tests, commits atomically (`Issue #{N}: {desc}`), pushes, and pings TL.
 
 ### Changes Report Format (written by dev to `changes.md`)
 
@@ -276,7 +289,7 @@ Dev writes a summary including: what changed (files list with descriptions), any
 
 ### Reviewer Task Format (sent via TaskCreate at spawn)
 
-Include these fields: ISSUE (`#{N} {title}`), BRANCH, BASE (`main`), ACCEPTANCE CRITERIA (bulleted), CHANGES (full content from dev's `changes.md`), GUIDEBOOKS (list of paths from plan). Reviewer reads CLAUDE.md + guidebooks, verifies the dev's changes report against actual `git diff`, performs two-pass review (code quality + acceptance), sends REJECT feedback directly to dev via SendMessage, and writes final verdict to `review.md` then pings TL. Peer names: dev=`dev`, planner=`planner`. Max 3 review rounds; after 3rd round write `review.md` with CHANGES_NEEDED and wait for shutdown.
+Include these fields: ISSUE (`#{N} {title}`), BRANCH, BASE (`{{BASE_BRANCH}}`), ACCEPTANCE CRITERIA (bulleted), CHANGES (full content from dev's `changes.md`), GUIDEBOOKS (list of paths from plan). Reviewer reads CLAUDE.md + guidebooks, verifies the dev's changes report against actual `git diff`, performs two-pass review (code quality + acceptance), sends REJECT feedback directly to dev via SendMessage, and writes final verdict to `review.md` then pings TL. Peer names: dev=`dev`, planner=`planner`. Max 3 review rounds; after 3rd round write `review.md` with CHANGES_NEEDED and wait for shutdown.
 
 ### TL Reads review.md
 
@@ -314,14 +327,14 @@ After TL reads `review.md` with `Status: APPROVE`:
 
 1. **Branch freshness check** (MANDATORY):
    ```bash
-   git stash --include-untracked && git fetch origin main && git rebase origin/main && git stash pop && git push --force-with-lease
+   git stash --include-untracked && git fetch origin {{BASE_BRANCH}} && git rebase origin/{{BASE_BRANCH}} && git stash pop && git push --force-with-lease
    ```
    The `git stash --include-untracked` is required because the CC runtime may leave unstaged changes (e.g., `.claude/settings.json`) that block rebase.
    If rebase fails (conflicts) → state Blocked.
 
 2. **TL creates PR**:
    ```bash
-   gh pr create --base main --title "Issue #{N}: {description}" --body "Closes #{N}"
+   gh pr create --base {{BASE_BRANCH}} --title "Issue #{N}: {description}" --body "Closes #{N}"
    ```
 
 3. **Set auto-merge immediately** (mandatory, no exceptions):
@@ -435,7 +448,7 @@ TL forwards `ci_red` details to dev. Same failure type does NOT count as a new u
 
 ### Rebase Conflict
 
-If rebase on `origin/main` fails with conflicts, state Blocked, comment on issue, and STOP.
+If rebase on `origin/{{BASE_BRANCH}}` fails with conflicts, state Blocked, comment on issue, and STOP.
 
 ---
 
@@ -467,7 +480,7 @@ Atomic commits — each commit should be a logical unit.
 
 - **One issue at a time** — atomic changes only
 - **CI must be green** — PR CANNOT be merged with red CI
-- **Branch from main** — NEVER commit directly to main
+- **Branch from {{BASE_BRANCH}}** — NEVER commit directly to {{BASE_BRANCH}}
 - **TL creates the PR** — dev pushes code, TL creates the PR and sets auto-merge
 - **P2P for review** — dev and reviewer talk directly, TL does not relay
 - **Idle = normal** — agents waiting for messages are expected to be idle
@@ -475,3 +488,4 @@ Atomic commits — each commit should be a logical unit.
 - **Respond to FC messages promptly** — FC messages arrive via stdin and require action
 - **TL does not implement** — spawn subagents for all work (except planner fallback)
 - **Planner failure is not fatal** — TL can produce a minimal plan if planner fails
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,24 @@ Configuration locations (defense-in-depth):
 - `hooks/settings.json.example` — template copied to every worktree's `.claude/settings.json` on team launch. Carries the top-level `"autoMemoryEnabled": false` key.
 - `src/server/utils/cc-spawn.ts` — the `buildEnv()` helper sets `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` on every spawned CC process. On Windows interactive launches, the var is also written into the temp `.cmd` launcher file by `writeLauncherCmdFile()` (which forwards every `CLAUDE_CODE_*` env key).
 
+## CC Subagent Worktree Isolation
+
+Claude Code 2.1.49+ supports `isolation: "worktree"` in subagent frontmatter (and as an Agent tool flag) to run a subagent inside a temporary git worktree. CC creates the worktree at subagent start and removes it at subagent exit when there are no uncommitted changes / new commits; on a clean exit the worktree is fully torn down. WorktreeCreate / WorktreeRemove hooks fire on both events (issue #731).
+
+**Fleet Commander's Diamond subagents (planner, dev, reviewer) do NOT use `isolation: "worktree"`.** Concrete reasons:
+
+- The Diamond workflow is strictly sequential (planner → dev → reviewer; see `templates/workflow.md`). No two FC subagents ever edit the same files concurrently, so the isolation flag's parallelism benefit is zero for the default workflow.
+- The planner and reviewer are read-only — they only write their handoff files (`plan.md`, `review.md`) into the team's main worktree and never edit source. Isolating them would just add a worktree create/destroy round-trip with no upside.
+- The dev is the only writer, and isolating the dev actively breaks it. CC's subagent worktrees branch from `origin/HEAD` (default branch) unless `worktree.baseRef: "head"` is set in CC settings. The dev's commits would end up on the wrong branch in a different directory, and the TL's Phase 4 rebase / push runs in the team's main worktree which would never see those commits. (See `worktree.baseRef` discussion in `https://code.claude.com/docs/en/worktrees`.)
+
+**When isolation IS useful (and permitted):** A TL may spawn multiple **read-only** research subagents in parallel via the `Agent` tool with `isolation: "worktree"` — for example, three subagents scanning different subtrees of a large repository. Each runs in its own throwaway worktree, no concurrent edits hit shared files, and CC tears the worktrees down automatically. This pattern is documented in `templates/workflow.md` under "Parallel research subagents (optional)". Do not use isolation for any subagent that needs to see uncommitted or unpushed work from a sibling subagent — the subworktree starts from `origin/HEAD` and is blind to in-flight changes elsewhere.
+
+**FC tracking and cleanup:**
+
+- Issue #731 added `WorktreeCreate` / `WorktreeRemove` hooks (`hooks/on_worktree_create.sh`, `hooks/on_worktree_remove.sh`) plus the `team_subworktrees` DB table. Every CC-initiated subworktree is recorded with `createdVia = 'cc'`; clean teardown sets `removed_at`.
+- Issue #737 added automatic cleanup of orphan CC subworktrees when a team transitions to `done` or `failed`. The function `cleanupTeamCcSubworktrees(teamId)` in `src/server/services/cleanup.ts` runs `git worktree remove --force` (with `fs.rmSync` fallback) for any active CC subworktree row, then marks `removed_at` so retries are bounded. It is invoked from `team-manager.ts` `stop()` and `handleProcessExit()` after the terminal-state DB transition.
+- The team's main worktree (the one FC itself created) is NOT auto-removed. That remains a manual operation via the Projects → Cleanup UI.
+
 ## MCP Server
 
 Fleet Commander exposes tools via the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio transport. This allows Claude Code (or any MCP client) to query fleet state programmatically.

--- a/src/server/services/cleanup.ts
+++ b/src/server/services/cleanup.ts
@@ -334,51 +334,9 @@ export function executeCleanup(
           continue;
         }
 
-        // Try git worktree remove first; fall back to fs.rmSync.
-        try {
-          execSync(
-            `git -C "${project.repoPath}" worktree remove --force "${item.path}"`,
-            { encoding: 'utf-8', stdio: 'pipe', timeout: 15000 },
-          );
-        } catch (e) {
-          console.error(
-            `[Cleanup] CC subworktree remove failed for ${item.path}:`,
-            e instanceof Error ? e.message : e,
-          );
-          try {
-            fs.rmSync(item.path, { recursive: true, force: true });
-          } catch (rmErr) {
-            // Both git and fs failed — still mark removed_at so we don't
-            // keep retrying this path on every subsequent cleanup.
-            console.error(
-              `[Cleanup] CC subworktree fs.rmSync failed for ${item.path}:`,
-              rmErr instanceof Error ? rmErr.message : rmErr,
-            );
-          }
-        }
-
-        // Prune stale worktree references (best-effort, like main worktree path).
-        try {
-          execSync(`git -C "${project.repoPath}" worktree prune`, {
-            stdio: 'pipe',
-            timeout: 5000,
-          });
-        } catch (e) {
-          console.error(`[Cleanup] worktree prune failed:`, e instanceof Error ? e.message : e);
-        }
-
-        // Mark the row removed in DB regardless of git/fs outcome — we don't
-        // want repeated retries against an already-vanished directory.
-        if (typeof db.recordCcSubworktreeRemove === 'function') {
-          try {
-            db.recordCcSubworktreeRemove({ teamId: ownerTeamId, path: item.path });
-          } catch (e) {
-            console.error(
-              `[Cleanup] recordCcSubworktreeRemove failed for ${item.path}:`,
-              e instanceof Error ? e.message : e,
-            );
-          }
-        }
+        // Delegate the actual git/fs/DB work to the shared helper so the
+        // same path is exercised by `cleanupTeamCcSubworktrees` (issue #737).
+        removeCcSubworktreePath(project.repoPath, ownerTeamId, item.path);
 
         removed.push(item.name);
       }
@@ -387,6 +345,148 @@ export function executeCleanup(
         name: item.name,
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+  }
+
+  return { removed, failed };
+}
+
+// ---------------------------------------------------------------------------
+// Per-team CC subworktree cleanup (issue #737)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared helper that removes a single CC-created subworktree directory and
+ * records the removal in the database. Used by both the `cc_subworktree`
+ * branch of `executeCleanup` (PM-initiated, project-scoped) and
+ * `cleanupTeamCcSubworktrees` (auto-cleanup at team done/failed,
+ * team-scoped). Behavior-preserving extraction of the original logic; do
+ * not change semantics without updating the corresponding tests.
+ *
+ * @param repoPath Project's repo path (used as `git -C` target).
+ * @param teamId The team that owns this subworktree row.
+ * @param swPath Absolute path to the CC subworktree.
+ * @returns `{ removed: true }` on success; `{ removed: false, error }` if
+ *   both `git worktree remove --force` and the `fs.rmSync` fallback
+ *   failed. The DB row is still marked `removed_at` regardless so we do
+ *   not retry indefinitely.
+ */
+function removeCcSubworktreePath(
+  repoPath: string,
+  teamId: number,
+  swPath: string,
+): { removed: boolean; error?: string } {
+  const db = getDatabase();
+  let removed = true;
+  let lastError: string | undefined;
+
+  // Try git worktree remove first; fall back to fs.rmSync.
+  try {
+    execSync(
+      `git -C "${repoPath}" worktree remove --force "${swPath}"`,
+      { encoding: 'utf-8', stdio: 'pipe', timeout: 15000 },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[Cleanup] CC subworktree remove failed for ${swPath}:`, msg);
+    lastError = msg;
+    try {
+      fs.rmSync(swPath, { recursive: true, force: true });
+      // fs fallback succeeded — clear the error so we report removed=true.
+      lastError = undefined;
+    } catch (rmErr) {
+      const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
+      console.error(`[Cleanup] CC subworktree fs.rmSync failed for ${swPath}:`, rmMsg);
+      lastError = rmMsg;
+      removed = false;
+    }
+  }
+
+  // Prune stale worktree references (best-effort, like main worktree path).
+  try {
+    execSync(`git -C "${repoPath}" worktree prune`, {
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+  } catch (e) {
+    console.error(`[Cleanup] worktree prune failed:`, e instanceof Error ? e.message : e);
+  }
+
+  // Mark the row removed in DB regardless of git/fs outcome — we don't
+  // want repeated retries against an already-vanished directory.
+  if (typeof db.recordCcSubworktreeRemove === 'function') {
+    try {
+      db.recordCcSubworktreeRemove({ teamId, path: swPath });
+    } catch (e) {
+      console.error(
+        `[Cleanup] recordCcSubworktreeRemove failed for ${swPath}:`,
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+
+  return lastError ? { removed, error: lastError } : { removed };
+}
+
+/**
+ * Auto-cleanup helper called after a team transitions to done/failed
+ * (issue #737). Removes only CC-created subworktrees (createdVia='cc')
+ * tracked for this team. Does NOT touch the team's main worktree — that
+ * remains manual via `getCleanupPreview` / `executeCleanup`.
+ *
+ * The function is fire-and-forget safe: it logs and swallows all errors,
+ * returns a `{ removed, failed }` summary, and never throws. Callers in
+ * `team-manager.ts` invoke it in a `Promise.resolve().then(...).catch(...)`
+ * microtask so a slow `git worktree remove` cannot block the queue or
+ * SSE broadcast.
+ *
+ * @param teamId The team whose CC subworktrees should be cleaned up.
+ */
+export function cleanupTeamCcSubworktrees(teamId: number): {
+  removed: string[];
+  failed: { path: string; error: string }[];
+} {
+  const db = getDatabase();
+  const removed: string[] = [];
+  const failed: { path: string; error: string }[] = [];
+
+  const team = db.getTeam(teamId);
+  if (!team) {
+    console.log(`[Cleanup] cleanupTeamCcSubworktrees: team ${teamId} not found`);
+    return { removed, failed };
+  }
+
+  if (!team.projectId) {
+    console.log(`[Cleanup] cleanupTeamCcSubworktrees: team ${teamId} has no project`);
+    return { removed, failed };
+  }
+
+  const project = db.getProject(team.projectId);
+  if (!project) {
+    console.log(
+      `[Cleanup] cleanupTeamCcSubworktrees: project ${team.projectId} for team ${teamId} not found`,
+    );
+    return { removed, failed };
+  }
+
+  if (typeof db.getTeamSubworktrees !== 'function') {
+    // DB doesn't support subworktree tracking (older schema) — nothing to do.
+    return { removed, failed };
+  }
+
+  const subworktrees = db.getTeamSubworktrees(teamId, { activeOnly: true }) as Array<{
+    path: string;
+    createdVia: 'cc' | 'fc';
+    removedAt: string | null;
+  }>;
+
+  for (const sw of subworktrees) {
+    if (sw.createdVia !== 'cc') continue;
+    const result = removeCcSubworktreePath(project.repoPath, teamId, sw.path);
+    if (result.removed) {
+      removed.push(sw.path);
+    } else {
+      failed.push({ path: sw.path, error: result.error ?? 'unknown error' });
     }
   }
 

--- a/src/server/services/team-manager.ts
+++ b/src/server/services/team-manager.ts
@@ -30,6 +30,7 @@ import { wasTaskSeenByHook } from './task-dedup.js';
 import type { TeamPhase } from '../../shared/types.js';
 import { isValidGithubRepo } from '../utils/exec-gh.js';
 import { generateIssueContext } from './issue-context-generator.js';
+import { cleanupTeamCcSubworktrees } from './cleanup.js';
 
 const execAsync = promisify(execCallback);
 
@@ -632,6 +633,10 @@ export class TeamManager {
     );
 
     this.broadcastSnapshot();
+
+    // Auto-cleanup CC-created subworktrees (issue #737). Fire-and-forget;
+    // any cleanup work must not block the queue or SSE broadcast.
+    this.fireSubworktreeCleanup(teamId);
 
     // Process queue when a slot frees up
     if (team.projectId) {
@@ -2023,6 +2028,9 @@ export class TeamManager {
       sseBroker.broadcast('team_stopped', { team_id: teamId }, teamId);
       this.broadcastSnapshot();
 
+      // Auto-cleanup CC-created subworktrees (issue #737). Fire-and-forget.
+      this.fireSubworktreeCleanup(teamId);
+
       if (currentTeam.projectId) {
         this.processQueue(currentTeam.projectId).catch((err) => {
           console.error(`[TeamManager] processQueue error after team exit:`, err);
@@ -2122,6 +2130,9 @@ export class TeamManager {
 
     sseBroker.broadcast('team_stopped', { team_id: teamId }, teamId);
     this.broadcastSnapshot();
+
+    // Auto-cleanup CC-created subworktrees (issue #737). Fire-and-forget.
+    this.fireSubworktreeCleanup(teamId);
 
     if (currentTeam.projectId) {
       this.processQueue(currentTeam.projectId).catch((err) => {
@@ -2420,6 +2431,28 @@ export class TeamManager {
     } catch (err) {
       console.error('[TeamManager] Failed to broadcast snapshot:', err);
     }
+  }
+
+  /**
+   * Fire-and-forget auto-cleanup of CC-created subworktrees after a team
+   * transitions to done/failed (issue #737). Runs in a microtask so any
+   * synchronous throw inside `cleanupTeamCcSubworktrees` cannot abort the
+   * caller's transition path; the helper itself already swallows errors,
+   * but the `.catch()` is defensive belt-and-suspenders.
+   *
+   * Extracted into a method so tests can spy on it via
+   * `(tm as any).fireSubworktreeCleanup = vi.fn()` without having to mock
+   * the entire cleanup module.
+   */
+  private fireSubworktreeCleanup(teamId: number): void {
+    void Promise.resolve()
+      .then(() => cleanupTeamCcSubworktrees(teamId))
+      .catch((err) => {
+        console.error(
+          `[TeamManager] cleanupTeamCcSubworktrees failed for team ${teamId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      });
   }
 
   private initOutputBuffer(teamId: number): void {

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -126,6 +126,19 @@ All implementation work is assigned to the single `fleet-dev` agent. The Planner
 | Generic / unknown | CLAUDE.md only (no language-specific guidebook) |
 | Mixed (A + B) | Multiple guidebooks — dev reads all relevant ones |
 
+## Parallel research subagents (optional)
+
+The Diamond team (planner + dev + reviewer) is strictly sequential. None of those three agents use `isolation: "worktree"` — see CLAUDE.md "CC Subagent Worktree Isolation" for why.
+
+You MAY, however, spawn ad-hoc **read-only research subagents in parallel** if you need to scan a large codebase or gather diverse perspectives quickly. When you do, pass `isolation: "worktree"` to the `Agent` tool so the parallel subagents each get their own throwaway worktree and cannot collide on shared files:
+
+- Use this ONLY for subagents that **read** code/docs and return findings — never for code-writing work.
+- Do NOT isolate any of `fleet-planner`, `fleet-dev`, or `fleet-reviewer` — they need access to the team's main worktree to read/write `plan.md`, source files, `changes.md`, and `review.md`.
+- Isolated subagents see `origin/{{BASE_BRANCH}}`, not the dev's in-flight commits or uncommitted work — do not isolate any subagent that must inspect work-in-progress.
+- Fleet Commander auto-cleans CC subworktrees when the team finishes (see `cleanupTeamCcSubworktrees` in `src/server/services/cleanup.ts`), so you do not need to worry about leaked directories if a parallel subagent crashes.
+
+Default behavior: **do not spawn parallel subagents at all.** The Diamond agents cover every standard implementation flow. Only reach for parallel research when the task explicitly calls for breadth (e.g., a multi-area refactor scoping exercise).
+
 ## Workflow State Machine
 
 ```mermaid

--- a/tests/server/cleanup.test.ts
+++ b/tests/server/cleanup.test.ts
@@ -15,6 +15,7 @@ import type { Team, Project } from '../../src/shared/types.js';
 
 const mockDb = {
   getProject: vi.fn(),
+  getTeam: vi.fn(),
   getTeams: vi.fn().mockReturnValue([]),
   getTeamByWorktree: vi.fn(),
   deleteTeamAndRelated: vi.fn(),
@@ -57,7 +58,7 @@ vi.mock('fs', () => ({
 }));
 
 // Import after mocks
-const { getCleanupPreview, executeCleanup } = await import(
+const { getCleanupPreview, executeCleanup, cleanupTeamCcSubworktrees } = await import(
   '../../src/server/services/cleanup.js'
 );
 
@@ -829,5 +830,238 @@ describe('cc_subworktree execute', () => {
     );
     expect(removeCalls.length).toBe(0);
     expect(mockDb.recordCcSubworktreeRemove).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// cleanupTeamCcSubworktrees (issue #737)
+// =============================================================================
+
+describe('cleanupTeamCcSubworktrees', () => {
+  it('removes active CC subworktrees and marks them in DB', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 1,
+        teamId: 10,
+        path: '/tmp/repo/sub-1',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockExecSync.mockReturnValue('');
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result.removed).toEqual(['/tmp/repo/sub-1']);
+    expect(result.failed).toEqual([]);
+
+    // Verify git worktree remove was called with the subworktree path
+    const removeCalls = mockExecSync.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('worktree remove') &&
+        call[0].includes('/tmp/repo/sub-1'),
+    );
+    expect(removeCalls.length).toBe(1);
+
+    // activeOnly filter was passed so historical removed_at rows are skipped
+    expect(mockDb.getTeamSubworktrees).toHaveBeenCalledWith(10, { activeOnly: true });
+
+    // DB row marked removed even though the path was deleted via git
+    expect(mockDb.recordCcSubworktreeRemove).toHaveBeenCalledWith({
+      teamId: 10,
+      path: '/tmp/repo/sub-1',
+    });
+  });
+
+  it('falls back to fs.rmSync when git worktree remove fails', () => {
+    const team = makeTeam({ id: 10, status: 'failed', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 2,
+        teamId: 10,
+        path: '/tmp/repo/sub-locked',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
+        throw new Error('worktree locked');
+      }
+      return '';
+    });
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result.removed).toEqual(['/tmp/repo/sub-locked']);
+    expect(mockFs.rmSync).toHaveBeenCalledWith('/tmp/repo/sub-locked', {
+      recursive: true,
+      force: true,
+    });
+    // Even on git failure, the DB row should be marked removed so retries are bounded
+    expect(mockDb.recordCcSubworktreeRemove).toHaveBeenCalledWith({
+      teamId: 10,
+      path: '/tmp/repo/sub-locked',
+    });
+  });
+
+  it('skips subworktree rows with createdVia=fc', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 3,
+        teamId: 10,
+        path: '/tmp/repo/.claude/worktrees/proj-10',
+        branch: 'worktree-proj-10',
+        createdVia: 'fc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockExecSync.mockReturnValue('');
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result.removed).toEqual([]);
+    expect(result.failed).toEqual([]);
+
+    // git worktree remove must NEVER have been called for an FC-created row
+    const removeCalls = mockExecSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('worktree remove'),
+    );
+    expect(removeCalls.length).toBe(0);
+    expect(mockDb.recordCcSubworktreeRemove).not.toHaveBeenCalled();
+  });
+
+  it('no active rows is a no-op', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([]);
+    mockExecSync.mockReturnValue('');
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result).toEqual({ removed: [], failed: [] });
+    const removeCalls = mockExecSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('worktree remove'),
+    );
+    expect(removeCalls.length).toBe(0);
+    expect(mockDb.recordCcSubworktreeRemove).not.toHaveBeenCalled();
+  });
+
+  it('returns early when team is not found', () => {
+    mockDb.getTeam.mockReturnValue(undefined);
+
+    const result = cleanupTeamCcSubworktrees(999);
+
+    expect(result).toEqual({ removed: [], failed: [] });
+    expect(mockDb.getProject).not.toHaveBeenCalled();
+    expect(mockDb.getTeamSubworktrees).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('returns early when project is not found', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 7 });
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(undefined);
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result).toEqual({ removed: [], failed: [] });
+    expect(mockDb.getProject).toHaveBeenCalledWith(7);
+    expect(mockDb.getTeamSubworktrees).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('returns early when team has no projectId', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: null });
+    mockDb.getTeam.mockReturnValue(team);
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result).toEqual({ removed: [], failed: [] });
+    expect(mockDb.getProject).not.toHaveBeenCalled();
+    expect(mockDb.getTeamSubworktrees).not.toHaveBeenCalled();
+  });
+
+  it('reports failed entries when both git and fs.rmSync throw', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 4,
+        teamId: 10,
+        path: '/tmp/repo/sub-stuck',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('worktree remove')) {
+        throw new Error('worktree locked');
+      }
+      return '';
+    });
+    mockFs.rmSync.mockImplementation(() => {
+      throw new Error('EBUSY');
+    });
+
+    const result = cleanupTeamCcSubworktrees(10);
+
+    expect(result.removed).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.path).toBe('/tmp/repo/sub-stuck');
+    expect(result.failed[0]!.error).toContain('EBUSY');
+    // Row still marked removed so we don't retry forever
+    expect(mockDb.recordCcSubworktreeRemove).toHaveBeenCalledWith({
+      teamId: 10,
+      path: '/tmp/repo/sub-stuck',
+    });
+  });
+
+  it('never throws even when recordCcSubworktreeRemove throws', () => {
+    const team = makeTeam({ id: 10, status: 'done', projectId: 1 });
+    const project = makeProject();
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.getProject.mockReturnValue(project);
+    mockDb.getTeamSubworktrees.mockReturnValue([
+      {
+        id: 5,
+        teamId: 10,
+        path: '/tmp/repo/sub-db-fail',
+        branch: null,
+        createdVia: 'cc',
+        createdAt: '2025-01-01T00:00:00Z',
+        removedAt: null,
+      },
+    ]);
+    mockExecSync.mockReturnValue('');
+    mockDb.recordCcSubworktreeRemove.mockImplementation(() => {
+      throw new Error('DB locked');
+    });
+
+    // Must not throw — auto-cleanup is best-effort
+    expect(() => cleanupTeamCcSubworktrees(10)).not.toThrow();
   });
 });

--- a/tests/server/team-manager-lifecycle.test.ts
+++ b/tests/server/team-manager-lifecycle.test.ts
@@ -92,6 +92,17 @@ vi.mock('../../src/server/services/issue-context-generator.js', () => ({
   generateIssueContext: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Issue #737: spy on cleanupTeamCcSubworktrees so we can assert it is invoked
+// at the right transition points. Default implementation returns an empty
+// result; individual tests override with mockImplementation when they need
+// to simulate a throw.
+const mockCleanupTeamCcSubworktrees = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ removed: [], failed: [] }),
+);
+vi.mock('../../src/server/services/cleanup.js', () => ({
+  cleanupTeamCcSubworktrees: mockCleanupTeamCcSubworktrees,
+}));
+
 import { TeamManager } from '../../src/server/services/team-manager.js';
 
 // ---------------------------------------------------------------------------
@@ -284,6 +295,66 @@ describe('TeamManager.stop', () => {
 
     // stop() completed without needing the full 5000ms
     expect(mockStdin.end).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #737 — fire CC subworktree auto-cleanup after stop
+  // ---------------------------------------------------------------------------
+
+  it('invokes cleanupTeamCcSubworktrees after PM stop (issue #737)', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+
+    (tm as any).stdinPipes.set(1, createMockStdin());
+    (tm as any).childProcesses.set(1, createMockChildProcess());
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.updateTeam.mockReturnValue(team);
+
+    const stopPromise = tm.stop(1);
+    await vi.advanceTimersByTimeAsync(6000);
+    await stopPromise;
+    // Flush the microtask that schedules cleanupTeamCcSubworktrees
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCleanupTeamCcSubworktrees).toHaveBeenCalledWith(1);
+  });
+
+  it('does not block stop() when cleanup helper throws (issue #737)', async () => {
+    const team = makeTeam({ id: 1, status: 'running', pid: 12345 });
+
+    (tm as any).stdinPipes.set(1, createMockStdin());
+    (tm as any).childProcesses.set(1, createMockChildProcess());
+
+    mockDb.getTeam.mockReturnValue(team);
+    mockDb.updateTeam.mockReturnValue(team);
+
+    // Simulate a synchronous throw inside cleanupTeamCcSubworktrees.
+    mockCleanupTeamCcSubworktrees.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const stopPromise = tm.stop(1);
+    await vi.advanceTimersByTimeAsync(6000);
+    // stop() must resolve normally even though the cleanup helper threw
+    await expect(stopPromise).resolves.toBeDefined();
+    // Let the microtask run so the .catch() fires
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // team_stopped SSE was still broadcast — transition completed
+    expect(mockSseBroker.broadcast).toHaveBeenCalledWith(
+      'team_stopped',
+      { team_id: 1 },
+      1,
+    );
+    // The throw was logged
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('cleanupTeamCcSubworktrees failed for team 1'),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
   });
 });
 
@@ -1061,6 +1132,114 @@ describe('TeamManager.attachProcessHandlers (exit)', () => {
 
     // After exit, purgeTeamMaps ran — the cache entry must be gone.
     expect((tm as any).lastAssistantMessages.has(1)).toBe(false);
+  });
+
+  // =========================================================================
+  // Issue #737 — auto-cleanup CC subworktrees on terminal transitions
+  // =========================================================================
+
+  it('issue #737: invokes cleanupTeamCcSubworktrees after done transition (code 0)', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: null });
+    setupTeamMaps(1, child);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    expect(mockCleanupTeamCcSubworktrees).toHaveBeenCalledWith(1);
+    // Transition still committed
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done' }),
+    );
+  });
+
+  it('issue #737: invokes cleanupTeamCcSubworktrees after failed transition (code != 0)', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+    setupTeamMaps(1, child);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 1, null);
+    await flushExit();
+
+    expect(mockCleanupTeamCcSubworktrees).toHaveBeenCalledWith(1);
+    // Transition still committed
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+  });
+
+  it('issue #737: does not block done transition when cleanup helper throws', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running', prNumber: null });
+    setupTeamMaps(1, child);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    mockCleanupTeamCcSubworktrees.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 0, null);
+    await flushExit();
+
+    // Transition still committed — the throw inside the microtask must not
+    // abort the synchronous done branch.
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        toStatus: 'done',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'done' }),
+    );
+    // The throw was logged from the .catch() handler
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('cleanupTeamCcSubworktrees failed for team 1'),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('issue #737: does not block failed transition when cleanup helper throws', async () => {
+    const child = createMockChildProcess();
+    const team = makeTeam({ id: 1, status: 'running' });
+    setupTeamMaps(1, child);
+
+    mockDb.getTeam.mockReturnValue(team);
+
+    mockCleanupTeamCcSubworktrees.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    (tm as any).attachProcessHandlers(1, child);
+    child.emit('exit', 1, null);
+    await flushExit();
+
+    // Transition still committed
+    expect(mockDb.insertTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 1,
+        toStatus: 'failed',
+      }),
+    );
+    expect(mockDb.updateTeamSilent).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status: 'failed' }),
+    );
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

- Document FC's "no `isolation: worktree` for Diamond subagents" policy in `CLAUDE.md`, including the `worktree.baseRef` gotcha that would break isolating the dev.
- Add a green-lit "Parallel research subagents (optional)" pattern to `templates/workflow.md` (mirrored in the dogfooded `.claude/prompts/fleet-workflow.md`) for ad-hoc parallel **read-only** research subagents.
- Add automatic cleanup of CC-created subworktrees: new `cleanupTeamCcSubworktrees(teamId)` in `src/server/services/cleanup.ts`, invoked fire-and-forget from `team-manager.ts` at `stop()`, `handleProcessExit` done branch, and `handleProcessExit` failed branch — never blocks the queue or SSE.
- Refactor the existing `cc_subworktree` execute branch into a shared `removeCcSubworktreePath` helper (behavior-preserving).
- 9 new tests for `cleanupTeamCcSubworktrees` + 6 new tests verifying terminal-state cleanup invocation with throw-resilience.

Closes #737

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/server/cleanup.test.ts` — 35 pass (26 pre-existing + 9 new)
- [x] `tests/server/team-manager-lifecycle.test.ts` — 53 pass (47 pre-existing + 6 new)
- [x] Full server suite — 2126/2129 pass (3 failures are pre-existing on `origin/main` in `cc-spawn.test.ts`; out of scope)
- [x] `diff <(tr -d '\r' <templates/workflow.md) <(tr -d '\r' <.claude/prompts/fleet-workflow.md)` is empty
- [x] No state-machine.ts changes; team's main worktree is never auto-removed