### PR TITLE
Issue #733: capture effort.level from hook stdin and surface in dashboard

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -497,6 +497,13 @@ export function TeamDetail() {
                           title={detail.modelInherited ? 'FC default' : undefined}
                         >{detail.model ?? '\u2014'}</span>
                       </span>
+                      {/* Issue #733: runtime effort.level mirror */}
+                      <span className="ml-3">
+                        Effort: <span
+                          className={detail.effortInherited ? 'text-dark-muted/50 italic' : undefined}
+                          title={detail.effortInherited ? 'Inherited from project (or FC default)' : 'Runtime effort'}
+                        >{detail.effort ?? 'default'}</span>
+                      </span>
                     </div>
 
                     {/* Background work pending (issue #730) */}

--- a/src/client/components/TeamRow.tsx
+++ b/src/client/components/TeamRow.tsx
@@ -75,6 +75,8 @@ function areTeamRowPropsEqual(prev: TeamRowProps, next: TeamRowProps): boolean {
     a.durationMin === b.durationMin &&
     a.model === b.model &&
     a.modelInherited === b.modelInherited &&
+    a.effort === b.effort &&
+    a.effortInherited === b.effortInherited &&
     a.issueTitle === b.issueTitle &&
     a.projectName === b.projectName &&
     a.issueNumber === b.issueNumber &&
@@ -226,7 +228,7 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
         </span>
       </td>
 
-      {/* Model */}
+      {/* Model + effort (issue #733) */}
       <td className="px-4 whitespace-nowrap">
         <span
           className={`text-sm ${team.modelInherited ? 'text-dark-muted/50' : 'text-dark-muted'}`}
@@ -234,6 +236,16 @@ export const TeamRow = memo(function TeamRow({ team, selected, isThinking: teamI
         >
           {team.model}
         </span>
+        {team.effort ? (
+          <span
+            className={`ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] rounded border border-dark-border ${
+              team.effortInherited ? 'text-dark-muted/50' : 'text-dark-muted'
+            }`}
+            title={team.effortInherited ? 'Inherited from project' : 'Runtime effort'}
+          >
+            {team.effort}
+          </span>
+        ) : null}
       </td>
 
       {/* Duration */}

--- a/src/client/context/FleetContext.tsx
+++ b/src/client/context/FleetContext.tsx
@@ -214,6 +214,17 @@ export function FleetProvider({ children }: { children: ReactNode }) {
         thinkingTeamIdsRef.current.delete(payload.team_id);
         forceThinkingUpdate((n) => n + 1);
       }
+    } else if (type === 'effort_changed') {
+      // Issue #733: incremental update — apply the new effort to the
+      // affected team. The event carries the resolved (runtime) value, so
+      // `effortInherited` is always false after this event.
+      const payload = data as { team_id?: number; effort?: string };
+      if (typeof payload.team_id === 'number' && typeof payload.effort === 'string') {
+        setTeams(prev => prev.map(team => {
+          if (team.id !== payload.team_id) return team;
+          return { ...team, effort: payload.effort as string, effortInherited: false };
+        }));
+      }
     }
     // usage_updated: no longer triggers team list refetch (C7)
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -154,6 +154,8 @@ export interface TeamUpdate {
   startedAt?: string | null;
   stoppedAt?: string | null;
   lastEventAt?: string | null;
+  /** Runtime effort mirror (issue #733). Pass `null` to clear back to project default. */
+  effort?: string | null;
 }
 
 export interface EventInsert {
@@ -463,6 +465,9 @@ export class FleetDatabase {
 
     // Add hook_mode column to projects (v25 migration — HTTP vs bash hooks, issue #735)
     this.addHookModeColumn();
+
+    // Add effort column to teams (v26 migration — runtime effort tracking, issue #733)
+    this.addTeamEffortColumn();
 
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
@@ -1485,6 +1490,52 @@ export class FleetDatabase {
   }
 
   /**
+   * Add effort column to teams table if it doesn't exist (v26 migration).
+   * Nullable TEXT with CHECK constraint restricting values to the 4 CC
+   * adaptive-reasoning effort levels: low, medium, high, xhigh ('max' was
+   * removed in CC 2.1.68). Mirrors the spawn-time effort lived on
+   * `projects.effort` and is updated at runtime from `cc_stdin.effort.level`
+   * so a `/effort high` mid-session change can be surfaced in the dashboard
+   * (issue #733).
+   *
+   * Also drops the existing v_team_dashboard view so schema.sql can recreate
+   * it with the new `team_effort` / `effort` / `project_effort` columns —
+   * same pattern as v18's started_at migration.
+   *
+   * Fresh databases get the column via schema.sql; upgraded databases use
+   * this migration. Idempotent across restarts.
+   *
+   * Note: bumped from v25 to v26 after rebasing onto origin/main because
+   * issue #735 (addHookModeColumn) had already claimed v25 by the time this
+   * branch was ready to merge. The two migrations are otherwise independent.
+   */
+  private addTeamEffortColumn(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(teams)').all() as Array<{ name: string }>;
+      // Fresh DB: teams table doesn't exist yet — schema.sql will create it
+      // with effort already present. Nothing to migrate.
+      if (cols.length === 0) return;
+      const hasColumn = cols.some((c) => c.name === 'effort');
+      if (!hasColumn) {
+        this.db.exec(
+          "ALTER TABLE teams ADD COLUMN effort TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh'))"
+        );
+        console.log('[DB] v26 migration: added effort column to teams');
+      }
+
+      // Drop the view so schema.sql can recreate it with the new effort columns.
+      // Safe to re-run — schema.sql will create the authoritative definition
+      // afterwards, but we drop the stale one here so the version check matches.
+      this.db.exec('DROP VIEW IF EXISTS v_team_dashboard');
+
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (26)');
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v26 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
    * Migrate branch_behind and branch_behind_resolved message templates
    * from hardcoded 'main' to use {{BASE_BRANCH}} placeholder.
    * Only updates templates that exactly match the old defaults (user edits are preserved).
@@ -2145,6 +2196,13 @@ export class FleetDatabase {
     if (fields.lastEventAt !== undefined) {
       setClauses.push('last_event_at = @lastEventAt');
       params.lastEventAt = fields.lastEventAt;
+    }
+    if (fields.effort !== undefined) {
+      // Issue #733: runtime effort mirror. CHECK constraint on the column
+      // restricts the value to the 4 canonical CC levels (low/medium/high/xhigh)
+      // or NULL; the caller is expected to normalize the value beforehand.
+      setClauses.push('effort = @effort');
+      params.effort = fields.effort;
     }
     if (fields.retryCount !== undefined) {
       setClauses.push('retry_count = @retryCount');
@@ -3527,6 +3585,7 @@ export class FleetDatabase {
       totalCostUsd: (row.total_cost_usd as number | undefined) ?? 0,
       blockedByJson: (row.blocked_by_json as string | null) ?? null,
       pendingChildrenJson: (row.pending_children_json as string | null) ?? null,
+      effort: (row.effort as string | null) ?? null,
       backgroundTasksJson: (row.background_tasks_json as string | null) ?? null,
       sessionCronsJson: (row.session_crons_json as string | null) ?? null,
       retryCount: (row.retry_count as number | undefined) ?? 0,
@@ -3610,6 +3669,12 @@ export class FleetDatabase {
       projectName: (row.project_name as string | null) ?? null,
       model: (row.model as string | null) ?? config.defaultModel,
       modelInherited: (row.model as string | null) === null,
+      // Issue #733: `effort` is the resolved value (COALESCE team→project),
+      // `team_effort` is the raw nullable team column used to compute
+      // inheritance. The view exposes both so the API can render the resolved
+      // value while still distinguishing inherited from explicit.
+      effort: (row.effort as string | null) ?? null,
+      effortInherited: (row.team_effort as string | null) === null,
       status: row.status as TeamStatus,
       phase: row.phase as TeamPhase,
       worktreeName: row.worktree_name as string,

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -109,6 +109,10 @@ function buildPayloadFromLegacy(body: Record<string, unknown>): EventPayload {
     msg_summary: str(body.msg_summary),
     owner: str(body.owner),
     duration_ms: durationMs,
+    // Issue #733: future-proof legacy shell that pre-extracts effort. The
+    // canonical extraction path is cc_stdin; this field exists so direct route
+    // callers can also surface a runtime effort change.
+    effort: str(body.effort),
   };
 }
 

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS teams (
   pr_number       INTEGER,
   custom_prompt   TEXT,                            -- custom prompt override (persisted for queued teams)
   headless        INTEGER NOT NULL DEFAULT 1,     -- 0=interactive terminal, 1=headless stream-json
+  effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh')),  -- runtime CC adaptive-reasoning effort mirror (issue #733); NULL = inherit project effort
   blocked_by_json TEXT,                            -- JSON array of blocking issue numbers e.g. [368, 370]
   pending_children_json TEXT,                     -- JSON array of open child issue numbers e.g. [371, 372]
   retry_count     INTEGER NOT NULL DEFAULT 0,     -- auto-retry count (0 = never retried)
@@ -180,6 +181,12 @@ SELECT
   t.project_id,
   p.name AS project_name,
   p.model AS model,
+  -- Issue #733: runtime effort mirror. `team_effort` exposes the raw nullable
+  -- team value so the API layer can compute `effortInherited`; `effort` is the
+  -- resolved value with project fallback so the UI can render a single string.
+  t.effort AS team_effort,
+  COALESCE(t.effort, p.effort) AS effort,
+  p.effort AS project_effort,
   p.max_active_teams,
   p.github_repo AS github_repo,
   p.issue_provider AS project_issue_provider,
@@ -448,4 +455,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_team_subworktrees_team_path_active
   ON team_subworktrees(team_id, path) WHERE removed_at IS NULL;
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (25);
+INSERT OR IGNORE INTO schema_version (version) VALUES (26);

--- a/src/server/services/event-collector.ts
+++ b/src/server/services/event-collector.ts
@@ -58,6 +58,7 @@ export interface EventPayload {
   background_tasks?: string;    // JSON-stringified array of pending background tasks
   session_crons?: string;       // JSON-stringified array of pending session crons
   duration_ms?: number;         // Tool execution time in ms (CC 2.1.119+, PostToolUse / PostToolUseFailure only)
+  effort?: string;              // CC 2.1.133+ effort.level extracted from cc_stdin (see routes/events.ts).
 }
 
 /** Result returned from processEvent */
@@ -69,7 +70,10 @@ export interface ProcessEventResult {
 
 /** Minimal DB abstraction (subset of methods used by EventCollector) */
 export interface EventCollectorDb {
-  getTeamByWorktree(worktreeName: string): { id: number; status: TeamStatus; phase: string } | undefined;
+  // Issue #733: include `effort` in the lookup shape so processEvent can diff
+  // against the stored runtime value without an extra DB roundtrip. The DB
+  // method already SELECTs *, so the marginal cost is negligible.
+  getTeamByWorktree(worktreeName: string): { id: number; status: TeamStatus; phase: string; effort: string | null } | undefined;
   insertEvent(event: {
     teamId: number;
     sessionId: string | null;
@@ -568,6 +572,37 @@ export function normalizeJsonArray(input: string | undefined): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Effort-level normalization (Issue #733)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical Claude Code adaptive-reasoning effort levels. Mirrors the
+ * `EffortLevel` union in `src/shared/types.ts` and the CHECK constraint on
+ * the `teams.effort` / `projects.effort` columns. `max` was removed by CC in
+ * 2.1.68 and is intentionally absent.
+ */
+const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh']);
+
+/**
+ * Normalize a raw effort string from `cc_stdin.effort.level` into one of the
+ * 4 canonical CC levels, or `null` when the input is missing or invalid.
+ *
+ * Returns the lowercased trimmed string when it matches a canonical level;
+ * returns `null` otherwise so the caller can treat missing / invalid input
+ * as "no-op" (no DB write, no SSE emission).
+ *
+ * Exported for unit-test access.
+ */
+export function normalizeEffortLevel(raw: string | undefined | null): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '') return null;
+  if (!VALID_EFFORT_LEVELS.has(trimmed)) return null;
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
 // StopFailure classification (Issue #727)
 // ---------------------------------------------------------------------------
 
@@ -859,6 +894,27 @@ export function processEvent(
     }
   }
 
+  // ── Effort-level change detection (Issue #733) ──────────────────────
+  // CC 2.1.133+ ships `effort.level` inside cc_stdin on every hook event.
+  // routes/events.ts flattens that nested string into `payload.effort`. We
+  // diff against the stored team value (loaded via getTeamByWorktree above)
+  // and only write/emit when the value actually changes — this keeps no-op
+  // events cheap (no DB churn, no SSE traffic) while still capturing every
+  // `/effort high` mid-session change as it lands. Invalid or missing values
+  // normalize to `null` and skip the write entirely.
+  //
+  // Terminal teams (done/failed) are excluded because their effort is fixed
+  // history and never receives new hook events that should mutate it.
+  let effortChange: { teamId: number; previous: string | null; current: string } | undefined;
+  if (!isTerminal) {
+    const normalizedEffort = normalizeEffortLevel(payload.effort);
+    if (normalizedEffort !== null && team.effort !== normalizedEffort) {
+      effortChange = { teamId, previous: team.effort, current: normalizedEffort };
+      statusUpdateData ??= { teamId, fields: {} };
+      statusUpdateData.fields.effort = normalizedEffort;
+    }
+  }
+
   // ── Throttle tool_use events ─────────────────────────────────────
   // Throttled events still need a heartbeat update and any transition
   // that was determined above. For throttled events, execute the
@@ -881,6 +937,17 @@ export function processEvent(
           team_id: teamId,
           status: 'running',
           previous_status: previousStatus,
+        }, teamId);
+      }
+      // Issue #733: a `/effort` change can land on a throttled tool_use; the
+      // DB write went through inside processThrottledUpdate (effort is on
+      // statusUpdate.fields), so we still need to emit the SSE so the UI
+      // converges. Skipping this branch would drop the change silently.
+      if (effortChange) {
+        sse.broadcast('effort_changed', {
+          team_id: effortChange.teamId,
+          effort: effortChange.current,
+          previous_effort: effortChange.previous,
         }, teamId);
       }
       return { event_id: null, team_id: teamId, processed: false };
@@ -1086,6 +1153,18 @@ export function processEvent(
       previous_status: team.status,
       phase: phaseUpdateData.phase,
       previous_phase: phaseUpdateData.previousPhase,
+    }, teamId);
+  }
+
+  // Issue #733: announce a runtime effort change. Standalone event (rather
+  // than a field on team_status_changed) so subscribers that only care about
+  // status transitions are not paged for effort-only deltas, and the
+  // FleetContext incremental update path stays focused on status/phase data.
+  if (effortChange) {
+    sse.broadcast('effort_changed', {
+      team_id: effortChange.teamId,
+      effort: effortChange.current,
+      previous_effort: effortChange.previous,
     }, teamId);
   }
 

--- a/src/server/services/sse-broker.ts
+++ b/src/server/services/sse-broker.ts
@@ -39,7 +39,11 @@ export type SSEEventType =
   | 'relations_updated'
   | 'team_handoff_file'
   | 'team_warning'
-  | 'usage_override_changed';
+  | 'usage_override_changed'
+  // Issue #733: runtime effort.level delta — emitted when EventCollector
+  // detects that `cc_stdin.effort.level` no longer matches the stored
+  // `teams.effort` value (e.g. TL ran `/effort high` mid-session).
+  | 'effort_changed';
 
 /** Payload shapes for each event type */
 export interface SSEEventPayloads {
@@ -64,6 +68,9 @@ export interface SSEEventPayloads {
   team_handoff_file: { team_id: number; file_type: string; agent_name: string | null; captured_at: string };
   team_warning: { team_id: number; warning_type: string; message: string; details?: Record<string, unknown> };
   usage_override_changed: { overrideActive: boolean; hardPaused: boolean };
+  // Issue #733: previous_effort is nullable because the first non-null value
+  // we observe replaces an inherited project default (raw teams.effort=NULL).
+  effort_changed: { team_id: number; effort: string; previous_effort: string | null };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/team-service.ts
+++ b/src/server/services/team-service.ts
@@ -480,13 +480,15 @@ export class TeamService {
       throw notFoundError(`Team ${teamId} not found`);
     }
 
-    // Look up project to get model and GitHub repo
+    // Look up project to get model, effort, and GitHub repo
     let projectModel: string | null = null;
+    let projectEffort: string | null = null;
     let projectGithubRepo: string | null = null;
     if (team.projectId) {
       const project = db.getProject(team.projectId);
       if (project) {
         projectModel = project.model ?? null;
+        projectEffort = project.effort ?? null;
         projectGithubRepo = project.githubRepo ?? null;
       }
     }
@@ -594,6 +596,11 @@ export class TeamService {
       issueProvider: team.issueProvider,
       model: projectModel ?? config.defaultModel,
       modelInherited: projectModel === null,
+      // Issue #733: resolved effort prefers the team's runtime mirror over the
+      // project's spawn-time default. `effortInherited=true` when the team has
+      // no runtime override (raw team.effort is NULL).
+      effort: team.effort ?? projectEffort ?? null,
+      effortInherited: team.effort === null,
       githubRepo: projectGithubRepo,
       status: team.status,
       phase: team.phase,

--- a/src/server/utils/build-event-payload.ts
+++ b/src/server/utils/build-event-payload.ts
@@ -101,6 +101,18 @@ export function buildEventPayloadFromCc(
   payload.owner = str(ccBody.owner);
   payload.cwd = str(ccBody.cwd);
 
+  // Issue #733: CC 2.1.133+ adds effort.level to hook stdin. Extract the
+  // nested string into a flat payload.effort field so EventCollector can
+  // diff against the stored team value without re-parsing JSON. Defensive
+  // shape check: cc.effort must be an object with a string `level` — any
+  // other shape (string, array, number) is dropped.
+  if (ccBody.effort && typeof ccBody.effort === 'object' && !Array.isArray(ccBody.effort)) {
+    const eff = ccBody.effort as Record<string, unknown>;
+    if (typeof eff.level === 'string') {
+      payload.effort = eff.level;
+    }
+  }
+
   // CC 2.1.145+ Stop / SubagentStop hook input ships arrays of pending
   // background tasks and session crons. Stringify them so they fit the
   // EventPayload string-only schema (see issue #730). The legacy shell

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -261,6 +261,14 @@ export interface Team {
   lastEventAt: string | null;
   blockedByJson: string | null;
   pendingChildrenJson: string | null;
+  /**
+   * Runtime adaptive-reasoning effort level (issue #733).
+   * Mirrors `effort.level` from CC 2.1.133+ hook stdin so a `/effort high`
+   * mid-session change can be surfaced in the dashboard. NULL means the team
+   * is inheriting the project's `effort` (or the FC default when both are NULL).
+   * Constrained to the canonical CC levels via a CHECK on the column.
+   */
+  effort: string | null;
   backgroundTasksJson: string | null;
   sessionCronsJson: string | null;
   retryCount: number;
@@ -615,6 +623,14 @@ export interface TeamDashboardRow {
   projectName: string | null;
   model: string | null;
   modelInherited: boolean;
+  /**
+   * Resolved adaptive-reasoning effort level for this team (issue #733).
+   * COALESCE(team.effort, project.effort) — team's runtime value wins over the
+   * project's spawn-time default. NULL when neither is set (CC picks default).
+   */
+  effort: string | null;
+  /** True when the resolved effort comes from the project (team's raw effort is NULL). */
+  effortInherited: boolean;
   status: TeamStatus;
   phase: TeamPhase;
   worktreeName: string;
@@ -659,6 +675,14 @@ export interface TeamDetail {
   issueProvider: string | null;
   model?: string | null;
   modelInherited?: boolean;
+  /**
+   * Resolved adaptive-reasoning effort level (issue #733). COALESCE of the
+   * team's runtime mirror and the project's spawn-time default. NULL when
+   * neither is set.
+   */
+  effort?: string | null;
+  /** True when the resolved effort comes from the project (team's raw effort is NULL). */
+  effortInherited?: boolean;
   status: TeamStatus;
   phase: TeamPhase;
   pid: number | null;

--- a/tests/server/services/event-collector-effort.test.ts
+++ b/tests/server/services/event-collector-effort.test.ts
@@ -1,0 +1,724 @@
+// =============================================================================
+// Fleet Commander — Event Collector effort.level capture tests
+// =============================================================================
+// Issue #733: CC 2.1.133+ emits `effort.level` on every hook stdin payload.
+// EventCollector diffs the value against the stored teams.effort row and
+// writes + emits `effort_changed` only when it actually changes. No-op events
+// (missing/invalid effort, same as stored) must NOT touch the DB or SSE.
+//
+// Covers:
+//   - extraction via buildPayloadFromCcStdin (route layer)
+//   - normalizeEffortLevel unit cases
+//   - persistence path: diff against stored, write effort + emit SSE
+//   - no-op cases: missing, invalid, same-as-stored
+//   - first-event (previous_effort=null) emission
+//   - throttled tool_use path still applies effort change
+//   - sequential mid-session changes
+//   - DB-layer round trip (real SQLite)
+// =============================================================================
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import {
+  processEvent,
+  normalizeEffortLevel,
+  resetThrottleState,
+  resetSubagentTrackers,
+  resetPrPollState,
+  resetEventDedupState,
+  type EventPayload,
+  type EventCollectorDb,
+  type SseBroker,
+} from '../../../src/server/services/event-collector.js';
+import {
+  buildPayloadFromCcStdin,
+  buildPayloadFromLegacy,
+} from '../../../src/server/routes/events.js';
+import { getDatabase, closeDatabase } from '../../../src/server/db.js';
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+interface MockTeam {
+  id: number;
+  status: 'queued' | 'launching' | 'running' | 'idle' | 'stuck' | 'done' | 'failed';
+  phase: string;
+  effort: string | null;
+}
+
+function createMockDb(
+  team: MockTeam = { id: 7, status: 'running', phase: 'implementing', effort: null },
+  overrides?: Partial<EventCollectorDb>,
+): EventCollectorDb {
+  let nextEventId = 1;
+  let nextMsgId = 1;
+
+  const insertEvent = vi.fn().mockImplementation(() => ({ id: nextEventId++ }));
+  const updateTeam = vi.fn();
+  const insertTransition = vi.fn();
+  const insertAgentMessage = vi.fn().mockImplementation(() => ({ id: nextMsgId++ }));
+
+  const processEventTransaction = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+      eventInsert: { teamId: number; sessionId: string | null; agentName: string | null; eventType: string; toolName?: string | null; payload: string; durationMs?: number | null };
+      agentMessages?: Array<{ teamId: number; sender: string; recipient: string; summary?: string | null; content?: string | null; sessionId?: string | null }>;
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+      const result = insertEvent(ops.eventInsert);
+      const eventId = result.id;
+      if (ops.agentMessages) {
+        for (const msg of ops.agentMessages) {
+          insertAgentMessage({ ...msg, eventId });
+        }
+      }
+      return { eventId };
+    },
+  );
+
+  const processThrottledUpdate = vi.fn().mockImplementation(
+    (ops: {
+      transition?: { teamId: number; fromStatus: string; toStatus: string; trigger: string; reason: string };
+      statusUpdate?: { teamId: number; fields: Record<string, unknown> };
+      heartbeatUpdate: { teamId: number; lastEventAt: string };
+    }) => {
+      if (ops.transition) {
+        insertTransition(ops.transition);
+      }
+      if (ops.statusUpdate) {
+        updateTeam(ops.statusUpdate.teamId, ops.statusUpdate.fields);
+      }
+      updateTeam(ops.heartbeatUpdate.teamId, { lastEventAt: ops.heartbeatUpdate.lastEventAt });
+    },
+  );
+
+  return {
+    getTeamByWorktree: vi.fn().mockReturnValue(team),
+    insertEvent,
+    updateTeam,
+    updateTeamSilent: updateTeam,
+    insertTransition,
+    insertAgentMessage,
+    processEventTransaction,
+    processThrottledUpdate,
+    ...overrides,
+  };
+}
+
+function createMockSse(): SseBroker {
+  return {
+    broadcast: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset state between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetThrottleState();
+  resetSubagentTrackers();
+  resetPrPollState();
+  resetEventDedupState();
+});
+
+// =============================================================================
+// normalizeEffortLevel — unit cases
+// =============================================================================
+
+describe('normalizeEffortLevel', () => {
+  it('accepts the 4 canonical CC levels lowercase', () => {
+    expect(normalizeEffortLevel('low')).toBe('low');
+    expect(normalizeEffortLevel('medium')).toBe('medium');
+    expect(normalizeEffortLevel('high')).toBe('high');
+    expect(normalizeEffortLevel('xhigh')).toBe('xhigh');
+  });
+
+  it('lowercases mixed-case input before validating', () => {
+    expect(normalizeEffortLevel('HIGH')).toBe('high');
+    expect(normalizeEffortLevel('XHigh')).toBe('xhigh');
+    expect(normalizeEffortLevel('Medium')).toBe('medium');
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(normalizeEffortLevel('  high  ')).toBe('high');
+    expect(normalizeEffortLevel('\thigh\n')).toBe('high');
+  });
+
+  it('returns null for the legacy "max" level (removed in CC 2.1.68)', () => {
+    expect(normalizeEffortLevel('max')).toBeNull();
+    expect(normalizeEffortLevel('MAX')).toBeNull();
+  });
+
+  it('returns null for unrecognized strings', () => {
+    expect(normalizeEffortLevel('extreme')).toBeNull();
+    expect(normalizeEffortLevel('huge')).toBeNull();
+    expect(normalizeEffortLevel('default')).toBeNull();
+  });
+
+  it('returns null for missing/empty input', () => {
+    expect(normalizeEffortLevel(undefined)).toBeNull();
+    expect(normalizeEffortLevel(null)).toBeNull();
+    expect(normalizeEffortLevel('')).toBeNull();
+    expect(normalizeEffortLevel('   ')).toBeNull();
+  });
+
+  it('returns null for non-string input (defensive)', () => {
+    // The type signature accepts string | undefined | null, but real-world
+    // payloads may bypass the contract (e.g. malformed cc_stdin).
+    expect(normalizeEffortLevel(42 as unknown as string)).toBeNull();
+    expect(normalizeEffortLevel({} as unknown as string)).toBeNull();
+    expect(normalizeEffortLevel([] as unknown as string)).toBeNull();
+  });
+});
+
+// =============================================================================
+// processEvent — effort write + SSE emit
+// =============================================================================
+
+describe('EventCollector — effort change detection (issue #733)', () => {
+  it('writes effort and emits effort_changed when payload differs from stored', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'medium' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'high',
+    };
+
+    processEvent(payload, db, sse);
+
+    // Verify the statusUpdate carried effort: 'high'
+    const transactionMock = db.processEventTransaction as ReturnType<typeof vi.fn>;
+    const ops = transactionMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    expect(ops.statusUpdate).toBeDefined();
+    expect(ops.statusUpdate!.fields.effort).toBe('high');
+
+    // Verify SSE broadcast
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'effort_changed',
+      {
+        team_id: 7,
+        effort: 'high',
+        previous_effort: 'medium',
+      },
+      7,
+    );
+  });
+
+  it('emits previous_effort: null when stored effort was null (first observation)', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: null });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'xhigh',
+    };
+
+    processEvent(payload, db, sse);
+
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'effort_changed',
+      {
+        team_id: 7,
+        effort: 'xhigh',
+        previous_effort: null,
+      },
+      7,
+    );
+  });
+
+  it('does NOT write or emit when payload effort matches stored', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'high' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'high',
+    };
+
+    processEvent(payload, db, sse);
+
+    // statusUpdate should be undefined (no fields to set besides the
+    // status-machine fields which don't fire on a plain running->running
+    // tool_use). Verify effort field never showed up.
+    const transactionMock = db.processEventTransaction as ReturnType<typeof vi.fn>;
+    const ops = transactionMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    if (ops.statusUpdate) {
+      expect(ops.statusUpdate.fields.effort).toBeUndefined();
+    }
+
+    // No SSE broadcast for effort_changed
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(0);
+  });
+
+  it('does NOT write or emit when payload effort is missing', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'medium' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      // effort omitted
+    };
+
+    processEvent(payload, db, sse);
+
+    const transactionMock = db.processEventTransaction as ReturnType<typeof vi.fn>;
+    const ops = transactionMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    if (ops.statusUpdate) {
+      expect(ops.statusUpdate.fields.effort).toBeUndefined();
+    }
+
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(0);
+  });
+
+  it('does NOT write or emit when payload effort is invalid', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'medium' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'extreme', // not in the canonical set
+    };
+
+    processEvent(payload, db, sse);
+
+    const transactionMock = db.processEventTransaction as ReturnType<typeof vi.fn>;
+    const ops = transactionMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    if (ops.statusUpdate) {
+      expect(ops.statusUpdate.fields.effort).toBeUndefined();
+    }
+
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(0);
+  });
+
+  it("rejects the legacy 'max' effort level (CC 2.1.68 removed it)", () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'high' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'max',
+    };
+
+    processEvent(payload, db, sse);
+
+    const transactionMock = db.processEventTransaction as ReturnType<typeof vi.fn>;
+    const ops = transactionMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    if (ops.statusUpdate) {
+      expect(ops.statusUpdate.fields.effort).toBeUndefined();
+    }
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(0);
+  });
+
+  it('does NOT write or emit when team is terminal (done)', () => {
+    const db = createMockDb({ id: 7, status: 'done', phase: 'done', effort: 'medium' });
+    const sse = createMockSse();
+    const payload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'high',
+    };
+
+    processEvent(payload, db, sse);
+
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(0);
+  });
+
+  it('applies effort change on the throttled tool_use path', () => {
+    const db = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'low' });
+    const sse = createMockSse();
+    const basePayload: EventPayload = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+    };
+
+    // First event lands outside the throttle window — primes the timestamp.
+    processEvent({ ...basePayload, effort: 'low' }, db, sse);
+    // Clear broadcast history so we only see the second event's emissions.
+    (sse.broadcast as ReturnType<typeof vi.fn>).mockClear();
+
+    // Second event arrives immediately — inside the throttle window. Carries
+    // a new effort. processThrottledUpdate (not processEventTransaction) must
+    // commit the effort and SSE must still emit.
+    processEvent({ ...basePayload, effort: 'xhigh' }, db, sse);
+
+    // Verify the throttled path was hit (no insertEvent on the second call)
+    // and the statusUpdate carried effort: 'xhigh'.
+    const throttledMock = db.processThrottledUpdate as ReturnType<typeof vi.fn>;
+    expect(throttledMock).toHaveBeenCalled();
+    const throttledOps = throttledMock.mock.calls[0]![0] as { statusUpdate?: { fields: Record<string, unknown> } };
+    expect(throttledOps.statusUpdate).toBeDefined();
+    expect(throttledOps.statusUpdate!.fields.effort).toBe('xhigh');
+
+    // SSE broadcast still fires
+    expect(sse.broadcast).toHaveBeenCalledWith(
+      'effort_changed',
+      {
+        team_id: 7,
+        effort: 'xhigh',
+        previous_effort: 'low',
+      },
+      7,
+    );
+  });
+
+  it('handles two sequential mid-session changes correctly', () => {
+    // Stored effort starts at 'low'. Two distinct events arrive carrying
+    // 'medium' and then 'high'. Both should emit; payload2 must NOT see
+    // payload1's previous_effort.
+    const sse = createMockSse();
+
+    // First call: stored=low -> medium
+    const db1 = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'low' });
+    processEvent(
+      {
+        event: 'subagent_start',
+        team: 'proj-100',
+        timestamp: new Date().toISOString(),
+        session_id: 'sess-1',
+        effort: 'medium',
+      },
+      db1,
+      sse,
+    );
+
+    // Second call: stored=medium (mock updated) -> high
+    const db2 = createMockDb({ id: 7, status: 'running', phase: 'implementing', effort: 'medium' });
+    processEvent(
+      {
+        event: 'subagent_start',
+        team: 'proj-100',
+        timestamp: new Date().toISOString(),
+        session_id: 'sess-1',
+        effort: 'high',
+      },
+      db2,
+      sse,
+    );
+
+    const sseMock = sse.broadcast as ReturnType<typeof vi.fn>;
+    const effortBroadcasts = sseMock.mock.calls.filter((c) => c[0] === 'effort_changed');
+    expect(effortBroadcasts).toHaveLength(2);
+    // Both broadcasts must use the correct previous values.
+    expect(effortBroadcasts[0]![1]).toMatchObject({ effort: 'medium', previous_effort: 'low' });
+    expect(effortBroadcasts[1]![1]).toMatchObject({ effort: 'high', previous_effort: 'medium' });
+  });
+});
+
+// =============================================================================
+// Route builders — extraction path
+// =============================================================================
+
+describe('buildPayloadFromCcStdin — effort.level extraction (issue #733)', () => {
+  it('extracts effort.level from a nested cc.effort object', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: { level: 'xhigh', remaining_budget: 100 },
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBe('xhigh');
+  });
+
+  it('returns undefined effort when cc_stdin omits the field', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      // no effort
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBeUndefined();
+  });
+
+  it('returns undefined effort when cc.effort is a string instead of an object', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: 'high', // wrong shape — should be { level: 'high' }
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBeUndefined();
+  });
+
+  it('returns undefined effort when cc.effort is an array', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: ['high'], // arrays don't match the { level: string } shape
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBeUndefined();
+  });
+
+  it('returns undefined effort when cc.effort.level is not a string', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      effort: { level: 5 }, // wrong type — should be a string
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBeUndefined();
+  });
+
+  it('extracts effort.level alongside other CC fields without interference', () => {
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      duration_ms: 1234,
+      model: 'opus',
+      effort: { level: 'high' },
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBe('high');
+    expect(payload.duration_ms).toBe(1234);
+    expect(payload.model).toBe('opus');
+    expect(payload.tool_name).toBe('Bash');
+  });
+
+  it('replays a realistic cc_stdin payload carrying effort.level=xhigh', () => {
+    // Sanity check: the canonical CC 2.1.133+ payload shape carrying every
+    // field EventCollector touches alongside the new effort.level.
+    const ccStdin = JSON.stringify({
+      session_id: 'sess-abc',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+      duration_ms: 850,
+      cwd: '/tmp/wt',
+      worktree_path: '/tmp/wt',
+      effort: { level: 'xhigh', remaining_budget: 42 },
+    });
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      cc_stdin: ccStdin,
+    };
+
+    const payload = buildPayloadFromCcStdin(body);
+
+    expect(payload.effort).toBe('xhigh');
+  });
+});
+
+describe('buildPayloadFromLegacy — effort extraction (issue #733)', () => {
+  it('extracts effort from a legacy body field', () => {
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      tool_name: 'Bash',
+      effort: 'high',
+    };
+
+    const payload = buildPayloadFromLegacy(body);
+
+    expect(payload.effort).toBe('high');
+  });
+
+  it('returns undefined effort when legacy body omits it', () => {
+    const body = {
+      event: 'tool_use',
+      team: 'proj-100',
+      timestamp: new Date().toISOString(),
+      tool_name: 'Bash',
+    };
+
+    const payload = buildPayloadFromLegacy(body);
+
+    expect(payload.effort).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// DB-layer round-trip — real SQLite instance
+// =============================================================================
+
+describe('Database — teams.effort persistence and v_team_dashboard exposure (issue #733)', () => {
+  let dbPath: string;
+  let teamId: number;
+  let projectId: number;
+
+  beforeAll(() => {
+    dbPath = path.join(
+      os.tmpdir(),
+      `fleet-evt-effort-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+
+    closeDatabase();
+    process.env['FLEET_DB_PATH'] = dbPath;
+    const db = getDatabase(dbPath);
+
+    // Project carries a spawn-time effort that the team inherits when not
+    // overridden. Tests below verify both the inherited and overridden paths.
+    const project = db.insertProject({
+      name: `evt-effort-project`,
+      repoPath: `C:/fake/evt-effort-repo-${Date.now()}`,
+      effort: 'medium',
+    });
+    projectId = project.id;
+    const team = db.insertTeam({
+      issueNumber: 733,
+      worktreeName: `evt-effort-${Date.now()}`,
+      status: 'running',
+      phase: 'implementing',
+      projectId: project.id,
+      launchedAt: new Date().toISOString(),
+    });
+    teamId = team.id;
+  });
+
+  afterAll(() => {
+    closeDatabase();
+
+    for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+      try {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    delete process.env['FLEET_DB_PATH'];
+  });
+
+  it('persists effort=NULL by default on a freshly inserted team', () => {
+    const db = getDatabase();
+    const team = db.getTeam(teamId);
+    expect(team).toBeDefined();
+    expect(team!.effort).toBeNull();
+  });
+
+  it('writes and reads back effort via updateTeam', () => {
+    const db = getDatabase();
+    db.updateTeam(teamId, { effort: 'high' });
+    const team = db.getTeam(teamId);
+    expect(team!.effort).toBe('high');
+  });
+
+  it('rejects invalid effort values via the CHECK constraint', () => {
+    const db = getDatabase();
+    // 'max' was removed in CC 2.1.68 and is now disallowed.
+    expect(() => db.updateTeam(teamId, { effort: 'max' })).toThrow();
+    // Unknown values are also rejected.
+    expect(() => db.updateTeam(teamId, { effort: 'extreme' })).toThrow();
+  });
+
+  it('exposes effort and team_effort on v_team_dashboard with COALESCE fallback', () => {
+    const db = getDatabase();
+
+    // Set team to 'low' first; resolved effort should be 'low' (team wins).
+    db.updateTeam(teamId, { effort: 'low' });
+    let row = db.getTeamDashboard().find((r) => r.id === teamId);
+    expect(row).toBeDefined();
+    expect(row!.effort).toBe('low');
+    expect(row!.effortInherited).toBe(false);
+
+    // Clear the team effort; resolved should fall back to the project's
+    // 'medium', and effortInherited should flip to true.
+    db.updateTeam(teamId, { effort: null });
+    row = db.getTeamDashboard().find((r) => r.id === teamId);
+    expect(row!.effort).toBe('medium');
+    expect(row!.effortInherited).toBe(true);
+  });
+
+  it('keeps projectId reachable for verification', () => {
+    expect(projectId).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a runtime mirror of the effort level on the `teams` table so mid-session `/effort` changes by the TL agent are reflected in the FC dashboard. CC 2.1.133+ ships `effort.level` on every hook stdin payload — this PR extracts it, persists on diff, emits an SSE `effort_changed` event, and surfaces the live value in `TeamRow` and `TeamDetail`.

- New `teams.effort` TEXT column with CHECK constraint matching CC's 4 canonical levels (`low|medium|high|xhigh`); migration is v26 (idempotent, follows v18 pattern of column-add + view recreate).
- `buildPayloadFromCcStdin` (now in the shared `build-event-payload.ts` utility per #735) extracts `cc.effort.level` to `payload.effort`.
- Event-collector diffs the new value against the stored team effort and only writes + broadcasts `effort_changed` when they differ (hot-path no-op when effort is unchanged).
- New SSE event type `effort_changed`; `FleetContext` patches the affected team incrementally without a full refetch.
- `TeamRow` adds a compact effort pill next to Model; `TeamDetail` shows `Effort:` inline. Inherited (project-default) effort is rendered muted.
- 30 new tests in `tests/server/services/event-collector-effort.test.ts` cover normalization, persistence + SSE emit, route extraction, and DB round-trip on real SQLite.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 2195 pass; 3 pre-existing failures in `cc-spawn.test.ts` (env-var leakage on origin/main, unrelated)
- [x] New effort test file — 30/30 passing
- [x] Build-event-payload parity tests — 12/12 still passing after #735 refactor merge
- [x] Targeted client tests (TeamRow, TeamDetail, FleetContext) — all pass

Closes #733