### PR TITLE
Issue #755: regression tests + debug-log enrichment for HTTP hook no-team path

### DIFF
--- a/src/server/routes/hooks.ts
+++ b/src/server/routes/hooks.ts
@@ -22,10 +22,14 @@
 // When the cwd does not resolve to a registered team (e.g. user runs CC
 // interactively in the main checkout, or CC fires WorktreeCreate before the
 // worktree exists), the route still returns success: 204 for fire-and-forget
-// hooks, 200 `{decision:"ask"}` for PermissionRequest. This matches the
-// silent-swallow behavior of the legacy bash hooks; otherwise synchronous
-// hooks (WorktreeCreate, PermissionRequest) would block CC entirely (issue
-// #755).
+// hooks, 200 `{decision:"ask"}` for PermissionRequest. The PermissionRequest
+// `ask` fallback hands control back to CC's own native prompt — exactly the
+// experience the user would get without FC hooks installed at all.
+// `allow` would silently auto-approve every tool call in unrelated user
+// sessions (privilege-escalation foot-gun); `deny` would gate the user's
+// own interactive work. This matches the silent-swallow behavior of the
+// legacy bash hooks; otherwise synchronous hooks (WorktreeCreate,
+// PermissionRequest) would block CC entirely (issue #755).
 //
 // All processing is best-effort: a route-level try/catch ensures failures
 // never propagate to CC, matching the fire-and-forget contract of the legacy
@@ -156,8 +160,15 @@ const hooksRoutes: FastifyPluginCallback = (
         const snakeEvent = PASCAL_TO_SNAKE[eventType];
 
         if (!teamRow) {
+          request.log.debug(
+            { eventType, cwd: body['cwd'], resolvedTeam: team },
+            'HTTP hook for cwd with no registered team — silently accepted',
+          );
           if (snakeEvent === 'permission_request') {
-            // Safe fallback — CC shows its own prompt.
+            // Safe fallback — CC shows its own native prompt, exactly the
+            // experience the user would get without FC hooks installed at
+            // all. `allow` would silently auto-approve every tool call in
+            // unrelated user sessions; `deny` would gate their work.
             return reply
               .code(200)
               .header('content-type', 'application/json')
@@ -165,10 +176,6 @@ const hooksRoutes: FastifyPluginCallback = (
           }
           // Fire-and-forget and synchronous WorktreeCreate / WorktreeRemove:
           // CC only needs a 2xx. Empty 204 is enough.
-          request.log.debug(
-            { eventType, worktree: team },
-            'HTTP hook: no team for cwd — silently accepting',
-          );
           return reply.code(204).send();
         }
 
@@ -271,6 +278,10 @@ const hooksRoutes: FastifyPluginCallback = (
           );
         } catch (err) {
           if (err instanceof EventCollectorError) {
+            // Race: team was deleted between the upfront check above and
+            // processEvent's own lookup. This is vanishingly rare; the 404
+            // surfaces a real anomaly (team existed, then vanished mid-
+            // request) that's worth logging loud rather than swallowing.
             const status = err.code === 'TEAM_NOT_FOUND' ? 404 : 400;
             return reply.code(status).send({
               error: status === 404 ? 'Not Found' : 'Bad Request',

--- a/tests/server/routes/hooks-routes.test.ts
+++ b/tests/server/routes/hooks-routes.test.ts
@@ -283,6 +283,54 @@ describe('POST /api/hooks — error paths', () => {
       cwd: makeCwd('nonexistent-team-99999'),
     });
     expect(res.statusCode).toBe(204);
+    expect(res.payload).toBe('');
+  });
+
+  it('returns 204 for a PostToolUse with no matching team (regression: issue #755)', async () => {
+    const res = await postHook('PostToolUse', {
+      session_id: 'sess-no-team',
+      cwd: makeCwd('definitely-not-a-team'),
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi' },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(res.payload).toBe('');
+  });
+
+  it('returns 204 for a WorktreeCreate with no matching team (launch-blocker regression: issue #755)', async () => {
+    // WorktreeCreate is synchronous — a non-2xx aborts the worktree creation
+    // and breaks every team launch in hook_mode=http.
+    const res = await postHook('WorktreeCreate', {
+      session_id: 'sess-wt-create',
+      cwd: 'C:/Git/some-project',
+      hookSpecificOutput: {
+        worktreePath: 'C:/Git/some-project/.claude/worktrees/foo',
+      },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('does not insert an events row when the cwd has no matching team (issue #755)', async () => {
+    // Silent-accept must skip the entire pipeline. If we wrote a row we would
+    // pollute the events table with orphan rows from interactive CC sessions.
+    // We seed a control team and ensure its event count is unchanged after a
+    // no-team hook fires — i.e. the no-team hook neither created a phantom
+    // row nor accidentally attached to a real team.
+    const worktree = `hooks-noteam-control-${Date.now()}`;
+    const controlTeam = seedTeam(worktree);
+    const db = getDatabase();
+    const beforeControl = db.getEventsByTeamCount(controlTeam.id);
+
+    const res = await postHook('PostToolUse', {
+      session_id: 'sess-no-team-no-row',
+      cwd: makeCwd('still-not-a-team-77777'),
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/whatever' },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const afterControl = db.getEventsByTeamCount(controlTeam.id);
+    expect(afterControl).toBe(beforeControl);
   });
 
   it('returns 400 when the body is null', async () => {
@@ -507,7 +555,10 @@ describe('POST /api/hooks/PermissionRequest', () => {
 
   it('returns 200 with decision=ask when the cwd resolves to an unknown team', async () => {
     // Issue #755: a 404 here would block CC waiting for a synchronous
-    // permission decision. `ask` falls back to CC's own prompt.
+    // permission decision. `ask` falls back to CC's own native prompt —
+    // exactly the experience the user would get without FC hooks
+    // installed. `allow` would silently auto-approve every tool call in
+    // unrelated user sessions (privilege-escalation foot-gun).
     const res = await postHook('PermissionRequest', {
       session_id: 'sess-perm-ask-no-team',
       cwd: makeCwd('nonexistent-perm-team-99998'),


### PR DESCRIPTION
## Summary

Slim observability-only follow-up to the already-merged `8d79428` (the core 404→2xx silent-accept fix for issue #755).

This PR is a **behavior no-op** vs `origin/main` — every HTTP response code/body for every path is byte-identical. It only adds:

- 3 regression tests in `tests/server/routes/hooks-routes.test.ts`:
  - `PostToolUse` with no matching team → 204
  - `WorktreeCreate` with no matching team → 204 (the launch-blocker scenario from the issue's update comment)
  - Silent-accept path inserts no row into the `events` table
- Tightened existing 204 no-team test to also assert empty payload
- `request.log.debug` hoisted above the `permission_request` branch so both no-team flows emit the silent-accept log (was only the fire-and-forget branch), with `cwd` added to the payload alongside `resolvedTeam`
- Header doc + inline comments explaining WHY `decision: "ask"` (not `allow` or `deny`) for `PermissionRequest` no-team and WHY the inner `TEAM_NOT_FOUND` race-condition mapping stays loud at 404

The plan originally proposed flipping the merged `{decision: "ask"}` to `{decision: "allow"}` for the `PermissionRequest` no-team case. On re-analysis the planner reversed: the no-team scenario is **interactive user sessions** in a project's main checkout (not FC-spawned), so `allow` would silently auto-approve every tool call in unrelated user sessions — a privilege-escalation foot-gun. The merged `ask` is correct: it returns control to CC's native interactive prompt, exactly the experience the user gets without FC hooks installed at all. This PR retains `ask`.

Closes #755

## Test plan

- [x] `npm run build` clean
- [x] `npm test -- hooks-routes` → 26 of 26 pass (including the 3 new regression tests)
- [x] Full server suite passes (3 pre-existing unrelated `cc-spawn.test.ts` env-leak failures, see #???)
- [x] `npx tsc --noEmit` clean
- [x] `git diff origin/main..HEAD -- src/server/routes/events.ts` empty (no diff vs main)
- [x] All `reply.code(...).send(...)` call sites for no-team paths byte-identical to merged code

🤖 Generated with [Claude Code](https://claude.com/claude-code)