### PR TITLE
Issue #754: tighten projects.effort CHECK constraint via v28 migration

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -480,6 +480,9 @@ export class FleetDatabase {
     // Add permission_policy and allowed_domains_json columns to projects (v27 migration — PermissionRequest hook, issue #736)
     this.addPermissionPolicyColumns();
 
+    // Tighten projects.effort CHECK constraint to drop legacy 'max' (v28 migration, issue #754)
+    this.tightenProjectsEffortCheckConstraint();
+
     // Migrate any 'paused' projects to 'active' (paused status removed in #228)
     this.migratePausedProjects();
 
@@ -1248,6 +1251,10 @@ export class FleetDatabase {
    * adaptive-reasoning effort levels: low, medium, high, xhigh, max.
    * Fresh databases get the column via schema.sql; upgraded databases use this
    * migration. Existing rows will have NULL effort which the CHECK allows.
+   *
+   * Note: the v19 CHECK still includes 'max' on legacy DBs for historical
+   * reasons. The v28 migration recreates the projects table with the tightened
+   * CHECK that drops 'max' (issue #754).
    */
   private addEffortColumn(): void {
     try {
@@ -1582,6 +1589,134 @@ export class FleetDatabase {
     } catch (err) {
       // Table may not exist yet (fresh database) — schema.sql will create it
       console.warn('[DB] v27 migration skipped:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Tighten the projects.effort CHECK constraint to drop legacy 'max' (v28
+   * migration, issue #754).
+   *
+   * The v19 ALTER added the column with `CHECK(effort IN ('low','medium',
+   * 'high','xhigh','max'))`. The v22 migration rewrote any DATA carrying
+   * 'max' to 'xhigh' but left the CHECK alone, so legacy DBs still accept
+   * `effort='max'` at the DB layer even though no client surface emits it.
+   * This is defense-in-depth: recreate the projects table with the tightened
+   * CHECK that matches schema.sql, so 'max' is rejected at the DB boundary.
+   *
+   * SQLite cannot ALTER a CHECK in place, so we use the standard
+   * "create new, copy, drop, rename" pattern inside a transaction with
+   * foreign keys temporarily disabled (better-sqlite3 ignores the PRAGMA
+   * when set inside a transaction, so we set it outside via try/finally).
+   *
+   * WARNING: keep `CREATE TABLE projects_new` in sync with the projects
+   * definition in src/server/schema.sql (lines 25-47). The migration mirrors
+   * the schema.sql definition character-for-character — bump v28 again (or
+   * add a new vN) if the projects shape changes.
+   *
+   * Idempotent: early-returns on fresh DB (projects table not yet created)
+   * and on databases that already report schema_version >= 28.
+   */
+  private tightenProjectsEffortCheckConstraint(): void {
+    try {
+      const cols = this.db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+      // Fresh DB: projects table doesn't exist yet — schema.sql will create it
+      // with the tightened CHECK already in place. Nothing to migrate.
+      if (cols.length === 0) return;
+
+      // Already migrated — second-run no-op.
+      const versionRow = this.db
+        .prepare('SELECT MAX(version) AS version FROM schema_version')
+        .get() as { version: number | null } | undefined;
+      if ((versionRow?.version ?? 0) >= 28) return;
+
+      // Disable FK enforcement OUTSIDE the transaction (better-sqlite3 ignores
+      // the PRAGMA inside one). The try/finally guarantees we restore FK
+      // enforcement even if the transaction throws.
+      this.db.pragma('foreign_keys = OFF');
+      try {
+        this.db.transaction(() => {
+          // 1. Create projects_new mirroring schema.sql lines 25-47 exactly,
+          //    with the tightened effort CHECK (no 'max').
+          this.db.exec(`
+            CREATE TABLE projects_new (
+              id              INTEGER PRIMARY KEY AUTOINCREMENT,
+              name            TEXT NOT NULL,
+              repo_path       TEXT NOT NULL UNIQUE,
+              github_repo     TEXT,
+              group_id        INTEGER REFERENCES project_groups(id),
+              status          TEXT NOT NULL DEFAULT 'active',
+              hooks_installed INTEGER NOT NULL DEFAULT 0,
+              max_active_teams INTEGER NOT NULL DEFAULT 5,
+              prompt_file     TEXT,
+              model           TEXT,
+              effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh')),
+              issue_provider  TEXT DEFAULT 'github',
+              project_key     TEXT,
+              provider_config TEXT,
+              auto_merge_enabled INTEGER,
+              auto_merge_checked_at TEXT,
+              hook_mode       TEXT,
+              permission_policy TEXT CHECK(permission_policy IS NULL OR permission_policy IN ('skip','hook')),
+              allowed_domains_json TEXT,
+              created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+              updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+          `);
+
+          // 2. Copy every row, naming columns explicitly so the migration
+          //    survives a future column re-order in either table.
+          this.db.exec(`
+            INSERT INTO projects_new (
+              id, name, repo_path, github_repo, group_id, status, hooks_installed,
+              max_active_teams, prompt_file, model, effort, issue_provider,
+              project_key, provider_config, auto_merge_enabled,
+              auto_merge_checked_at, hook_mode, permission_policy,
+              allowed_domains_json, created_at, updated_at
+            )
+            SELECT
+              id, name, repo_path, github_repo, group_id, status, hooks_installed,
+              max_active_teams, prompt_file, model, effort, issue_provider,
+              project_key, provider_config, auto_merge_enabled,
+              auto_merge_checked_at, hook_mode, permission_policy,
+              allowed_domains_json, created_at, updated_at
+            FROM projects
+          `);
+
+          // 3. Drop the dashboard view (depends on projects) so the rename
+          //    can proceed; schema.sql will recreate it at the end of
+          //    initSchema().
+          this.db.exec('DROP VIEW IF EXISTS v_team_dashboard');
+
+          // 4. Drop old projects table and rename projects_new -> projects.
+          this.db.exec('DROP TABLE projects');
+          this.db.exec('ALTER TABLE projects_new RENAME TO projects');
+
+          // 5. Recreate the projects indexes (schema.sql lines 49-50).
+          this.db.exec('CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)');
+          this.db.exec('CREATE INDEX IF NOT EXISTS idx_projects_group ON projects(group_id)');
+
+          // 6. Sanity-check FK integrity before committing — abort the
+          //    transaction if anything broke (teams.project_id /
+          //    project_issue_sources.project_id should still resolve).
+          const fkViolations = this.db.prepare('PRAGMA foreign_key_check').all();
+          if (fkViolations.length > 0) {
+            throw new Error(
+              `v28 migration: foreign_key_check returned ${fkViolations.length} violation(s); aborting`,
+            );
+          }
+        })();
+      } finally {
+        // Always restore FK enforcement, even if the transaction threw.
+        this.db.pragma('foreign_keys = ON');
+      }
+
+      this.db.exec('INSERT OR IGNORE INTO schema_version (version) VALUES (28)');
+      console.log(
+        '[DB] v28 migration: recreated projects table with tightened effort CHECK constraint (max no longer accepted at DB level)',
+      );
+    } catch (err) {
+      // Table may not exist yet (fresh database) — schema.sql will create it
+      console.warn('[DB] v28 migration skipped:', err instanceof Error ? err.message : err);
     }
   }
 

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Fleet Commander — SQLite Schema (v27, permission_policy + allowed_domains_json on projects)
+-- Fleet Commander — SQLite Schema (v28, projects.effort CHECK tightened — 'max' no longer valid)
 -- =============================================================================
 
 -- Schema version tracking for migrations
@@ -457,4 +457,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_team_subworktrees_team_path_active
   ON team_subworktrees(team_id, path) WHERE removed_at IS NULL;
 
 -- Insert schema version (or upgrade from earlier versions)
-INSERT OR IGNORE INTO schema_version (version) VALUES (27);
+INSERT OR IGNORE INTO schema_version (version) VALUES (28);

--- a/tests/server/db.test.ts
+++ b/tests/server/db.test.ts
@@ -2232,6 +2232,295 @@ describe("v22 migration: effort='max' -> 'xhigh'", () => {
   });
 });
 
+// =============================================================================
+// v28 migration: projects.effort CHECK tightened — 'max' rejected at DB level
+// =============================================================================
+
+describe("v28 migration: projects.effort CHECK tightened — 'max' rejected at DB level", () => {
+  /**
+   * Build a fully-migrated FleetDatabase, then revert the projects table to
+   * the pre-v28 shape (CHECK still permits 'max'), bump schema_version DOWN,
+   * and seed a representative row plus a team referencing it. Re-opening as
+   * FleetDatabase drives the v28 migration on the second initSchema().
+   *
+   * This mirrors the recommended seeding strategy from the planner: trust
+   * the live schema for every column except `effort`, where we install the
+   * legacy CHECK that still permits 'max'.
+   */
+  function seedPreV28Db(): {
+    dbPath: string;
+    projectId: number;
+    teamId: number;
+    issueSourceId: number;
+  } {
+    const seedPath = path.join(
+      os.tmpdir(),
+      `fleet-test-v28-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+
+    // 1. Run a full initSchema() against the fresh seed DB so every other
+    //    table/index/view is shaped exactly like a live install.
+    {
+      const bootstrap = new FleetDatabase(seedPath);
+      bootstrap.initSchema();
+      bootstrap.close();
+    }
+
+    // 2. Re-open with raw better-sqlite3, drop the live projects table, and
+    //    recreate it with the legacy CHECK that still includes 'max'. Also
+    //    drop the dashboard view (depends on projects) and re-bump
+    //    schema_version DOWN to simulate a pre-v28 database.
+    const seed = new Database(seedPath);
+    seed.pragma('foreign_keys = OFF');
+    try {
+      seed.exec('DROP VIEW IF EXISTS v_team_dashboard');
+      seed.exec('DROP TABLE projects');
+      seed.exec(`
+        CREATE TABLE projects (
+          id              INTEGER PRIMARY KEY AUTOINCREMENT,
+          name            TEXT NOT NULL,
+          repo_path       TEXT NOT NULL UNIQUE,
+          github_repo     TEXT,
+          group_id        INTEGER REFERENCES project_groups(id),
+          status          TEXT NOT NULL DEFAULT 'active',
+          hooks_installed INTEGER NOT NULL DEFAULT 0,
+          max_active_teams INTEGER NOT NULL DEFAULT 5,
+          prompt_file     TEXT,
+          model           TEXT,
+          effort          TEXT CHECK(effort IS NULL OR effort IN ('low','medium','high','xhigh','max')),
+          issue_provider  TEXT DEFAULT 'github',
+          project_key     TEXT,
+          provider_config TEXT,
+          auto_merge_enabled INTEGER,
+          auto_merge_checked_at TEXT,
+          hook_mode       TEXT,
+          permission_policy TEXT CHECK(permission_policy IS NULL OR permission_policy IN ('skip','hook')),
+          allowed_domains_json TEXT,
+          created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      seed.exec('CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)');
+      seed.exec('CREATE INDEX IF NOT EXISTS idx_projects_group ON projects(group_id)');
+      seed.exec('DELETE FROM schema_version WHERE version >= 28');
+    } finally {
+      seed.pragma('foreign_keys = ON');
+    }
+
+    // 3. Insert a representative project row (effort='high' — survives the
+    //    migration unchanged) and a team referencing it via FK so the FK
+    //    integrity check has something to validate.
+    const projectInfo = seed.prepare(
+      "INSERT INTO projects (name, repo_path, effort) VALUES (?, ?, 'high')",
+    ).run('legacy-v28', `/tmp/legacy-v28-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const projectId = Number(projectInfo.lastInsertRowid);
+
+    const teamInfo = seed.prepare(
+      'INSERT INTO teams (issue_number, worktree_name, project_id) VALUES (?, ?, ?)',
+    ).run(754, `legacy-v28-team-${Date.now()}-${Math.random().toString(36).slice(2)}`, projectId);
+    const teamId = Number(teamInfo.lastInsertRowid);
+
+    const sourceInfo = seed.prepare(
+      "INSERT INTO project_issue_sources (project_id, provider, config_json) VALUES (?, 'github', '{}')",
+    ).run(projectId);
+    const issueSourceId = Number(sourceInfo.lastInsertRowid);
+
+    seed.close();
+    return { dbPath: seedPath, projectId, teamId, issueSourceId };
+  }
+
+  function cleanupSeedDb(p: string): void {
+    for (const f of [p, p + '-wal', p + '-shm']) {
+      try { if (fs.existsSync(f)) fs.unlinkSync(f); } catch { /* best effort */ }
+    }
+  }
+
+  it("rewrites projects so INSERT effort='max' throws CHECK constraint failed", () => {
+    const { dbPath: seedPath } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      // After the migration, the tightened CHECK must reject 'max' at the DB
+      // layer (not just at the service-validator layer).
+      const insertMax = () =>
+        upgraded!.raw
+          .prepare("INSERT INTO projects (name, repo_path, effort) VALUES (?, ?, 'max')")
+          .run('reject-max', `/tmp/reject-max-${Date.now()}`);
+      expect(insertMax).toThrow(/CHECK constraint failed/i);
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('preserves all project rows during the recreate', () => {
+    const { dbPath: seedPath, projectId } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      const row = upgraded.raw
+        .prepare('SELECT id, name, repo_path, effort FROM projects WHERE id = ?')
+        .get(projectId) as { id: number; name: string; repo_path: string; effort: string };
+      expect(row.id).toBe(projectId);
+      expect(row.name).toBe('legacy-v28');
+      expect(row.effort).toBe('high');
+      expect(row.repo_path).toContain('/tmp/legacy-v28-');
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('preserves FK references from teams and project_issue_sources', () => {
+    const { dbPath: seedPath, projectId, teamId, issueSourceId } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      // FKs from teams.project_id and project_issue_sources.project_id must
+      // still resolve to the recreated projects row.
+      const teamRow = upgraded.raw
+        .prepare('SELECT project_id FROM teams WHERE id = ?')
+        .get(teamId) as { project_id: number };
+      expect(teamRow.project_id).toBe(projectId);
+
+      const sourceRow = upgraded.raw
+        .prepare('SELECT project_id FROM project_issue_sources WHERE id = ?')
+        .get(issueSourceId) as { project_id: number };
+      expect(sourceRow.project_id).toBe(projectId);
+
+      // PRAGMA foreign_key_check returns zero rows = no orphaned references.
+      const violations = upgraded.raw.prepare('PRAGMA foreign_key_check').all();
+      expect(violations).toEqual([]);
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('bumps schema_version to >= 28 after running the migration', () => {
+    const { dbPath: seedPath } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      const row = upgraded.raw
+        .prepare('SELECT MAX(version) AS version FROM schema_version')
+        .get() as { version: number };
+      expect(row.version).toBeGreaterThanOrEqual(28);
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('is idempotent on restart (second initSchema is a no-op; log emitted once)', () => {
+    const { dbPath: seedPath, projectId } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+
+    // Note: we override console.log directly rather than via vi.spyOn because
+    // vi.spyOn(console, 'log') does not reliably intercept module-internal
+    // console.log calls under the vitest "server" project's node environment
+    // on Windows — observed empty mock.calls even though stdout shows the
+    // line. The override-and-restore pattern works deterministically.
+    const captured: string[] = [];
+    const origLog = console.log;
+    const installSpy = () => {
+      console.log = (...args: unknown[]) => {
+        captured.push(String((args[0] as unknown) ?? ''));
+      };
+    };
+    const restoreSpy = () => {
+      console.log = origLog;
+    };
+
+    try {
+      // First run — migrates the projects table.
+      upgraded = new FleetDatabase(seedPath);
+      installSpy();
+      try {
+        upgraded.initSchema();
+      } finally {
+        restoreSpy();
+      }
+      const v28LogsFirst = captured.filter((s) => s.includes('v28 migration: recreated projects table'));
+      expect(v28LogsFirst.length).toBe(1);
+
+      // Capture the projects table's created_at as a recreate proxy — if the
+      // second initSchema accidentally rebuilt the table, the row's created_at
+      // would shift to "now".
+      const firstCreatedAt = (upgraded.raw
+        .prepare('SELECT created_at FROM projects WHERE id = ?')
+        .get(projectId) as { created_at: string }).created_at;
+
+      // Second run — must be a no-op (schema_version >= 28 early-return).
+      captured.length = 0;
+      installSpy();
+      try {
+        upgraded.initSchema();
+      } finally {
+        restoreSpy();
+      }
+      const v28LogsSecond = captured.filter((s) => s.includes('v28 migration: recreated projects table'));
+      expect(v28LogsSecond).toEqual([]);
+
+      const afterCreatedAt = (upgraded.raw
+        .prepare('SELECT created_at FROM projects WHERE id = ?')
+        .get(projectId) as { created_at: string }).created_at;
+      expect(afterCreatedAt).toBe(firstCreatedAt);
+    } finally {
+      // Always restore in case any path threw before restoreSpy was called.
+      console.log = origLog;
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+
+  it('is a no-op on a fresh database (CHECK already tight + schema_version already 28)', () => {
+    // The standard test db (created by beforeEach) is fresh — its projects
+    // table was created via schema.sql with the tightened CHECK already in
+    // place. INSERT effort='max' must throw immediately.
+    const insertMax = () =>
+      db.raw
+        .prepare("INSERT INTO projects (name, repo_path, effort) VALUES (?, ?, 'max')")
+        .run('fresh-no-max', `/tmp/fresh-no-max-${Date.now()}`);
+    expect(insertMax).toThrow(/CHECK constraint failed/i);
+
+    const row = db.raw
+      .prepare('SELECT MAX(version) AS version FROM schema_version')
+      .get() as { version: number };
+    expect(row.version).toBeGreaterThanOrEqual(28);
+  });
+
+  it('keeps v_team_dashboard view queryable after the migration', () => {
+    const { dbPath: seedPath } = seedPreV28Db();
+    let upgraded: FleetDatabase | null = null;
+    try {
+      upgraded = new FleetDatabase(seedPath);
+      upgraded.initSchema();
+
+      // The migration drops v_team_dashboard before renaming projects_new;
+      // schema.sql recreates it. A SELECT against the view must succeed.
+      const viewRows = upgraded.raw
+        .prepare("SELECT name FROM sqlite_master WHERE type='view' AND name='v_team_dashboard'")
+        .all();
+      expect(viewRows.length).toBe(1);
+
+      // Smoke-test: querying the view must not throw.
+      expect(() => upgraded!.raw.prepare('SELECT * FROM v_team_dashboard LIMIT 1').all()).not.toThrow();
+    } finally {
+      try { upgraded?.close(); } catch { /* ignore */ }
+      cleanupSeedDb(seedPath);
+    }
+  });
+});
+
 describe('team_subworktrees', () => {
   let teamId: number;
 

--- a/tests/server/routes/projects-routes.test.ts
+++ b/tests/server/routes/projects-routes.test.ts
@@ -249,6 +249,32 @@ describe('POST /api/projects', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it("should reject deprecated effort='max' with 400 on create (issue #754)", async () => {
+    // validateRepoPath() runs before the effort validator and rejects
+    // non-existent paths, so we need a real temp dir for this POST to reach
+    // the effort check. exec-gh is mocked above so the git-repo check passes.
+    const realRepoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'fc-754-post-'));
+    try {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/projects',
+        payload: {
+          name: `reject-max-${Date.now()}`,
+          repoPath: realRepoPath,
+          effort: 'max',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      // Error message must point users at the replacement so they know what to do.
+      const body = res.json();
+      const message = body?.message ?? body?.error?.message ?? JSON.stringify(body);
+      expect(String(message)).toContain('xhigh');
+    } finally {
+      try { fs.rmSync(realRepoPath, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to the v22 migration. Adds a v28 SQLite migration that recreates the `projects` table with a tightened `effort` CHECK constraint (`IN ('low','medium','high','xhigh')`), removing the legacy `'max'` value at the DB layer.

- **No client change required.** Audit confirmed every UI surface (`ProjectsPage`, `AddProjectDialog`, `TeamRow`, `TeamDetail`, `shared/types.ts`), service-level validators (`ProjectService.createProject`/`updateProject`), the MCP `add-project` tool, and `event-collector` already reject `'max'`. The user-reported repro is almost certainly stale browser bundle from v0.0.24.
- **Why the DB needs hardening anyway.** The v19 `addEffortColumn()` migration installed `CHECK(effort IN ('low','medium','high','xhigh','max'))`. v22 rewrote DATA from `max` → `xhigh` but SQLite cannot ALTER a CHECK in place — so legacy DBs still accept `'max'` via direct API/MCP call or future regression. v28 closes that loophole.
- **Approach.** Standard SQLite "create new table, copy, drop, rename" pattern inside a transaction, with `PRAGMA foreign_keys=OFF` toggled OUTSIDE the transaction in a `try/finally`. `v_team_dashboard` dropped inside the transaction; schema.sql recreates it at end of `initSchema()`. `PRAGMA foreign_key_check` runs before commit. Migration is idempotent (fresh DB + `schema_version >= 28` short-circuits).

Closes #754

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] 7 new v28 migration tests in `tests/server/db.test.ts` pass:
  - rewrites projects so `INSERT effort='max'` throws CHECK constraint failed
  - preserves all project rows during recreate
  - preserves FK references from teams/project_issue_sources
  - bumps `schema_version` to >= 28
  - idempotent on restart (log emitted exactly once)
  - no-op on fresh DB
  - `v_team_dashboard` view exists after migration
- [x] New POST validator test in `tests/server/routes/projects-routes.test.ts` confirms `effort='max'` returns 400 with `'xhigh'` in the message (closes the gap where only PUT was tested)
- [x] No client files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)