### PR TITLE
Issue #762: promote State Transitions, PR, and Slowest Tools to TeamDetail tabs

### DIFF
--- a/src/client/components/TeamDetail.tsx
+++ b/src/client/components/TeamDetail.tsx
@@ -120,7 +120,9 @@ export function TeamDetail() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [quickActionLoading, setQuickActionLoading] = useState<string | null>(null);
   const [quickActionSent, setQuickActionSent] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'session-log' | 'tasks' | 'files' | 'team'>('session-log');
+  const [activeTab, setActiveTab] = useState<
+    'session-log' | 'tasks' | 'files' | 'team' | 'transitions' | 'pr' | 'slowest-tools'
+  >('session-log');
   const [tasks, setTasks] = useState<TeamTask[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [handoffFiles, setHandoffFiles] = useState<HandoffFile[]>([]);
@@ -385,6 +387,21 @@ export function TeamDetail() {
       ? getMergeStatusLabel(detail.pr.mergeStatus)
       : null;
 
+  // Issue #762: promoted-tab visibility. PR tab is shown whenever the team has
+  // a PR number (even if `pr` detail is still loading). Slowest tools tab is
+  // shown only when CC supplied at least one duration_ms value. Transitions
+  // tab is always visible.
+  const hasPrTab = detail?.prNumber != null;
+  const hasSlowestToolsTab =
+    Array.isArray(detail?.slowestToolCalls) && detail.slowestToolCalls.length > 0;
+
+  // Auto-redirect to Session Log if the active tab is no longer visible
+  // (e.g. PR closed mid-session, or slowest tools data churned out).
+  useEffect(() => {
+    if (activeTab === 'pr' && !hasPrTab) setActiveTab('session-log');
+    if (activeTab === 'slowest-tools' && !hasSlowestToolsTab) setActiveTab('session-log');
+  }, [activeTab, hasPrTab, hasSlowestToolsTab]);
+
   return (
     <>
       {/* Backdrop overlay */}
@@ -553,205 +570,12 @@ export function TeamDetail() {
                     )}
                   </section>
 
-                  {/* ---- Transition History ---- */}
-                  {transitions.length > 0 && (
-                    <section className="min-w-0">
-                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
-                        State Transitions
-                      </h4>
-                      <div className="flex items-center gap-0 overflow-x-auto pb-1 custom-scrollbar max-w-full">
-                        {transitions.map((t, i) => {
-                          const isFirst = i === 0;
-                          const toColor = STATUS_COLORS[t.toStatus] ?? '#8B949E';
-                          const timeStr = (() => {
-                            try {
-                              const d = new Date(t.createdAt);
-                              return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-                            } catch {
-                              return '';
-                            }
-                          })();
-                          return (
-                            <div key={t.id} className="flex items-center shrink-0">
-                              {/* Show from_status pill only for the first transition */}
-                              {isFirst && (
-                                <>
-                                  <div className="flex flex-col items-center">
-                                    <span
-                                      className="text-[10px] font-medium px-1.5 py-0.5 rounded"
-                                      style={{
-                                        color: STATUS_COLORS[t.fromStatus] ?? '#8B949E',
-                                        backgroundColor: (STATUS_COLORS[t.fromStatus] ?? '#8B949E') + '18',
-                                      }}
-                                    >
-                                      {t.fromStatus}
-                                    </span>
-                                  </div>
-                                  <svg className="w-3 h-3 text-dark-muted shrink-0 mx-0.5" viewBox="0 0 12 12" fill="currentColor">
-                                    <path d="M4.5 2l4 4-4 4" stroke="currentColor" strokeWidth="1.5" fill="none" />
-                                  </svg>
-                                </>
-                              )}
-                              <div
-                                className="flex flex-col items-center group relative"
-                              >
-                                <span
-                                  className="text-[10px] font-medium px-1.5 py-0.5 rounded"
-                                  style={{
-                                    color: toColor,
-                                    backgroundColor: toColor + '18',
-                                  }}
-                                >
-                                  {t.toStatus}
-                                </span>
-                                <span className="text-[9px] text-dark-muted mt-0.5 leading-none">
-                                  {timeStr}
-                                </span>
-                                {/* Tooltip with reason */}
-                                {t.reason && (
-                                  <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-dark-surface border border-dark-border rounded text-[10px] text-dark-text whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 shadow-lg max-w-[240px] truncate">
-                                    {t.reason}
-                                  </div>
-                                )}
-                              </div>
-                              {i < transitions.length - 1 && (
-                                <svg className="w-3 h-3 text-dark-muted shrink-0 mx-0.5" viewBox="0 0 12 12" fill="currentColor">
-                                  <path d="M4.5 2l4 4-4 4" stroke="currentColor" strokeWidth="1.5" fill="none" />
-                                </svg>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </section>
-                  )}
-
-                  {/* ---- PR Section ---- */}
-                  {detail.pr && (
-                    <section>
-                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
-                        Pull Request
-                      </h4>
-
-                      <div className="flex items-center gap-3 mb-3 text-sm">
-                        {detail.githubRepo ? (
-                          <a
-                            href={`https://github.com/${detail.githubRepo}/pull/${detail.pr.number}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-dark-accent font-medium hover:underline"
-                          >
-                            PR #{detail.pr.number}
-                          </a>
-                        ) : (
-                          <span className="text-dark-accent font-medium">
-                            PR #{detail.pr.number}
-                          </span>
-                        )}
-                        <span
-                          className="text-xs px-1.5 py-0.5 rounded border"
-                          style={{
-                            color:
-                              detail.pr.state === 'merged'
-                                ? '#A371F7'
-                                : detail.pr.state === 'open'
-                                  ? '#3FB950'
-                                  : detail.pr.state === 'closed'
-                                    ? '#F85149'
-                                    : '#8B949E',
-                            borderColor:
-                              (detail.pr.state === 'merged'
-                                ? '#A371F7'
-                                : detail.pr.state === 'open'
-                                  ? '#3FB950'
-                                  : detail.pr.state === 'closed'
-                                    ? '#F85149'
-                                    : '#8B949E') + '40',
-                          }}
-                        >
-                          {detail.pr.state?.toUpperCase() ?? 'UNKNOWN'}
-                        </span>
-                        {mergeStatusLabelText && (
-                          <span className="text-xs text-dark-muted">
-                            Merge: {mergeStatusLabelText}
-                          </span>
-                        )}
-                        {detail.pr.autoMerge && (
-                          <span className="text-xs text-[#3FB950]">Auto-merge</span>
-                        )}
-                      </div>
-
-                      {/* CI Checks */}
-                      <div className="ml-1">
-                        <p className="text-xs text-dark-muted mb-1.5 uppercase tracking-wide">CI Checks</p>
-                        <div className="max-h-[120px] overflow-y-auto custom-scrollbar">
-                          <CIChecks checks={detail.pr.checks ?? []} />
-                        </div>
-                      </div>
-                    </section>
-                  )}
-
-                  {!detail.pr && detail.prNumber && (
-                    <section>
-                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
-                        Pull Request
-                      </h4>
-                      <p className="text-sm text-dark-muted">
-                        {detail.githubRepo ? (
-                          <a
-                            href={`https://github.com/${detail.githubRepo}/pull/${detail.prNumber}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-dark-accent hover:underline"
-                          >
-                            PR #{detail.prNumber}
-                          </a>
-                        ) : (
-                          <>PR #{detail.prNumber}</>
-                        )}
-                        {' '}(details loading...)
-                      </p>
-                    </section>
-                  )}
-
-                  {/* ---- Slowest Tool Calls (issue #732) ---- */}
                   {/*
-                    Renders only when CC supplied at least one duration_ms value
-                    (CC 2.1.119+ PostToolUse / PostToolUseFailure hooks). For
-                    older teams or CC versions the array is empty and the
-                    section is omitted entirely.
+                    Issue #762: State Transitions, Pull Request and Slowest
+                    Tool Calls sections previously rendered inline here have
+                    been promoted to top-level tabs (Transitions / PR /
+                    Slowest tools) in the tab bar below.
                   */}
-                  {Array.isArray(detail.slowestToolCalls) && detail.slowestToolCalls.length > 0 && (
-                    <section>
-                      <h4 className="text-sm font-semibold text-dark-text mb-2 border-b border-dark-border/50 pb-1">
-                        Slowest Tool Calls
-                      </h4>
-                      <ul className="space-y-1.5">
-                        {detail.slowestToolCalls.slice(0, 5).map((evt) => {
-                          const label = parseToolFromPayload(evt.payload, evt.toolName);
-                          const durationLabel = formatMs(evt.durationMs);
-                          return (
-                            <li
-                              key={evt.id}
-                              className="flex items-center gap-2 text-sm"
-                            >
-                              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono bg-dark-border/30 text-dark-text shrink-0">
-                                {durationLabel}
-                              </span>
-                              <span className="text-dark-text truncate" title={label}>
-                                {label}
-                              </span>
-                              {evt.agentName && evt.agentName !== 'team-lead' && (
-                                <span className="text-xs text-dark-muted shrink-0">
-                                  {evt.agentName}
-                                </span>
-                              )}
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    </section>
-                  )}
                 </div>
                 </div>
               </div>
@@ -810,6 +634,48 @@ export function TeamDetail() {
                   >
                     Team
                   </button>
+                  <button
+                    onClick={() => setActiveTab('transitions')}
+                    className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                      activeTab === 'transitions'
+                        ? 'border-dark-accent text-dark-text'
+                        : 'border-transparent text-dark-muted hover:text-dark-text'
+                    }`}
+                  >
+                    Transitions
+                    {Array.isArray(transitions) && transitions.length > 0 && (
+                      <span className="ml-1.5 text-xs text-dark-muted">
+                        ({transitions.length})
+                      </span>
+                    )}
+                  </button>
+                  {hasPrTab && (
+                    <button
+                      onClick={() => setActiveTab('pr')}
+                      className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                        activeTab === 'pr'
+                          ? 'border-dark-accent text-dark-text'
+                          : 'border-transparent text-dark-muted hover:text-dark-text'
+                      }`}
+                    >
+                      PR
+                      <span className="ml-1.5 text-xs text-dark-muted">
+                        #{detail.prNumber}
+                      </span>
+                    </button>
+                  )}
+                  {hasSlowestToolsTab && (
+                    <button
+                      onClick={() => setActiveTab('slowest-tools')}
+                      className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                        activeTab === 'slowest-tools'
+                          ? 'border-dark-accent text-dark-text'
+                          : 'border-transparent text-dark-muted hover:text-dark-text'
+                      }`}
+                    >
+                      Slowest tools
+                    </button>
+                  )}
                 </div>
 
                 {/* Tab content */}
@@ -1006,6 +872,191 @@ export function TeamDetail() {
                         )}
                       </div>
                     </div>
+                  </div>
+                )}
+
+                {/*
+                  Issue #762: Transitions tab. Always rendered (no visibility
+                  predicate) — when there are no transitions yet, show an
+                  empty-state placeholder rather than hiding the tab.
+                */}
+                {activeTab === 'transitions' && (
+                  <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-5 py-3">
+                    {!Array.isArray(transitions) || transitions.length === 0 ? (
+                      <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <p className="text-sm text-dark-muted">No state transitions yet.</p>
+                        <p className="text-xs text-dark-muted/60 mt-1">Transitions appear as the team's status changes.</p>
+                      </div>
+                    ) : (
+                      <ul className="space-y-1.5">
+                        {transitions.map((t) => {
+                          const fromColor = STATUS_COLORS[t.fromStatus] ?? '#8B949E';
+                          const toColor = STATUS_COLORS[t.toStatus] ?? '#8B949E';
+                          const timeStr = (() => {
+                            try {
+                              const d = new Date(t.createdAt);
+                              return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                            } catch {
+                              return '';
+                            }
+                          })();
+                          return (
+                            <li
+                              key={t.id}
+                              className="flex items-center gap-2 px-2 py-1.5 rounded border border-dark-border/40 bg-dark-border/5"
+                            >
+                              <span
+                                className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0"
+                                style={{
+                                  color: fromColor,
+                                  backgroundColor: fromColor + '18',
+                                }}
+                              >
+                                {t.fromStatus}
+                              </span>
+                              <svg className="w-3 h-3 text-dark-muted shrink-0" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+                                <path d="M4.5 2l4 4-4 4" stroke="currentColor" strokeWidth="1.5" fill="none" />
+                              </svg>
+                              <span
+                                className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0"
+                                style={{
+                                  color: toColor,
+                                  backgroundColor: toColor + '18',
+                                }}
+                              >
+                                {t.toStatus}
+                              </span>
+                              <span className="text-xs text-dark-muted shrink-0 font-mono">
+                                {timeStr}
+                              </span>
+                              {t.reason && (
+                                <span className="flex-1 min-w-0 text-xs text-dark-muted truncate" title={t.reason}>
+                                  {t.reason}
+                                </span>
+                              )}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                )}
+
+                {/*
+                  Issue #762: Pull Request tab. Shown when detail.prNumber is
+                  set. Renders the "loaded" branch when detail.pr is populated,
+                  and a loading fallback when only prNumber is known.
+                */}
+                {activeTab === 'pr' && hasPrTab && (
+                  <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-5 py-3">
+                    {detail.pr ? (
+                      <>
+                        <div className="flex items-center gap-3 mb-3 text-sm flex-wrap">
+                          {detail.githubRepo ? (
+                            <a
+                              href={`https://github.com/${detail.githubRepo}/pull/${detail.pr.number}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-dark-accent font-medium hover:underline"
+                            >
+                              PR #{detail.pr.number}
+                            </a>
+                          ) : (
+                            <span className="text-dark-accent font-medium">
+                              PR #{detail.pr.number}
+                            </span>
+                          )}
+                          <span
+                            className="text-xs px-1.5 py-0.5 rounded border"
+                            style={{
+                              color:
+                                detail.pr.state === 'merged'
+                                  ? '#A371F7'
+                                  : detail.pr.state === 'open'
+                                    ? '#3FB950'
+                                    : detail.pr.state === 'closed'
+                                      ? '#F85149'
+                                      : '#8B949E',
+                              borderColor:
+                                (detail.pr.state === 'merged'
+                                  ? '#A371F7'
+                                  : detail.pr.state === 'open'
+                                    ? '#3FB950'
+                                    : detail.pr.state === 'closed'
+                                      ? '#F85149'
+                                      : '#8B949E') + '40',
+                            }}
+                          >
+                            {detail.pr.state?.toUpperCase() ?? 'UNKNOWN'}
+                          </span>
+                          {mergeStatusLabelText && (
+                            <span className="text-xs text-dark-muted">
+                              Merge: {mergeStatusLabelText}
+                            </span>
+                          )}
+                          {detail.pr.autoMerge && (
+                            <span className="text-xs text-[#3FB950]">Auto-merge</span>
+                          )}
+                        </div>
+
+                        {/* CI Checks — full-height scroll inside the tab pane */}
+                        <div>
+                          <p className="text-xs text-dark-muted mb-1.5 uppercase tracking-wide">CI Checks</p>
+                          <CIChecks checks={detail.pr.checks ?? []} />
+                        </div>
+                      </>
+                    ) : (
+                      <p className="text-sm text-dark-muted">
+                        {detail.githubRepo ? (
+                          <a
+                            href={`https://github.com/${detail.githubRepo}/pull/${detail.prNumber}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-dark-accent hover:underline"
+                          >
+                            PR #{detail.prNumber}
+                          </a>
+                        ) : (
+                          <>PR #{detail.prNumber}</>
+                        )}
+                        {' '}(details loading...)
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/*
+                  Issue #762: Slowest Tool Calls tab. Only rendered when CC
+                  supplied at least one duration_ms value (CC 2.1.119+
+                  PostToolUse / PostToolUseFailure hooks). Tab is otherwise
+                  hidden entirely — no empty state needed here.
+                */}
+                {activeTab === 'slowest-tools' && hasSlowestToolsTab && (
+                  <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-5 py-3">
+                    <ul className="space-y-1.5">
+                      {detail.slowestToolCalls.slice(0, 5).map((evt) => {
+                        const label = parseToolFromPayload(evt.payload, evt.toolName);
+                        const durationLabel = formatMs(evt.durationMs);
+                        return (
+                          <li
+                            key={evt.id}
+                            className="flex items-center gap-2 text-sm"
+                          >
+                            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono bg-dark-border/30 text-dark-text shrink-0">
+                              {durationLabel}
+                            </span>
+                            <span className="text-dark-text truncate" title={label}>
+                              {label}
+                            </span>
+                            {evt.agentName && evt.agentName !== 'team-lead' && (
+                              <span className="text-xs text-dark-muted shrink-0">
+                                {evt.agentName}
+                              </span>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
                   </div>
                 )}
               </div>

--- a/tests/client/TeamDetail.test.tsx
+++ b/tests/client/TeamDetail.test.tsx
@@ -3,7 +3,7 @@
 // =============================================================================
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +52,10 @@ vi.mock('../../src/client/components/CommGraph', () => ({
   CommGraph: () => <div data-testid="comm-graph">CommGraph</div>,
 }));
 
+vi.mock('../../src/client/components/CIChecks', () => ({
+  CIChecks: () => <div data-testid="ci-checks">CIChecks</div>,
+}));
+
 vi.mock('../../src/client/hooks/useFleetSSE', () => ({
   useFleetSSE: vi.fn(),
 }));
@@ -85,6 +89,7 @@ function makeDetail(overrides: Record<string, unknown> = {}) {
     totalCacheReadTokens: 0,
     totalCostUsd: 0.50,
     githubRepo: 'user/repo',
+    slowestToolCalls: [],
     ...overrides,
   };
 }
@@ -237,9 +242,10 @@ describe('TeamDetail', () => {
     });
   });
 
-  it('renders PR section when PR data is present', async () => {
+  it('renders PR link inside PR tab when PR data is present', async () => {
     mockSelectedTeamId = 1;
     mockGet.mockResolvedValue(makeDetail({
+      prNumber: 42,
       githubRepo: 'user/repo',
       pr: {
         number: 42,
@@ -252,19 +258,20 @@ describe('TeamDetail', () => {
       },
     }));
     render(<TeamDetail />);
+    const prTab = await screen.findByRole('button', { name: /^PR\s*#42$/ });
+    fireEvent.click(prTab);
     await waitFor(() => {
-      expect(screen.getByText('Pull Request')).toBeInTheDocument();
-      const link = screen.getByText('PR #42');
-      expect(link.tagName).toBe('A');
+      const link = screen.getByRole('link', { name: 'PR #42' });
       expect(link).toHaveAttribute('href', 'https://github.com/user/repo/pull/42');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
   });
 
-  it('renders PR number as plain text when githubRepo is null', async () => {
+  it('renders PR number as plain text inside PR tab when githubRepo is null', async () => {
     mockSelectedTeamId = 1;
     mockGet.mockResolvedValue(makeDetail({
+      prNumber: 42,
       githubRepo: null,
       pr: {
         number: 42,
@@ -277,14 +284,19 @@ describe('TeamDetail', () => {
       },
     }));
     render(<TeamDetail />);
+    const prTab = await screen.findByRole('button', { name: /^PR\s*#42$/ });
+    fireEvent.click(prTab);
     await waitFor(() => {
-      const prText = screen.getByText('PR #42');
-      expect(prText.tagName).toBe('SPAN');
-      expect(prText).not.toHaveAttribute('href');
+      // No link should be rendered when githubRepo is null
+      expect(screen.queryByRole('link', { name: 'PR #42' })).not.toBeInTheDocument();
+      // The PR number still renders as plain text inside the tab pane
+      const prMatches = screen.getAllByText('PR #42');
+      // One in the tab button, one in the tab content as a plain span
+      expect(prMatches.some((el) => el.tagName === 'SPAN')).toBe(true);
     });
   });
 
-  it('renders PR link in loading fallback when prNumber is set but pr detail is null', async () => {
+  it('renders PR link loading fallback inside PR tab when prNumber is set but pr detail is null', async () => {
     mockSelectedTeamId = 1;
     mockGet.mockResolvedValue(makeDetail({
       githubRepo: 'user/repo',
@@ -292,12 +304,14 @@ describe('TeamDetail', () => {
       pr: null,
     }));
     render(<TeamDetail />);
+    const prTab = await screen.findByRole('button', { name: /^PR\s*#99$/ });
+    fireEvent.click(prTab);
     await waitFor(() => {
-      const link = screen.getByText('PR #99');
-      expect(link.tagName).toBe('A');
+      const link = screen.getByRole('link', { name: 'PR #99' });
       expect(link).toHaveAttribute('href', 'https://github.com/user/repo/pull/99');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByText(/details loading/)).toBeInTheDocument();
     });
   });
 
@@ -318,5 +332,185 @@ describe('TeamDetail', () => {
       expect(screen.getByText('Quick:')).toBeInTheDocument();
       expect(screen.getByText('Status?')).toBeInTheDocument();
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #762: Promoted tabs (Transitions / PR / Slowest tools)
+  // ---------------------------------------------------------------------------
+
+  it('renders Transitions tab and always shows it', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail());
+    render(<TeamDetail />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Transitions/ })).toBeInTheDocument();
+    });
+  });
+
+  it('hides PR tab when team has no PR', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({ prNumber: null, pr: null }));
+    render(<TeamDetail />);
+    // Wait for the panel to render fully (Transitions tab is the marker that
+    // the post-load tab bar is present).
+    await screen.findByRole('button', { name: /^Transitions/ });
+    expect(screen.queryByRole('button', { name: /^PR\s*#/ })).not.toBeInTheDocument();
+  });
+
+  it('shows PR tab when prNumber is set (even with pr detail null)', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({ prNumber: 7, pr: null }));
+    render(<TeamDetail />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^PR\s*#7$/ })).toBeInTheDocument();
+    });
+  });
+
+  it('shows PR tab when prNumber is set and pr detail is loaded', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({
+      prNumber: 8,
+      pr: {
+        number: 8,
+        state: 'open',
+        ciStatus: 'passing',
+        mergeStatus: 'clean',
+        autoMerge: false,
+        ciFailCount: 0,
+        checks: [],
+      },
+    }));
+    render(<TeamDetail />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^PR\s*#8$/ })).toBeInTheDocument();
+    });
+  });
+
+  it('hides Slowest tools tab when slowestToolCalls is empty', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({ slowestToolCalls: [] }));
+    render(<TeamDetail />);
+    await screen.findByRole('button', { name: /^Transitions/ });
+    expect(screen.queryByRole('button', { name: 'Slowest tools' })).not.toBeInTheDocument();
+  });
+
+  it('shows Slowest tools tab when slowestToolCalls has data', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({
+      slowestToolCalls: [
+        {
+          id: 101,
+          teamId: 1,
+          type: 'tool_use',
+          payload: null,
+          toolName: 'Read',
+          durationMs: 4200,
+          agentName: 'team-lead',
+          createdAt: '2026-03-21T10:05:00Z',
+        },
+      ],
+    }));
+    render(<TeamDetail />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Slowest tools' })).toBeInTheDocument();
+    });
+  });
+
+  it('renders Slowest tools content after clicking the tab', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({
+      slowestToolCalls: [
+        {
+          id: 102,
+          teamId: 1,
+          type: 'tool_use',
+          payload: null,
+          toolName: 'Glob',
+          durationMs: 1500,
+          agentName: 'planner',
+          createdAt: '2026-03-21T10:06:00Z',
+        },
+      ],
+    }));
+    render(<TeamDetail />);
+    const tab = await screen.findByRole('button', { name: 'Slowest tools' });
+    fireEvent.click(tab);
+    await waitFor(() => {
+      // 1500ms formats to "1.5s"
+      expect(screen.getByText('1.5s')).toBeInTheDocument();
+      expect(screen.getByText('Glob')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render inline State Transitions / Pull Request / Slowest Tool Calls headings', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({
+      prNumber: 42,
+      pr: {
+        number: 42,
+        state: 'open',
+        ciStatus: 'passing',
+        mergeStatus: 'clean',
+        autoMerge: false,
+        ciFailCount: 0,
+        checks: [],
+      },
+      slowestToolCalls: [
+        {
+          id: 1,
+          teamId: 1,
+          type: 'tool_use',
+          payload: null,
+          toolName: 'Read',
+          durationMs: 200,
+          agentName: 'team-lead',
+          createdAt: '2026-03-21T10:05:00Z',
+        },
+      ],
+    }));
+    render(<TeamDetail />);
+    await screen.findByRole('button', { name: /^Transitions/ });
+    // Inline section headings should be gone — they were <h4> in the metadata
+    // panel previously and have no replacement at the same DOM level.
+    expect(screen.queryByText('State Transitions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pull Request')).not.toBeInTheDocument();
+    expect(screen.queryByText('Slowest Tool Calls')).not.toBeInTheDocument();
+  });
+
+  it('renders the tabs in the documented order after Team', async () => {
+    mockSelectedTeamId = 1;
+    mockGet.mockResolvedValue(makeDetail({
+      prNumber: 42,
+      pr: null,
+      slowestToolCalls: [
+        {
+          id: 1,
+          teamId: 1,
+          type: 'tool_use',
+          payload: null,
+          toolName: 'Read',
+          durationMs: 200,
+          agentName: 'team-lead',
+          createdAt: '2026-03-21T10:05:00Z',
+        },
+      ],
+    }));
+    render(<TeamDetail />);
+    await screen.findByRole('button', { name: /^Transitions/ });
+    const buttons = screen.getAllByRole('button').map((b) => b.textContent ?? '');
+    const sessionLogIdx = buttons.findIndex((t) => t.startsWith('Session Log'));
+    const tasksIdx = buttons.findIndex((t) => t.startsWith('Tasks'));
+    const filesIdx = buttons.findIndex((t) => t.startsWith('Files'));
+    const teamIdx = buttons.findIndex((t) => t === 'Team');
+    const transitionsIdx = buttons.findIndex((t) => t.startsWith('Transitions'));
+    const prIdx = buttons.findIndex((t) => /^PR\s*#/.test(t));
+    const slowestIdx = buttons.findIndex((t) => t === 'Slowest tools');
+    expect(sessionLogIdx).toBeGreaterThanOrEqual(0);
+    expect(tasksIdx).toBeGreaterThan(sessionLogIdx);
+    expect(filesIdx).toBeGreaterThan(tasksIdx);
+    expect(teamIdx).toBeGreaterThan(filesIdx);
+    expect(transitionsIdx).toBeGreaterThan(teamIdx);
+    expect(prIdx).toBeGreaterThan(transitionsIdx);
+    expect(slowestIdx).toBeGreaterThan(prIdx);
   });
 });


### PR DESCRIPTION
Closes #762

## Summary

Promotes three substantial inline metadata sections in `TeamDetail.tsx` to top-level tabs, matching the existing Tasks/Files pattern.

Tab bar is now: `Session Log | Tasks | Files | Team | Transitions | PR | Slowest tools`

- **Transitions** — always visible, vertical list with from/to pills, timestamp, reason.
- **PR** — hidden when `prNumber == null`. Label is `PR #{N}`. Ports both loaded and loading-fallback render branches.
- **Slowest tools** — hidden when `slowestToolCalls` is empty. Top-5 list with duration pills.

An auto-redirect effect resets to Session Log if the active tab becomes hidden mid-session (e.g. PR closed).

No new data-fetching, no new SSE subscriptions, no new types — all three datasets are already on `detail` / `transitions` from `useTeamDetailData`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm run test:client -- TeamDetail` — 27/27 passing (3 updated existing PR tests + 8 new visibility/order tests + 16 unchanged)
- [ ] Visual: tab bar shows new tabs in correct order; clicking each loads the expected content; height matches Session Log tab